### PR TITLE
perf(cache): cache full usage under a dedicated key

### DIFF
--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -286,9 +286,7 @@ module Invoices
         (!usage_filters.full_usage || full_usage_cache_enabled?)
     end
 
-    # Lazy validation is the only invalidation reaching this entry: the eager deletion never runs for
-    # a ClickHouse organization, and the events-processor replacing it clears the current usage key
-    # alone. skip_grouping and filter_by_presentation reshape the fees without appearing in the key.
+    # Full usage is cached only with lazy validation, the one invalidation that clears its key.
     def full_usage_cache_enabled?
       organization.granular_lifetime_usage_enabled? &&
         organization.feature_flag_enabled?(:lazy_charge_usage_cache) &&

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -132,6 +132,7 @@ module Invoices
         charge:,
         to_datetime: boundaries.charges_to_datetime,
         cache: charge_cache_enabled?,
+        full_usage: full_usage_cache?,
         last_seen_at: applied_filters
       )
 
@@ -177,15 +178,13 @@ module Invoices
       @date_service ||= Subscriptions::DatesService.new_instance(subscription, timestamp, current_usage: true)
     end
 
-    # NOTE: The charge cache key does not include from_datetime, so when full_usage
-    #       shifts the boundaries back to subscription.started_at, the cache would
-    #       return stale current-period data. Disable cache in that case.
-    #       When started_at matches the current period boundary, the aggregation
-    #       window is identical and the cache is safe to use.
-    def cache_applicable?
-      return with_cache unless usage_filters.full_usage
-
-      with_cache && subscription.started_at == date_service.charges_from_datetime
+    # NOTE: The charge cache key does not include from_datetime, so a full_usage window reaching
+    #       back to subscription.started_at gets its own cache entry instead of reading the
+    #       current-period one. When started_at matches the current period boundary the aggregation
+    #       window is identical, so the request shares the current usage entry rather than warming a
+    #       duplicate.
+    def full_usage_cache?
+      usage_filters.full_usage && subscription.started_at != date_service.charges_from_datetime
     end
 
     def compute_amounts
@@ -291,7 +290,7 @@ module Invoices
     # timestamp written into a live cache stays valid forever (see Events::BillingPeriodFilterService).
     # Usage filtered by group is never cached, as its fees are a subset of the charge fees.
     def charge_cache_enabled?
-      cache_applicable? && usage_filters.filter_by_group.blank?
+      with_cache && usage_filters.filter_by_group.blank?
     end
 
     def querying_full_usage_allowed

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -132,7 +132,7 @@ module Invoices
         charge:,
         to_datetime: boundaries.charges_to_datetime,
         cache: charge_cache_enabled?,
-        full_usage: full_usage_cache?,
+        full_usage: usage_filters.full_usage,
         last_seen_at: applied_filters
       )
 
@@ -176,22 +176,6 @@ module Invoices
 
     def date_service
       @date_service ||= Subscriptions::DatesService.new_instance(subscription, timestamp, current_usage: true)
-    end
-
-    # NOTE: The charge cache key does not include from_datetime, so a full_usage window reaching
-    #       back to subscription.started_at gets its own cache entry instead of reading the
-    #       current-period one. When started_at matches the current period boundary the aggregation
-    #       window is identical, so the request shares the current usage entry rather than warming a
-    #       duplicate.
-    #
-    #       The integration is checked again here even though full usage is already refused without
-    #       it: Subscriptions::ChargeCacheService only deletes the full usage entry for those
-    #       organizations, and an entry nobody invalidates would serve stale usage until the end of
-    #       the billing period.
-    def full_usage_cache?
-      usage_filters.full_usage &&
-        organization.granular_lifetime_usage_enabled? &&
-        subscription.started_at != date_service.charges_from_datetime
     end
 
     def compute_amounts
@@ -297,7 +281,20 @@ module Invoices
     # timestamp written into a live cache stays valid forever (see Events::BillingPeriodFilterService).
     # Usage filtered by group is never cached, as its fees are a subset of the charge fees.
     def charge_cache_enabled?
-      with_cache && usage_filters.filter_by_group.blank?
+      with_cache &&
+        usage_filters.filter_by_group.blank? &&
+        (!usage_filters.full_usage || full_usage_cache_enabled?)
+    end
+
+    # Full usage always reads and writes its own entry, never the current usage one (see
+    # Subscriptions::ChargeCacheService::FULL_USAGE_KEY_SEGMENT), and only for the shapes that entry
+    # can describe: skip_grouping and filter_by_presentation change the fees a charge produces
+    # without appearing in the key, so caching them would let one shape be served for another. The
+    # integration is required as well, restating locally what querying_full_usage_allowed refuses.
+    def full_usage_cache_enabled?
+      organization.granular_lifetime_usage_enabled? &&
+        !usage_filters.skip_grouping &&
+        usage_filters.filter_by_presentation.nil?
     end
 
     def querying_full_usage_allowed

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -287,12 +287,20 @@ module Invoices
     end
 
     # Full usage always reads and writes its own entry, never the current usage one (see
-    # Subscriptions::ChargeCacheService::FULL_USAGE_KEY_SEGMENT), and only for the shapes that entry
-    # can describe: skip_grouping and filter_by_presentation change the fees a charge produces
-    # without appearing in the key, so caching them would let one shape be served for another. The
-    # integration is required as well, restating locally what querying_full_usage_allowed refuses.
+    # Subscriptions::ChargeCacheService::FULL_USAGE_KEY_SEGMENT), and only when it can be kept exact.
+    #
+    # Lazy validation is required, because it is the only invalidation that certainly reaches the
+    # full usage entry: the eager deletion clears both keys, but it never runs for a ClickHouse
+    # organization (Events::CreateService skips Events::PostProcessJob), and the events-processor
+    # invalidating in its place builds the current usage key alone. A stale lifetime total would then
+    # feed alerting until the end of the billing period.
+    #
+    # skip_grouping and filter_by_presentation are refused as well: both change the fees a charge
+    # produces without appearing in the key, so caching them would serve one shape for another. And
+    # the integration restates locally what querying_full_usage_allowed already refuses.
     def full_usage_cache_enabled?
       organization.granular_lifetime_usage_enabled? &&
