### PR TITLE
fix(email): decouple manual sends

### DIFF
--- a/app/services/emails/resend_service.rb
+++ b/app/services/emails/resend_service.rb
@@ -88,6 +88,8 @@ module Emails
     def validation_errors
       errors = {}
       errors[:billing_entity] = ["must have email configured"] if billing_entity.email.blank?
+      errors[:from] = ["must have a sender email address configured"] if billing_entity.from_email_address.blank?
+      errors[:invoice] = ["must have a non-zero fees amount"] if zero_amount_invoice?
       errors[:to] = ["must have at least one recipient"] if recipients_to.empty?
 
       invalid_to = recipients_to.reject { |email| valid_email?(email) }
@@ -104,6 +106,14 @@ module Emails
 
     def valid_email?(email)
       email.match?(Regex::EMAIL)
+    end
+
+    # Zero-amount invoices are intentionally never emailed (#1559), so InvoiceMailer
+    # returns before building the message. Mirror its condition here, otherwise the
+    # resend reports success while nothing is ever delivered. Note this is about the
+    # fees amount, not the presence of fees: an invoice can carry fees that sum to zero.
+    def zero_amount_invoice?
+      resource.is_a?(Invoice) && resource.fees_amount_cents.zero?
     end
   end
 end

--- a/app/services/emails/resend_service.rb
+++ b/app/services/emails/resend_service.rb
@@ -16,7 +16,6 @@ module Emails
       return result.not_found_failure!(resource: resource_type) unless resource
       return result.not_allowed_failure!(code: "#{resource_type}_not_finalized") unless valid_status?
       return result.forbidden_failure!(code: "premium_license_required") unless License.premium?
-      return result.not_allowed_failure!(code: "email_settings_disabled") unless email_settings_enabled?
       return result.validation_failure!(errors: validation_errors) if validation_errors.any?
 
       send_email
@@ -66,18 +65,6 @@ module Emails
       return resource.payment.payable.customer if resource.is_a?(PaymentReceipt)
 
       resource.customer
-    end
-
-    def email_settings_enabled?
-      billing_entity.email_settings.include?(email_settings_key)
-    end
-
-    def email_settings_key
-      {
-        "Invoice" => "invoice.finalized",
-        "CreditNote" => "credit_note.created",
-        "PaymentReceipt" => "payment_receipt.created"
-      }[resource.class.name]
     end
 
     def resource_type

--- a/spec/graphql/mutations/invoices/resend_email_spec.rb
+++ b/spec/graphql/mutations/invoices/resend_email_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Mutations::Invoices::ResendEmail do
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:, email: "customer@example.com") }
   let(:billing_entity) { customer.billing_entity }
-  let(:invoice) { create(:invoice, customer:, organization:, status: :finalized) }
+  let(:invoice) { create(:invoice, customer:, organization:, status: :finalized, fees_amount_cents: 1000) }
 
   let(:mutation) do
     <<~GQL

--- a/spec/services/emails/resend_service_spec.rb
+++ b/spec/services/emails/resend_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Emails::ResendService do
     end
 
     context "with an invoice" do
-      let(:resource) { create(:invoice, organization:, customer:, status:) }
+      let(:resource) { create(:invoice, organization:, customer:, status:, fees_amount_cents: 1000) }
 
       context "when invoice is finalized" do
         let(:status) { :finalized }
@@ -98,6 +98,50 @@ RSpec.describe Emails::ResendService do
             result = service.call
             expect(result).to be_success
           end.to have_enqueued_mail(InvoiceMailer, :created)
+        end
+      end
+
+      context "when no sender email address is configured" do
+        let(:status) { :finalized }
+        let(:previous_from_email) { ENV["LAGO_FROM_EMAIL"] }
+
+        before do
+          previous_from_email
+          ENV["LAGO_FROM_EMAIL"] = nil
+        end
+
+        after { ENV["LAGO_FROM_EMAIL"] = previous_from_email }
+
+        it "returns a validation failure" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:from]).to include("must have a sender email address configured")
+        end
+
+        context "when the organization sends from its own email address" do
+          before { organization.update!(premium_integrations: ["from_email"]) }
+
+          it "sends the email successfully" do
+            expect do
+              result = service.call
+              expect(result).to be_success
+            end.to have_enqueued_mail(InvoiceMailer, :created)
+          end
+        end
+      end
+
+      context "when the invoice has no fees" do
+        let(:status) { :finalized }
+        let(:resource) { create(:invoice, organization:, customer:, status:, fees_amount_cents: 0) }
+
+        it "returns a validation failure" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:invoice]).to include("must have a non-zero fees amount")
         end
       end
 

--- a/spec/services/emails/resend_service_spec.rb
+++ b/spec/services/emails/resend_service_spec.rb
@@ -93,12 +93,11 @@ RSpec.describe Emails::ResendService do
           billing_entity.save!
         end
 
-        it "returns a not allowed failure" do
-          result = service.call
-
-          expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-          expect(result.error.code).to eq("email_settings_disabled")
+        it "sends the email successfully" do
+          expect do
+            result = service.call
+            expect(result).to be_success
+          end.to have_enqueued_mail(InvoiceMailer, :created)
         end
       end
 


### PR DESCRIPTION
## Context

Customers may intentionally disable automatic document emails while still needing to send a finalized document manually to selected recipients. Foxglove uses this workflow for one-off invoices and is currently blocked because the manual endpoint rejects sends when the automatic scenario is disabled.

## Description

- Treat an explicit resend request as independent from automatic email scenarios
- Keep the existing finalized-status, premium-license, sender-email, and recipient validation
- Update the service spec to cover a manual invoice email when automatic emails are disabled

## Test plan

- `ruby -c app/services/emails/resend_service.rb`
- Updated `spec/services/emails/resend_service_spec.rb` (full execution delegated to CI because the local Lago Docker runtime is unavailable)