### PR TITLE
feat(taxes): add product integration mappings

### DIFF
--- a/app/graphql/mutations/integration_mappings/create.rb
+++ b/app/graphql/mutations/integration_mappings/create.rb
@@ -16,9 +16,7 @@ module Mutations
       type Types::IntegrationMappings::Object
 
       def resolve(**args)
-        result = ::IntegrationMappings::CreateService
-          .new(context[:current_user])
-          .call(**args.merge(organization_id: current_organization.id))
+        result = ::IntegrationMappings::CreateService.call(organization: current_organization, params: args)
 
         result.success? ? result.integration_mapping : result_error(result)
       end

--- a/app/graphql/sources/integration_mappings_by_mappable.rb
+++ b/app/graphql/sources/integration_mappings_by_mappable.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Sources
+  class IntegrationMappingsByMappable < GraphQL::Dataloader::Source
+    def initialize(integration_id = nil)
+      @integration_id = integration_id
+    end
+
+    def fetch(mappables)
+      mappings = IntegrationMappings::BaseMapping.where(mappable: mappables)
+      mappings = mappings.where(integration_id: @integration_id) if @integration_id
+      mappings_by_mappable = mappings.group_by { [it.mappable_type, it.mappable_id] }
+
+      mappables.map do |mappable|
+        mappings_by_mappable.fetch([mappable.class.polymorphic_name, mappable.id], [])
+      end
+    end
+  end
+end

--- a/app/graphql/types/products/object.rb
+++ b/app/graphql/types/products/object.rb
@@ -38,10 +38,7 @@ module Types
       end
 
       def integration_mappings(integration_id: nil)
-        mappings = dataloader.with(Sources::ActiveRecordAssociation, :integration_mappings).load(object)
-        return mappings unless integration_id
-
-        mappings.select { |mapping| mapping.integration_id == integration_id }
+        dataloader.with(Sources::IntegrationMappingsByMappable, integration_id).load(object)
       end
     end
   end

--- a/app/graphql/types/products/object.rb
+++ b/app/graphql/types/products/object.rb
@@ -19,6 +19,9 @@ module Types
       field :product_type, Types::Products::ProductTypeEnum, null: false
 
       field :billable_metric, Types::BillableMetrics::Object, null: true
+      field :integration_mappings, [Types::IntegrationMappings::Object], null: true do
+        argument :integration_id, ID, required: false
+      end
       field :product_category, Types::ProductCategories::Object, null: true
 
       field :filters_count, Integer, null: false
@@ -32,6 +35,13 @@ module Types
 
       def filters_count
         dataloader.with(Sources::CountByForeignKey, ProductFilter, :product_id).load(object.id)
+      end
+
+      def integration_mappings(integration_id: nil)
+        mappings = dataloader.with(Sources::ActiveRecordAssociation, :integration_mappings).load(object)
+        return mappings unless integration_id
+
+        mappings.select { |mapping| mapping.integration_id == integration_id }
       end
     end
   end

--- a/app/models/integration_mappings/base_mapping.rb
+++ b/app/models/integration_mappings/base_mapping.rb
@@ -12,7 +12,7 @@ module IntegrationMappings
     belongs_to :organization
     belongs_to :billing_entity, optional: true
 
-    MAPPABLE_TYPES = %i[AddOn BillableMetric].freeze
+    MAPPABLE_TYPES = %i[AddOn BillableMetric Product].freeze
 
     validates :mappable_type, inclusion: {in: MAPPABLE_TYPES.map(&:to_s)}
     validates :mappable_type,

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -4,6 +4,7 @@ class Product < ApplicationRecord
   include PaperTrailTraceable
   include Discard::Model
   include CatalogAttachable
+  include IntegrationMappable
 
   self.discard_column = :deleted_at
 

--- a/app/services/integration_mappings/create_service.rb
+++ b/app/services/integration_mappings/create_service.rb
@@ -4,27 +4,45 @@ module IntegrationMappings
   class CreateService < BaseService
     Result = BaseResult[:integration_mapping]
 
