### PR TITLE
perf(usage): skip the last seen event aggregate

### DIFF
--- a/app/services/events/billing_period_filter_service.rb
+++ b/app/services/events/billing_period_filter_service.rb
@@ -63,18 +63,14 @@ module Events
       )
     end
 
-    # Every billable metric code of the plan, restricted to the requested codes when given.
-    # Intersecting instead of using codes directly keeps an unknown code from widening the lookup.
+    # The billable metric codes the event lookup covers: the requested ones, or every code of the
+    # plan when the caller did not restrict them. codes is expected to be derived from the plan, as
+    # every caller does today. An unrelated code is harmless, since codes only ever narrows the
+    # subscription events down to a `code IN (...)` restriction it cannot match, but intersecting
+    # with the plan to drop it is not: the charge would then be missing from the result and billed
+    # as zero units (see Fees::ChargeService#skip_unused_filter?) rather than reported as unknown.
     def plan_codes
-      @plan_codes ||= if codes.nil?
-        all_plan_codes
-      else
-        all_plan_codes & codes
-      end
-    end
-
-    def all_plan_codes
-      @all_plan_codes ||= plan.billable_metrics.distinct.pluck(:code)
+      @plan_codes ||= codes || plan.billable_metrics.distinct.pluck(:code)
     end
 
     def charges_and_filters

--- a/app/services/events/billing_period_filter_service.rb
+++ b/app/services/events/billing_period_filter_service.rb
@@ -4,9 +4,17 @@ module Events
   class BillingPeriodFilterService < BaseService
     Result = BaseResult[:charges]
 
-    def initialize(subscription:, boundaries:)
+    # codes restricts the event lookup to those billable metric codes. Callers that only bill a
+    # subset of the plan (usage filtered by charge or metric) pass it so the event store does not
+    # resolve combinations they will discard. Recurring charges are still seeded for the whole plan.
+    #
+    # with_last_seen_at can be disabled by callers that never read the timestamps, which lets the
+    # event store skip the MAX() aggregate and stop reading the ingestion column entirely.
+    def initialize(subscription:, boundaries:, codes: nil, with_last_seen_at: true)
       @subscription = subscription
       @boundaries = boundaries
+      @codes = codes
+      @with_last_seen_at = with_last_seen_at
       super
     end
 
@@ -15,6 +23,8 @@ module Events
     # result.charges is a nested hash: { charge_id => { filter_id => last_seen_at } } (nil filter
     # is the default bucket). last_seen_at is the most recent event ingestion timestamp for that
     # charge/filter (created_at on PG, enriched_at on CH), used to lazily invalidate the cache.
+    # It is nil when with_last_seen_at is disabled, which leaves the cache relying on its expiration
+    # instead of the lazy invalidation, so only callers that ignore it may disable it.
     # Recurring charges with no in-period event are seeded with the period start (see #period_start).
     def call
       result.charges = charges_and_filters
@@ -23,7 +33,7 @@ module Events
 
     private
 
-    attr_reader :subscription, :boundaries
+    attr_reader :subscription, :boundaries, :codes, :with_last_seen_at
 
     delegate :plan, :organization, to: :subscription
 
@@ -44,8 +54,18 @@ module Events
       )
     end
 
+    # Every billable metric code of the plan, restricted to the requested codes when given.
+    # Intersecting instead of using codes directly keeps an unknown code from widening the lookup.
     def plan_codes
-      @plan_codes ||= plan.billable_metrics.distinct.pluck(:code)
+      @plan_codes ||= if codes.nil?
+        all_plan_codes
+      else
+        all_plan_codes & codes
+      end
+    end
+
+    def all_plan_codes
+      @all_plan_codes ||= plan.billable_metrics.distinct.pluck(:code)
     end
 
     def charges_and_filters
@@ -60,7 +80,8 @@ module Events
     def charges_and_filters_from_events
       combinations = event_store.distinct_codes_and_property_combinations(
         codes: non_recurring_plan_codes,
-        filter_keys: billable_metric_filter_keys
+        filter_keys: billable_metric_filter_keys,
+        with_last_seen_at:
       )
 
       # Recurring usage carries over all-time, so its lazy cache key must reflect events ingested
@@ -69,7 +90,8 @@ module Events
         combinations += event_store.distinct_codes_and_property_combinations(
           codes: recurring_plan_codes,
           filter_keys: billable_metric_filter_keys,
-          include_all_history: true
+          include_all_history: true,
+          with_last_seen_at:
         )
       end
 
@@ -135,10 +157,10 @@ module Events
         .includes(billable_metric: :filters, filters: {values: :billable_metric_filter})
     end
 
-    # Union of every filter key defined across the plan billable metrics
+    # Union of every filter key defined across the billable metrics the event lookup covers
     def billable_metric_filter_keys
       @billable_metric_filter_keys ||= BillableMetricFilter
-        .where(billable_metric_id: plan.billable_metrics.select(:id))
+        .where(billable_metric_id: plan.billable_metrics.where(code: plan_codes).select(:id))
         .distinct
         .pluck(:key)
     end
@@ -147,12 +169,16 @@ module Events
     # the period, including the recurring ones.
     # Shape: { charge_id => { filter_id => last_seen_at } } (nil filter is the default bucket).
     def charges_and_filters_from_pre_enriched_events
-      values = event_store.distinct_charges_and_filters(codes: non_recurring_plan_codes)
+      values = event_store.distinct_charges_and_filters(codes: non_recurring_plan_codes, with_last_seen_at:)
 
       # Recurring usage carries over all-time, so its lazy cache key must reflect events ingested
       # for prior periods
       if recurring_plan_codes.any?
