### PR TITLE
feat: add taxes to rate cards

### DIFF
--- a/app/controllers/api/v2/rate_cards_controller.rb
+++ b/app/controllers/api/v2/rate_cards_controller.rb
@@ -74,11 +74,10 @@ module Api
         if result.success?
           render(
             json: ::CollectionSerializer.new(
-              result.rate_cards.includes(:product, :product_filter, :rates, :taxes),
+              result.rate_cards.includes(:product, :product_filter, :rates),
               ::V1::RateCardSerializer,
               collection_name: "rate_cards",
-              meta: pagination_metadata(result.rate_cards),
-              includes: %i[taxes]
+              meta: pagination_metadata(result.rate_cards)
             )
           )
         else

--- a/app/controllers/api/v2/rate_cards_controller.rb
+++ b/app/controllers/api/v2/rate_cards_controller.rb
@@ -74,10 +74,11 @@ module Api
         if result.success?
           render(
             json: ::CollectionSerializer.new(
-              result.rate_cards.includes(:product, :product_filter, :rates),
+              result.rate_cards.includes(:product, :product_filter, :rates, :taxes),
               ::V1::RateCardSerializer,
               collection_name: "rate_cards",
-              meta: pagination_metadata(result.rate_cards)
+              meta: pagination_metadata(result.rate_cards),
+              includes: %i[taxes]
             )
           )
         else
@@ -115,6 +116,7 @@ module Api
           :regroup_paid_fees,
           :applied_pricing_unit_code,
           :wallet_targetable,
+          tax_codes: [],
           rates: [
             :code,
             :effective_from,
@@ -139,12 +141,13 @@ module Api
           :display_on_invoice,
           :regroup_paid_fees,
           :applied_pricing_unit_code,
-          :wallet_targetable
+          :wallet_targetable,
+          tax_codes: []
         )
       end
 
       def render_rate_card(rate_card)
-        render(json: ::V1::RateCardSerializer.new(rate_card, root_name: "rate_card", includes: %i[active_rate]))
+        render(json: ::V1::RateCardSerializer.new(rate_card, root_name: "rate_card", includes: %i[active_rate taxes]))
       end
 
       def resource_name

--- a/app/graphql/types/rate_cards/create_input.rb
+++ b/app/graphql/types/rate_cards/create_input.rb
@@ -18,6 +18,7 @@ module Types
       argument :proration, Boolean, required: false
       argument :rates, [Types::RateCardRates::Input], required: false
       argument :regroup_paid_fees, Types::RateCards::RegroupPaidFeesEnum, required: false
+      argument :tax_codes, [String], required: false
       argument :wallet_targetable, Boolean, required: false
     end
   end

--- a/app/graphql/types/rate_cards/object.rb
+++ b/app/graphql/types/rate_cards/object.rb
@@ -6,7 +6,7 @@ module Types
       graphql_name "RateCard"
       description "Base rate card"
 
-      dataload_association :product, :product_filter
+      dataload_association :product, :product_filter, :taxes
 
       field :id, ID, null: false
       field :organization, Types::Organizations::OrganizationType
@@ -31,6 +31,7 @@ module Types
 
       field :product, Types::Products::Object, null: false
       field :product_filter, Types::ProductFilters::Object, null: true
+      field :taxes, [Types::Taxes::Object], null: false
 
       field :active_rate, Types::RateCardRates::Object, null: true
       field :rates_count, Integer, null: false

--- a/app/graphql/types/rate_cards/update_input.rb
+++ b/app/graphql/types/rate_cards/update_input.rb
@@ -16,6 +16,7 @@ module Types
       argument :name, String, required: false
       argument :proration, Boolean, required: false
       argument :regroup_paid_fees, Types::RateCards::RegroupPaidFeesEnum, required: false
+      argument :tax_codes, [String], required: false
       argument :wallet_targetable, Boolean, required: false
     end
   end

--- a/app/models/rate_card.rb
+++ b/app/models/rate_card.rb
@@ -27,6 +27,8 @@ class RateCard < ApplicationRecord
   has_many :rates, class_name: "RateCardRate"
   has_many :plan_applied_rate_cards, class_name: "PlanRateCard"
   has_many :contract_applied_rate_cards, class_name: "ContractRateCard"
+  has_many :applied_taxes, class_name: "RateCard::AppliedTax", dependent: :destroy
+  has_many :taxes, through: :applied_taxes
 
   enum :billing_timing, BILLING_TIMINGS, validate: true
   # prefix: a bare `none` value would define a RateCard.none scope, which

--- a/app/models/rate_card/applied_tax.rb
+++ b/app/models/rate_card/applied_tax.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class RateCard::AppliedTax < ApplicationRecord
+  self.table_name = "rate_cards_taxes"
+
+  include PaperTrailTraceable
+
+  belongs_to :rate_card
+  belongs_to :tax
+  belongs_to :organization
+end
+
+# == Schema Information
+#
+# Table name: rate_cards_taxes
+# Database name: primary
+#
+#  id              :uuid             not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#  rate_card_id    :uuid             not null
+#  tax_id          :uuid             not null
+#
+# Indexes
+#
+#  index_rate_cards_taxes_on_organization_id          (organization_id)
+#  index_rate_cards_taxes_on_rate_card_id             (rate_card_id)
+#  index_rate_cards_taxes_on_rate_card_id_and_tax_id  (rate_card_id,tax_id) UNIQUE
+#  index_rate_cards_taxes_on_tax_id                   (tax_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (rate_card_id => rate_cards.id)
+#  fk_rails_...  (tax_id => taxes.id)
+#