-    def call(**args)
-      integration = Integrations::BaseIntegration.find_by(id: args[:integration_id])
+    def initialize(organization:, params:)
+      @organization = organization
+      @params = params
+
+      super()
+    end
+
+    def call
+      integration = organization.integrations.find_by(id: params[:integration_id])
 
       return result.not_found_failure!(resource: "integration") unless integration
 
-      if (billing_entity_id = args[:billing_entity_id])
-        billing_entity = integration.organization.billing_entities.find_by(id: billing_entity_id)
+      if (billing_entity_id = params[:billing_entity_id])
+        billing_entity = organization.billing_entities.find_by(id: billing_entity_id)
         return result.not_found_failure!(resource: "billing_entity") unless billing_entity
       end
 
+      mappable_attributes = {
+        mappable_id: params[:mappable_id],
+        mappable_type: params[:mappable_type]
+      }
+
+      if params[:mappable_type] == "Product"
+        product = organization.products.find_by(id: params[:mappable_id])
+        return result.not_found_failure!(resource: "product") unless product
+
+        mappable_attributes = {mappable: product}
+      end
+
       integration_mapping = IntegrationMappings::Factory.new_instance(integration:).new(
-        organization_id: integration.organization_id,
-        integration_id: args[:integration_id],
-        mappable_id: args[:mappable_id],
-        mappable_type: args[:mappable_type],
-        billing_entity_id: billing_entity_id
+        organization:,
+        integration:,
+        billing_entity:,
+        **mappable_attributes
       )
 
-      integration_mapping.external_id = args[:external_id] if args.key?(:external_id)
-      integration_mapping.external_account_code = args[:external_account_code] if args.key?(:external_account_code)
-      integration_mapping.external_name = args[:external_name] if args.key?(:external_name)
+      integration_mapping.external_id = params[:external_id] if params.key?(:external_id)
+      integration_mapping.external_account_code = params[:external_account_code] if params.key?(:external_account_code)
+      integration_mapping.external_name = params[:external_name] if params.key?(:external_name)
 
       integration_mapping.save!
 
@@ -33,5 +51,9 @@ module IntegrationMappings
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
     end
+
+    private
+
+    attr_reader :organization, :params
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -7819,6 +7819,7 @@ input LoseInvoiceDisputeInput {
 enum MappableTypeEnum {
   AddOn
   BillableMetric
+  Product
 }
 
 type Mapping {
@@ -11227,6 +11228,7 @@ type Product {
   description: String
   filtersCount: Int!
   id: ID!
+  integrationMappings(integrationId: ID): [Mapping!]
   invoiceDisplayName: String
   name: String!
   organization: Organization

--- a/schema.json
+++ b/schema.json
@@ -40799,6 +40799,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "Product",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null
@@ -56966,6 +56972,39 @@
                   "kind": "SCALAR",
                   "name": "ID",
                   "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "integrationMappings",
+              "description": null,
+              "args": [
+                {
+                  "name": "integrationId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Mapping",
+                    "ofType": null
+                  }
                 }
               },
               "isDeprecated": false,

--- a/spec/graphql/mutations/integration_mappings/create_spec.rb
+++ b/spec/graphql/mutations/integration_mappings/create_spec.rb
@@ -64,6 +64,42 @@ RSpec.describe Mutations::IntegrationMappings::Create do
     )
   end
 
+  context "with a Product" do
+    let(:integration) { create(:anrok_integration, organization:) }
+    let(:mappable) { create(:product, organization:) }
+    let(:input) { super().merge(mappableType: "Product") }
+
+    it "creates a Product integration mapping" do
+      result = create_integration_mapping(input:)
+
+      expect(result).to include(
+        "integrationId" => integration.id,
+        "mappableId" => mappable.id,
+        "mappableType" => "Product"
+      )
+    end
+
+    context "when the Product belongs to another organization" do
+      let(:mappable) { create(:product) }
+
+      it "returns an error" do
+        result = create_integration_mapping(input:, raw: true)
+
+        expect_graphql_error(result:, message: "Resource not found")
+      end
+    end
+  end
+
+  context "when the integration belongs to another organization" do
+    let(:integration) { create(:netsuite_integration) }
+
+    it "returns an error" do
+      result = create_integration_mapping(input:, raw: true)
+
+      expect_graphql_error(result:, message: "Resource not found")
+    end
+  end
+
   context "with billing entity" do
     let(:billing_entity) { create(:billing_entity, organization: organization) }
     let(:billing_entity_id) { billing_entity.id }

--- a/spec/graphql/mutations/integration_mappings/destroy_spec.rb
+++ b/spec/graphql/mutations/integration_mappings/destroy_spec.rb
@@ -4,8 +4,9 @@ require "rails_helper"
 
 RSpec.describe Mutations::IntegrationMappings::Destroy do
   let(:required_permission) { "organization:integrations:update" }
-  let(:integration_mapping) { create(:netsuite_mapping, integration:) }
+  let(:integration_mapping) { create(:netsuite_mapping, integration:, mappable: product, organization:) }
   let(:integration) { create(:netsuite_integration, organization:) }
+  let(:product) { create(:product, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }
 
@@ -48,6 +49,30 @@ RSpec.describe Mutations::IntegrationMappings::Destroy do
           input: {id: "123456"}
         }
       )
