### PR TITLE
feat(payment_terms): REST API write and read

### DIFF
--- a/app/controllers/api/v1/billing_entities_controller.rb
+++ b/app/controllers/api/v1/billing_entities_controller.rb
@@ -3,6 +3,8 @@
 module Api
   module V1
     class BillingEntitiesController < Api::BaseController
+      include RawPaymentTermParams
+
       def index
         render(
           json: ::CollectionSerializer.new(
@@ -139,18 +141,6 @@ module Api
         )
 
         with_raw_payment_term(permitted, params[:billing_entity])
-      end
-
-      # payment_term is a discriminated union validated in PaymentTerms::ValidateService.
-      # Strong params would silently drop null and non-hash values before validation,
-      # breaking clear-by-null and hiding invalid_format errors.
-      def with_raw_payment_term(permitted, raw)
-        if raw.respond_to?(:key?) && raw.key?(:payment_term)
-          permitted[:payment_term] = raw[:payment_term]
-          permitted[:payment_term].permit! if permitted[:payment_term].is_a?(ActionController::Parameters)
-        end
-
-        permitted
       end
 
       def resource_name

--- a/app/controllers/api/v1/billing_entities_controller.rb
+++ b/app/controllers/api/v1/billing_entities_controller.rb
@@ -67,7 +67,7 @@ module Api
       private
 
       def create_params
-        params.require(:billing_entity).permit(
+        permitted = params.require(:billing_entity).permit(
           :code,
           :name,
           :einvoicing,
@@ -99,10 +99,12 @@ module Api
             :document_locale
           ]
         )
+
+        with_raw_payment_term(permitted, params[:billing_entity])
       end
 
       def update_params
-        params.require(:billing_entity).permit(
+        permitted = params.require(:billing_entity).permit(
           :name,
           :einvoicing,
           :email,
@@ -135,6 +137,20 @@ module Api
           tax_codes: [],
           invoice_custom_section_codes: []
         )
+
+        with_raw_payment_term(permitted, params[:billing_entity])
+      end
+
+      # payment_term is a discriminated union validated in PaymentTerms::ValidateService.
+      # Strong params would silently drop null and non-hash values before validation,
+      # breaking clear-by-null and hiding invalid_format errors.
+      def with_raw_payment_term(permitted, raw)
+        if raw.respond_to?(:key?) && raw.key?(:payment_term)
+          permitted[:payment_term] = raw[:payment_term]
+          permitted[:payment_term].permit! if permitted[:payment_term].is_a?(ActionController::Parameters)
+        end
+
+        permitted
       end
 
       def resource_name

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -121,7 +121,7 @@ module Api
       private
 
       def create_params
-        params.expect(customer: [
+        permitted = params.expect(customer: [
           :account_type,
           :external_id,
           :name,
@@ -191,6 +191,20 @@ module Api
           tax_codes: [],
           invoice_custom_section_codes: []
         ])
+
+        with_raw_payment_term(permitted, params[:customer])
+      end
+
+      # payment_term is a discriminated union validated in PaymentTerms::ValidateService.
+      # Strong params would silently drop null and non-hash values before validation,
+      # breaking clear-by-null and hiding invalid_format errors.
+      def with_raw_payment_term(permitted, raw)
+        if raw.respond_to?(:key?) && raw.key?(:payment_term)
+          permitted[:payment_term] = raw[:payment_term]
+          permitted[:payment_term].permit! if permitted[:payment_term].is_a?(ActionController::Parameters)
+        end
+
+        permitted
       end
 
       def render_customer(customer)

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -3,6 +3,8 @@
 module Api
   module V1
     class CustomersController < Api::BaseController
+      include RawPaymentTermParams
+
       def create
         result = ::Customers::UpsertFromApiService.call(
           organization: current_organization,
@@ -193,18 +195,6 @@ module Api
         ])
 
         with_raw_payment_term(permitted, params[:customer])
-      end
-
-      # payment_term is a discriminated union validated in PaymentTerms::ValidateService.
-      # Strong params would silently drop null and non-hash values before validation,
-      # breaking clear-by-null and hiding invalid_format errors.
-      def with_raw_payment_term(permitted, raw)
-        if raw.respond_to?(:key?) && raw.key?(:payment_term)
-          permitted[:payment_term] = raw[:payment_term]
-          permitted[:payment_term].permit! if permitted[:payment_term].is_a?(ActionController::Parameters)
-        end
-
-        permitted
       end
 
       def render_customer(customer)

--- a/app/controllers/concerns/raw_payment_term_params.rb
+++ b/app/controllers/concerns/raw_payment_term_params.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module RawPaymentTermParams
+  private
+
+  # Strong params drop null and wrong-type values before validation.
+  # As a solution, this method copies raw values into the permitted params,
+  # so the PaymentTerms::ValidateService receives every value that the client sent.
+  def with_raw_payment_term(permitted, raw)
+    %i[payment_term net_payment_term].each do |key|
+      next unless raw.respond_to?(:key?) && raw.key?(key)
+
+      permitted[key] = raw[key]
+      permitted[key].permit! if permitted[key].is_a?(ActionController::Parameters)
+    end
+
+    permitted
+  end
+end

--- a/app/serializers/v1/billing_entity_serializer.rb
+++ b/app/serializers/v1/billing_entity_serializer.rb
@@ -23,6 +23,7 @@ module V1
         legal_number: model.legal_number,
         timezone: model.timezone,
         net_payment_term: model.net_payment_term,
+        payment_term: model.payment_term,
         email_settings: model.email_settings,
         document_numbering: model.document_numbering,
         document_number_prefix: model.document_number_prefix,

--- a/app/serializers/v1/customer_serializer.rb
+++ b/app/serializers/v1/customer_serializer.rb
@@ -33,6 +33,7 @@ module V1
         timezone: model.timezone,
         applicable_timezone: model.applicable_timezone,
         net_payment_term: model.net_payment_term,
+        payment_term: model.payment_term,
         external_salesforce_id: model.external_salesforce_id,
         finalize_zero_amount_invoice: model.finalize_zero_amount_invoice,
         billing_configuration:,

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -12,6 +12,7 @@ module V1
         issuing_date: model.issuing_date&.iso8601,
         payment_due_date: model.payment_due_date&.iso8601,
         net_payment_term: model.net_payment_term,
+        payment_term: model.snapshotted_payment_term&.to_h,
         invoice_type: model.invoice_type,
         status: model.status,
         payment_status: model.payment_status,

--- a/app/services/billing_entities/create_service.rb
+++ b/app/services/billing_entities/create_service.rb
@@ -19,7 +19,7 @@ module BillingEntities
     def call
       return result.forbidden_failure! unless organization.can_create_billing_entity?
 
-      unless PaymentTerms::ValidateService.new(result, payment_term: params[:payment_term]).valid?
+      unless PaymentTerms::ValidateService.new(result, payment_term: params[:payment_term], net_payment_term: params[:net_payment_term]).valid?
         return result
       end
 

--- a/app/services/billing_entities/create_service.rb
+++ b/app/services/billing_entities/create_service.rb
@@ -19,6 +19,10 @@ module BillingEntities
     def call
       return result.forbidden_failure! unless organization.can_create_billing_entity?
 
+      unless PaymentTerms::ValidateService.new(result, payment_term: params[:payment_term]).valid?
+        return result
+      end
+
       ActiveRecord::Base.transaction do
         billing_entity.assign_attributes(create_attributes)
         billing_entity.id = params[:id] if params[:id]
@@ -77,7 +81,6 @@ module BillingEntities
           legal_name
           legal_number
           name
-          net_payment_term
           phone
           state
           tax_identification_number

--- a/app/services/billing_entities/update_service.rb
+++ b/app/services/billing_entities/update_service.rb
@@ -19,7 +19,7 @@ module BillingEntities
     def call
       return result.not_found_failure!(resource: "billing_entity") unless billing_entity
 
-      unless PaymentTerms::ValidateService.new(result, payment_term: params[:payment_term]).valid?
+      unless PaymentTerms::ValidateService.new(result, payment_term: params[:payment_term], net_payment_term: params[:net_payment_term]).valid?
         return result
       end
 

--- a/app/services/billing_entities/update_service.rb
+++ b/app/services/billing_entities/update_service.rb
@@ -19,6 +19,10 @@ module BillingEntities
     def call
       return result.not_found_failure!(resource: "billing_entity") unless billing_entity
 
+      unless PaymentTerms::ValidateService.new(result, payment_term: params[:payment_term]).valid?
+        return result
+      end
+
       original_attributes = billing_entity.attributes
       old_tax_codes = billing_entity.taxes.pluck(:code)
 

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -34,6 +34,10 @@ module Customers
         )
       end
 
+      unless PaymentTerms::ValidateService.new(result, payment_term: args[:payment_term]).valid?
+        return result
+      end
+
       customer = billing_entity.customers.new(
         organization_id: organization.id,
         external_id: args[:external_id],
@@ -56,7 +60,6 @@ module Customers
         logo_url: args[:logo_url],
         legal_name: args[:legal_name],
         legal_number: args[:legal_number],
-        net_payment_term: args[:net_payment_term],
         external_salesforce_id: args[:external_salesforce_id],
         payment_provider: args[:payment_provider],
         payment_provider_code: args[:payment_provider_code],

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -34,7 +34,7 @@ module Customers
         )
       end
 
-      unless PaymentTerms::ValidateService.new(result, payment_term: args[:payment_term]).valid?
+      unless PaymentTerms::ValidateService.new(result, payment_term: args[:payment_term], net_payment_term: args[:net_payment_term]).valid?
         return result
       end
 

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -29,6 +29,10 @@ module Customers
         )
       end
 
+      unless PaymentTerms::ValidateService.new(result, payment_term: args[:payment_term]).valid?
+        return result
+      end
+
       old_payment_provider = customer.payment_provider
       old_provider_customer = customer.provider_customer
       original_tax_values = customer.slice(:tax_identification_number, :zipcode, :country).symbolize_keys

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -29,7 +29,7 @@ module Customers
         )
       end
 
