### PR TITLE
fix(billing): prorate on the whole period

### DIFF
--- a/app/services/subscriptions/dates/monthly_service.rb
+++ b/app/services/subscriptions/dates/monthly_service.rb
@@ -28,11 +28,14 @@ module Subscriptions
         compute_to_date(compute_charges_from_date)
       end
 
+      # NOTE: `from_date` is not necessarily the beginning of the period: on a subscription resulting
+      #       from an upgrade, it is clamped to `started_at` while the anniversary is inherited from the
+      #       previous subscription. The duration is the one of the whole period, so it is measured from
+      #       the beginning of the period holding `from_date`.
       def compute_duration(from_date:)
-        return Time.days_in_month(from_date.month, from_date.year) if calendar?
+        period_start = compute_previous_beginning_of_period(from_date.to_date)
 
-        next_month_date = compute_to_date(from_date)
-        (next_month_date.to_date + 1.day - from_date.to_date).to_i
+        (compute_to_date(period_start).to_date + 1.day - period_start).to_i
       end
 
       alias_method :compute_charges_duration, :compute_duration

--- a/app/services/subscriptions/dates/quarterly_service.rb
+++ b/app/services/subscriptions/dates/quarterly_service.rb
@@ -30,10 +30,14 @@ module Subscriptions
         compute_to_date(compute_charges_from_date)
       end
 
+      # NOTE: `from_date` is not necessarily the beginning of the period: on a subscription resulting
+      #       from an upgrade, it is clamped to `started_at` while the anniversary is inherited from the
+      #       previous subscription. The duration is the one of the whole period, so it is measured from
+      #       the beginning of the period holding `from_date`.
       def compute_duration(from_date:)
-        next_to_date = compute_to_date(from_date)
+        period_start = compute_previous_beginning_of_period(from_date.to_date)
 
-        (next_to_date.to_date + 1.day - from_date.to_date).to_i
+        (compute_to_date(period_start).to_date + 1.day - period_start).to_i
       end
 
       alias_method :compute_charges_duration, :compute_duration

--- a/app/services/subscriptions/dates/semiannual_service.rb
+++ b/app/services/subscriptions/dates/semiannual_service.rb
@@ -101,10 +101,14 @@ module Subscriptions
         compute_to_date(compute_fixed_charges_from_date)
       end
 
+      # NOTE: `from_date` is not necessarily the beginning of the period: on a subscription resulting
+      #       from an upgrade, it is clamped to `started_at` while the anniversary is inherited from the
+      #       previous subscription. The duration is the one of the whole period, so it is measured from
+      #       the beginning of the period holding `from_date`.
       def compute_duration(from_date:)
-        next_to_date = compute_to_date(from_date)
+        period_start = compute_previous_beginning_of_period(from_date.to_date)
 
-        (next_to_date.to_date + 1.day - from_date.to_date).to_i
+        (compute_to_date(period_start).to_date + 1.day - period_start).to_i
       end
 
       def compute_charges_duration(from_date:)