+
+      expect_not_found(result)
+    end
+  end
+
+  context "when the integration mapping belongs to another organization" do
+    let(:other_organization) { create(:organization) }
+    let(:integration) { create(:netsuite_integration, organization: other_organization) }
+    let(:product) { create(:product, organization: other_organization) }
+
+    it "returns an error and keeps the mapping" do
+      result = nil
+
+      expect do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query: mutation,
+          variables: {
+            input: {id: integration_mapping.id}
+          }
+        )
+      end.not_to change(::IntegrationMappings::BaseMapping, :count)
 
       expect_not_found(result)
     end

--- a/spec/graphql/mutations/integration_mappings/update_spec.rb
+++ b/spec/graphql/mutations/integration_mappings/update_spec.rb
@@ -4,8 +4,9 @@ require "rails_helper"
 
 RSpec.describe Mutations::IntegrationMappings::Update do
   let(:required_permission) { "organization:integrations:update" }
-  let(:integration_mapping) { create(:netsuite_mapping, integration:) }
+  let(:integration_mapping) { create(:netsuite_mapping, integration:, mappable: product, organization:) }
   let(:integration) { create(:netsuite_integration, organization:) }
+  let(:product) { create(:product, organization:) }
   let(:mappable) { integration_mapping.mappable }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }
@@ -44,7 +45,7 @@ RSpec.describe Mutations::IntegrationMappings::Update do
           id: integration_mapping.id,
           integrationId: integration.id,
           mappableId: mappable.id,
-          mappableType: "AddOn",
+          mappableType: "Product",
           externalAccountCode: external_account_code,
           externalId: external_id,
           externalName: external_name
@@ -56,9 +57,32 @@ RSpec.describe Mutations::IntegrationMappings::Update do
 
     expect(result_data["integrationId"]).to eq(integration.id)
     expect(result_data["mappableId"]).to eq(mappable.id)
-    expect(result_data["mappableType"]).to eq("AddOn")
+    expect(result_data["mappableType"]).to eq("Product")
     expect(result_data["externalAccountCode"]).to eq(external_account_code)
     expect(result_data["externalId"]).to eq(external_id)
     expect(result_data["externalName"]).to eq(external_name)
+  end
+
+  context "when the integration mapping belongs to another organization" do
+    let(:other_organization) { create(:organization) }
+    let(:integration) { create(:netsuite_integration, organization: other_organization) }
+    let(:product) { create(:product, organization: other_organization) }
+
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            id: integration_mapping.id,
+            externalId: external_id
+          }
+        }
+      )
+
+      expect_graphql_error(result:, message: "Resource not found")
+    end
   end
 end

--- a/spec/graphql/resolvers/product_resolver_spec.rb
+++ b/spec/graphql/resolvers/product_resolver_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Resolvers::ProductResolver do
       current_organization: organization,
       permissions: required_permission,
       query:,
-      variables: {productId: product.id}
+      variables:
     )
   end
 