--- a/app/models/tax.rb
+++ b/app/models/tax.rb
@@ -32,6 +32,8 @@ class Tax < ApplicationRecord
   has_many :commitments, through: :commitments_taxes
   has_many :fixed_charges_taxes, class_name: "FixedCharge::AppliedTax", dependent: :destroy
   has_many :fixed_charges, through: :fixed_charges_taxes
+  has_many :rate_cards_taxes, class_name: "RateCard::AppliedTax", dependent: :destroy
+  has_many :rate_cards, through: :rate_cards_taxes
 
   belongs_to :organization
 

--- a/app/serializers/v1/rate_card_serializer.rb
+++ b/app/serializers/v1/rate_card_serializer.rb
@@ -23,6 +23,7 @@ module V1
       }
 
       payload[:active_rate] = active_rate if include?(:active_rate)
+      payload.merge!(taxes) if include?(:taxes)
       # Full timeline for activity-log payloads; API payloads stay lean.
       payload.merge!(rates) if include?(:rates)
       payload
@@ -42,6 +43,14 @@ module V1
         model.rates,
         ::V1::RateCardRateSerializer,
         collection_name: "rates"
+      ).serialize
+    end
+
+    def taxes
+      ::CollectionSerializer.new(
+        model.taxes,
+        ::V1::TaxSerializer,
+        collection_name: "taxes"
       ).serialize
     end
   end

--- a/app/services/rate_cards/apply_taxes_service.rb
+++ b/app/services/rate_cards/apply_taxes_service.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module RateCards
+  class ApplyTaxesService < BaseService
+    Result = BaseResult[:applied_taxes]
+
+    def initialize(rate_card:, tax_codes:)
+      @rate_card = rate_card
+      @tax_codes = tax_codes.uniq
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: "rate_card") unless rate_card
+      return result.not_found_failure!(resource: "tax") if (tax_codes - taxes_by_code.keys).present?
+
+      rate_card.with_lock do
+        rate_card.applied_taxes.where.not(tax_id: taxes_by_code.values.map(&:id)).destroy_all
+
+        result.applied_taxes = tax_codes.map do |tax_code|
+          rate_card.applied_taxes
+            .create_with(organization: rate_card.organization)
+            .find_or_create_by!(tax: taxes_by_code.fetch(tax_code))
+        end
+
+        rate_card.applied_taxes.reset
+        rate_card.taxes.reset
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :rate_card, :tax_codes
+
+    def taxes_by_code
+      @taxes_by_code ||= rate_card.organization.taxes.where(code: tax_codes).index_by(&:code)
+    end
+  end
+end

--- a/app/services/rate_cards/create_service.rb
+++ b/app/services/rate_cards/create_service.rb
@@ -56,6 +56,7 @@ module RateCards
       ActiveRecord::Base.transaction do
         rate_card = product.rate_cards.create!(**attributes)
 
+        apply_taxes(rate_card)
         create_rates(rate_card)
 
         result.rate_card = rate_card
@@ -65,13 +66,7 @@ module RateCards
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
     rescue BaseService::FailedResult => e
-      # Only the nested rate creations are called with call! here.
-      if e.result.error.is_a?(BaseService::ValidationFailure)
-        errors = e.result.error.messages.transform_keys { |key| :"rates.#{key}" }
-        result.validation_failure!(errors:)
-      else
-        e.result
-      end
+      result.fail_with_error!(e.result.error)
     end
 
     private
@@ -82,10 +77,19 @@ module RateCards
       product.organization
     end
 
+    def apply_taxes(rate_card)
+      return unless params.key?(:tax_codes) && !params[:tax_codes].nil?
+
+      RateCards::ApplyTaxesService.call!(rate_card:, tax_codes: params[:tax_codes])
+    end
+
     def create_rates(rate_card)
       (params[:rates] || []).each do |rate_params|
         RateCardRates::CreateService.call!(rate_card:, params: rate_params, emit_activity_log: false)
       end
+    rescue BaseService::ValidationFailure => e
+      errors = e.messages.transform_keys { |key| :"rates.#{key}" }
+      result.validation_failure!(errors:).raise_if_error!
     end
   end
 end

--- a/app/services/rate_cards/update_service.rb
+++ b/app/services/rate_cards/update_service.rb
@@ -58,18 +58,29 @@ module RateCards
         return result.single_validation_failure!(field: :code, error_code: "attached_to_plan_or_subscription")
       end
 
-      assign_attributes
-      rate_card.save!
+      ActiveRecord::Base.transaction do
+        assign_attributes
+        rate_card.save!
+        apply_taxes
+      end
 
       result.rate_card = rate_card
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
+    rescue BaseService::FailedResult => e
+      result.fail_with_error!(e.result.error)
     end
 
     private
 
     attr_reader :rate_card, :params
+
+    def apply_taxes
+      return unless params.key?(:tax_codes) && !params[:tax_codes].nil?
+
+      RateCards::ApplyTaxesService.call!(rate_card:, tax_codes: params[:tax_codes])
+    end
 
     def assign_attributes
       rate_card.code = params[:code]&.strip if params.key?(:code)

--- a/app/services/taxes/destroy_service.rb
+++ b/app/services/taxes/destroy_service.rb
@@ -35,6 +35,7 @@ module Taxes
         tax.charges_taxes.delete_all
         tax.commitments_taxes.delete_all
         tax.fixed_charges_taxes.delete_all
+        tax.rate_cards_taxes.delete_all
 
         tax.deleted_at = Time.current
         tax.save!