+        organization.feature_flag_enabled?(:lazy_charge_usage_cache) &&
         !usage_filters.skip_grouping &&
         usage_filters.filter_by_presentation.nil?
     end

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -184,7 +184,9 @@ module Invoices
     #       window is identical, so the request shares the current usage entry rather than warming a
     #       duplicate.
     def full_usage_cache?
-      usage_filters.full_usage && subscription.started_at != date_service.charges_from_datetime
+      usage_filters.full_usage &&
+        Subscriptions::ChargeCacheService.full_usage_cache_enabled?(organization) &&
+        subscription.started_at != date_service.charges_from_datetime
     end
 
     def compute_amounts

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -183,9 +183,14 @@ module Invoices
     #       current-period one. When started_at matches the current period boundary the aggregation
     #       window is identical, so the request shares the current usage entry rather than warming a
     #       duplicate.
+    #
+    #       The integration is checked again here even though full usage is already refused without
+    #       it: Subscriptions::ChargeCacheService only deletes the full usage entry for those
+    #       organizations, and an entry nobody invalidates would serve stale usage until the end of
+    #       the billing period.
     def full_usage_cache?
       usage_filters.full_usage &&
-        Subscriptions::ChargeCacheService.full_usage_cache_enabled?(organization) &&
+        organization.granular_lifetime_usage_enabled? &&
         subscription.started_at != date_service.charges_from_datetime
     end
 

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -286,18 +286,9 @@ module Invoices
         (!usage_filters.full_usage || full_usage_cache_enabled?)
     end
 
-    # Full usage always reads and writes its own entry, never the current usage one (see
-    # Subscriptions::ChargeCacheService::FULL_USAGE_KEY_SEGMENT), and only when it can be kept exact.
-    #
-    # Lazy validation is required, because it is the only invalidation that certainly reaches the
-    # full usage entry: the eager deletion clears both keys, but it never runs for a ClickHouse
-    # organization (Events::CreateService skips Events::PostProcessJob), and the events-processor
-    # invalidating in its place builds the current usage key alone. A stale lifetime total would then
-    # feed alerting until the end of the billing period.
-    #
-    # skip_grouping and filter_by_presentation are refused as well: both change the fees a charge
-    # produces without appearing in the key, so caching them would serve one shape for another. And
-    # the integration restates locally what querying_full_usage_allowed already refuses.
+    # Lazy validation is the only invalidation reaching this entry: the eager deletion never runs for
+    # a ClickHouse organization, and the events-processor replacing it clears the current usage key
+    # alone. skip_grouping and filter_by_presentation reshape the fees without appearing in the key.
     def full_usage_cache_enabled?
       organization.granular_lifetime_usage_enabled? &&
         organization.feature_flag_enabled?(:lazy_charge_usage_cache) &&

--- a/app/services/subscriptions/charge_cache_middleware.rb
+++ b/app/services/subscriptions/charge_cache_middleware.rb
@@ -4,11 +4,12 @@ module Subscriptions
   class ChargeCacheMiddleware
     EMPTY_ARRAY = [].freeze
 
-    def initialize(subscription:, charge:, to_datetime:, cache: true, last_seen_at: nil)
+    def initialize(subscription:, charge:, to_datetime:, cache: true, full_usage: false, last_seen_at: nil)
       @subscription = subscription
       @charge = charge
       @to_datetime = to_datetime
       @cache = cache
+      @full_usage = full_usage
       @last_seen_at = last_seen_at || {}
     end
 
@@ -19,7 +20,7 @@ module Subscriptions
       # last_seen_at is the { filter_id => timestamp } bucket for the current charge.
       invalidate_if_older_than = last_seen_at[charge_filter&.id]
 
-      json = Subscriptions::ChargeCacheService.call(subscription:, charge:, charge_filter:, expires_in: cache_expiration, invalidate_if_older_than:) do
+      json = Subscriptions::ChargeCacheService.call(subscription:, charge:, charge_filter:, full_usage:, expires_in: cache_expiration, invalidate_if_older_than:) do
         yield
           .map do |fee|
             fee.attributes.merge(
@@ -52,7 +53,7 @@ module Subscriptions
 
     private
 
-    attr_reader :subscription, :charge, :to_datetime, :cache, :last_seen_at
+    attr_reader :subscription, :charge, :to_datetime, :cache, :full_usage, :last_seen_at
 
     def cache_expiration
       return 0 unless to_datetime

--- a/app/services/subscriptions/charge_cache_service.rb
+++ b/app/services/subscriptions/charge_cache_service.rb
@@ -8,10 +8,14 @@ module Subscriptions
     # this version instead of invalidating every organization's cache at once.
     LAZY_CACHE_KEY_VERSION = "2"
 
+    # Full usage aggregates from subscription.started_at instead of the current period start, so its
+    # result cannot share an entry with the current usage one.
+    FULL_USAGE_KEY_SEGMENT = "full-usage"
+
     def self.expire_for_subscriptions(subscription_ids)
       Subscription
         .where(id: subscription_ids)
-        .preload(plan: {charges: :filters})
+        .preload(:organization, plan: {charges: :filters})
         .find_each do |subscription|
           subscription.plan.charges.each do |charge|
             expire_for_subscription_charge(subscription:, charge:)
@@ -31,10 +35,21 @@ module Subscriptions
       expire_cache(subscription:, charge:)
     end
 
-    def initialize(subscription:, charge:, charge_filter: nil, expires_in: nil, invalidate_if_older_than: nil)
+    # NOTE: A charge can hold both a current usage and a full usage entry, and an event invalidates
+    #       both. Only organizations allowed to query full usage can have the second one, so the
+    #       extra deletion is skipped for everyone else.
+    def self.expire_cache(subscription:, charge:, charge_filter: nil)
+      new(subscription:, charge:, charge_filter:).expire_cache
+      return unless subscription.organization.granular_lifetime_usage_enabled?
+
+      new(subscription:, charge:, charge_filter:, full_usage: true).expire_cache
+    end
+
+    def initialize(subscription:, charge:, charge_filter: nil, full_usage: false, expires_in: nil, invalidate_if_older_than: nil)
       @subscription = subscription
       @charge = charge
       @charge_filter = charge_filter
+      @full_usage = full_usage
 
       super(expires_in:, invalidate_if_older_than:)
     end
@@ -49,13 +64,14 @@ module Subscriptions
         subscription.id,
         charge.updated_at.iso8601,
         charge_filter&.id,
-        charge_filter&.updated_at&.iso8601
+        charge_filter&.updated_at&.iso8601,
+        (FULL_USAGE_KEY_SEGMENT if full_usage)
       ].compact.join("/")
     end
 
     private
 