-      unless PaymentTerms::ValidateService.new(result, payment_term: args[:payment_term]).valid?
+      unless PaymentTerms::ValidateService.new(result, payment_term: args[:payment_term], net_payment_term: args[:net_payment_term]).valid?
         return result
       end
 

--- a/app/services/customers/upsert_from_api_service.rb
+++ b/app/services/customers/upsert_from_api_service.rb
@@ -44,7 +44,7 @@ module Customers
         )
       end
 
-      unless PaymentTerms::ValidateService.new(result, payment_term: params[:payment_term]).valid?
+      unless PaymentTerms::ValidateService.new(result, payment_term: params[:payment_term], net_payment_term: params[:net_payment_term]).valid?
         return result
       end
 

--- a/app/services/customers/upsert_from_api_service.rb
+++ b/app/services/customers/upsert_from_api_service.rb
@@ -44,6 +44,10 @@ module Customers
         )
       end
 
+      unless PaymentTerms::ValidateService.new(result, payment_term: params[:payment_term]).valid?
+        return result
+      end
+
       ActiveRecord::Base.transaction do
         original_tax_values = customer.slice(:tax_identification_number, :zipcode, :country).symbolize_keys
 
@@ -71,7 +75,6 @@ module Customers
         customer.logo_url = params[:logo_url] if params.key?(:logo_url)
         customer.legal_name = params[:legal_name] if params.key?(:legal_name)
         customer.legal_number = params[:legal_number] if params.key?(:legal_number)
