### PR TITLE
feat(graphql): provider identity on the connection

### DIFF
--- a/app/graphql/types/payment_provider_customers/provider.rb
+++ b/app/graphql/types/payment_provider_customers/provider.rb
@@ -25,7 +25,7 @@ module Types
       end
 
       def payment_provider_code
-        object.payment_provider&.code
+        dataloader.with(Sources::ActiveRecordAssociation, :payment_provider).load(object)&.code
       end
     end
   end

--- a/app/graphql/types/payment_provider_customers/provider.rb
+++ b/app/graphql/types/payment_provider_customers/provider.rb
@@ -9,9 +9,24 @@ module Types
       field :id, ID, null: false
       field :is_default, Boolean, null: false
       field :payment_methods, resolver: Resolvers::PaymentProviderCustomers::PaymentMethodsResolver
+      field :payment_provider, Types::PaymentProviders::ProviderTypeEnum, null: true
+      field :payment_provider_code, String, null: true
       field :provider_customer_id, ID, null: true
       field :provider_payment_methods, [Types::PaymentProviderCustomers::ProviderPaymentMethodsEnum], null: true
       field :sync_with_provider, Boolean, null: true
+
+      # The table also holds provider-less rows (the STI base class, no
+      # association): both fields resolve to nil there instead of assuming
+      # a provider exists.
+      def payment_provider
+        provider_type = object.type.demodulize.underscore.delete_suffix("_customer")
+
+        ::Customer::PAYMENT_PROVIDERS.include?(provider_type) ? provider_type : nil
+      end
+
+      def payment_provider_code
+        object.payment_provider&.code
+      end
     end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -11219,6 +11219,8 @@ type ProviderCustomer {
   Query payment methods of a payment connection
   """
   paymentMethods(limit: Int, page: Int, withDeleted: Boolean): PaymentMethodCollection!
+  paymentProvider: ProviderTypeEnum
+  paymentProviderCode: String
   providerCustomerId: ID
   providerPaymentMethods: [ProviderPaymentMethodsEnum!]
   syncWithProvider: Boolean

--- a/schema.json
+++ b/schema.json
@@ -57639,6 +57639,30 @@
               "deprecationReason": null
             },
             {
+              "name": "paymentProvider",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "ProviderTypeEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paymentProviderCode",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "providerCustomerId",
               "description": null,
               "args": [],

--- a/spec/graphql/types/payment_provider_customers/provider_spec.rb
+++ b/spec/graphql/types/payment_provider_customers/provider_spec.rb
@@ -24,11 +24,10 @@ RSpec.describe Types::PaymentProviderCustomers::Provider do
       let(:payment_provider) { create(:stripe_provider, code: "stripe_eu") }
       let(:connection) { create(:stripe_customer, payment_provider:) }
 
-      it "derives the provider from the row and the code from its association" do
+      it "derives the provider from the row type" do
         type = described_class.authorized_new(connection, context)
 
         expect(type.payment_provider).to eq("stripe")
-        expect(type.payment_provider_code).to eq("stripe_eu")
       end
     end
 
@@ -40,12 +39,61 @@ RSpec.describe Types::PaymentProviderCustomers::Provider do
         )
       end
 
-      it "resolves both fields to nil" do
+      it "resolves the provider to nil" do
         type = described_class.authorized_new(connection, context)
 
         expect(type.payment_provider).to be_nil
-        expect(type.payment_provider_code).to be_nil
       end
+    end
+  end
+
+  describe "payment provider code over several rows" do
+    let(:membership) { create(:membership) }
+    let(:organization) { membership.organization }
+
+    let(:stripe_provider) { create(:stripe_provider, organization:, code: "stripe_eu") }
+    let(:adyen_provider) { create(:adyen_provider, organization:, code: "adyen_us") }
+
+    let(:customer_one) do
+      create(:customer, organization:, payment_provider: "stripe", payment_provider_code: "stripe_eu")
+    end
+    let(:customer_two) do
+      create(:customer, organization:, payment_provider: "adyen", payment_provider_code: "adyen_us")
+    end
+
+    let(:query) do
+      <<~GQL
+        query($idOne: ID!, $idTwo: ID!) {
+          one: customer(id: $idOne) {
+            providerCustomer { paymentProvider paymentProviderCode }
+          }
+          two: customer(id: $idTwo) {
+            providerCustomer { paymentProvider paymentProviderCode }
+          }
+        }
+      GQL
+    end
+
+    before do
+      create(:stripe_customer, customer: customer_one, payment_provider: stripe_provider)
+      create(:adyen_customer, customer: customer_two, payment_provider: adyen_provider)
+    end
+
+    it "resolves each row's own provider within a single execution" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: "customers:view",
+        query:,
+        variables: {idOne: customer_one.id, idTwo: customer_two.id}
+      )
+
+      expect(result["data"]["one"]["providerCustomer"]).to eq(
+        "paymentProvider" => "stripe", "paymentProviderCode" => "stripe_eu"
+      )
+      expect(result["data"]["two"]["providerCustomer"]).to eq(
+        "paymentProvider" => "adyen", "paymentProviderCode" => "adyen_us"
+      )
     end
   end
 end

--- a/spec/graphql/types/payment_provider_customers/provider_spec.rb
+++ b/spec/graphql/types/payment_provider_customers/provider_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::PaymentProviderCustomers::Provider do
+  subject { described_class }
+
+  it do
+    expect(subject).to have_field(:code).of_type("String")
+    expect(subject).to have_field(:id).of_type("ID!")
+    expect(subject).to have_field(:is_default).of_type("Boolean!")
+    expect(subject).to have_field(:payment_methods).of_type("PaymentMethodCollection!")
+    expect(subject).to have_field(:payment_provider).of_type("ProviderTypeEnum")
+    expect(subject).to have_field(:payment_provider_code).of_type("String")
+    expect(subject).to have_field(:provider_customer_id).of_type("ID")
+    expect(subject).to have_field(:provider_payment_methods).of_type("[ProviderPaymentMethodsEnum!]")
+    expect(subject).to have_field(:sync_with_provider).of_type("Boolean")
+  end
+
+  describe "provider identity fields" do
+    let(:context) { GraphQL::Query.new(LagoApiSchema, "{ __typename }").context }
+
+    context "with a provider-backed connection" do
+      let(:payment_provider) { create(:stripe_provider, code: "stripe_eu") }
+      let(:connection) { create(:stripe_customer, payment_provider:) }
+
+      it "derives the provider from the row and the code from its association" do
+        type = described_class.authorized_new(connection, context)
+
+        expect(type.payment_provider).to eq("stripe")
+        expect(type.payment_provider_code).to eq("stripe_eu")
+      end
+    end
+
+    context "with a provider-less row" do
+      let(:connection) do
+        PaymentProviderCustomers::BaseCustomer.new(
+          type: "PaymentProviderCustomers::BaseCustomer",
+          code: PaymentProviderCustomers::BaseCustomer::MANUAL_CODE
+        )
+      end
+
+      it "resolves both fields to nil" do
+        type = described_class.authorized_new(connection, context)
+
+        expect(type.payment_provider).to be_nil
+        expect(type.payment_provider_code).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

The `ProviderCustomer` type does not say which PSP the connection points at: the frontend reads the provider identity from the customer's top-level `paymentProvider` / `paymentProviderCode`, which only works while there is exactly one payment connection per customer. Lifting the max-1 cap (ING-435 / ING-442) breaks that — a single pair of customer-level fields cannot label N rows. Integration connections already carry their identity per row (`integrationType` / `integrationCode`).

## Description

Expose `paymentProvider` (ProviderTypeEnum) and `paymentProviderCode` on `ProviderCustomer`, read from the row:

- the provider enum is derived from the STI type (the demodulize pattern already used by `PaymentProviderCustomers::DestroyService#provider_type`), guarded so the base class resolves to `nil` rather than garbage;
- the code comes from the `payment_provider` association with nil-safety (deleted provider → `nil`, never an error);
- both fields nullable: the table can hold provider-less rows (STI base class), and they flow through this same type.

Purely additive — no migration, no behavior change for existing consumers (no existing operation selects the new fields), schema diff is the two fields only. Note for the array reader in #6081: resolving `paymentProviderCode` per row goes through the association, worth a preload once lists get real.

Fixes ING-602