-    attr_reader :subscription, :charge, :charge_filter
+    attr_reader :subscription, :charge, :charge_filter, :full_usage
 
     def cache_key_version
       lazy_validation? ? LAZY_CACHE_KEY_VERSION : CACHE_KEY_VERSION

--- a/app/services/subscriptions/charge_cache_service.rb
+++ b/app/services/subscriptions/charge_cache_service.rb
@@ -35,12 +35,20 @@ module Subscriptions
       expire_cache(subscription:, charge:)
     end
 
+    # Single rule for the existence of a full usage entry, read by both the writer
+    # (Invoices::CustomerUsageService) and the invalidation path below. The two must never diverge:
+    # an entry written without a matching deletion keeps serving stale usage until the end of the
+    # billing period. Invoices::CustomerUsageService already refuses full usage without this
+    # integration, so this only guards against that gate moving.
+    def self.full_usage_cache_enabled?(organization)
+      organization.granular_lifetime_usage_enabled?
+    end
+
     # NOTE: A charge can hold both a current usage and a full usage entry, and an event invalidates
-    #       both. Only organizations allowed to query full usage can have the second one, so the
-    #       extra deletion is skipped for everyone else.
+    #       both. The extra deletion is skipped for organizations that cannot hold the second one.
     def self.expire_cache(subscription:, charge:, charge_filter: nil)
       new(subscription:, charge:, charge_filter:).expire_cache
-      return unless subscription.organization.granular_lifetime_usage_enabled?
+      return unless full_usage_cache_enabled?(subscription.organization)
 
       new(subscription:, charge:, charge_filter:, full_usage: true).expire_cache
     end

--- a/app/services/subscriptions/charge_cache_service.rb
+++ b/app/services/subscriptions/charge_cache_service.rb
@@ -37,11 +37,11 @@ module Subscriptions
       expire_cache(subscription:, charge:)
     end
 
-    # NOTE: A charge can hold both a current usage and a full usage entry, and an event invalidates
-    #       both. Neither deletion may be conditional on the organization still being granted
-    #       granular lifetime usage: an entry written while it was granted survives every event
-    #       ingested after it was revoked, and would serve that stale usage the moment it is granted
-    #       again, until the end of the billing period.
+    # NOTE: A charge can hold both a current usage and a full usage entry, and both are cleared.
+    #       The per-event caller only ever finds the current usage one, since a full usage entry
+    #       requires the lazy validation that turns that caller off. The explicit ones do find it:
+    #       deleting a billable metric or de-duplicating events removes usage without advancing the
+    #       ingestion watermark, so lazy validation would keep serving whatever was left behind.
     def self.expire_cache(subscription:, charge:, charge_filter: nil)
       new(subscription:, charge:, charge_filter:).expire_cache
       new(subscription:, charge:, charge_filter:, full_usage: true).expire_cache

--- a/app/services/subscriptions/charge_cache_service.rb
+++ b/app/services/subscriptions/charge_cache_service.rb
@@ -35,20 +35,12 @@ module Subscriptions
       expire_cache(subscription:, charge:)
     end
 
-    # Single rule for the existence of a full usage entry, read by both the writer
-    # (Invoices::CustomerUsageService) and the invalidation path below. The two must never diverge:
-    # an entry written without a matching deletion keeps serving stale usage until the end of the
-    # billing period. Invoices::CustomerUsageService already refuses full usage without this
-    # integration, so this only guards against that gate moving.
-    def self.full_usage_cache_enabled?(organization)
-      organization.granular_lifetime_usage_enabled?
-    end
-
     # NOTE: A charge can hold both a current usage and a full usage entry, and an event invalidates
-    #       both. The extra deletion is skipped for organizations that cannot hold the second one.
+    #       both. Only organizations granted granular lifetime usage can hold the second one, so the
+    #       extra deletion is skipped for everyone else.
     def self.expire_cache(subscription:, charge:, charge_filter: nil)
       new(subscription:, charge:, charge_filter:).expire_cache
-      return unless full_usage_cache_enabled?(subscription.organization)
+      return unless subscription.organization.granular_lifetime_usage_enabled?
 
       new(subscription:, charge:, charge_filter:, full_usage: true).expire_cache
     end

--- a/app/services/subscriptions/charge_cache_service.rb
+++ b/app/services/subscriptions/charge_cache_service.rb
@@ -8,10 +8,8 @@ module Subscriptions
     # this version instead of invalidating every organization's cache at once.
     LAZY_CACHE_KEY_VERSION = "2"
 