-        values += event_store.distinct_charges_and_filters(codes: recurring_plan_codes, include_all_history: true)
+        values += event_store.distinct_charges_and_filters(
+          codes: recurring_plan_codes,
+          include_all_history: true,
+          with_last_seen_at:
+        )
       end
 
       charge_filter_ids = values.map { |v| v[1] }.reject(&:blank?)
@@ -224,7 +250,7 @@ module Events
     end
 
     def recurring_plan_codes
-      @recurring_plan_codes ||= plan.billable_metrics.where(recurring: true).distinct.pluck(:code)
+      @recurring_plan_codes ||= plan.billable_metrics.where(recurring: true).where(code: plan_codes).distinct.pluck(:code)
     end
 
     def non_recurring_plan_codes

--- a/app/services/events/billing_period_filter_service.rb
+++ b/app/services/events/billing_period_filter_service.rb
@@ -8,8 +8,9 @@ module Events
     # subset of the plan (usage filtered by charge or metric) pass it so the event store does not
     # resolve combinations they will discard. Recurring charges are still seeded for the whole plan.
     #
-    # with_last_seen_at can be disabled by callers that never read the timestamps, which lets the
-    # event store skip the MAX() aggregate and stop reading the ingestion column entirely.
+    # with_last_seen_at can be disabled only by callers that compute usage without the charge cache,
+    # which lets the event store skip the MAX() aggregate and stop reading the ingestion column
+    # entirely. See #call for why a cached caller must never disable it.
     def initialize(subscription:, boundaries:, codes: nil, with_last_seen_at: true)
       @subscription = subscription
       @boundaries = boundaries
@@ -23,8 +24,12 @@ module Events
     # result.charges is a nested hash: { charge_id => { filter_id => last_seen_at } } (nil filter
     # is the default bucket). last_seen_at is the most recent event ingestion timestamp for that
     # charge/filter (created_at on PG, enriched_at on CH), used to lazily invalidate the cache.
-    # It is nil when with_last_seen_at is disabled, which leaves the cache relying on its expiration
-    # instead of the lazy invalidation, so only callers that ignore it may disable it.
+    # It is nil when with_last_seen_at is disabled, so the flag may only be turned off when the
+    # charge cache is off entirely: a nil watermark does not fall back to the expiration, it makes
+    # the entry unconditionally valid (CacheService#settled? and #valid_cache? both return early)
+    # and stamps cached_at from a wall clock reading instead of an event timestamp. Later readers
+    # that do compute a watermark then accept that entry, because any real event timestamp is older
+    # than the wall clock, and stale usage is served for the rest of the billing period.
     # Recurring charges with no in-period event are seeded with the period start (see #period_start).
     def call
       result.charges = charges_and_filters

--- a/app/services/events/billing_period_filter_service.rb
+++ b/app/services/events/billing_period_filter_service.rb
@@ -4,17 +4,6 @@ module Events
   class BillingPeriodFilterService < BaseService
     Result = BaseResult[:charges]
 
-    # codes restricts the event lookup to those billable metric codes. Callers that only bill a
-    # subset of the plan (usage filtered by charge or metric) pass it so the event store does not
-    # resolve combinations they will discard. It bounds the lookup, not the result: recurring
-    # charges are seeded from the plan or from previous usage, neither of which codes narrows, so
-    # charges outside of it may still be returned. The first billing period of the pre-enriched
-    # path is the exception, as nothing is seeded there and a recurring charge is only returned
-    # when its code is part of codes. Callers must read the charges they asked for, no more.
-    #
-    # with_last_seen_at can be disabled only by callers that compute usage without the charge cache,
-    # which lets the event store skip the MAX() aggregate and stop reading the ingestion column
-    # entirely. See #call for why a cached caller must never disable it.
     def initialize(subscription:, boundaries:, codes: nil, with_last_seen_at: true)
       @subscription = subscription
       @boundaries = boundaries
@@ -28,12 +17,7 @@ module Events
     # result.charges is a nested hash: { charge_id => { filter_id => last_seen_at } } (nil filter
     # is the default bucket). last_seen_at is the most recent event ingestion timestamp for that
     # charge/filter (created_at on PG, enriched_at on CH), used to lazily invalidate the cache.
-    # It is nil when with_last_seen_at is disabled, so the flag may only be turned off when the
-    # charge cache is off entirely: a nil watermark does not fall back to the expiration, it makes
-    # the entry unconditionally valid (CacheService#settled? and #valid_cache? both return early)
-    # and stamps cached_at from a wall clock reading instead of an event timestamp. Later readers
-    # that do compute a watermark then accept that entry, because any real event timestamp is older
-    # than the wall clock, and stale usage is served for the rest of the billing period.
+    # It is nil when with_last_seen_at is disabled, which keeps a cached entry valid forever.
     # Recurring charges with no in-period event are seeded with the period start (see #period_start).
     def call
       result.charges = charges_and_filters
@@ -63,12 +47,8 @@ module Events
       )
     end
 
-    # The billable metric codes the event lookup covers: the requested ones, or every code of the
-    # plan when the caller did not restrict them. codes is expected to be derived from the plan, as
-    # every caller does today. An unrelated code is harmless, since codes only ever narrows the
-    # subscription events down to a `code IN (...)` restriction it cannot match, but intersecting
-    # with the plan to drop it is not: the charge would then be missing from the result and billed
-    # as zero units (see Fees::ChargeService#skip_unused_filter?) rather than reported as unknown.
+    # A code outside of the plan matches no event, so codes is used as is: dropping it would leave
+    # its charge out of the result, billed as zero units instead of surfaced.
     def plan_codes
       @plan_codes ||= codes || plan.billable_metrics.distinct.pluck(:code)
     end