-        customer.net_payment_term = params[:net_payment_term] if params.key?(:net_payment_term)
         customer.external_salesforce_id = params[:external_salesforce_id] if params.key?(:external_salesforce_id)
         customer.finalize_zero_amount_invoice = params[:finalize_zero_amount_invoice] || "inherit" if params.key?(:finalize_zero_amount_invoice)
         customer.firstname = params[:firstname] if params.key?(:firstname)

--- a/app/services/payment_terms/validate_service.rb
+++ b/app/services/payment_terms/validate_service.rb
@@ -49,8 +49,14 @@ module PaymentTerms
       valid_month_offset?
     end
 
+    # Normalized to an indifferent-access Hash so API input arrives the same
+    # whether it comes as ActionController::Parameters or a plain hash.
     def payment_term
-      args[:payment_term]
+      return @payment_term if defined?(@payment_term)
+
+      raw = args[:payment_term]
+      raw = raw.to_unsafe_h if raw.is_a?(ActionController::Parameters)
+      @payment_term = raw.is_a?(Hash) ? raw.with_indifferent_access : raw
     end
 
     def term_type

--- a/spec/requests/api/v1/billing_entities_controller_spec.rb
+++ b/spec/requests/api/v1/billing_entities_controller_spec.rb
@@ -323,6 +323,39 @@ RSpec.describe Api::V1::BillingEntitiesController do
       end
     end
 