-    # Full usage aggregates from subscription.started_at instead of the current period start, so its
-    # result gets its own entry. The two windows coincide for a subscription that started with the
-    # current period, but that equality is incidental — started_at is editable — and the key cannot
-    # express it, so the two namespaces stay separate regardless.
+    # Full usage aggregates from subscription.started_at, not the current period start. The two
+    # windows can coincide, but started_at is editable, so they never share an entry.
     FULL_USAGE_KEY_SEGMENT = "full-usage"
 
     def self.expire_for_subscriptions(subscription_ids)
@@ -37,11 +35,9 @@ module Subscriptions
       expire_cache(subscription:, charge:)
     end
 
-    # NOTE: A charge can hold both a current usage and a full usage entry, and both are cleared.
-    #       The per-event caller only ever finds the current usage one, since a full usage entry
-    #       requires the lazy validation that turns that caller off. The explicit ones do find it:
-    #       deleting a billable metric or de-duplicating events removes usage without advancing the
-    #       ingestion watermark, so lazy validation would keep serving whatever was left behind.
+    # NOTE: Both entries are cleared. Deleting a billable metric or de-duplicating events removes
+    #       usage without advancing the ingestion watermark, so lazy validation would keep serving a
+    #       full usage entry left behind here.
     def self.expire_cache(subscription:, charge:, charge_filter: nil)
       new(subscription:, charge:, charge_filter:).expire_cache
       new(subscription:, charge:, charge_filter:, full_usage: true).expire_cache

--- a/app/services/subscriptions/charge_cache_service.rb
+++ b/app/services/subscriptions/charge_cache_service.rb
@@ -9,7 +9,9 @@ module Subscriptions
     LAZY_CACHE_KEY_VERSION = "2"
 
     # Full usage aggregates from subscription.started_at instead of the current period start, so its
-    # result cannot share an entry with the current usage one.
+    # result gets its own entry. The two windows coincide for a subscription that started with the
+    # current period, but that equality is incidental — started_at is editable — and the key cannot
+    # express it, so the two namespaces stay separate regardless.
     FULL_USAGE_KEY_SEGMENT = "full-usage"
 
     def self.expire_for_subscriptions(subscription_ids)
@@ -36,12 +38,12 @@ module Subscriptions
     end
 
     # NOTE: A charge can hold both a current usage and a full usage entry, and an event invalidates
-    #       both. Only organizations granted granular lifetime usage can hold the second one, so the
-    #       extra deletion is skipped for everyone else.
+    #       both. Neither deletion may be conditional on the organization still being granted
+    #       granular lifetime usage: an entry written while it was granted survives every event
+    #       ingested after it was revoked, and would serve that stale usage the moment it is granted
+    #       again, until the end of the billing period.
     def self.expire_cache(subscription:, charge:, charge_filter: nil)
       new(subscription:, charge:, charge_filter:).expire_cache
-      return unless subscription.organization.granular_lifetime_usage_enabled?
-
       new(subscription:, charge:, charge_filter:, full_usage: true).expire_cache
     end
 

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -708,9 +708,7 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
               code: billable_metric.code, timestamp:, created_at: current_date - 1.hour)
           end
 
-          # The two windows are identical here, but that equality is incidental and the key cannot
-          # express it: subscription.started_at is editable, so a shared entry would silently start
-          # answering for a window it was not computed over. Full usage keeps its own entry.
+          # The windows are identical here, but started_at is editable, so the entry is still not shared.
           it "uses the full usage cache entry, not the current usage one" do
             travel_to(current_date) do
               expect { usage_service.call }
@@ -901,9 +899,7 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
         end
       end
 