--- a/app/services/utils/activity_log.rb
+++ b/app/services/utils/activity_log.rb
@@ -10,7 +10,7 @@ module Utils
 
     SERIALIZED_INCLUDED_OBJECTS = {
       billing_entity: %i[taxes],
-      rate_card: %i[rates],
+      rate_card: %i[rates taxes],
       credit_note: %i[items applied_taxes error_details],
       customer: %i[taxes integration_customers applicable_invoice_custom_sections],
       invoice: %i[customer integration_customers billing_periods subscriptions fees credits metadata applied_taxes error_details applied_invoice_custom_sections],

--- a/db/migrate/20260824115446_create_rate_cards_taxes.rb
+++ b/db/migrate/20260824115446_create_rate_cards_taxes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateRateCardsTaxes < ActiveRecord::Migration[8.0]
+  def change
+    create_table :rate_cards_taxes, id: :uuid do |t|
+      t.references :rate_card, type: :uuid, null: false, foreign_key: true
+      t.references :tax, type: :uuid, null: false, foreign_key: true
+      t.references :organization, type: :uuid, null: false, foreign_key: true
+
+      t.index %i[rate_card_id tax_id], unique: true
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -50,6 +50,7 @@ ALTER TABLE IF EXISTS ONLY public.charge_filters DROP CONSTRAINT IF EXISTS fk_ra
 ALTER TABLE IF EXISTS ONLY public.user_devices DROP CONSTRAINT IF EXISTS fk_rails_e700a96826;
 ALTER TABLE IF EXISTS ONLY public.integration_mappings DROP CONSTRAINT IF EXISTS fk_rails_e4a58fbcac;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_triggered_alerts DROP CONSTRAINT IF EXISTS fk_rails_e3cf54daac;
+ALTER TABLE IF EXISTS ONLY public.rate_cards_taxes DROP CONSTRAINT IF EXISTS fk_rails_e2dbfbb01e;
 ALTER TABLE IF EXISTS ONLY public.integration_collection_mappings DROP CONSTRAINT IF EXISTS fk_rails_e148d17c1f;
 ALTER TABLE IF EXISTS ONLY public.product_categories DROP CONSTRAINT IF EXISTS fk_rails_e13d306a35;
 ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk_rails_dfac602b2c;
@@ -148,6 +149,7 @@ ALTER TABLE IF EXISTS ONLY public.fixed_charge_events DROP CONSTRAINT IF EXISTS 
 ALTER TABLE IF EXISTS ONLY public.pending_vies_checks DROP CONSTRAINT IF EXISTS fk_rails_96fc54cd9a;
 ALTER TABLE IF EXISTS ONLY public.entitlement_subscription_feature_removals DROP CONSTRAINT IF EXISTS fk_rails_95df3194c5;
 ALTER TABLE IF EXISTS ONLY public.customers DROP CONSTRAINT IF EXISTS fk_rails_94cc21031f;
+ALTER TABLE IF EXISTS ONLY public.rate_cards_taxes DROP CONSTRAINT IF EXISTS fk_rails_9457f0d2da;
 ALTER TABLE IF EXISTS ONLY public.data_export_parts DROP CONSTRAINT IF EXISTS fk_rails_9298b8fdad;
 ALTER TABLE IF EXISTS ONLY public.adjusted_fees DROP CONSTRAINT IF EXISTS fk_rails_91802dc891;
 ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXISTS fk_rails_90d93bd016;
@@ -335,6 +337,7 @@ ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXIST
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_1454058c96;
 ALTER TABLE IF EXISTS ONLY public.invoices_taxes DROP CONSTRAINT IF EXISTS fk_rails_142809fee1;
 ALTER TABLE IF EXISTS ONLY public.plan_rate_cards DROP CONSTRAINT IF EXISTS fk_rails_135fe57b68;
+ALTER TABLE IF EXISTS ONLY public.rate_cards_taxes DROP CONSTRAINT IF EXISTS fk_rails_133ae613c4;
 ALTER TABLE IF EXISTS ONLY public.daily_usages DROP CONSTRAINT IF EXISTS fk_rails_12d29bc654;
 ALTER TABLE IF EXISTS ONLY public.entitlement_subscription_feature_removals DROP CONSTRAINT IF EXISTS fk_rails_123667657c;
 ALTER TABLE IF EXISTS ONLY public.quote_versions DROP CONSTRAINT IF EXISTS fk_rails_10ee148d0d;
@@ -503,6 +506,10 @@ DROP INDEX IF EXISTS public.index_rate_phases_on_contract_rate_card_id_and_code;
 DROP INDEX IF EXISTS public.index_rate_phases_on_contract_rate_card_id;
 DROP INDEX IF EXISTS public.index_rate_overrides_on_organization_id;
 DROP INDEX IF EXISTS public.index_rate_overrides_on_deleted_at;
+DROP INDEX IF EXISTS public.index_rate_cards_taxes_on_tax_id;
+DROP INDEX IF EXISTS public.index_rate_cards_taxes_on_rate_card_id_and_tax_id;
+DROP INDEX IF EXISTS public.index_rate_cards_taxes_on_rate_card_id;
+DROP INDEX IF EXISTS public.index_rate_cards_taxes_on_organization_id;
 DROP INDEX IF EXISTS public.index_rate_cards_on_product_id;
 DROP INDEX IF EXISTS public.index_rate_cards_on_product_filter_id;
 DROP INDEX IF EXISTS public.index_rate_cards_on_organization_id_and_code;
@@ -1062,6 +1069,7 @@ ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules DROP CONSTRAINT IF
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules_invoice_custom_sections DROP CONSTRAINT IF EXISTS recurring_transaction_rules_invoice_custom_sections_pkey;
 ALTER TABLE IF EXISTS ONLY public.rate_phases DROP CONSTRAINT IF EXISTS rate_phases_pkey;
 ALTER TABLE IF EXISTS ONLY public.rate_overrides DROP CONSTRAINT IF EXISTS rate_overrides_pkey;
+ALTER TABLE IF EXISTS ONLY public.rate_cards_taxes DROP CONSTRAINT IF EXISTS rate_cards_taxes_pkey;
 ALTER TABLE IF EXISTS ONLY public.rate_cards DROP CONSTRAINT IF EXISTS rate_cards_pkey;
 ALTER TABLE IF EXISTS ONLY public.rate_card_rates DROP CONSTRAINT IF EXISTS rate_card_rates_pkey;
 ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS quotes_pkey;
@@ -1199,6 +1207,7 @@ DROP TABLE IF EXISTS public.recurring_transaction_rules_invoice_custom_sections;
 DROP TABLE IF EXISTS public.recurring_transaction_rules;
 DROP TABLE IF EXISTS public.rate_phases;
 DROP TABLE IF EXISTS public.rate_overrides;
+DROP TABLE IF EXISTS public.rate_cards_taxes;
 DROP TABLE IF EXISTS public.rate_cards;
 DROP TABLE IF EXISTS public.rate_card_rates;
 DROP TABLE IF EXISTS public.quotes;
@@ -5641,6 +5650,20 @@ CREATE TABLE public.rate_cards (
 
 
 --
+-- Name: rate_cards_taxes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.rate_cards_taxes (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    rate_card_id uuid NOT NULL,
+    tax_id uuid NOT NULL,
+    organization_id uuid NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: rate_overrides; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6973,6 +6996,14 @@ ALTER TABLE ONLY public.rate_card_rates
 
 ALTER TABLE ONLY public.rate_cards
     ADD CONSTRAINT rate_cards_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: rate_cards_taxes rate_cards_taxes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rate_cards_taxes
+    ADD CONSTRAINT rate_cards_taxes_pkey PRIMARY KEY (id);
 
 
 --
@@ -10950,6 +10981,34 @@ CREATE INDEX index_rate_cards_on_product_id ON public.rate_cards USING btree (pr
 
 
 --
+-- Name: index_rate_cards_taxes_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rate_cards_taxes_on_organization_id ON public.rate_cards_taxes USING btree (organization_id);
+
+
+--
+-- Name: index_rate_cards_taxes_on_rate_card_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rate_cards_taxes_on_rate_card_id ON public.rate_cards_taxes USING btree (rate_card_id);
+
+
+--
+-- Name: index_rate_cards_taxes_on_rate_card_id_and_tax_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_rate_cards_taxes_on_rate_card_id_and_tax_id ON public.rate_cards_taxes USING btree (rate_card_id, tax_id);
+
+
+--
+-- Name: index_rate_cards_taxes_on_tax_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rate_cards_taxes_on_tax_id ON public.rate_cards_taxes USING btree (tax_id);
+
+
+--
 -- Name: index_rate_overrides_on_deleted_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12059,6 +12118,14 @@ ALTER TABLE ONLY public.entitlement_subscription_feature_removals
 
 ALTER TABLE ONLY public.daily_usages
     ADD CONSTRAINT fk_rails_12d29bc654 FOREIGN KEY (subscription_id) REFERENCES public.subscriptions(id);
+
+
+--
+-- Name: rate_cards_taxes fk_rails_133ae613c4; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rate_cards_taxes
+    ADD CONSTRAINT fk_rails_133ae613c4 FOREIGN KEY (tax_id) REFERENCES public.taxes(id);
 
 
 --
@@ -13558,6 +13625,14 @@ ALTER TABLE ONLY public.data_export_parts
 
 
 --
+-- Name: rate_cards_taxes fk_rails_9457f0d2da; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rate_cards_taxes
+    ADD CONSTRAINT fk_rails_9457f0d2da FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: customers fk_rails_94cc21031f; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -14342,6 +14417,14 @@ ALTER TABLE ONLY public.integration_collection_mappings
 
 
 --
+-- Name: rate_cards_taxes fk_rails_e2dbfbb01e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rate_cards_taxes
+    ADD CONSTRAINT fk_rails_e2dbfbb01e FOREIGN KEY (rate_card_id) REFERENCES public.rate_cards(id);
+
+
+--
 -- Name: usage_monitoring_triggered_alerts fk_rails_e3cf54daac; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -14681,6 +14764,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260826235314'),
 ('20260826235313'),
 ('20260826235312'),
+('20260824115446'),
 ('20260819111435'),
 ('20260819111434'),
 ('20260819000710'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -3687,6 +3687,7 @@ input CreateRateCardInput {
   proration: Boolean
   rates: [RateCardRateInput!]
   regroupPaidFees: RateCardRegroupPaidFeesEnum
+  taxCodes: [String!]
   walletTargetable: Boolean
 }
 
@@ -12615,6 +12616,7 @@ type RateCard {
   proration: Boolean!
   ratesCount: Int!
   regroupPaidFees: RateCardRegroupPaidFeesEnum!
+  taxes: [Tax!]!
   updatedAt: ISO8601DateTime!
   walletTargetable: Boolean
 }
@@ -15338,6 +15340,7 @@ input UpdateRateCardInput {
   name: String
   proration: Boolean
   regroupPaidFees: RateCardRegroupPaidFeesEnum
+  taxCodes: [String!]
   walletTargetable: Boolean
 }
 

--- a/schema.json
+++ b/schema.json
@@ -17205,6 +17205,26 @@
               "deprecationReason": null
             },
             {
+              "name": "taxCodes",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "walletTargetable",
               "description": null,
               "type": {
@@ -68924,6 +68944,30 @@
               "deprecationReason": null
             },
             {
+              "name": "taxes",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Tax",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "updatedAt",
               "description": null,
               "args": [],
@@ -82319,6 +82363,26 @@
                 "kind": "ENUM",
                 "name": "RateCardRegroupPaidFeesEnum",
                 "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxCodes",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/factories/rate_card_applied_taxes.rb
+++ b/spec/factories/rate_card_applied_taxes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :rate_card_applied_tax, class: "RateCard::AppliedTax" do
+    rate_card
+    tax { association(:tax, organization: rate_card.organization) }
+    organization { rate_card.organization }
+  end
+end

--- a/spec/graphql/mutations/rate_cards/create_spec.rb
+++ b/spec/graphql/mutations/rate_cards/create_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Mutations::RateCards::Create do
         createRateCard(input: $input) {
           id name code currency billingTiming proration
           product { id }
+          taxes { id code rate }
           ratesCount
           activeRate { id }
         }
@@ -53,8 +54,32 @@ RSpec.describe Mutations::RateCards::Create do
     expect(result_data["currency"]).to eq("USD")
     expect(result_data["proration"]).to eq(false) # omitted -> column default
     expect(result_data["product"]["id"]).to eq(product.id)
+    expect(result_data["taxes"]).to eq([])
     expect(result_data["ratesCount"]).to eq(0)
     expect(result_data["activeRate"]).to be_nil
+  end
+
+  context "with taxes" do
+    let(:tax1) { create(:tax, organization:) }
+    let(:tax2) { create(:tax, organization:) }
+
+    before { input[:taxCodes] = [tax1.code, tax2.code] }
+
+    it "applies and returns the taxes" do
+      result_data = execution["data"]["createRateCard"]
+
+      expect(result_data["taxes"].pluck("code")).to match_array([tax1.code, tax2.code])
+    end
+
+    context "when a tax belongs to another organization" do
+      let(:other_tax) { create(:tax) }
+
+      before { input[:taxCodes] = [other_tax.code] }
+
+      it "returns a not found error" do
+        expect_graphql_error(result: execution, message: "Resource not found")
+      end
+    end
   end
 
   context "with nested rates" do

--- a/spec/graphql/mutations/rate_cards/update_spec.rb
+++ b/spec/graphql/mutations/rate_cards/update_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Mutations::RateCards::Update do
       mutation($input: UpdateRateCardInput!) {
         updateRateCard(input: $input) {
           id name code
+          taxes { id code rate }
         }
       }
     GQL
@@ -39,6 +40,48 @@ RSpec.describe Mutations::RateCards::Update do
 
     expect(result_data["id"]).to eq(rate_card.id)
     expect(result_data["name"]).to eq("After")
+  end
+
+  context "with taxes" do
+    let(:tax1) { create(:tax, organization:) }
+    let(:tax2) { create(:tax, organization:) }
+    let(:input) { {id: rate_card.id, taxCodes: [tax2.code]} }
+
+    before { create(:rate_card_applied_tax, rate_card:, tax: tax1, organization:) }
+
+    it "replaces and returns the taxes" do
+      result_data = execution["data"]["updateRateCard"]
+
+      expect(result_data["taxes"].pluck("code")).to eq([tax2.code])
+    end
+
+    context "when tax codes are empty" do
+      let(:input) { {id: rate_card.id, taxCodes: []} }
+
+      it "removes the tax override" do
+        expect(execution["data"]["updateRateCard"]["taxes"]).to eq([])
+      end
+    end
+
+    context "when tax codes are null" do
+      let(:input) { {id: rate_card.id, taxCodes: nil} }
+
+      it "keeps the existing tax" do
+        taxes = execution["data"]["updateRateCard"]["taxes"]
+
+        expect(taxes.pluck("code")).to eq([tax1.code])
+      end
+    end
+
+    context "when a tax belongs to another organization" do
+      let(:other_tax) { create(:tax) }
+      let(:input) { {id: rate_card.id, taxCodes: [other_tax.code]} }
+
+      it "returns a not found error and keeps the existing tax" do
+        expect_graphql_error(result: execution, message: "Resource not found")
+        expect(rate_card.reload.taxes).to eq([tax1])
+      end
+    end
   end
 
   context "when the rate card belongs to another organization" do

--- a/spec/graphql/resolvers/rate_card_resolver_spec.rb
+++ b/spec/graphql/resolvers/rate_card_resolver_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Resolvers::RateCardResolver do
           id name code currency
           ratesCount
           activeRate { id }
+          taxes { id code rate }
         }
       }
     GQL
@@ -35,12 +36,16 @@ RSpec.describe Resolvers::RateCardResolver do
   it_behaves_like "requires current organization"
   it_behaves_like "requires permission", "rate_cards:view"
 
-  it "returns a single rate card with its rates count and active rate" do
+  it "returns a single rate card with its rates count, active rate, and taxes" do
+    tax = create(:tax, organization:)
+    create(:rate_card_applied_tax, rate_card:, tax:, organization:)
+
     response = execution["data"]["rateCard"]
 
     expect(response["id"]).to eq(rate_card.id)
     expect(response["ratesCount"]).to eq(1)
     expect(response["activeRate"]["id"]).to eq(rate.id)
+    expect(response["taxes"].pluck("code")).to eq([tax.code])
   end
 
   context "when the rate card belongs to another organization" do

--- a/spec/models/rate_card/applied_tax_spec.rb
+++ b/spec/models/rate_card/applied_tax_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RateCard::AppliedTax do
+  subject(:applied_tax) { build(:rate_card_applied_tax) }
+
+  it_behaves_like "paper_trail traceable"
+
+  describe "associations" do
+    it do
+      expect(applied_tax).to belong_to(:rate_card)
+      expect(applied_tax).to belong_to(:tax)
+      expect(applied_tax).to belong_to(:organization)
+    end
+  end
+end

--- a/spec/models/rate_card_spec.rb
+++ b/spec/models/rate_card_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe RateCard do
       expect(rate_card).to belong_to(:product_filter).optional
       expect(rate_card).to have_many(:rates).class_name("RateCardRate")
       expect(rate_card).to have_many(:plan_applied_rate_cards).class_name("PlanRateCard")
-      expect(rate_card).to have_many(:subscription_applied_rate_cards).class_name("SubscriptionRateCard")
+      expect(rate_card).to have_many(:contract_applied_rate_cards).class_name("ContractRateCard")
       expect(rate_card).to have_many(:applied_taxes).class_name("RateCard::AppliedTax").dependent(:destroy)
       expect(rate_card).to have_many(:taxes).through(:applied_taxes)
     end

--- a/spec/models/rate_card_spec.rb
+++ b/spec/models/rate_card_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe RateCard do
       expect(rate_card).to belong_to(:product)
       expect(rate_card).to belong_to(:product_filter).optional
       expect(rate_card).to have_many(:rates).class_name("RateCardRate")
+      expect(rate_card).to have_many(:plan_applied_rate_cards).class_name("PlanRateCard")
+      expect(rate_card).to have_many(:subscription_applied_rate_cards).class_name("SubscriptionRateCard")
+      expect(rate_card).to have_many(:applied_taxes).class_name("RateCard::AppliedTax").dependent(:destroy)
+      expect(rate_card).to have_many(:taxes).through(:applied_taxes)
     end
   end
 

--- a/spec/requests/api/v2/rate_cards_controller_spec.rb
+++ b/spec/requests/api/v2/rate_cards_controller_spec.rb
@@ -28,6 +28,33 @@ RSpec.describe Api::V2::RateCardsController do
       expect(json[:rate_card][:product_code]).to eq(product.code)
       expect(json[:rate_card][:code]).to eq("standard")
       expect(json[:rate_card][:currency]).to eq("EUR")
+      expect(json[:rate_card][:taxes]).to eq([])
+    end
+
+    context "with taxes" do
+      let(:tax1) { create(:tax, organization:) }
+      let(:tax2) { create(:tax, organization:) }
+
+      before { create_params[:tax_codes] = [tax1.code, tax2.code] }
+
+      it "applies and returns the taxes" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:rate_card][:taxes].pluck(:code)).to match_array([tax1.code, tax2.code])
+      end
+
+      context "when a tax belongs to another organization" do
+        let(:other_tax) { create(:tax) }
+
+        before { create_params[:tax_codes] = [other_tax.code] }
+
+        it "returns a tax not found error" do
+          expect { subject }.not_to change(RateCard, :count)
+
+          expect(response).to be_not_found_error("tax")
+        end
+      end
     end
 
     context "when the product does not exist" do
@@ -180,6 +207,55 @@ RSpec.describe Api::V2::RateCardsController do
       expect(json[:rate_card][:name]).to eq("After")
     end
 
+    context "with taxes" do
+      let(:tax1) { create(:tax, organization:) }
+      let(:tax2) { create(:tax, organization:) }
+      let(:update_params) { {tax_codes: [tax2.code]} }
+
+      before { create(:rate_card_applied_tax, rate_card:, tax: tax1, organization:) }
+
+      it "replaces and returns the taxes" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:rate_card][:taxes].pluck(:code)).to eq([tax2.code])
+      end
+
+      context "when tax codes are empty" do
+        let(:update_params) { {tax_codes: []} }
+
+        it "removes the tax override" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:rate_card][:taxes]).to eq([])
+        end
+      end
+
+      context "when tax codes are null" do
+        let(:update_params) { {tax_codes: nil} }
+
+        it "keeps the existing tax" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:rate_card][:taxes].pluck(:code)).to eq([tax1.code])
+        end
+      end
+
+      context "when a tax belongs to another organization" do
+        let(:other_tax) { create(:tax) }
+        let(:update_params) { {tax_codes: [other_tax.code]} }
+
+        it "returns a tax not found error and keeps the existing tax" do
+          subject
+
+          expect(response).to be_not_found_error("tax")
+          expect(rate_card.reload.taxes).to eq([tax1])
+        end
+      end
+    end
+
     context "when the rate card does not exist" do
       subject { put_with_token(organization, "/api/v2/rate_cards/unknown", {rate_card: update_params}) }
 
