### PR TITLE
turn off delete events job

### DIFF
--- a/app/jobs/billable_metrics/delete_events_job.rb
+++ b/app/jobs/billable_metrics/delete_events_job.rb
@@ -4,9 +4,8 @@ module BillableMetrics
   class DeleteEventsJob < ApplicationJob
     queue_as :default
 
-    def perform(metric)
+    def perform(_metric)
       return true
-      Events::DeleteForMetricService.call!(billable_metric: metric)
     end
   end
 end

--- a/app/jobs/billable_metrics/delete_events_job.rb
+++ b/app/jobs/billable_metrics/delete_events_job.rb
@@ -5,6 +5,7 @@ module BillableMetrics
     queue_as :default
 
     def perform(metric)
+      return true
       Events::DeleteForMetricService.call!(billable_metric: metric)
     end
   end

--- a/app/jobs/billable_metrics/delete_events_job.rb
+++ b/app/jobs/billable_metrics/delete_events_job.rb
@@ -5,7 +5,7 @@ module BillableMetrics
     queue_as :default
 
     def perform(_metric)
-      return true
+      true
     end
   end
 end

--- a/spec/jobs/billable_metrics/delete_events_job_spec.rb
+++ b/spec/jobs/billable_metrics/delete_events_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BillableMetrics::DeleteEventsJob, type: :job do
   it "delegates to Events::DeleteForMetricService" do
     described_class.perform_now(billable_metric)
 
-    expect(Events::DeleteForMetricService).to have_received(:call!)
+    expect(Events::DeleteForMetricService).not_to have_received(:call!)
       .with(billable_metric: billable_metric)
   end
 end


### PR DESCRIPTION
we don't want to run this job anymore, but we have it executing, so it restarts on each deploy