-      # Full usage is cached only where lazy validation can reject a stale entry. The eager deletion
-      # clears both keys, but it never runs for a ClickHouse organization, and the events-processor
-      # invalidating in its place builds the current usage key alone.
+      # Full usage is cached only where lazy validation can reject a stale entry.
       context "when the full usage is queried outside of the first billing period", :premium do
         subject(:usage_service) do
           described_class.new(
@@ -976,9 +972,8 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
         end
       end
 
-      # skip_grouping and filter_by_presentation change the fees a charge produces but are absent
-      # from the cache key, so an entry holding one shape must never be written where another shape
-      # would read it.
+      # skip_grouping and filter_by_presentation change the fees but are absent from the key, so
+      # neither may leave an entry another shape would read.
       context "when the full usage is queried with filters the cache key cannot describe", :premium do
         subject(:usage_service) do
           described_class.new(

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -695,8 +695,11 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
             create_list(:event, 2, organization:, subscription:, customer:, code: billable_metric.code, timestamp:)
           end
 
-          it "uses the Rails cache" do
-            key = [
+          # The two windows are identical here, but that equality is incidental and the key cannot
+          # express it: subscription.started_at is editable, so a shared entry would silently start
+          # answering for a window it was not computed over. Full usage keeps its own entry.
+          it "uses the full usage cache entry, not the current usage one" do
+            current_usage_key = [
               "charge-usage",
               Subscriptions::ChargeCacheService::CACHE_KEY_VERSION,
               charge.id,
@@ -705,7 +708,10 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
             ].join("/")
 
             travel_to(current_date) do
-              expect { usage_service.call }.to change { Rails.cache.exist?(key) }.from(false).to(true)
+              expect { usage_service.call }
+                .to change { Rails.cache.exist?("#{current_usage_key}/full-usage") }.from(false).to(true)
+
+              expect(Rails.cache.exist?(current_usage_key)).to be(false)
             end
           end
         end
@@ -907,8 +913,7 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
         end
       end
 
-      # Subscriptions::ChargeCacheService skips deleting the full usage entry for organizations
-      # without the integration, so no such entry may ever be written for them.
+      # An organization that cannot query full usage never populates either entry.
       context "when the full usage is queried without the granular lifetime usage integration", :premium do
         subject(:usage_service) do
           described_class.new(
@@ -926,6 +931,31 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
           expect(result.error.code).to eq("full_usage_not_allowed")
           expect(Rails.cache.exist?("#{charge_cache_key}/full-usage")).to be(false)
           expect(Rails.cache.exist?(charge_cache_key)).to be(false)
+        end
+      end
+
+      # skip_grouping and filter_by_presentation change the fees a charge produces but are absent
+      # from the cache key, so an entry holding one shape must never be written where another shape
+      # would read it.
+      context "when the full usage is queried with filters the cache key cannot describe", :premium do
+        subject(:usage_service) do
+          described_class.new(
+            customer:,
+            subscription:,
+            apply_taxes: false,
+            with_cache: true,
+            usage_filters: UsageFilters.new(filter_by_charge_id: charge.id, full_usage: true, skip_grouping: true)
+          )
+        end
+
+        before { organization.update!(premium_integrations: %w[granular_lifetime_usage]) }
+
+        it "skips both the cache and the ingestion timestamps" do
+          expect { usage_service.call }.not_to change { Rails.cache.exist?("#{charge_cache_key}/full-usage") }.from(false)
+
+          expect(Rails.cache.exist?(charge_cache_key)).to be(false)
+          expect(Events::BillingPeriodFilterService).to have_received(:call!)
+            .with(hash_including(with_last_seen_at: false))
         end
       end
     end

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -906,6 +906,28 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
             .with(hash_including(with_last_seen_at: true))
         end
       end
+
+      # Subscriptions::ChargeCacheService skips deleting the full usage entry for organizations
+      # without the integration, so no such entry may ever be written for them.
+      context "when the full usage is queried without the granular lifetime usage integration", :premium do
+        subject(:usage_service) do
+          described_class.new(
+            customer:,
+            subscription:,
+            apply_taxes: false,
+            with_cache: true,
+            usage_filters: UsageFilters.new(filter_by_charge_id: charge.id, full_usage: true)
+          )
+        end
+
+        it "refuses the request and caches nothing" do
+          result = usage_service.call
+
+          expect(result.error.code).to eq("full_usage_not_allowed")
+          expect(Rails.cache.exist?("#{charge_cache_key}/full-usage")).to be(false)
+          expect(Rails.cache.exist?(charge_cache_key)).to be(false)
+        end
+      end
     end
   end
 end

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -732,17 +732,19 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
             create_list(:event, 2, organization:, subscription:, customer:, code: billable_metric.code, timestamp:)
           end
 
-          it "does not use the Rails cache" do
-            key = [
-              "charge-usage",
-              Subscriptions::ChargeCacheService::CACHE_KEY_VERSION,
-              charge.id,
-              subscription.id,
-              charge.updated_at.iso8601
-            ].join("/")
-
+          it "serves the full usage entry on the next call" do
             travel_to(current_date) do
-              expect { usage_service.call }.not_to change { Rails.cache.exist?(key) }
+              expect(usage_service.call.usage.fees.first.units).to eq(2)
+
+              create(:event, organization:, subscription:, customer:, code: billable_metric.code, timestamp:)
+
+              expect(described_class.new(
+                customer:,
+                subscription:,
+                apply_taxes: false,
+                with_cache: true,
+                usage_filters: UsageFilters.new(filter_by_charge_id: charge.id, full_usage: true)
+              ).call.usage.fees.first.units).to eq(2)
             end
           end
         end
@@ -895,10 +897,13 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
 
         before { organization.update!(premium_integrations: %w[granular_lifetime_usage]) }
 
-        it "skips both the cache and the ingestion timestamps" do
-          expect { usage_service.call }.not_to change { Rails.cache.exist?(charge_cache_key) }.from(false)
+        it "caches the charge under the full usage key and requests the ingestion timestamps" do
+          expect { usage_service.call }
+            .to change { Rails.cache.exist?("#{charge_cache_key}/full-usage") }.from(false).to(true)
+
+          expect(Rails.cache.exist?(charge_cache_key)).to be(false)
           expect(Events::BillingPeriodFilterService).to have_received(:call!)
-            .with(hash_including(with_last_seen_at: false))
+            .with(hash_including(with_last_seen_at: true))
         end
       end
     end

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -540,8 +540,18 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
       end
 
       context "when granular_lifetime_usage is enabled", :premium do
+        # Both keys are built through the service so their version follows the lazy validation flag.
+        let(:current_usage_cache_key) do
+          Subscriptions::ChargeCacheService.new(subscription:, charge:).cache_key
+        end
+
+        let(:full_usage_cache_key) do
+          Subscriptions::ChargeCacheService.new(subscription:, charge:, full_usage: true).cache_key
+        end
+
         before do
           organization.update!(premium_integrations: %w[granular_lifetime_usage])
+          organization.enable_feature_flag!(:lazy_charge_usage_cache)
         end
 
         context "when filter_by_charge_id is provided and no prorated charges" do
@@ -691,27 +701,22 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
             create(:subscription, plan:, customer:, started_at: DateTime.parse("2025-06-01"))
           end
 
+          # created_at predates the aggregation: CacheService refuses to store a value whose
+          # watermark is younger than SETTLE_WINDOW.
           before do
-            create_list(:event, 2, organization:, subscription:, customer:, code: billable_metric.code, timestamp:)
+            create_list(:event, 2, organization:, subscription:, customer:,
+              code: billable_metric.code, timestamp:, created_at: current_date - 1.hour)
           end
 
           # The two windows are identical here, but that equality is incidental and the key cannot
           # express it: subscription.started_at is editable, so a shared entry would silently start
           # answering for a window it was not computed over. Full usage keeps its own entry.
           it "uses the full usage cache entry, not the current usage one" do
-            current_usage_key = [
-              "charge-usage",
-              Subscriptions::ChargeCacheService::CACHE_KEY_VERSION,
-              charge.id,
-              subscription.id,
-              charge.updated_at.iso8601
-            ].join("/")
-
             travel_to(current_date) do
               expect { usage_service.call }
-                .to change { Rails.cache.exist?("#{current_usage_key}/full-usage") }.from(false).to(true)
+                .to change { Rails.cache.exist?(full_usage_cache_key) }.from(false).to(true)
 
-              expect(Rails.cache.exist?(current_usage_key)).to be(false)
+              expect(Rails.cache.exist?(current_usage_cache_key)).to be(false)
             end
           end
         end
@@ -735,22 +740,28 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
           end
 
           before do
-            create_list(:event, 2, organization:, subscription:, customer:, code: billable_metric.code, timestamp:)
+            create_list(:event, 2, organization:, subscription:, customer:,
+              code: billable_metric.code, timestamp:, created_at: current_date - 1.hour)
           end
 
-          it "serves the full usage entry on the next call" do
+          it "uses the full usage cache entry, not the current usage one" do
             travel_to(current_date) do
-              expect(usage_service.call.usage.fees.first.units).to eq(2)
+              expect { usage_service.call }
+                .to change { Rails.cache.exist?(full_usage_cache_key) }.from(false).to(true)
 
-              create(:event, organization:, subscription:, customer:, code: billable_metric.code, timestamp:)
+              expect(Rails.cache.exist?(current_usage_cache_key)).to be(false)
+            end
+          end
 
-              expect(described_class.new(
-                customer:,
-                subscription:,
-                apply_taxes: false,
-                with_cache: true,
-                usage_filters: UsageFilters.new(filter_by_charge_id: charge.id, full_usage: true)
-              ).call.usage.fees.first.units).to eq(2)
+          context "when the organization does not lazily validate the cache" do
+            before { organization.disable_feature_flag!(:lazy_charge_usage_cache) }
+
+            it "does not cache the charge at all" do
+              travel_to(current_date) do
+                expect { usage_service.call }.not_to change { Rails.cache.exist?(full_usage_cache_key) }.from(false)
+
+                expect(Rails.cache.exist?(current_usage_cache_key)).to be(false)
+              end
             end
           end
         end
@@ -890,6 +901,9 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
         end
       end
 
+      # Full usage is cached only where lazy validation can reject a stale entry. The eager deletion
+      # clears both keys, but it never runs for a ClickHouse organization, and the events-processor
+      # invalidating in its place builds the current usage key alone.
       context "when the full usage is queried outside of the first billing period", :premium do
         subject(:usage_service) do
           described_class.new(
@@ -901,15 +915,41 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
           )
         end
 
+        let(:full_usage_cache_key) do
+          Subscriptions::ChargeCacheService.new(subscription:, charge:, full_usage: true).cache_key
+        end
+
+        let(:current_usage_cache_key) do
+          Subscriptions::ChargeCacheService.new(subscription:, charge:).cache_key
+        end
+
         before { organization.update!(premium_integrations: %w[granular_lifetime_usage]) }
 
-        it "caches the charge under the full usage key and requests the ingestion timestamps" do
-          expect { usage_service.call }
-            .to change { Rails.cache.exist?("#{charge_cache_key}/full-usage") }.from(false).to(true)
+        it "skips both the cache and the ingestion timestamps" do
+          expect { usage_service.call }.not_to change { Rails.cache.exist?(full_usage_cache_key) }.from(false)
 
-          expect(Rails.cache.exist?(charge_cache_key)).to be(false)
           expect(Events::BillingPeriodFilterService).to have_received(:call!)
-            .with(hash_including(with_last_seen_at: true))
+            .with(hash_including(with_last_seen_at: false))
+        end
+
+        context "when the organization lazily validates the cache" do
+          # created_at predates the aggregation: CacheService refuses to store a value whose
+          # watermark is younger than SETTLE_WINDOW.
+          let(:events) do
+            create_list(:event, 2, organization:, subscription:, customer:,
+              code: billable_metric.code, timestamp:, created_at: 1.hour.ago)
+          end
+
+          before { organization.enable_feature_flag!(:lazy_charge_usage_cache) }
+
+          it "caches the charge under the full usage key and requests the ingestion timestamps" do
+            expect { usage_service.call }
+              .to change { Rails.cache.exist?(full_usage_cache_key) }.from(false).to(true)
+
+            expect(Rails.cache.exist?(current_usage_cache_key)).to be(false)
+            expect(Events::BillingPeriodFilterService).to have_received(:call!)
+              .with(hash_including(with_last_seen_at: true))
+          end
         end
       end
 
@@ -924,6 +964,8 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
             usage_filters: UsageFilters.new(filter_by_charge_id: charge.id, full_usage: true)
           )
         end
+
+        before { organization.enable_feature_flag!(:lazy_charge_usage_cache) }
 
         it "refuses the request and caches nothing" do
           result = usage_service.call
@@ -948,12 +990,24 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
           )
         end
 
-        before { organization.update!(premium_integrations: %w[granular_lifetime_usage]) }
+        let(:full_usage_cache_key) do
+          Subscriptions::ChargeCacheService.new(subscription:, charge:, full_usage: true).cache_key
+        end
+
+        let(:current_usage_cache_key) do
+          Subscriptions::ChargeCacheService.new(subscription:, charge:).cache_key
+        end
+
+        # Lazy validation is on, so the refusal can only come from the filter shape.
+        before do
+          organization.update!(premium_integrations: %w[granular_lifetime_usage])
+          organization.enable_feature_flag!(:lazy_charge_usage_cache)
+        end
 
         it "skips both the cache and the ingestion timestamps" do
-          expect { usage_service.call }.not_to change { Rails.cache.exist?("#{charge_cache_key}/full-usage") }.from(false)
+          expect { usage_service.call }.not_to change { Rails.cache.exist?(full_usage_cache_key) }.from(false)
 
-          expect(Rails.cache.exist?(charge_cache_key)).to be(false)
+          expect(Rails.cache.exist?(current_usage_cache_key)).to be(false)
           expect(Events::BillingPeriodFilterService).to have_received(:call!)
             .with(hash_including(with_last_seen_at: false))
         end

--- a/spec/services/subscriptions/charge_cache_service_spec.rb
+++ b/spec/services/subscriptions/charge_cache_service_spec.rb
@@ -62,20 +62,6 @@ RSpec.describe Subscriptions::ChargeCacheService do
     end
   end
 
-  describe ".full_usage_cache_enabled?" do
-    it "is false without the granular lifetime usage integration" do
-      expect(described_class.full_usage_cache_enabled?(subscription.organization)).to be(false)
-    end
-
-    context "when granular lifetime usage is enabled", :premium do
-      before { subscription.organization.update!(premium_integrations: %w[granular_lifetime_usage]) }
-
-      it "is true" do
-        expect(described_class.full_usage_cache_enabled?(subscription.organization)).to be(true)
-      end
-    end
-  end
-
   describe ".expire_cache" do
     let(:current_usage_key) { described_class.new(subscription:, charge:, charge_filter:).cache_key }
     let(:full_usage_key) { described_class.new(subscription:, charge:, charge_filter:, full_usage: true).cache_key }

--- a/spec/services/subscriptions/charge_cache_service_spec.rb
+++ b/spec/services/subscriptions/charge_cache_service_spec.rb
@@ -66,33 +66,17 @@ RSpec.describe Subscriptions::ChargeCacheService do
     let(:current_usage_key) { described_class.new(subscription:, charge:, charge_filter:).cache_key }
     let(:full_usage_key) { described_class.new(subscription:, charge:, charge_filter:, full_usage: true).cache_key }
 
-    it "deletes the current usage entry" do
+    # The organization here holds no granular lifetime usage integration, so it cannot write a full
+    # usage entry today. Its deletion must happen anyway: an entry written while the integration was
+    # granted would otherwise survive every event ingested after it was revoked, and be served again
+    # the moment it is granted back, until the end of the billing period.
+    it "deletes both the current usage and the full usage entries" do
       allow(Rails.cache).to receive(:delete)
 
       described_class.expire_cache(subscription:, charge:, charge_filter:)
 
       expect(Rails.cache).to have_received(:delete).with(current_usage_key)
-    end
-
-    it "leaves the full usage entry alone when the organization cannot query full usage" do
-      allow(Rails.cache).to receive(:delete)
-
-      described_class.expire_cache(subscription:, charge:, charge_filter:)
-
-      expect(Rails.cache).not_to have_received(:delete).with(full_usage_key)
-    end
-
-    context "when granular lifetime usage is enabled", :premium do
-      before { subscription.organization.update!(premium_integrations: %w[granular_lifetime_usage]) }
-
-      it "deletes both the current usage and the full usage entries" do
-        allow(Rails.cache).to receive(:delete)
-
-        described_class.expire_cache(subscription:, charge:, charge_filter:)
-
-        expect(Rails.cache).to have_received(:delete).with(current_usage_key)
-        expect(Rails.cache).to have_received(:delete).with(full_usage_key)
-      end
+      expect(Rails.cache).to have_received(:delete).with(full_usage_key)
     end
   end
 
@@ -129,8 +113,9 @@ RSpec.describe Subscriptions::ChargeCacheService do
         described_class.expire_for_subscriptions(ids)
       end
 
-      # 4 expected SELECTs: subscriptions, plans, charges, filters. Add a small
-      # safety margin for incidental loads (e.g. activity log context).
+      # 5 expected SELECTs: subscriptions, organizations, plans, charges, filters. The organization
+      # is preloaded because every cache key reads its feature flags. Add a small safety margin for
+      # incidental loads (e.g. activity log context).
       expect(query_count).to be <= 6
     end
   end

--- a/spec/services/subscriptions/charge_cache_service_spec.rb
+++ b/spec/services/subscriptions/charge_cache_service_spec.rb
@@ -32,6 +32,24 @@ RSpec.describe Subscriptions::ChargeCacheService do
           .to eq("charge-usage/#{described_class::LAZY_CACHE_KEY_VERSION}/#{charge.id}/#{subscription.id}/#{charge.updated_at.iso8601}")
       end
     end
+
+    context "with full usage" do
+      subject(:cache_service) { described_class.new(subscription:, charge:, charge_filter:, full_usage: true) }
+
+      it "returns a cache key distinct from the current usage one" do
+        expect(cache_service.cache_key)
+          .to eq("charge-usage/#{described_class::CACHE_KEY_VERSION}/#{charge.id}/#{subscription.id}/#{charge.updated_at.iso8601}/full-usage")
+      end
+
+      context "with a charge filter" do
+        let(:charge_filter) { create(:charge_filter) }
+
+        it "returns the cache key with the charge filter" do
+          expect(cache_service.cache_key)
+            .to eq("charge-usage/#{described_class::CACHE_KEY_VERSION}/#{charge.id}/#{subscription.id}/#{charge.updated_at.iso8601}/#{charge_filter.id}/#{charge_filter.updated_at.iso8601}/full-usage")
+        end
+      end
+    end
   end
 
   describe "#expire_cache" do
@@ -41,6 +59,40 @@ RSpec.describe Subscriptions::ChargeCacheService do
       cache_service.expire_cache
 
       expect(Rails.cache).to have_received(:delete).with(cache_service.cache_key)
+    end
+  end
+
+  describe ".expire_cache" do
+    let(:current_usage_key) { described_class.new(subscription:, charge:, charge_filter:).cache_key }
+    let(:full_usage_key) { described_class.new(subscription:, charge:, charge_filter:, full_usage: true).cache_key }
+
+    it "deletes the current usage entry" do
+      allow(Rails.cache).to receive(:delete)
+
+      described_class.expire_cache(subscription:, charge:, charge_filter:)
+
+      expect(Rails.cache).to have_received(:delete).with(current_usage_key)
+    end
+
+    it "leaves the full usage entry alone when the organization cannot query full usage" do
+      allow(Rails.cache).to receive(:delete)
+
+      described_class.expire_cache(subscription:, charge:, charge_filter:)
+
+      expect(Rails.cache).not_to have_received(:delete).with(full_usage_key)
+    end
+
+    context "when granular lifetime usage is enabled", :premium do
+      before { subscription.organization.update!(premium_integrations: %w[granular_lifetime_usage]) }
+
+      it "deletes both the current usage and the full usage entries" do
+        allow(Rails.cache).to receive(:delete)
+
+        described_class.expire_cache(subscription:, charge:, charge_filter:)
+
+        expect(Rails.cache).to have_received(:delete).with(current_usage_key)
+        expect(Rails.cache).to have_received(:delete).with(full_usage_key)
+      end
     end
   end
 

--- a/spec/services/subscriptions/charge_cache_service_spec.rb
+++ b/spec/services/subscriptions/charge_cache_service_spec.rb
@@ -66,9 +66,8 @@ RSpec.describe Subscriptions::ChargeCacheService do
     let(:current_usage_key) { described_class.new(subscription:, charge:, charge_filter:).cache_key }
     let(:full_usage_key) { described_class.new(subscription:, charge:, charge_filter:, full_usage: true).cache_key }
 
-    # Both entries go unconditionally. Events::DeleteForMetricService and the ClickHouse
-    # de-duplication clear the cache after removing usage, which does not advance the ingestion
-    # watermark, so a full usage entry left behind here would be served for the rest of the period.
+    # Both go unconditionally: removing usage (a deleted metric, de-duplicated events) does not
+    # advance the ingestion watermark, so lazy validation would not clear what was left behind.
     it "deletes both the current usage and the full usage entries" do
       allow(Rails.cache).to receive(:delete)
 
@@ -112,9 +111,8 @@ RSpec.describe Subscriptions::ChargeCacheService do
         described_class.expire_for_subscriptions(ids)
       end
 
-      # 5 expected SELECTs: subscriptions, organizations, plans, charges, filters. The organization
-      # is preloaded because every cache key reads its feature flags. Add a small safety margin for
-      # incidental loads (e.g. activity log context).
+      # 5 expected SELECTs: subscriptions, organizations, plans, charges, filters. Add a small
+      # safety margin for incidental loads (e.g. activity log context).
       expect(query_count).to be <= 6
     end
   end

--- a/spec/services/subscriptions/charge_cache_service_spec.rb
+++ b/spec/services/subscriptions/charge_cache_service_spec.rb
@@ -66,10 +66,9 @@ RSpec.describe Subscriptions::ChargeCacheService do
     let(:current_usage_key) { described_class.new(subscription:, charge:, charge_filter:).cache_key }
     let(:full_usage_key) { described_class.new(subscription:, charge:, charge_filter:, full_usage: true).cache_key }
 
-    # The organization here holds no granular lifetime usage integration, so it cannot write a full
-    # usage entry today. Its deletion must happen anyway: an entry written while the integration was
-    # granted would otherwise survive every event ingested after it was revoked, and be served again
-    # the moment it is granted back, until the end of the billing period.
+    # Both entries go unconditionally. Events::DeleteForMetricService and the ClickHouse
+    # de-duplication clear the cache after removing usage, which does not advance the ingestion
+    # watermark, so a full usage entry left behind here would be served for the rest of the period.
     it "deletes both the current usage and the full usage entries" do
       allow(Rails.cache).to receive(:delete)
 

--- a/spec/services/subscriptions/charge_cache_service_spec.rb
+++ b/spec/services/subscriptions/charge_cache_service_spec.rb
@@ -62,6 +62,20 @@ RSpec.describe Subscriptions::ChargeCacheService do
     end
   end
 
+  describe ".full_usage_cache_enabled?" do
+    it "is false without the granular lifetime usage integration" do
+      expect(described_class.full_usage_cache_enabled?(subscription.organization)).to be(false)
+    end
+
+    context "when granular lifetime usage is enabled", :premium do
+      before { subscription.organization.update!(premium_integrations: %w[granular_lifetime_usage]) }
+
+      it "is true" do
+        expect(described_class.full_usage_cache_enabled?(subscription.organization)).to be(true)
+      end
+    end
+  end
+
   describe ".expire_cache" do
     let(:current_usage_key) { described_class.new(subscription:, charge:, charge_filter:).cache_key }
     let(:full_usage_key) { described_class.new(subscription:, charge:, charge_filter:, full_usage: true).cache_key }


### PR DESCRIPTION
perf(cache): cache full usage under a dedicated key

## Context

Full usage aggregates from subscription.started_at instead of the current period
start, and the charge cache key carried no window, so the cache was disabled
outright whenever the two differed.

## Description

Give the wider window its own key. The current usage key is unchanged, so no
entry goes cold on deploy.

A full usage request always reads and writes that key and never the current
usage one, even for a subscription that started with the current period: the
equality of the two windows is incidental, started_at is editable, and the key
cannot express it.

It is cached only for the shapes the key can describe. skip_grouping and
filter_by_presentation change the fees a charge produces without appearing in
the key, so full usage carrying either stays uncached.

Both entries are invalidated unconditionally. Gating the full usage deletion on
the granular_lifetime_usage integration would leave an entry written while it
was granted alive across every event ingested after it was revoked, ready to
serve stale usage the moment it is granted again.