@@ -162,7 +142,7 @@ module Events
         .includes(billable_metric: :filters, filters: {values: :billable_metric_filter})
     end
 
-    # Union of every filter key defined across the billable metrics the event lookup covers
+    # Union of every filter key defined across the billable metrics the lookup covers
     def billable_metric_filter_keys
       @billable_metric_filter_keys ||= BillableMetricFilter
         .where(billable_metric_id: plan.billable_metrics.where(code: plan_codes).select(:id))
@@ -171,9 +151,8 @@ module Events
     end
 
     # Return the charges and filters matching the events pre-enriched in ClickHouse or Postgres for
-    # the period, including the recurring ones carrying usage over from the previous periods. In the
-    # first billing period there is none to carry over, so recurring charges are only returned when
-    # the event lookup covers their code (see #recurring_charges_and_filters).
+    # the period, including the recurring ones, except in the first period where they are only
+    # returned when the event lookup covers their code.
     # Shape: { charge_id => { filter_id => last_seen_at } } (nil filter is the default bucket).
     def charges_and_filters_from_pre_enriched_events
       values = event_store.distinct_charges_and_filters(codes: non_recurring_plan_codes, with_last_seen_at:)

--- a/app/services/events/billing_period_filter_service.rb
+++ b/app/services/events/billing_period_filter_service.rb
@@ -6,7 +6,11 @@ module Events
 
     # codes restricts the event lookup to those billable metric codes. Callers that only bill a
     # subset of the plan (usage filtered by charge or metric) pass it so the event store does not
-    # resolve combinations they will discard. Recurring charges are still seeded for the whole plan.
+    # resolve combinations they will discard. It bounds the lookup, not the result: recurring
+    # charges are seeded from the plan or from previous usage, neither of which codes narrows, so
+    # charges outside of it may still be returned. The first billing period of the pre-enriched
+    # path is the exception, as nothing is seeded there and a recurring charge is only returned
+    # when its code is part of codes. Callers must read the charges they asked for, no more.
     #
     # with_last_seen_at can be disabled only by callers that compute usage without the charge cache,
     # which lets the event store skip the MAX() aggregate and stop reading the ingestion column
@@ -171,7 +175,9 @@ module Events
     end
 
     # Return the charges and filters matching the events pre-enriched in ClickHouse or Postgres for
-    # the period, including the recurring ones.
+    # the period, including the recurring ones carrying usage over from the previous periods. In the
+    # first billing period there is none to carry over, so recurring charges are only returned when
+    # the event lookup covers their code (see #recurring_charges_and_filters).
     # Shape: { charge_id => { filter_id => last_seen_at } } (nil filter is the default bucket).
     def charges_and_filters_from_pre_enriched_events
       values = event_store.distinct_charges_and_filters(codes: non_recurring_plan_codes, with_last_seen_at:)

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -103,7 +103,7 @@ module Events
         raise NotImplementedError
       end
 
-      def distinct_codes_and_property_combinations(codes:, filter_keys:, include_all_history: false)
+      def distinct_codes_and_property_combinations(codes:, filter_keys:, include_all_history: false, with_last_seen_at: true)
         []
       end
 

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -152,7 +152,9 @@ module Events
 
       # Returns [charge_id, charge_filter_id, last_seen_at] tuples, where last_seen_at is the
       # enriched_at of the most recent event for that charge/filter in the period.
-      def distinct_charges_and_filters(codes: nil, include_all_history: false)
+      # With with_last_seen_at disabled the aggregate is not computed and last_seen_at is nil, which
+      # callers that never read it use to avoid scanning the column (see BillingPeriodFilterService).
+      def distinct_charges_and_filters(codes: nil, include_all_history: false, with_last_seen_at: true)
         lower_bound = include_all_history ? nil : from_datetime
         Events::Stores::Utils::ClickhouseConnection.with_retry do
           scope = ::Clickhouse::EventsEnrichedExpanded
@@ -161,8 +163,14 @@ module Events
             .where(timestamp: lower_bound..to_datetime)
 
           scope = scope.where(code: codes) unless codes.nil?
-          scope.group("charge_id", "charge_filter_id")
-            .pluck("charge_id", Arel.sql("nullIf(charge_filter_id, '')"), Arel.sql("MAX(enriched_at)"))
+          scope = scope.group("charge_id", "charge_filter_id")
+
+          if with_last_seen_at
+            scope.pluck("charge_id", Arel.sql("nullIf(charge_filter_id, '')"), Arel.sql("MAX(enriched_at)"))
+          else
+            scope.pluck("charge_id", Arel.sql("nullIf(charge_filter_id, '')"))
+              .map { |charge_id, filter_id| [charge_id, filter_id, nil] }
+          end
         end
       end
 

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -165,12 +165,11 @@ module Events
           scope = scope.where(code: codes) unless codes.nil?
           scope = scope.group("charge_id", "charge_filter_id")
 