+    context "when updating net_payment_term with a digit string" do
+      let(:update_params) { {billing_entity: {net_payment_term: "45"}} }
+
+      it "fails with invalid_format" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json[:error_details][:net_payment_term]).to eq(["invalid_format"])
+      end
+    end
+
+    context "when updating net_payment_term with a decimal" do
+      let(:update_params) { {billing_entity: {net_payment_term: 30.5}} }
+
+      it "fails with invalid_format" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json[:error_details][:net_payment_term]).to eq(["invalid_format"])
+      end
+    end
+
+    context "when updating net_payment_term with a negative value" do
+      let(:update_params) { {billing_entity: {net_payment_term: -1}} }
+
+      it "fails with the legacy value_is_out_of_range code" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json[:error_details][:net_payment_term]).to eq(["value_is_out_of_range"])
+      end
+    end
+
     context "when the payment_term shape is invalid" do
       let(:update_params) do
         {billing_entity: {payment_term: {term_type: "net"}}}

--- a/spec/requests/api/v1/billing_entities_controller_spec.rb
+++ b/spec/requests/api/v1/billing_entities_controller_spec.rb
@@ -309,6 +309,64 @@ RSpec.describe Api::V1::BillingEntitiesController do
       before { subject }
     end
 
+    context "when updating a structured payment_term" do
+      let(:update_params) do
+        {billing_entity: {payment_term: {term_type: "net_end_of_month", days: 10}}}
+      end
+
+      it "writes the term and returns it with a null alias" do
+        subject
+
+        expect(response).to be_successful
+        expect(json[:billing_entity][:payment_term]).to eq(term_type: "net_end_of_month", days: 10)
+        expect(json[:billing_entity][:net_payment_term]).to be_nil
+      end
+    end
+
+    context "when the payment_term shape is invalid" do
+      let(:update_params) do
+        {billing_entity: {payment_term: {term_type: "net"}}}
+      end
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json[:error_details][:payment_term]).to eq(["invalid_days"])
+      end
+    end
+
+    context "when the payment_term is not a hash" do
+      let(:update_params) do
+        {billing_entity: {payment_term: "net 30"}}
+      end
+
+      it "returns a validation error instead of silently dropping the value" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json[:error_details][:payment_term]).to eq(["invalid_format"])
+      end
+    end
+
+    context "when the payment_term is null" do
+      let(:update_params) do
+        {billing_entity: {payment_term: nil}}
+      end
+
+      before do
+        billing_entity1.update!(payment_term: {"term_type" => "net", "days" => 30}, net_payment_term: 30)
+      end
+
+      it "clears the term" do
+        subject
+
+        expect(response).to be_successful
+        expect(json[:billing_entity][:payment_term]).to be_nil
+        expect(json[:billing_entity][:net_payment_term]).to be_nil
+      end
+    end
+
     context "when updating the applicable invoice custom sections" do
       let(:update_params) do
         {

--- a/spec/requests/api/v1/customers_controller_spec.rb
+++ b/spec/requests/api/v1/customers_controller_spec.rb
@@ -23,6 +23,72 @@ RSpec.describe Api::V1::CustomersController do
 
     include_examples "requires API permission", "customer", "write"
 
+    context "with a structured payment_term" do
+      before { create_params[:payment_term] = {term_type: "day_of_month", day_of_month: 15, month_offset: 2} }
+
+      it "writes the term and returns it with a null alias" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:customer][:payment_term]).to eq(term_type: "day_of_month", day_of_month: 15, month_offset: 2)
+        expect(json[:customer][:net_payment_term]).to be_nil
+      end
+    end
+
+    context "with a payment_term carrying an unexpected field" do
+      before { create_params[:payment_term] = {term_type: "end_of_month", days: 3} }
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json[:error_details][:payment_term]).to eq(["unexpected_fields"])
+      end
+    end
+
+    context "with a non-hash payment_term" do
+      before { create_params[:payment_term] = "net 30" }
+
+      it "returns a validation error instead of silently dropping the value" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json[:error_details][:payment_term]).to eq(["invalid_format"])
+      end
+    end
+
+    context "with a null payment_term" do
+      let(:customer) do
+        create(:customer, organization:, payment_term: {"term_type" => "net", "days" => 30}, net_payment_term: 30)
+      end
+
+      before { create_params.merge!(external_id: customer.external_id, payment_term: nil) }
+
+      it "clears the term" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:customer][:payment_term]).to be_nil
+        expect(json[:customer][:net_payment_term]).to be_nil
+      end
+    end
+
+    context "with a null payment_term alongside a net_payment_term (alias matrix row 9)" do
+      let(:customer) do
+        create(:customer, organization:, payment_term: {"term_type" => "net", "days" => 30}, net_payment_term: 30)
+      end
+
+      before { create_params.merge!(external_id: customer.external_id, net_payment_term: 20, payment_term: nil) }
+
+      it "lets payment_term win and clears the term" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:customer][:payment_term]).to be_nil
+        expect(json[:customer][:net_payment_term]).to be_nil
+      end
+    end
+
     context "when firstname and lastname contain null bytes" do
       let(:create_params) do
         {

--- a/spec/requests/api/v1/customers_controller_spec.rb
+++ b/spec/requests/api/v1/customers_controller_spec.rb
@@ -89,6 +89,39 @@ RSpec.describe Api::V1::CustomersController do
       end
     end
 
+    context "with a net_payment_term as a digit string" do
+      before { create_params.merge!(net_payment_term: "45") }
+
+      it "fails with invalid_format" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json[:error_details][:net_payment_term]).to eq(["invalid_format"])
+      end
+    end
+
+    context "with a decimal net_payment_term" do
+      before { create_params.merge!(net_payment_term: 30.5) }
+
+      it "fails with invalid_format" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json[:error_details][:net_payment_term]).to eq(["invalid_format"])
+      end
+    end
+
+    context "with a negative net_payment_term" do
+      before { create_params.merge!(net_payment_term: -1) }
+
+      it "fails with the legacy value_is_out_of_range code" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json[:error_details][:net_payment_term]).to eq(["value_is_out_of_range"])
+      end
+    end
+
     context "when firstname and lastname contain null bytes" do
       let(:create_params) do
         {

--- a/spec/serializers/v1/billing_entity_serializer_spec.rb
+++ b/spec/serializers/v1/billing_entity_serializer_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe V1::BillingEntitySerializer do
     expect(billing_entity_serialized.fetch("legal_number")).to eq(billing_entity.legal_number)
     expect(billing_entity_serialized.fetch("timezone")).to eq(billing_entity.timezone)
     expect(billing_entity_serialized.fetch("net_payment_term")).to eq(billing_entity.net_payment_term)
+    expect(billing_entity_serialized.fetch("payment_term")).to eq(billing_entity.payment_term)
     expect(billing_entity_serialized.fetch("email_settings")).to eq(billing_entity.email_settings)
     expect(billing_entity_serialized.fetch("document_numbering")).to eq(billing_entity.document_numbering)
     expect(billing_entity_serialized.fetch("document_number_prefix")).to eq(billing_entity.document_number_prefix)

--- a/spec/serializers/v1/customer_serializer_spec.rb
+++ b/spec/serializers/v1/customer_serializer_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe ::V1::CustomerSerializer do
       "timezone" => customer.timezone,
       "applicable_timezone" => customer.applicable_timezone,
       "net_payment_term" => customer.net_payment_term,
+      "payment_term" => customer.payment_term,
       "finalize_zero_amount_invoice" => customer.finalize_zero_amount_invoice,
       "tax_identification_number" => customer.tax_identification_number,
       "taxes" => customer.taxes.map { hash_including("lago_id" => it.id) },

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe ::V1::InvoiceSerializer do
       "issuing_date" => invoice.issuing_date.iso8601,
       "payment_due_date" => invoice.payment_due_date.iso8601,
       "net_payment_term" => invoice.net_payment_term,
+      "payment_term" => {"term_type" => "net", "days" => invoice.net_payment_term},
       "invoice_type" => invoice.invoice_type,
       "status" => invoice.status,
       "payment_status" => invoice.payment_status,

--- a/spec/services/billing_entities/create_service_spec.rb
+++ b/spec/services/billing_entities/create_service_spec.rb
@@ -53,6 +53,22 @@ RSpec.describe BillingEntities::CreateService do
         expect(result.billing_entity.reload.payment_term).to eq("term_type" => "net", "days" => 0)
       end
 
+      it "writes a provided payment_term with a null alias" do
+        params[:payment_term] = {term_type: "end_of_month"}
+
+        expect(result).to be_success
+        expect(result.billing_entity.reload.payment_term).to eq("term_type" => "end_of_month")
+        expect(result.billing_entity.reload.net_payment_term).to be_nil
+      end
+
+      it "returns a validation failure on an invalid payment_term shape" do
+        params[:payment_term] = "not-an-object"
+
+        expect(result).to be_failure
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:payment_term]).to eq(["invalid_format"])
+      end
+
       it "does not set eu_tax_management when not provided" do
         expect(result).to be_success
         expect(result.billing_entity.eu_tax_management).to be false