@@ -198,7 +274,9 @@ RSpec.describe Api::V2::RateCardsController do
 
     include_examples "requires API permission", "rate_card", "read"
 
-    it "returns the rate card with its rates count and active rate" do
+    it "returns the rate card with its rates count, active rate, and taxes" do
+      tax = create(:tax, organization:)
+      create(:rate_card_applied_tax, rate_card:, tax:, organization:)
       create(:rate_card_rate, organization:, rate_card:, effective_from: 1.day.ago.beginning_of_day)
 
       subject
@@ -207,6 +285,7 @@ RSpec.describe Api::V2::RateCardsController do
       expect(json[:rate_card][:lago_id]).to eq(rate_card.id)
       expect(json[:rate_card][:rates_count]).to eq(1)
       expect(json[:rate_card][:active_rate][:status]).to eq("active")
+      expect(json[:rate_card][:taxes].pluck(:code)).to eq([tax.code])
     end
 
     context "when the rate card belongs to another organization" do
@@ -230,10 +309,14 @@ RSpec.describe Api::V2::RateCardsController do
     include_examples "requires API permission", "rate_card", "read"
 
     it "returns the rate cards" do
+      tax = create(:tax, organization:)
+      create(:rate_card_applied_tax, rate_card:, tax:, organization:)
+
       subject
 
       expect(response).to have_http_status(:success)
       expect(json[:rate_cards].map { it[:lago_id] }).to match_array([rate_card.id, other.id])