-          if with_last_seen_at
-            scope.pluck("charge_id", Arel.sql("nullIf(charge_filter_id, '')"), Arel.sql("MAX(enriched_at)"))
-          else
-            scope.pluck("charge_id", Arel.sql("nullIf(charge_filter_id, '')"))
-              .map { |charge_id, filter_id| [charge_id, filter_id, nil] }
-          end
+          scope.pluck(
+            "charge_id",
+            Arel.sql("nullIf(charge_filter_id, '')"),
+            Arel.sql(with_last_seen_at ? "MAX(enriched_at)" : "NULL")
+          )
         end
       end
 

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -184,7 +184,7 @@ module Events
             selects << ActiveRecord::Base.sanitize_sql_array(["properties[?] AS prop_#{index}", key.to_s])
             group_columns << "prop_#{index}"
           end
-          selects << "MAX(enriched_at) AS last_seen_at" if with_last_seen_at
+          selects << (with_last_seen_at ? "MAX(enriched_at) AS last_seen_at" : "NULL AS last_seen_at")
 
           scope.select(selects.join(", ")).group(group_columns.join(", ")).map do |row|
             combination = {}
@@ -193,7 +193,7 @@ module Events
               combination[key] = value if value.present?
             end
 
-            [row.code, combination, (row.read_attribute("last_seen_at") if with_last_seen_at)]
+            [row.code, combination, row.read_attribute("last_seen_at")]
           end
         end
       end

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -148,24 +148,26 @@ module Events
         conditions.join(" AND ")
       end
 
-      def distinct_charges_and_filters(codes: nil, include_all_history: false)
+      def distinct_charges_and_filters(codes: nil, include_all_history: false, with_last_seen_at: true)
         # Implementation relies directly on the events_enriched_expanded table,
         # so we delegate the implementation to the ClickhouseEnrichedStore
         Events::Stores::ClickhouseEnrichedStore.new(
           subscription:,
           boundaries:
-        ).distinct_charges_and_filters(codes:, include_all_history:)
+        ).distinct_charges_and_filters(codes:, include_all_history:, with_last_seen_at:)
       end
 
       # Returns the distinct [code, properties, last_seen_at] combinations present in the events
       # of the period. Only properties present in the filter_keys are considered, so the result
       # holds only the dimensions that can be matched against charge filters.
       # An empty hash represents the default (no filter) bucket.
-      # last_seen_at is the enriched_at of the most recent event in the combination.
+      # last_seen_at is the enriched_at of the most recent event in the combination. With
+      # with_last_seen_at disabled the aggregate is not computed and last_seen_at is nil, which
+      # callers that never read it use to avoid scanning the column (see BillingPeriodFilterService).
       #
       # ClickHouse stores properties as a Map(String, String); a missing key reads back as an
       # empty string, so blank values are dropped to mirror the Postgres jsonb behaviour.
-      def distinct_codes_and_property_combinations(codes:, filter_keys:, include_all_history: false)
+      def distinct_codes_and_property_combinations(codes:, filter_keys:, include_all_history: false, with_last_seen_at: true)
         return [] if codes.empty?
 
         Events::Stores::Utils::ClickhouseConnection.with_retry do
@@ -182,7 +184,7 @@ module Events
             selects << ActiveRecord::Base.sanitize_sql_array(["properties[?] AS prop_#{index}", key.to_s])
             group_columns << "prop_#{index}"
           end
-          selects << "MAX(enriched_at) AS last_seen_at"
+          selects << "MAX(enriched_at) AS last_seen_at" if with_last_seen_at
 
           scope.select(selects.join(", ")).group(group_columns.join(", ")).map do |row|
             combination = {}
@@ -191,7 +193,7 @@ module Events
               combination[key] = value if value.present?
             end
 
-            [row.code, combination, row.read_attribute("last_seen_at")]
+            [row.code, combination, (row.read_attribute("last_seen_at") if with_last_seen_at)]
           end
         end
       end

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -24,41 +24,52 @@ module Events
 
       # Returns [charge_id, charge_filter_id, last_seen_at] tuples, where last_seen_at is the
       # enriched_at of the most recent event for that charge/filter in the period.
-      def distinct_charges_and_filters(codes: nil, include_all_history: false)
+      # With with_last_seen_at disabled the aggregate is not computed and last_seen_at is nil, which
+      # callers that never read it use to avoid scanning the column (see BillingPeriodFilterService).
+      def distinct_charges_and_filters(codes: nil, include_all_history: false, with_last_seen_at: true)
         lower_bound = include_all_history ? nil : from_datetime
         scope = EnrichedEvent.where(organization_id: subscription.organization_id)
           .where(subscription_id: subscription.id)
           .where(timestamp: lower_bound..to_datetime)
 
         scope = scope.where(code: codes) unless codes.nil?
-        scope.group(:charge_id, :charge_filter_id)
-          .pluck(:charge_id, :charge_filter_id, Arel.sql("MAX(enriched_at)"))
+        scope = scope.group(:charge_id, :charge_filter_id)
+
+        if with_last_seen_at
+          scope.pluck(:charge_id, :charge_filter_id, Arel.sql("MAX(enriched_at)"))
+        else
+          scope.pluck(:charge_id, :charge_filter_id).map { |charge_id, filter_id| [charge_id, filter_id, nil] }
+        end
       end
 
       # Returns the distinct [code, properties, last_seen_at] combinations present in the events
       # of the period. Only properties present in the filter_keys are considered, so the result
       # holds only the dimensions that can be matched against charge filters.
       # An empty hash represents the default (no filter) bucket.