--- a/spec/services/billing_entities/update_service_spec.rb
+++ b/spec/services/billing_entities/update_service_spec.rb
@@ -205,6 +205,37 @@ RSpec.describe BillingEntities::UpdateService do
           )
         end
       end
+
+      context "when updating payment_term" do
+        before do
+          billing_entity.update!(net_payment_term: 30, payment_term: {"term_type" => "net", "days" => 30})
+        end
+
+        context "with a structured term" do
+          let(:params) { {payment_term: {term_type: "days_end_of_month", days: 10}} }
+
+          it "writes the term and mirrors a null alias" do
+            result = update_service.call
+
+            expect(result.billing_entity).to have_attributes(
+              payment_term: {"term_type" => "days_end_of_month", "days" => 10},
+              net_payment_term: nil
+            )
+          end
+        end
+
+        context "with an invalid shape" do
+          let(:params) { {payment_term: {term_type: "day_of_month", day_of_month: 32}} }
+
+          it "returns a validation failure and changes nothing" do
+            result = update_service.call
+
+            expect(result).to be_failure
+            expect(result.error.messages[:payment_term]).to eq(["invalid_day_of_month"])
+            expect(billing_entity.reload.payment_term).to eq("term_type" => "net", "days" => 30)
+          end
+        end
+      end
     end
 
     context "with base64 logo" do

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -79,6 +79,27 @@ RSpec.describe Customers::CreateService do
     end
   end
 