+      expect(json[:rate_cards].find { it[:lago_id] == rate_card.id }[:taxes].pluck(:code)).to eq([tax.code])
     end
 
     context "with a product_id filter" do

--- a/spec/requests/api/v2/rate_cards_controller_spec.rb
+++ b/spec/requests/api/v2/rate_cards_controller_spec.rb
@@ -309,14 +309,10 @@ RSpec.describe Api::V2::RateCardsController do
     include_examples "requires API permission", "rate_card", "read"
 
     it "returns the rate cards" do
-      tax = create(:tax, organization:)
-      create(:rate_card_applied_tax, rate_card:, tax:, organization:)
-
       subject
 
       expect(response).to have_http_status(:success)
       expect(json[:rate_cards].map { it[:lago_id] }).to match_array([rate_card.id, other.id])
-      expect(json[:rate_cards].find { it[:lago_id] == rate_card.id }[:taxes].pluck(:code)).to eq([tax.code])
     end
 
     context "with a product_id filter" do

--- a/spec/services/rate_cards/apply_taxes_service_spec.rb
+++ b/spec/services/rate_cards/apply_taxes_service_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RateCards::ApplyTaxesService do
+  subject(:result) { described_class.call(rate_card:, tax_codes:) }
+
+  let(:organization) { create(:organization) }
+  let(:rate_card) { create(:rate_card, organization:) }
+  let(:tax1) { create(:tax, organization:) }
+  let(:tax2) { create(:tax, organization:) }
+  let(:tax_codes) { [tax1.code, tax2.code] }
+
+  it "applies the organization taxes to the rate card" do
+    expect { result }.to change(rate_card.applied_taxes, :count).from(0).to(2)
+
+    expect(result).to be_success
+    expect(result.applied_taxes.map(&:tax)).to match_array([tax1, tax2])
+    expect(rate_card.reload.taxes).to match_array([tax1, tax2])
+    expect(rate_card.applied_taxes.pluck(:organization_id).uniq).to eq([organization.id])
+  end
+
+  it "locks the rate card while replacing taxes" do
+    allow(rate_card).to receive(:with_lock).and_call_original
+
+    result
+
+    expect(rate_card).to have_received(:with_lock)
+  end
+
+  context "when tax codes contain duplicates" do
+    let(:tax_codes) { [tax1.code, tax1.code] }
+
+    it "applies the tax once" do
+      expect { result }.to change(rate_card.applied_taxes, :count).from(0).to(1)
+
+      expect(result).to be_success
+      expect(result.applied_taxes.map(&:tax)).to eq([tax1])
+    end
+  end
+
+  context "when the rate card already has taxes" do
+    before do
+      create(:rate_card_applied_tax, rate_card:, tax: tax1, organization:)
+      rate_card.taxes.load
+    end
+
+    let(:tax_codes) { [tax2.code] }
+
+    it "replaces the existing taxes" do
+      expect { result }.not_to change(rate_card.applied_taxes, :count)
+
+      expect(result).to be_success
+      expect(rate_card.taxes).to eq([tax2])
+    end
+  end
+
+  context "when tax codes are empty" do
+    before { create(:rate_card_applied_tax, rate_card:, tax: tax1, organization:) }
+
+    let(:tax_codes) { [] }
+
+    it "removes all taxes" do
+      expect { result }.to change(rate_card.applied_taxes, :count).from(1).to(0)
+
+      expect(result).to be_success
+      expect(result.applied_taxes).to be_empty
+    end
+  end
+
+  context "when a tax code does not exist" do
+    let(:tax_codes) { [tax1.code, "unknown"] }
+
+    it "returns a tax not found failure without changing assignments" do
+      expect { result }.not_to change(rate_card.applied_taxes, :count)
+
+      expect(result).not_to be_success
+      expect(result.error.resource).to eq("tax")
+    end
+  end
+
+  context "when the tax belongs to another organization" do
+    let(:other_tax) { create(:tax) }
+    let(:tax_codes) { [other_tax.code] }
+
+    it "returns a tax not found failure" do
+      expect(result).not_to be_success
+      expect(result.error.resource).to eq("tax")
+    end
+  end
+
+  context "when the rate card is nil" do
+    let(:rate_card) { nil }
+
+    it "returns a rate card not found failure" do
+      expect(result).not_to be_success
+      expect(result.error.resource).to eq("rate_card")
+    end
+  end
+end