-      # last_seen_at is the created_at of the most recent event in the combination.
-      def distinct_codes_and_property_combinations(codes:, filter_keys:, include_all_history: false)
+      # last_seen_at is the created_at of the most recent event in the combination. With
+      # with_last_seen_at disabled the aggregate is not computed and last_seen_at is nil, which
+      # callers that never read it use to avoid scanning the column (see BillingPeriodFilterService).
+      def distinct_codes_and_property_combinations(codes:, filter_keys:, include_all_history: false, with_last_seen_at: true)
         scope = Event.where(external_subscription_id: subscription.external_id)
           .where(organization_id: subscription.organization_id)
           .where(code: codes)
           .to_datetime(applicable_to_datetime)
         scope = scope.from_datetime(from_datetime) unless include_all_history
 
+        selects = [<<~SQL.squish]
+          events.code AS code,
+          coalesce((
+            SELECT jsonb_object_agg(props.key, props.value)
+            FROM jsonb_each_text(events.properties) AS props(key, value)
+            WHERE props.key = ANY(#{filter_keys_array_sql(filter_keys)})
+          ), '{}'::jsonb) AS combination
+        SQL
+        selects << "MAX(events.created_at) AS last_seen_at" if with_last_seen_at
+
         scope
-          .select(Arel.sql(<<~SQL.squish))
-            events.code AS code,
-            coalesce((
-              SELECT jsonb_object_agg(props.key, props.value)
-              FROM jsonb_each_text(events.properties) AS props(key, value)
-              WHERE props.key = ANY(#{filter_keys_array_sql(filter_keys)})
-            ), '{}'::jsonb) AS combination,
-            MAX(events.created_at) AS last_seen_at
-          SQL
+          .select(Arel.sql(selects.join(", ")))
           .group("code, combination")
-          .map { |row| [row.code, parse_combination(row), row.last_seen_at] }
+          .map { |row| [row.code, parse_combination(row), with_last_seen_at ? row.last_seen_at : nil] }
       end
 
       def events_values(limit: nil, force_from: false, exclude_event: false)

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -35,11 +35,7 @@ module Events
         scope = scope.where(code: codes) unless codes.nil?
         scope = scope.group(:charge_id, :charge_filter_id)
 
-        if with_last_seen_at
-          scope.pluck(:charge_id, :charge_filter_id, Arel.sql("MAX(enriched_at)"))
-        else
-          scope.pluck(:charge_id, :charge_filter_id).map { |charge_id, filter_id| [charge_id, filter_id, nil] }
-        end
+        scope.pluck(:charge_id, :charge_filter_id, Arel.sql(with_last_seen_at ? "MAX(enriched_at)" : "NULL"))
       end
 
       # Returns the distinct [code, properties, last_seen_at] combinations present in the events
@@ -64,12 +60,12 @@ module Events
             WHERE props.key = ANY(#{filter_keys_array_sql(filter_keys)})
           ), '{}'::jsonb) AS combination
         SQL
-        selects << "MAX(events.created_at) AS last_seen_at" if with_last_seen_at
+        selects << (with_last_seen_at ? "MAX(events.created_at) AS last_seen_at" : "NULL AS last_seen_at")
 
         scope
           .select(Arel.sql(selects.join(", ")))
           .group("code, combination")
-          .map { |row| [row.code, parse_combination(row), with_last_seen_at ? row.last_seen_at : nil] }
+          .map { |row| [row.code, parse_combination(row), row.last_seen_at] }
       end
 
       def events_values(limit: nil, force_from: false, exclude_event: false)

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -421,9 +421,6 @@ module Invoices
       context == :finalize || Invoice::GENERATED_INVOICE_STATUSES.include?(invoice.status)
     end
 
-    # Fees are computed without a charge cache middleware here, so the ingestion timestamps driving
-    # its lazy invalidation are never read. Only the charge/filter keys matter, and skipping the
-    # aggregate keeps the event store from reading the ingestion column.
     def event_filters(subscription, boundaries)
       Events::BillingPeriodFilterService.call!(
         subscription:, boundaries:, with_last_seen_at: false

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -421,9 +421,12 @@ module Invoices
       context == :finalize || Invoice::GENERATED_INVOICE_STATUSES.include?(invoice.status)
     end
 
+    # Fees are computed without a charge cache middleware here, so the ingestion timestamps driving
+    # its lazy invalidation are never read. Only the charge/filter keys matter, and skipping the
+    # aggregate keeps the event store from reading the ingestion column.
     def event_filters(subscription, boundaries)
       Events::BillingPeriodFilterService.call!(
-        subscription:, boundaries:
+        subscription:, boundaries:, with_last_seen_at: false
       )
     end
   end

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -131,15 +131,12 @@ module Invoices
         subscription:,
         charge:,
         to_datetime: boundaries.charges_to_datetime,
-        cache: cache_applicable?,
+        cache: charge_cache_enabled?,
         last_seen_at: applied_filters
       )
 
       applied_boundaries = boundaries
       applied_boundaries = boundaries.dup.tap { it.max_timestamp = max_timestamp } if max_timestamp
-      if usage_filters.filter_by_group.present?
-        cache_middleware = nil
-      end
 
       Fees::ChargeService
         .call!(
@@ -289,8 +286,10 @@ module Invoices
       charges.except(:includes).joins(:billable_metric).distinct.pluck("billable_metrics.code")
     end
 
-    # charge_usage drops the cache middleware entirely when usage is filtered by group, so the
-    # ingestion timestamps driving its lazy invalidation are only read when both conditions hold.
+    # Single gate for the charge cache: it drives both the middleware passed to Fees::ChargeService
+    # and whether the ingestion timestamps are requested. The two must never diverge, because a nil
+    # timestamp written into a live cache stays valid forever (see Events::BillingPeriodFilterService).
+    # Usage filtered by group is never cached, as its fees are a subset of the charge fees.
     def charge_cache_enabled?
       cache_applicable? && usage_filters.filter_by_group.blank?
     end

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -270,10 +270,29 @@ module Invoices
       @customer_provider_taxation ||= invoice.customer.tax_customer
     end
 
+    # Only the charges being computed are billed, so restricting the event lookup to their codes
+    # avoids resolving combinations for the rest of the plan. The ingestion timestamps are requested
+    # only when the charge cache can actually read them.
     def event_filters(subscription, boundaries)
       Events::BillingPeriodFilterService.call!(
-        subscription:, boundaries:
+        subscription:,
+        boundaries:,
+        codes: filtered_metric_codes,
+        with_last_seen_at: charge_cache_enabled?
       )
+    end
+
+    # nil when every charge of the plan is computed, so the whole plan is looked up as before.
+    def filtered_metric_codes
+      return nil unless usage_filters.has_charge_filter?
+
+      charges.except(:includes).joins(:billable_metric).distinct.pluck("billable_metrics.code")
+    end
+
+    # charge_usage drops the cache middleware entirely when usage is filtered by group, so the
+    # ingestion timestamps driving its lazy invalidation are only read when both conditions hold.
+    def charge_cache_enabled?
+      cache_applicable? && usage_filters.filter_by_group.blank?
     end
 
     def querying_full_usage_allowed

--- a/app/services/invoices/progressive_billing_service.rb
+++ b/app/services/invoices/progressive_billing_service.rb
@@ -163,9 +163,12 @@ module Invoices
       invoice.total_amount_cents -= prepaid_credit_result.prepaid_credit_amount_cents
     end
 
+    # Fees are computed without a charge cache middleware here, so the ingestion timestamps driving
+    # its lazy invalidation are never read. Only the charge/filter keys matter, and skipping the
+    # aggregate keeps the event store from reading the ingestion column.
     def event_filters(subscription, boundaries)
       Events::BillingPeriodFilterService.call!(
-        subscription:, boundaries:
+        subscription:, boundaries:, with_last_seen_at: false
       )
     end
   end

--- a/app/services/invoices/progressive_billing_service.rb
+++ b/app/services/invoices/progressive_billing_service.rb
@@ -163,9 +163,6 @@ module Invoices
       invoice.total_amount_cents -= prepaid_credit_result.prepaid_credit_amount_cents
     end
 
-    # Fees are computed without a charge cache middleware here, so the ingestion timestamps driving
-    # its lazy invalidation are never read. Only the charge/filter keys matter, and skipping the
-    # aggregate keeps the event store from reading the ingestion column.
     def event_filters(subscription, boundaries)
       Events::BillingPeriodFilterService.call!(
         subscription:, boundaries:, with_last_seen_at: false

--- a/spec/services/events/billing_period_filter_service_spec.rb
+++ b/spec/services/events/billing_period_filter_service_spec.rb
@@ -1416,7 +1416,10 @@ RSpec.describe Events::BillingPeriodFilterService do
           .with(codes: [billable_metric.code], filter_keys: [], with_last_seen_at: true)
       end
 
-      it "ignores a code that is not part of the plan" do
+      # A code outside of the plan matches no event of the subscription, so it is forwarded as is
+      # rather than intersected away: dropping it would remove the charge from the result and bill
+      # it as zero units instead of surfacing the unknown code.
+      it "forwards a code that is not part of the plan" do
         service = described_class.new(subscription:, boundaries:, codes: [billable_metric.code, "unknown_code"])
         event_store = instance_double(Events::Stores::PostgresStore, distinct_codes_and_property_combinations: [])
         allow(Events::Stores::StoreFactory).to receive(:new_instance).and_return(event_store)
@@ -1424,7 +1427,7 @@ RSpec.describe Events::BillingPeriodFilterService do
         service.call
 
         expect(event_store).to have_received(:distinct_codes_and_property_combinations)
-          .with(codes: [billable_metric.code], filter_keys: [], with_last_seen_at: true)
+          .with(codes: [billable_metric.code, "unknown_code"], filter_keys: [], with_last_seen_at: true)
       end
 
       it "still seeds recurring charges left out of the codes" do

--- a/spec/services/events/billing_period_filter_service_spec.rb
+++ b/spec/services/events/billing_period_filter_service_spec.rb
@@ -678,7 +678,7 @@ RSpec.describe Events::BillingPeriodFilterService do
         filter_service.call
 
         expect(event_store).to have_received(:distinct_codes_and_property_combinations)
-          .with(codes: [billable_metric.code], filter_keys: [])
+          .with(codes: [billable_metric.code], filter_keys: [], with_last_seen_at: true)
       end
     end
 
@@ -1317,7 +1317,123 @@ RSpec.describe Events::BillingPeriodFilterService do
 
         filter_service.call
 
-        expect(event_store).to have_received(:distinct_charges_and_filters).with(codes: [billable_metric.code])
+        expect(event_store).to have_received(:distinct_charges_and_filters)
+          .with(codes: [billable_metric.code], with_last_seen_at: true)
+      end
+    end
+
+    context "when last_seen_at is not requested" do
+      subject(:filter_service) do
+        described_class.new(subscription:, boundaries:, with_last_seen_at: false)
+      end
+
+      let(:default_service) { described_class.new(subscription:, boundaries:) }
+
+      before do
+        create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          timestamp: boundaries.charges_from_datetime + 5.days,
+          code: billable_metric.code
+        )
+      end
+
+      it "returns the same charges and filters as when it is requested" do
+        result = filter_service.call
+
+        expect(result).to be_success
+        expect(result.charges.transform_values(&:keys)).to eq(default_service.call.charges.transform_values(&:keys))
+      end
+
+      it "returns no timestamp" do
+        result = filter_service.call
+
+        expect(result.charges[charge.id]).to eq({nil => nil})
+      end
+
+      it "does not request the aggregate from the event store" do
+        event_store = instance_double(Events::Stores::PostgresStore, distinct_codes_and_property_combinations: [])
+        allow(Events::Stores::StoreFactory).to receive(:new_instance).and_return(event_store)
+
+        filter_service.call
+
+        expect(event_store).to have_received(:distinct_codes_and_property_combinations)
+          .with(codes: [billable_metric.code], filter_keys: [], with_last_seen_at: false)
+      end
+
+      context "when the organization pre-filters events" do
+        let(:organization) { create(:organization, pre_filter_events: true) }
+
+        it "does not request the aggregate from the event store" do
+          event_store = instance_double(Events::Stores::PostgresStore, distinct_charges_and_filters: [])
+          allow(Events::Stores::StoreFactory).to receive(:new_instance).and_return(event_store)
+
+          filter_service.call
+
+          expect(event_store).to have_received(:distinct_charges_and_filters)
+            .with(codes: [billable_metric.code], with_last_seen_at: false)
+        end
+      end
+    end
+
+    context "when codes restrict the lookup" do
+      subject(:filter_service) do
+        described_class.new(subscription:, boundaries:, codes: [billable_metric.code])
+      end
+
+      let(:billable_metric_2) { create(:billable_metric, organization:) }
+      let(:charge_2) { create(:standard_charge, plan:, billable_metric: billable_metric_2) }
+
+      before do
+        charge_2
+
+        [billable_metric, billable_metric_2].each do |metric|
+          create(
+            :event,
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            timestamp: boundaries.charges_from_datetime + 5.days,
+            code: metric.code
+          )
+        end
+      end
+
+      it "returns only the charges of the requested codes" do
+        result = filter_service.call
+
+        expect(result).to be_success
+        expect(result.charges.transform_values(&:keys)).to eq({charge.id => [nil]})
+      end
+
+      it "queries the event store for the requested codes only" do
+        event_store = instance_double(Events::Stores::PostgresStore, distinct_codes_and_property_combinations: [])
+        allow(Events::Stores::StoreFactory).to receive(:new_instance).and_return(event_store)
+
+        filter_service.call
+
+        expect(event_store).to have_received(:distinct_codes_and_property_combinations)
+          .with(codes: [billable_metric.code], filter_keys: [], with_last_seen_at: true)
+      end
+
+      it "ignores a code that is not part of the plan" do
+        service = described_class.new(subscription:, boundaries:, codes: [billable_metric.code, "unknown_code"])
+        event_store = instance_double(Events::Stores::PostgresStore, distinct_codes_and_property_combinations: [])
+        allow(Events::Stores::StoreFactory).to receive(:new_instance).and_return(event_store)
+
+        service.call
+
+        expect(event_store).to have_received(:distinct_codes_and_property_combinations)
+          .with(codes: [billable_metric.code], filter_keys: [], with_last_seen_at: true)
+      end
+
+      it "still seeds recurring charges left out of the codes" do
+        recurring_metric = create(:sum_billable_metric, :recurring, organization:)
+        recurring_charge = create(:standard_charge, plan:, billable_metric: recurring_metric)
+
+        result = filter_service.call
+
+        expect(result.charges[recurring_charge.id]).to eq({nil => boundaries.charges_from_datetime})
       end
     end
   end

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -2749,6 +2749,16 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           expect(event_store.distinct_charges_and_filters(codes: ["unknown_code"])).to eq([])
         end
       end
+
+      context "when the last seen timestamp is not requested" do
+        it "returns the same charges and filters without the timestamp" do
+          result = event_store.distinct_charges_and_filters(with_last_seen_at: false)
+
+          expect(result.map { |row| row[0..1] })
+            .to match_array(event_store.distinct_charges_and_filters.map { |row| row[0..1] })
+          expect(result.map(&:last)).to all(be_nil)
+        end
+      end
     end
   end
 
@@ -2796,6 +2806,23 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           result = event_store.distinct_codes_and_property_combinations(codes: [], filter_keys: %w[region provider])
 
           expect(result).to eq([])
+        end
+      end
+
+      context "when the last seen timestamp is not requested" do
+        it "returns the same combinations without the timestamp" do
+          result = event_store.distinct_codes_and_property_combinations(
+            codes: [code],
+            filter_keys: %w[region provider],
+            with_last_seen_at: false
+          )
+
+          expect(result.map { |row| row[0..1] }).to match_array(
+            event_store
+              .distinct_codes_and_property_combinations(codes: [code], filter_keys: %w[region provider])
+              .map { |row| row[0..1] }
+          )
+          expect(result.map(&:last)).to all(be_nil)
         end
       end
 

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -791,5 +791,116 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
         expect(result.usage.fees.first.grouped_by).to eq({})
       end
     end
+
+    # The charge cache is lazily invalidated with the ingestion timestamps requested by
+    # Events::BillingPeriodFilterService, so a cached charge must always have asked for them:
+    # an entry stored without a timestamp stays valid for the rest of the billing period, for
+    # every later reader. Each example asserts both halves so they cannot drift apart.
+    describe "charge cache gate" do
+      let(:charge_cache_key) do
+        [
+          "charge-usage",
+          Subscriptions::ChargeCacheService::CACHE_KEY_VERSION,
+          charge.id,
+          subscription.id,
+          charge.updated_at.iso8601
+        ].join("/")
+      end
+
+      before { allow(Events::BillingPeriodFilterService).to receive(:call!).and_call_original }
+
+      context "when the usage is not filtered" do
+        subject(:usage_service) do
+          described_class.new(customer:, subscription:, apply_taxes: false, with_cache: true)
+        end
+
+        it "caches the charge and requests the ingestion timestamps" do
+          expect { usage_service.call }.to change { Rails.cache.exist?(charge_cache_key) }.from(false).to(true)
+          expect(Events::BillingPeriodFilterService).to have_received(:call!)
+            .with(hash_including(codes: nil, with_last_seen_at: true))
+        end
+      end
+
+      context "when the usage is filtered by charge" do
+        subject(:usage_service) do
+          described_class.new(
+            customer:,
+            subscription:,
+            apply_taxes: false,
+            with_cache: true,
+            usage_filters: UsageFilters.new(filter_by_charge_id: charge.id)
+          )
+        end
+
+        it "restricts the lookup to the filtered codes and keeps the timestamps" do
+          expect { usage_service.call }.to change { Rails.cache.exist?(charge_cache_key) }.from(false).to(true)
+          expect(Events::BillingPeriodFilterService).to have_received(:call!)
+            .with(hash_including(codes: [billable_metric.code], with_last_seen_at: true))
+        end
+      end
+
+      context "when the cache is disabled by the caller" do
+        subject(:usage_service) do
+          described_class.new(customer:, subscription:, apply_taxes: false, with_cache: false)
+        end
+
+        it "skips both the cache and the ingestion timestamps" do
+          expect { usage_service.call }.not_to change { Rails.cache.exist?(charge_cache_key) }.from(false)
+          expect(Events::BillingPeriodFilterService).to have_received(:call!)
+            .with(hash_including(with_last_seen_at: false))
+        end
+      end
+
+      context "when the usage is filtered by group" do
+        subject(:usage_service) do
+          described_class.new(
+            customer:,
+            subscription:,
+            apply_taxes: false,
+            with_cache: true,
+            usage_filters: UsageFilters.new(filter_by_group: {"cloud" => ["aws"]})
+          )
+        end
+
+        let(:billable_metric) { create(:billable_metric, aggregation_type: "sum_agg", field_name: "value") }
+
+        let(:charge) do
+          create(:standard_charge, plan:, billable_metric:, properties: {amount: "10", pricing_group_keys: %w[cloud]})
+        end
+
+        let(:events) { [] }
+
+        before do
+          create(:event, organization:, subscription:, customer:, code: billable_metric.code,
+            timestamp:, properties: {cloud: "aws", value: 10})
+        end
+
+        it "skips both the cache and the ingestion timestamps" do
+          expect { usage_service.call }.not_to change { Rails.cache.exist?(charge_cache_key) }.from(false)
+          expect(Events::BillingPeriodFilterService).to have_received(:call!)
+            .with(hash_including(with_last_seen_at: false))
+        end
+      end
+
+      context "when the full usage is queried outside of the first billing period", :premium do
+        subject(:usage_service) do
+          described_class.new(
+            customer:,
+            subscription:,
+            apply_taxes: false,
+            with_cache: true,
+            usage_filters: UsageFilters.new(filter_by_charge_id: charge.id, full_usage: true)
+          )
+        end
+
+        before { organization.update!(premium_integrations: %w[granular_lifetime_usage]) }
+
+        it "skips both the cache and the ingestion timestamps" do
+          expect { usage_service.call }.not_to change { Rails.cache.exist?(charge_cache_key) }.from(false)
+          expect(Events::BillingPeriodFilterService).to have_received(:call!)
+            .with(hash_including(with_last_seen_at: false))
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Resolving which charges and filters take part in a usage or billing computation relies on a
`MAX(enriched_at)` aggregate over the events of the period, which makes the query read the ingestion
timestamp of every event in the window. A full usage request widens that window to the whole
subscription history.

That aggregate only feeds the lazy invalidation of the charge usage cache. The charge and filter
keys, which drive the aggregation pre-filtering, do not depend on it. Invoicing and progressive
billing never build a charge cache middleware, and a full usage request cannot use the cache at all
because its boundaries no longer match the cached period, so the timestamps are computed and then
discarded. The lookup also always covers every billable metric of the plan, while a usage request
filtered by charge only ever reads the entries of the charges it computes.

## Description

The billing period filter service now takes the codes to look up and whether the timestamps are
needed. Both default to the previous behaviour and the returned shape is unchanged, so the
pre-filtering benefit is preserved in every case.

Requested codes are used as they are rather than intersected with the plan. Dropping a code that
matches no event would leave its charge out of the result, which bills it as zero units instead of
surfacing it. An unknown code cannot widen the lookup either, since the codes come from the charges
being computed and a request naming a charge outside the plan is rejected before the lookup runs.

Recurring charges are still seeded for the whole plan so their carried-over usage keeps its floor,
but the recurring event lookup now follows the requested codes like the non-recurring one, as only
the charges being computed read it.

Whether the timestamps are requested is the same expression that decides whether the charge cache is
used, and the two must not diverge: read with a nil timestamp, a cached entry stays valid whatever
has been ingested since. That single gate also covers usage filtered by group, which previously
discarded the middleware after building it.

The two existing store expectations in the filter service spec changed only to carry the new
keyword.