@@ -17,6 +17,7 @@ RSpec.describe Resolvers::ProductResolver do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:product) { create(:product, organization:) }
+  let(:variables) { {productId: product.id} }
 
   let(:query) do
     <<~GQL
@@ -45,6 +46,41 @@ RSpec.describe Resolvers::ProductResolver do
 
     it "returns a not found error" do
       expect_graphql_error(result: execution, message: "Resource not found")
+    end
+  end
+
+  context "with integration mappings" do
+    let(:netsuite_integration) { create(:netsuite_integration, organization:) }
+    let(:xero_integration) { create(:xero_integration, organization:) }
+    let!(:netsuite_mapping) { create(:netsuite_mapping, integration: netsuite_integration, organization:, mappable: product) }
+    let!(:xero_mapping) { create(:xero_mapping, integration: xero_integration, organization:, mappable: product) }
+    let(:integration_id) { nil }
+    let(:variables) { {productId: product.id, integrationId: integration_id} }
+
+    let(:query) do
+      <<~GQL
+        query($productId: ID!, $integrationId: ID) {
+          product(id: $productId) {
+            integrationMappings(integrationId: $integrationId) { id }
+          }
+        }
+      GQL
+    end
+
+    it "returns all Product integration mappings" do
+      mappings = execution.dig("data", "product", "integrationMappings")
+
+      expect(mappings.pluck("id")).to match_array([netsuite_mapping.id, xero_mapping.id])
+    end
+
+    context "with an integration ID" do
+      let(:integration_id) { netsuite_integration.id }
+
+      it "returns only the mapping for that integration" do
+        mappings = execution.dig("data", "product", "integrationMappings")
+
+        expect(mappings.pluck("id")).to eq([netsuite_mapping.id])
+      end
     end
   end
 end

--- a/spec/graphql/resolvers/products_resolver_spec.rb
+++ b/spec/graphql/resolvers/products_resolver_spec.rb
@@ -44,6 +44,36 @@ RSpec.describe Resolvers::ProductsResolver do
     expect(response["metadata"]["totalCount"]).to eq(2)
   end
 
+  context "with integration mappings" do
+    let(:integration) { create(:anrok_integration, organization:) }
+    let!(:usage_mapping) { create(:anrok_mapping, integration:, organization:, mappable: usage_item) }
+    let!(:fixed_mapping) { create(:anrok_mapping, integration:, organization:, mappable: fixed_item) }
+
+    let(:query) do
+      <<~GQL
+        query {
+          products(limit: 5) {
+            collection { id integrationMappings { id } }
+          }
+        }
+      GQL
+    end
+
+    it "loads mappings for all Products in one query" do
+      query_count = 0
+      counter = lambda do |_name, _start, _finish, _id, payload|
+        query_count += 1 if payload[:sql]&.include?('FROM "integration_mappings"')
+      end
+
+      ActiveSupport::Notifications.subscribed(counter, "sql.active_record") { execution }
+
+      products = execution.dig("data", "products", "collection").index_by { it["id"] }
+      expect(products[usage_item.id]["integrationMappings"].pluck("id")).to eq([usage_mapping.id])
+      expect(products[fixed_item.id]["integrationMappings"].pluck("id")).to eq([fixed_mapping.id])
+      expect(query_count).to eq(1)
+    end
+  end
+
   context "with an item type filter" do
     let(:variables) { {productType: "fixed"} }
 

--- a/spec/graphql/resolvers/products_resolver_spec.rb
+++ b/spec/graphql/resolvers/products_resolver_spec.rb
@@ -46,20 +46,26 @@ RSpec.describe Resolvers::ProductsResolver do
 
   context "with integration mappings" do
     let(:integration) { create(:anrok_integration, organization:) }
+    let(:other_integration) { create(:xero_integration, organization:) }
     let!(:usage_mapping) { create(:anrok_mapping, integration:, organization:, mappable: usage_item) }
     let!(:fixed_mapping) { create(:anrok_mapping, integration:, organization:, mappable: fixed_item) }
+    let(:variables) { {integrationId: integration.id} }
 
     let(:query) do
       <<~GQL