--- a/spec/services/rate_cards/create_service_spec.rb
+++ b/spec/services/rate_cards/create_service_spec.rb
@@ -117,8 +117,35 @@ RSpec.describe RateCards::CreateService do
 
       it "returns a validation failure with prefixed keys and creates nothing" do
         expect { result }.not_to change(RateCard, :count)
+        expect(result).to be_a(described_class::Result)
         expect(result).not_to be_success
         expect(result.error.messages[:"rates.rate_properties"]).to be_present
+      end
+    end
+  end
+
+  context "with taxes" do
+    let(:tax1) { create(:tax, organization:) }
+    let(:tax2) { create(:tax, organization:) }
+
+    before { params[:tax_codes] = [tax1.code, tax2.code] }
+
+    it "applies the taxes to the rate card" do
+      expect(result).to be_success
+      expect(result.rate_card.taxes).to match_array([tax1, tax2])
+    end
+
+    context "when a tax belongs to another organization" do
+      let(:other_tax) { create(:tax) }
+
+      before { params[:tax_codes] = [other_tax.code] }
+
+      it "returns a tax not found failure and rolls back the rate card" do
+        expect { result }.not_to change(RateCard, :count)
+
+        expect(result).to be_a(described_class::Result)
+        expect(result).not_to be_success
+        expect(result.error.resource).to eq("tax")
       end
     end
   end