+  context "when payment_term is provided" do
+    before { create_args[:payment_term] = {term_type: "end_of_month"} }
+
+    it "writes the structured term with a null alias" do
+      expect(result.customer.reload).to have_attributes(
+        net_payment_term: nil,
+        payment_term: {"term_type" => "end_of_month"}
+      )
+    end
+  end
+
+  context "when payment_term has an invalid shape" do
+    before { create_args[:payment_term] = {term_type: "net", days: -1} }
+
+    it "returns a validation failure" do
+      expect(result).to be_failure
+      expect(result.error).to be_a(BaseService::ValidationFailure)
+      expect(result.error.messages[:payment_term]).to eq(["invalid_days"])
+    end
+  end
+
   it "calls SendWebhookJob with customer.created" do
     result
 

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -546,6 +546,60 @@ RSpec.describe Customers::UpdateService do
       end
     end
 
+    context "when updating payment_term" do
+      before do
+        customer.update!(net_payment_term: 30, payment_term: {"term_type" => "net", "days" => 30})
+      end
+
+      context "with a structured term" do
+        let(:update_args) { {id: customer.id, payment_term: {term_type: "net_end_of_month", days: 10}} }
+
+        it "writes the term and mirrors a null alias" do
+          result = customers_service.call
+
+          expect(result.customer).to have_attributes(
+            payment_term: {"term_type" => "net_end_of_month", "days" => 10},
+            net_payment_term: nil
+          )
+        end
+      end
+
+      context "with null" do
+        let(:update_args) { {id: customer.id, payment_term: nil} }
+
+        it "clears both columns" do
+          result = customers_service.call
+
+          expect(result.customer).to have_attributes(payment_term: nil, net_payment_term: nil)
+        end
+      end
+
+      context "with both fields sent" do
+        let(:update_args) { {id: customer.id, net_payment_term: 45, payment_term: {term_type: "end_of_month"}} }
+
+        it "lets payment_term win" do
+          result = customers_service.call
+
+          expect(result.customer).to have_attributes(
+            payment_term: {"term_type" => "end_of_month"},
+            net_payment_term: nil
+          )
+        end
+      end
+
+      context "with an invalid shape" do
+        let(:update_args) { {id: customer.id, payment_term: {term_type: "end_of_month", days: 3}} }
+
+        it "returns a validation failure and changes nothing" do
+          result = customers_service.call
+
+          expect(result).to be_failure
+          expect(result.error.messages[:payment_term]).to eq(["unexpected_fields"])
+          expect(customer.reload.payment_term).to eq("term_type" => "net", "days" => 30)
+        end
+      end
+    end
+
     context "when updating invoice_custom_sections" do
       let(:invoice_custom_sections) { create_list(:invoice_custom_section, 4, organization:) }
 