-        query {
+        query($integrationId: ID) {
           products(limit: 5) {
-            collection { id integrationMappings { id } }
+            collection { id integrationMappings(integrationId: $integrationId) { id } }
           }
         }
       GQL
     end
 
-    it "loads mappings for all Products in one query" do
+    before do
+      create(:xero_mapping, integration: other_integration, organization:, mappable: usage_item)
+    end
+
+    it "loads filtered mappings for all Products in one query" do
       query_count = 0
       counter = lambda do |_name, _start, _finish, _id, payload|
         query_count += 1 if payload[:sql]&.include?('FROM "integration_mappings"')

--- a/spec/graphql/sources/integration_mappings_by_mappable_spec.rb
+++ b/spec/graphql/sources/integration_mappings_by_mappable_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Sources::IntegrationMappingsByMappable do
+  subject(:source) { described_class.new(integration_id) }
+
+  let(:organization) { create(:organization) }
+  let(:integration) { create(:anrok_integration, organization:) }
+  let(:other_integration) { create(:xero_integration, organization:) }
+  let(:integration_id) { integration.id }
+  let(:product) { create(:product, organization:) }
+  let(:other_product) { create(:product, organization:) }
+  let!(:mapping) { create(:anrok_mapping, integration:, organization:, mappable: product) }
+  let!(:other_mapping) { create(:anrok_mapping, integration:, organization:, mappable: other_product) }
+  let!(:mapping_for_other_integration) do
+    create(:xero_mapping, integration: other_integration, organization:, mappable: product)
+  end
+
+  describe "#fetch" do
+    it "returns mappings for the requested integration grouped by mappable" do
+      expect(source.fetch([product, other_product])).to eq([[mapping], [other_mapping]])
+    end
+
+    context "without an integration ID" do
+      let(:integration_id) { nil }
+
+      it "returns all mappings grouped by mappable" do
+        result = source.fetch([product, other_product])
+
+        expect(result.first).to match_array([mapping, mapping_for_other_integration])
+        expect(result.second).to eq([other_mapping])
+      end
+    end
+  end
+end

--- a/spec/models/integration_mappings/base_mapping_spec.rb
+++ b/spec/models/integration_mappings/base_mapping_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe IntegrationMappings::BaseMapping do
   end
 
   describe "validations" do
-    it { is_expected.to validate_inclusion_of(:mappable_type).in_array(%w[AddOn BillableMetric]) }
+    it { is_expected.to validate_inclusion_of(:mappable_type).in_array(%w[AddOn BillableMetric Product]) }
 
     describe "uniqueness validations" do
       let(:mapping) do

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -27,6 +27,15 @@ RSpec.describe Product do
       expect(product).to belong_to(:charge).optional
       expect(product).to have_many(:filters).class_name("ProductFilter")
       expect(product).to have_many(:rate_cards)
+      expect(product).to have_many(:integration_mappings)
+        .class_name("IntegrationMappings::BaseMapping")
+        .dependent(:destroy)
+      expect(product).to have_many(:netsuite_mappings)
+        .class_name("IntegrationMappings::NetsuiteMapping")
+        .dependent(:destroy)
+      expect(product).to have_many(:xero_mappings)
+        .class_name("IntegrationMappings::XeroMapping")
+        .dependent(:destroy)
     end
   end
 

--- a/spec/services/integration_mappings/create_service_spec.rb
+++ b/spec/services/integration_mappings/create_service_spec.rb
@@ -3,15 +3,12 @@
 require "rails_helper"
 
 RSpec.describe IntegrationMappings::CreateService do
-  let(:service) { described_class.new(membership.user) }
-
   let(:integration) { create(:netsuite_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
+  let(:organization) { create(:organization) }
   let(:add_on) { create(:add_on, organization:) }
 
   describe "#call" do
-    subject(:service_call) { service.call(**create_args) }
+    subject(:service_call) { described_class.call(organization:, params: create_args) }
 
     let(:create_args) do
       {
@@ -72,6 +69,49 @@ RSpec.describe IntegrationMappings::CreateService do
             expect(service_call.error.message).to eq("billing_entity_not_found")
           end
         end
+      end
+
+      context "with a Product" do
+        let(:integration) { create(:anrok_integration, organization:) }
+        let(:product) { create(:product, organization:) }
+        let(:create_args) do
+          {
+            mappable_type: "Product",
+            mappable_id: product.id,
+            integration_id: integration.id,
+            external_id: "external_123"
+          }
+        end
+
+        it "creates the integration mapping" do
+          expect { service_call }.to change(IntegrationMappings::AnrokMapping, :count).by(1)
+
+          expect(service_call.integration_mapping).to have_attributes(
+            organization:,
+            integration:,
+            mappable: product
+          )
+        end
+
+        context "when the Product belongs to another organization" do
+          let(:product) { create(:product) }
+
+          it "returns a not found error" do
+            expect(service_call).not_to be_success
+            expect(service_call.error).to be_a(BaseService::NotFoundFailure)
+            expect(service_call.error.message).to eq("product_not_found")
+          end
+        end
+      end
+    end
+
+    context "when the integration belongs to another organization" do
+      let(:integration) { create(:netsuite_integration) }
+
+      it "returns a not found error" do
+        expect(service_call).not_to be_success
+        expect(service_call.error).to be_a(BaseService::NotFoundFailure)
+        expect(service_call.error.message).to eq("integration_not_found")
       end
     end
 

--- a/spec/services/integrations/aggregator/base_payload_spec.rb
+++ b/spec/services/integrations/aggregator/base_payload_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Integrations::Aggregator::BasePayload do
+  subject(:payload) { described_class.new(integration:, billing_entity:) }
+
+  let(:organization) { create(:organization) }
+  let(:billing_entity) { create(:billing_entity, organization:) }
+  let(:integration) { create(:anrok_integration, organization:) }
+  let(:product) { create(:product, organization:) }
+
+  describe "Product mapping fallback" do
+    let!(:fallback_mapping) do
+      create(
+        :anrok_collection_mapping,
+        integration:,
+        organization:,
+        mapping_type: :fallback_item
+      )
+    end
+
+    it "returns the integration fallback when the Product has no mapping" do
+      mapping = payload.send(:lookup_mapping, "Product", product.id)
+
+      expect(mapping).to eq(fallback_mapping)
+    end
+  end
+end

--- a/spec/services/integrations/aggregator/base_payload_spec.rb
+++ b/spec/services/integrations/aggregator/base_payload_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Integrations::Aggregator::BasePayload do
   let(:integration) { create(:anrok_integration, organization:) }
   let(:product) { create(:product, organization:) }
 
-  describe "Product mapping fallback" do
+  describe "Product mapping lookup" do
     let!(:fallback_mapping) do
       create(
         :anrok_collection_mapping,
@@ -24,6 +24,18 @@ RSpec.describe Integrations::Aggregator::BasePayload do
       mapping = payload.send(:lookup_mapping, "Product", product.id)
 
       expect(mapping).to eq(fallback_mapping)
+    end
+
+    context "when the Product has a mapping" do
+      let!(:product_mapping) do
+        create(:anrok_mapping, integration:, organization:, mappable: product)
+      end
+
+      it "returns the Product mapping" do
+        mapping = payload.send(:lookup_mapping, "Product", product.id)
+
+        expect(mapping).to eq(product_mapping)
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

_Part of the products and plans project._

Anrok and Avalara need an external item ID for each billed line.

The existing billing system stores this mapping on BillableMetric or AddOn. Product-catalog fees should use a mapping stored on Product.

## Description

- Add Product to the existing integration mapping system.
- Support creating, reading, updating, and deleting Product mappings through GraphQL.
- Scope Product and Integration lookups to the current organization.
- Prevent mappings from referencing another organization's Product or Integration.
- Batch integration mapping reads on Product lists.
- Keep existing BillableMetric and AddOn mappings unchanged.
- Add coverage for the existing integration fallback when a Product has no mapping.

No database migration is required because integration mappings already use a polymorphic association.

Frontend PR for compatibility => https://github.com/getlago/lago-front/pull/4177

## Testing

- Product mapping model and service specs
- GraphQL create, read, update, and delete specs
- Organization-isolation specs
- Product list query batching
- Integration fallback coverage
- GraphQL schema consistency