--- a/spec/services/rate_cards/update_service_spec.rb
+++ b/spec/services/rate_cards/update_service_spec.rb
@@ -218,6 +218,68 @@ RSpec.describe RateCards::UpdateService do
     end
   end
 
+  describe "taxes" do
+    let(:tax1) { create(:tax, organization:) }
+    let(:tax2) { create(:tax, organization:) }
+    let(:params) { {tax_codes: [tax2.code]} }
+
+    before { create(:rate_card_applied_tax, rate_card:, tax: tax1, organization:) }
+
+    it "replaces the rate card taxes" do
+      expect(result).to be_success
+      expect(result.rate_card.taxes).to eq([tax2])
+    end
+
+    context "when tax codes are empty" do
+      let(:params) { {tax_codes: []} }
+
+      it "removes the rate card tax override" do
+        expect(result).to be_success
+        expect(result.rate_card.taxes).to be_empty
+      end
+    end
+
+    context "when tax codes are null" do
+      let(:params) { {tax_codes: nil} }
+
+      it "keeps the existing taxes" do
+        expect(result).to be_success
+        expect(result.rate_card.taxes).to eq([tax1])
+      end
+    end
+
+    context "when tax codes are omitted" do
+      let(:params) { {name: "Renamed"} }
+
+      it "keeps the existing taxes" do
+        expect(result).to be_success
+        expect(result.rate_card.taxes).to eq([tax1])
+      end
+    end
+
+    context "when the rate card is attached to a subscription" do
+      before { create(:subscription_rate_card, organization:, rate_card:) }
+
+      it "still updates the taxes" do
+        expect(result).to be_success
+        expect(result.rate_card.taxes).to eq([tax2])
+      end
+    end
+
+    context "when a tax belongs to another organization" do
+      let(:other_tax) { create(:tax) }
+      let(:params) { {name: "Should roll back", tax_codes: [other_tax.code]} }
+
+      it "returns a tax not found failure and rolls back other changes" do
+        expect(result).to be_a(described_class::Result)
+        expect(result).not_to be_success
+        expect(result.error.resource).to eq("tax")
+        expect(rate_card.reload.name).to eq("Before")
+        expect(rate_card.taxes).to eq([tax1])
+      end
+    end
+  end
+
   context "when rate_card is nil" do
     let(:rate_card) { nil }
 