--- a/spec/services/customers/upsert_from_api_service_spec.rb
+++ b/spec/services/customers/upsert_from_api_service_spec.rb
@@ -139,6 +139,40 @@ RSpec.describe Customers::UpsertFromApiService do
     end
   end
 
+  context "when payment_term is provided" do
+    let(:customer) do
+      create(
+        :customer,
+        organization:,
+        external_id:,
+        net_payment_term: 30,
+        payment_term: {"term_type" => "net", "days" => 30}
+      )
+    end
+
+    before do
+      customer
+      create_args[:payment_term] = {term_type: "day_of_month", day_of_month: 15}
+    end
+
+    it "writes the structured term with a null alias" do
+      expect(result.customer).to have_attributes(
+        net_payment_term: nil,
+        payment_term: {"term_type" => "day_of_month", "day_of_month" => 15, "month_offset" => 1}
+      )
+    end
+  end
+
+  context "when payment_term has an invalid shape" do
+    before { create_args[:payment_term] = {term_type: "fortnightly"} }
+
+    it "returns a validation failure" do
+      expect(result).to be_failure
+      expect(result.error).to be_a(BaseService::ValidationFailure)
+      expect(result.error.messages[:payment_term]).to eq(["invalid_term_type"])
+    end
+  end
+
   it "calls SendWebhookJob with customer.created" do
     customer = result.customer
 


### PR DESCRIPTION
## Context

Earlier steps in this stack added the structured `payment_term` to customers and billing entities, with the `net_payment_term` integer as a compatibility alias. This PR exposes it via the REST API. Before this change, clients could only send the integer.

## Description

_Write path_

- `payment_term` is accepted on customer and billing entity create/update.
- `PaymentTerms::ValidateService` runs in all five write services before any persistence. Invalid input returns a validation error.
- The redundant direct `net_payment_term` column writes are removed. `PaymentTerms::AssignService` is now the only term write path.
- A new `RawPaymentTermParams` controller concern copies the raw `payment_term` and `net_payment_term` values into the permitted params. Without this concern, invalid input would be dropped silently instead of returning a validation error.
- `PaymentTerms::ValidateService` normalizes its input, so ActionController::Parameters and plain hashes give the same result.

_Read path_

- Added `payment_term` to customer and billing entity serializers.
- The invoice serializer returns the snapshotted `payment_term`. For invoices from before this feature, it builds `{term_type: "net", days: N}` from the invoice's own integer.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>