### PR TITLE
fix(invoices): relax the search terms refresh lock

### DIFF
--- a/app/jobs/customers/refresh_invoices_search_terms_job.rb
+++ b/app/jobs/customers/refresh_invoices_search_terms_job.rb
@@ -3,7 +3,7 @@
 module Customers
   class RefreshInvoicesSearchTermsJob < ApplicationJob
     queue_as "default"
-    unique :until_executed
+    unique :until_executing, on_conflict: :log
 
     def perform(customer_id)
       customer = Customer.with_discarded.find_by(id: customer_id)

--- a/spec/jobs/customers/refresh_invoices_search_terms_job_spec.rb
+++ b/spec/jobs/customers/refresh_invoices_search_terms_job_spec.rb
@@ -9,10 +9,19 @@ RSpec.describe Customers::RefreshInvoicesSearchTermsJob do
   let(:customer) { create(:customer, organization:) }
   let(:customer_id) { customer.id }
 
-  let(:refresh_service) { instance_double(Customers::RefreshInvoicesSearchTermsService) }
-
   before do
     allow(Customers::RefreshInvoicesSearchTermsService).to receive(:call!).and_return(BaseResult.new)
+  end
+
+  it_behaves_like "a unique job" do
+    let(:job_args) { [customer.id] }
+  end
+
+  describe "unique" do
+    it "has unique :until_executing constraint" do
+      expect(described_class.lock_strategy_class).to eq(ActiveJob::Uniqueness::Strategies::UntilExecuting)
+      expect(described_class.lock_options).to eq(on_conflict: :log)
+    end
   end
 
   it "refreshes the invoices of the customer" do


### PR DESCRIPTION
## Context

`Customers::RefreshInvoicesSearchTermsJob` declared `unique :until_executed` with no `on_conflict:`, so it inherited the gem default `:raise`. It is enqueued from an after-commit callback (`Customers::UpdateService`, `Customers::UpsertFromApiService`, `CustomerPortal::CustomerUpdateService`), so two quick successive updates of the same customer raised `JobNotUnique` in the second request, after its change had already committed.

## Description

Conflicts now log instead of raising: dropping the duplicate is the wanted behaviour, and it costs nothing since the service recomputes from live rows in SQL, so the surviving run writes the latest values.

The strategy also moves to `until_executing`, which releases the lock before `perform`:

- A customer update landing mid-run still gets its own follow-up job. `until_executed` would silently drop it, leaving those invoices stale, and the run can take minutes on a large customer.
- No stuck lock. With `retry: 0` on `ApplicationJob`, a raise under `until_executed` skips `after_perform` and holds the lock for the full 1h TTL with no retry to release it.

Overlapping runs for one customer are now possible but benign: the service is a pure idempotent recompute-and-overwrite.