--- a/spec/scenarios/subscriptions/upgrade_proration_spec.rb
+++ b/spec/scenarios/subscriptions/upgrade_proration_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Subscription Proration On Termination Scenario" do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:, timezone: "UTC") }
+
+  # NOTE: the amount is a multiple of the quarter duration, so that a single day costs 1000 cents
+  #       when the proration is based on the whole period.
+  let(:plan) do
+    create(:plan, organization:, interval: :quarterly, pay_in_advance: false, amount_cents: 91_000)
+  end
+
+  let(:cheaper_plan) do
+    create(:plan, organization:, interval: :quarterly, pay_in_advance: false, amount_cents: 45_500)
+  end
+
+  context "when the subscription results from an upgrade" do
+    it "prorates the terminated fee on the whole period" do
+      subscription = nil
+
+      travel_to(Time.zone.parse("2024-01-15T10:00:00Z")) do
+        create_subscription(
+          {external_customer_id: customer.external_id,
+           external_id: customer.external_id,
+           plan_code: cheaper_plan.code,
+           billing_time: "anniversary"}
+        )
+      end
+
+      # NOTE: the upgrade terminates the first subscription and starts the new one in the middle of
+      #       the period opened on 15 Apr, whose anniversary the new subscription inherits.
+      travel_to(Time.zone.parse("2024-05-20T10:00:00Z")) do
+        create_subscription(
+          {external_customer_id: customer.external_id,
+           external_id: customer.external_id,
+           plan_code: plan.code,
+           billing_time: "anniversary"}
+        )
+
+        subscription = customer.subscriptions.order(:created_at).last
+        expect(subscription.plan).to eq(plan)
+        expect(subscription.subscription_at.iso8601).to eq("2024-01-15T10:00:00Z")
+        expect(subscription.started_at.iso8601).to eq("2024-05-20T10:00:00Z")
+      end
+
+      travel_to(Time.zone.parse("2024-06-20T10:00:00Z")) do
+        terminate_subscription(subscription)
+
+        invoice = subscription.reload.invoices.order(:created_at).last
+        fee = invoice.fees.subscription.sole
+
+        expect(fee.amount_cents).to eq(32_000)
+      end
+    end
+  end
+
+  context "when the subscription started in the middle of a calendar period" do
+    it "prorates the terminated fee on the whole period" do
+      subscription = nil
+
+      travel_to(Time.zone.parse("2024-05-20T10:00:00Z")) do
+        create_subscription(
+          {external_customer_id: customer.external_id,
+           external_id: customer.external_id,
+           plan_code: plan.code,
+           billing_time: "calendar"}
+        )
+
+        subscription = customer.subscriptions.sole
+        expect(subscription.started_at.iso8601).to eq("2024-05-20T10:00:00Z")
+      end
+
+      travel_to(Time.zone.parse("2024-06-20T10:00:00Z")) do
+        terminate_subscription(subscription)
+
+        invoice = subscription.reload.invoices.order(:created_at).last
+        fee = invoice.fees.subscription.sole
+
+        expect(fee.amount_cents).to eq(32_000)
+      end
+    end
+  end
+end

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -917,6 +917,21 @@ RSpec.describe Subscriptions::Dates::MonthlyService do
           expect(result).to eq(plan.amount_cents.fdiv(29))
         end
       end
+
+      # NOTE: a subscription created by an upgrade inherits the anniversary of the one it replaces, so it
+      #       starts in the middle of its first period. The termination and trial fees pass the boundary
+      #       start, which is clamped to `started_at`, and must still be prorated on the whole period.
+      context "when subscription started in the middle of a period" do
+        let(:result) { date_service.single_day_price(optional_from_date: started_at.to_date) }
+
+        let(:subscription_at) { Time.zone.parse("10 Jan 2024") }
+        let(:started_at) { Time.zone.parse("20 Mar 2024") }
+        let(:billing_at) { Time.zone.parse("01 Apr 2024") }
+
+        it "returns the price of single day of the whole period" do
+          expect(result).to eq(plan.amount_cents.fdiv(31))
+        end
+      end
     end
   end
 

--- a/spec/services/subscriptions/dates/quarterly_service_spec.rb
+++ b/spec/services/subscriptions/dates/quarterly_service_spec.rb
@@ -840,6 +840,21 @@ RSpec.describe Subscriptions::Dates::QuarterlyService do
           expect(result).to eq(plan.amount_cents.fdiv(91))
         end
       end
+
+      # NOTE: a subscription created by an upgrade inherits the anniversary of the one it replaces, so it
+      #       starts in the middle of its first period. The termination and trial fees pass the boundary
+      #       start, which is clamped to `started_at`, and must still be prorated on the whole period.
+      context "when subscription started in the middle of a period" do
+        let(:result) { date_service.single_day_price(optional_from_date: started_at.to_date) }
+
+        let(:subscription_at) { Time.zone.parse("01 Jan 2024") }
+        let(:started_at) { Time.zone.parse("20 May 2024") }
+        let(:billing_at) { Time.zone.parse("01 Jun 2024") }
+
+        it "returns the price of single day of the whole period" do
+          expect(result).to eq(plan.amount_cents.fdiv(91))
+        end
+      end
     end
 
     context "when billing_time is anniversary" do
@@ -855,6 +870,21 @@ RSpec.describe Subscriptions::Dates::QuarterlyService do
 
         it "returns the month duration" do
           expect(result).to eq(plan.amount_cents.fdiv(89))
+        end
+      end
+
+      # NOTE: a subscription created by an upgrade inherits the anniversary of the one it replaces, so it
+      #       starts in the middle of its first period. The termination and trial fees pass the boundary
+      #       start, which is clamped to `started_at`, and must still be prorated on the whole period.
+      context "when subscription started in the middle of a period" do
+        let(:result) { date_service.single_day_price(optional_from_date: started_at.to_date) }
+
+        let(:subscription_at) { Time.zone.parse("15 Jan 2024") }
+        let(:started_at) { Time.zone.parse("20 May 2024") }
+        let(:billing_at) { Time.zone.parse("01 Jun 2024") }
+
+        it "returns the price of single day of the whole period" do
+          expect(result).to eq(plan.amount_cents.fdiv(91))
         end
       end
     end