--- a/spec/services/rate_cards/update_service_spec.rb
+++ b/spec/services/rate_cards/update_service_spec.rb
@@ -257,8 +257,8 @@ RSpec.describe RateCards::UpdateService do
       end
     end
 
-    context "when the rate card is attached to a subscription" do
-      before { create(:subscription_rate_card, organization:, rate_card:) }
+    context "when the rate card is attached to a contract" do
+      before { create(:contract_rate_card, organization:, rate_card:) }
 
       it "still updates the taxes" do
         expect(result).to be_success

--- a/spec/services/taxes/destroy_service_spec.rb
+++ b/spec/services/taxes/destroy_service_spec.rb
@@ -54,6 +54,9 @@ RSpec.describe Taxes::DestroyService do
       fixed_charge = create(:fixed_charge, organization:)
       fixed_charge_tax = create(:fixed_charge_applied_tax, fixed_charge:, tax:)
 
+      rate_card = create(:rate_card, organization:)
+      rate_card_tax = create(:rate_card_applied_tax, rate_card:, tax:, organization:)
+
       credit_note = create(:credit_note, organization:)
       credit_note_tax = create(:credit_note_applied_tax, credit_note:, tax:)
 
@@ -79,6 +82,7 @@ RSpec.describe Taxes::DestroyService do
       expect { charge_tax.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { commitment_tax.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { fixed_charge_tax.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { rate_card_tax.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { credit_note_tax.reload }.to raise_error(ActiveRecord::RecordNotFound)
 
       # Draft invoice/fee taxes removed

--- a/spec/services/utils/activity_log_spec.rb
+++ b/spec/services/utils/activity_log_spec.rb
@@ -412,6 +412,17 @@ RSpec.describe Utils::ActivityLog, :capture_kafka_messages do
       end
     end
 
+    context "when the object is a rate card" do
+      let(:object) { create(:rate_card, organization:) }
+      let(:tax) { create(:tax, organization:) }
+
+      before { create(:rate_card_applied_tax, rate_card: object, tax:, organization:) }
+
+      it "serializes the taxes" do
+        expect(method_call[:taxes].pluck(:code)).to eq([tax.code])
+      end
+    end
+
     context "when the object is a subscription" do
       let(:object) { create(:subscription, organization:, plan:) }
       let(:plan) { create(:plan, organization:) }
@@ -477,6 +488,14 @@ RSpec.describe Utils::ActivityLog, :capture_kafka_messages do
 
       it "includes the billing items but not the content" do
         expect(method_call).to eq(%i[billing_items])
+      end
+    end
+
+    context "when object is a rate card" do
+      let(:object) { create(:rate_card, organization:) }
+
+      it "includes rates and taxes" do
+        expect(method_call).to eq(%i[rates taxes])
       end
     end
 


### PR DESCRIPTION
## Context

_First step of the taxes support for Products and Plans._

Taxes for the product catalog are configured on Rate Cards. They can override taxes inherited from the Plan, Customer, or Billing Entity.

## Description

This PR adds tax assignments to Rate Cards and exposes them through the REST and GraphQL APIs.

It doesn't resolve taxes on product-catalog fees yet. This will be handled in future PRs.

## Implementation details

- **New `rate_cards_taxes` table** linking Rate Cards and Taxes.
- **Tax management on Rate Cards**:
  - `tax_codes` can be provided when creating or updating a Rate Card,
  - an empty list removes the Rate Card tax override,
  - an omitted or `null` value keeps the current assignments,
  - taxes can still be changed when the Rate Card is in use.
- **REST and GraphQL responses** now include the assigned taxes.
- Tax codes are resolved within the Rate Card organization.
- Tax assignments are replaced inside a transaction with a Rate Card lock.
- Removing a Tax also removes its Rate Card assignments.
- Tax changes are included in activity logs and PaperTrail history.