--- a/spec/services/subscriptions/dates/semiannual_service_spec.rb
+++ b/spec/services/subscriptions/dates/semiannual_service_spec.rb
@@ -1086,6 +1086,21 @@ RSpec.describe Subscriptions::Dates::SemiannualService do
           expect(result).to eq(plan.amount_cents.fdiv(182))
         end
       end
+
+      # NOTE: a subscription created by an upgrade inherits the anniversary of the one it replaces, so it
+      #       starts in the middle of its first period. The termination and trial fees pass the boundary
+      #       start, which is clamped to `started_at`, and must still be prorated on the whole period.
+      context "when subscription started in the middle of a period" do
+        let(:result) { date_service.single_day_price(optional_from_date: started_at.to_date) }
+
+        let(:subscription_at) { Time.zone.parse("01 Jan 2024") }
+        let(:started_at) { Time.zone.parse("20 Sep 2024") }
+        let(:billing_at) { Time.zone.parse("01 Oct 2024") }
+
+        it "returns the price of single day of the whole period" do
+          expect(result).to eq(plan.amount_cents.fdiv(184))
+        end
+      end
     end
 
     context "when billing_time is anniversary" do
@@ -1103,6 +1118,21 @@ RSpec.describe Subscriptions::Dates::SemiannualService do
 
         it "returns the month duration" do
           expect(result).to eq(plan.amount_cents.fdiv(181))
+        end
+      end
+
+      # NOTE: a subscription created by an upgrade inherits the anniversary of the one it replaces, so it
+      #       starts in the middle of its first period. The termination and trial fees pass the boundary
+      #       start, which is clamped to `started_at`, and must still be prorated on the whole period.
+      context "when subscription started in the middle of a period" do
+        let(:result) { date_service.single_day_price(optional_from_date: started_at.to_date) }
+
+        let(:subscription_at) { Time.zone.parse("15 Jan 2024") }
+        let(:started_at) { Time.zone.parse("20 Sep 2024") }
+        let(:billing_at) { Time.zone.parse("01 Oct 2024") }
+
+        it "returns the price of single day of the whole period" do
+          expect(result).to eq(plan.amount_cents.fdiv(184))
         end
       end
     end


### PR DESCRIPTION
> Follow-up of #6173, which fixes the same flaw in the yearly service. Not stacked on it: this branch is off `main` and the two touch distinct files.

## Context

The duration of a period is the denominator of the proration: a subscription fee bills a number of days at the price of a single day, the plan amount divided by the length of the whole period. That duration is derived from a date the callers choose, and the terminated and the trial fees pass the start of the invoice boundaries, which `DatesService#from_datetime` clamps to the start date of the subscription.

A subscription created by an upgrade inherits the anniversary of the one it replaces, so it starts in the middle of its first period, and that clamped date is not the beginning of the period. The window was then measured from it instead:

```
single_day_price = plan_amount / period_duration
period_duration  = period_end + 1 day - period_start

# calendar, started on 20 May 2024, period 01 Apr -> 30 Jun
before: 2024-06-30 + 1 day - 2024-05-20 = 42   # truncated to the rest of the period
after:  2024-06-30 + 1 day - 2024-04-01 = 91

# anniversary on the 15th, started on 20 May 2024, period 15 Apr -> 14 Jul
before: 2024-08-14 + 1 day - 2024-05-20 = 87   # whole window, walked from started_at
after:  2024-07-14 + 1 day - 2024-04-15 = 91
```

Both shapes shrink the denominator, so the price of a day is too high and the customer is overcharged on termination. Monthly drops to 21 days instead of 31, semiannual to 103 instead of 184.

## Description

Resolve the beginning of the period holding the given date and measure from there, so a date taken in the middle of a period still yields the duration of the whole period. `compute_previous_beginning_of_period` already answers this for both billing times, which is why the calendar early return of the monthly service could go with it.

Each interval spec gains a mid-period case, and a scenario reaches the termination invoice through the API on a plan whose amount makes a single day cost 1000 cents over the whole quarter, covering both shapes: terminating 32 days into the period billed 33471 cents on the upgrade and 69333 on the calendar subscription, where 32000 is due.

The weekly service is immune, its duration being a constant. The clamping itself is left alone, since the boundaries of the invoice are correct.

## Behavior change to be aware of

Termination and trial invoices of subscriptions started in the middle of a period become smaller, prorated on the whole period. Invoices already issued are untouched and nothing needs backfilling.
