### PR TITLE
refactor(api): expose v2 subscriptions as contracts

### DIFF
--- a/app/controllers/api/v2/contract_rate_cards/rate_phases_controller.rb
+++ b/app/controllers/api/v2/contract_rate_cards/rate_phases_controller.rb
@@ -2,7 +2,7 @@
 
 module Api
   module V2
-    module SubscriptionRateCards
+    module ContractRateCards
       class RatePhasesController < Api::BaseController
         include Api::RequiresProductCatalog
 
@@ -60,7 +60,7 @@ module Api
 
         def subscription_rate_card
           @subscription_rate_card ||= begin
-            subscriptions = current_organization.subscriptions.where(external_id: params[:subscription_external_id])
+            subscriptions = current_organization.subscriptions.where(external_id: params[:contract_external_id])
             subscription = subscriptions.pending.first || subscriptions.order(created_at: :desc).first
 
             if subscription
@@ -154,7 +154,7 @@ module Api
         end
 
         def resource_name
-          "subscription_rate_card"
+          "contract_rate_card"
         end
       end
     end

--- a/app/controllers/api/v2/contract_rate_cards_controller.rb
+++ b/app/controllers/api/v2/contract_rate_cards_controller.rb
@@ -2,12 +2,17 @@
 
 module Api
   module V2
-    class SubscriptionRateCardsController < Api::BaseController
+    class ContractRateCardsController < Api::BaseController
       include Api::RequiresProductCatalog
 
       def create
+        # The service speaks the internal name; the contract 404 belongs to the
+        # API boundary, so the lookup happens here.
+        subscription = find_subscription
+        return not_found_error(resource: "contract") unless subscription
+
         result = ::SubscriptionRateCards::CreateService.call(
-          subscription: find_subscription,
+          subscription:,
           params: create_params.to_h.deep_symbolize_keys
         )
 
@@ -53,7 +58,7 @@ module Api
 
       def index
         subscription = find_subscription
-        return not_found_error(resource: "subscription") unless subscription
+        return not_found_error(resource: "contract") unless subscription
 
         # Scope by id, not external_id: several subscriptions can share an
         # external_id over time and the list must match the version the nested
@@ -71,7 +76,7 @@ module Api
           render(
             json: ::CollectionSerializer.new(
               result.subscription_rate_cards,
-              ::V1::SubscriptionRateCardSerializer,
+              ::V2::ContractAppliedRateCardSerializer,
               collection_name: "applied_rate_cards",
               meta: pagination_metadata(result.subscription_rate_cards)
             )
@@ -101,7 +106,7 @@ module Api
       # A pending subscription can share its external_id with a past one;
       # prefer the pending one (the only editable state), then the latest.
       def find_subscription
-        subscriptions = current_organization.subscriptions.where(external_id: params[:subscription_external_id])
+        subscriptions = current_organization.subscriptions.where(external_id: params[:contract_external_id])
         subscriptions.pending.first || subscriptions.order(created_at: :desc).first
       end
 
@@ -139,11 +144,11 @@ module Api
       end
 
       def render_subscription_rate_card(subscription_rate_card)
-        render(json: ::V1::SubscriptionRateCardSerializer.new(subscription_rate_card, root_name: "applied_rate_card"))
+        render(json: ::V2::ContractAppliedRateCardSerializer.new(subscription_rate_card, root_name: "applied_rate_card"))
       end
 
       def resource_name
-        "subscription_rate_card"
+        "contract_rate_card"
       end
     end
   end

--- a/app/controllers/api/v2/contracts_controller.rb
+++ b/app/controllers/api/v2/contracts_controller.rb
@@ -2,7 +2,7 @@
 
 module Api
   module V2
-    class SubscriptionsController < Api::BaseController
+    class ContractsController < Api::BaseController
       include Api::RequiresProductCatalog
 
       def index
@@ -30,8 +30,8 @@ module Api
           render(
             json: ::CollectionSerializer.new(
               subscriptions,
-              ::V2::SubscriptionSerializer,
-              collection_name: "subscriptions",
+              ::V2::ContractSerializer,
+              collection_name: "contracts",
               meta: pagination_metadata(subscriptions),
               applied_rate_cards_counts:
             )
@@ -48,12 +48,12 @@ module Api
             external_id: params[:external_id],
             status: params[:status] || :active
           )
-        return not_found_error(resource: "subscription") unless subscription
+        return not_found_error(resource: "contract") unless subscription
 
         render(
-          json: ::V2::SubscriptionSerializer.new(
+          json: ::V2::ContractSerializer.new(
             subscription,
-            root_name: "subscription",
+            root_name: "contract",
             includes: %i[applied_rate_cards]
           )
         )
@@ -62,7 +62,7 @@ module Api
       private
 
       def resource_name
-        "subscription"
+        "contract"
       end
     end
   end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -8,7 +8,7 @@ class ApiKey < ApplicationRecord
     customer event fee invoice organization order order_form payment payment_receipt payment_request payment_method plan subscription lifetime_usage
     tax wallet wallet_transaction webhook_endpoint webhook_jwt_public_key invoice_custom_section
     billing_entity alert feature security_log quote product_category product rate_card plan_rate_card
-    subscription_rate_card
+    contract contract_rate_card
   ].freeze
 
   MODES = %w[read write].freeze

--- a/app/models/metadata/item_metadata.rb
+++ b/app/models/metadata/item_metadata.rb
@@ -45,13 +45,13 @@ end
 # Table name: item_metadata
 # Database name: primary
 #
-#  id                                             :uuid             not null, primary key
-#  owner_type(Polymorphic owner type)             :string           not null
-#  value(item_metadata key-value pairs)           :jsonb            not null
-#  created_at                                     :datetime         not null
-#  updated_at                                     :datetime         not null
-#  organization_id(Reference to the organization) :uuid             not null
-#  owner_id(Polymorphic owner id)                 :uuid             not null
+#  id              :uuid             not null, primary key
+#  owner_type      :string           not null
+#  value           :jsonb            not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#  owner_id        :uuid             not null
 #
 # Indexes
 #

--- a/app/serializers/v2/contract_applied_rate_card_serializer.rb
+++ b/app/serializers/v2/contract_applied_rate_card_serializer.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-module V1
-  class SubscriptionRateCardSerializer < ModelSerializer
+module V2
+  class ContractAppliedRateCardSerializer < ModelSerializer
     def serialize
       {
         lago_id: model.id,
-        external_subscription_id: model.subscription.external_id,
+        external_contract_id: model.subscription.external_id,
         rate_card_code: model.rate_card.code,
         units: model.units,
         started_at: model.started_at.iso8601,

--- a/app/serializers/v2/contract_serializer.rb
+++ b/app/serializers/v2/contract_serializer.rb
@@ -4,7 +4,7 @@ module V2
   # The v2 shape drops the plan-interval fields (amounts, billing periods,
   # trial): a product-catalog subscription prices through its rate card
   # entries, each carrying its own billing cycle.
-  class SubscriptionSerializer < ModelSerializer
+  class ContractSerializer < ModelSerializer
     def serialize
       payload = {
         lago_id: model.id,
@@ -46,7 +46,7 @@ module V2
     def applied_rate_cards
       ::CollectionSerializer.new(
         model.applied_rate_cards.current_and_scheduled.includes(:rate_phases, :rate_card, :subscription),
-        ::V1::SubscriptionRateCardSerializer,
+        ::V2::ContractAppliedRateCardSerializer,
         collection_name: "applied_rate_cards"
       ).serialize[:applied_rate_cards]
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,14 +50,14 @@ Rails.application.routes.draw do
       end
       # The constraint mirrors v1: without it, an external id containing a
       # dot is truncated at the format separator.
-      resources :subscriptions, param: :external_id, constraints: {external_id: /[^\/]+/}, only: [] do
-        resources :applied_rate_cards, param: :code, code: /.*/, only: %i[index create show update destroy], controller: "subscription_rate_cards" do
-          scope module: :subscription_rate_cards do
+      resources :contracts, param: :external_id, constraints: {external_id: /[^\/]+/}, only: [] do
+        resources :applied_rate_cards, param: :code, code: /.*/, only: %i[index create show update destroy], controller: "contract_rate_cards" do
+          scope module: :contract_rate_cards do
             resources :rate_phases, param: :code, code: /.*/, only: %i[index create update destroy]
           end
         end
       end
-      resources :subscriptions, only: %i[index show], param: :external_id, constraints: {external_id: /[^\/]+/}
+      resources :contracts, only: %i[index show], param: :external_id, constraints: {external_id: /[^\/]+/}
     end
 
     namespace :v2, module: :v1 do

--- a/spec/requests/api/v2/contract_rate_cards/rate_phases_controller_spec.rb
+++ b/spec/requests/api/v2/contract_rate_cards/rate_phases_controller_spec.rb
@@ -2,19 +2,19 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V2::SubscriptionRateCards::RatePhasesController do
+RSpec.describe Api::V2::ContractRateCards::RatePhasesController do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, :pending, customer:, organization:) }
   let(:rate_card) { create(:rate_card, organization:) }
   let(:subscription_rate_card) { create(:subscription_rate_card, organization:, subscription:, rate_card:) }
 
-  describe "GET /api/v2/subscriptions/:external_id/applied_rate_cards/:rate_card_code/rate_phases" do
-    subject { get_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases") }
+  describe "GET /api/v2/contracts/:external_id/applied_rate_cards/:rate_card_code/rate_phases" do
+    subject { get_with_token(organization, "/api/v2/contracts/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases") }
 
     let!(:rate_phase) { create(:rate_phase, :subscription_level, organization:, subscription_rate_card:, position: 1) }
 
-    include_examples "requires API permission", "subscription_rate_card", "read"
+    include_examples "requires API permission", "contract_rate_card", "read"
 
     it "returns the entry's rate phases with their codes" do
       subject
@@ -25,7 +25,7 @@ RSpec.describe Api::V2::SubscriptionRateCards::RatePhasesController do
     end
 
     context "when the entry does not exist" do
-      subject { get_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/unknown/rate_phases") }
+      subject { get_with_token(organization, "/api/v2/contracts/#{subscription.external_id}/applied_rate_cards/unknown/rate_phases") }
 
       it "returns a not found error" do
         subject
@@ -35,11 +35,11 @@ RSpec.describe Api::V2::SubscriptionRateCards::RatePhasesController do
     end
   end
 
-  describe "POST /api/v2/subscriptions/:external_id/applied_rate_cards/:rate_card_code/rate_phases" do
+  describe "POST /api/v2/contracts/:external_id/applied_rate_cards/:rate_card_code/rate_phases" do
     subject do
       post_with_token(
         organization,
-        "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases",
+        "/api/v2/contracts/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases",
         {rate_phase: phase_params}
       )
     end
@@ -53,7 +53,7 @@ RSpec.describe Api::V2::SubscriptionRateCards::RatePhasesController do
       }
     end
 
-    include_examples "requires API permission", "subscription_rate_card", "write"
+    include_examples "requires API permission", "contract_rate_card", "write"
 
     it "inserts the phase with its override before the indefinite tail" do
       subject
@@ -86,13 +86,13 @@ RSpec.describe Api::V2::SubscriptionRateCards::RatePhasesController do
     let!(:terminal) { create(:rate_phase, :subscription_level, organization:, subscription_rate_card:, position: 1, billing_interval_cycle_count: nil) }
 
     it "keeps the phases addressable during the authoring window" do
-      get_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{rate_card.code}/rate_phases")
+      get_with_token(organization, "/api/v2/contracts/#{subscription.external_id}/applied_rate_cards/#{rate_card.code}/rate_phases")
       expect(response).to have_http_status(:success)
       expect(json[:rate_phases].map { |phase| phase[:lago_id] }).to eq([terminal.id])
 
       post_with_token(
         organization,
-        "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{rate_card.code}/rate_phases",
+        "/api/v2/contracts/#{subscription.external_id}/applied_rate_cards/#{rate_card.code}/rate_phases",
         {rate_phase: {code: "intro", billing_interval_cycle_count: 3}}
       )
       expect(response).to have_http_status(:success)
@@ -100,18 +100,18 @@ RSpec.describe Api::V2::SubscriptionRateCards::RatePhasesController do
     end
   end
 
-  describe "PUT /api/v2/subscriptions/:external_id/applied_rate_cards/:rate_card_code/rate_phases/:code" do
+  describe "PUT /api/v2/contracts/:external_id/applied_rate_cards/:rate_card_code/rate_phases/:code" do
     subject do
       put_with_token(
         organization,
-        "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases/#{rate_phase.code}",
+        "/api/v2/contracts/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases/#{rate_phase.code}",
         {rate_phase: {name: "Renamed"}}
       )
     end
 
     let!(:rate_phase) { create(:rate_phase, :subscription_level, organization:, subscription_rate_card:, position: 1, code: "negotiated") }
 
-    include_examples "requires API permission", "subscription_rate_card", "write"
+    include_examples "requires API permission", "contract_rate_card", "write"
 
     it "updates the phase" do
       subject
@@ -124,7 +124,7 @@ RSpec.describe Api::V2::SubscriptionRateCards::RatePhasesController do
       subject do
         put_with_token(
           organization,
-          "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases/#{rate_phase.code}",
+          "/api/v2/contracts/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases/#{rate_phase.code}",
           {rate_phase: {name: "Renamed", position: 4}}
         )
       end
@@ -141,7 +141,7 @@ RSpec.describe Api::V2::SubscriptionRateCards::RatePhasesController do
       subject do
         put_with_token(
           organization,
-          "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases/#{rate_phase.code}",
+          "/api/v2/contracts/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases/#{rate_phase.code}",
           {rate_phase: {rate_override: nil}}
         )
       end
@@ -164,7 +164,7 @@ RSpec.describe Api::V2::SubscriptionRateCards::RatePhasesController do
       subject do
         put_with_token(
           organization,
-          "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases/#{rate_phase.code}",
+          "/api/v2/contracts/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases/#{rate_phase.code}",
           {rate_phase: {rate_override: {rate_model: "standard", rate_properties: {amount: "0.02"}, currency: "EUR"}}}
         )
       end
@@ -190,18 +190,18 @@ RSpec.describe Api::V2::SubscriptionRateCards::RatePhasesController do
     end
   end
 
-  describe "DELETE /api/v2/subscriptions/:external_id/applied_rate_cards/:rate_card_code/rate_phases/:code" do
+  describe "DELETE /api/v2/contracts/:external_id/applied_rate_cards/:rate_card_code/rate_phases/:code" do
     subject do
       delete_with_token(
         organization,
-        "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases/#{terminal.code}"
+        "/api/v2/contracts/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases/#{terminal.code}"
       )
     end
 
     let!(:launch) { create(:rate_phase, :subscription_level, organization:, subscription_rate_card:, position: 1, billing_interval_cycle_count: 3) }
     let!(:terminal) { create(:rate_phase, :subscription_level, organization:, subscription_rate_card:, position: 2, billing_interval_cycle_count: nil) }
 
-    include_examples "requires API permission", "subscription_rate_card", "write"
+    include_examples "requires API permission", "contract_rate_card", "write"
 
     it "deletes the phase and promotes the new last phase to indefinite" do
       subject

--- a/spec/requests/api/v2/contract_rate_cards_controller_spec.rb
+++ b/spec/requests/api/v2/contract_rate_cards_controller_spec.rb
@@ -2,30 +2,30 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V2::SubscriptionRateCardsController do
+RSpec.describe Api::V2::ContractRateCardsController do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, :pending, customer:, organization:) }
   let(:rate_card) { create(:rate_card, organization:) }
 
-  describe "POST /api/v2/subscriptions/:external_id/applied_rate_cards" do
-    subject { post_with_token(organization, "/api/v2/subscriptions/#{external_id}/applied_rate_cards", {applied_rate_card: create_params}) }
+  describe "POST /api/v2/contracts/:external_id/applied_rate_cards" do
+    subject { post_with_token(organization, "/api/v2/contracts/#{external_id}/applied_rate_cards", {applied_rate_card: create_params}) }
 
     let(:external_id) { subscription.external_id }
     let(:create_params) do
       {rate_card_code: rate_card.code, units: "10"}
     end
 
-    include_examples "requires API permission", "subscription_rate_card", "write"
+    include_examples "requires API permission", "contract_rate_card", "write"
 
     it "attaches the rate card to the subscription with a default rate phase" do
       subject
 
       expect(response).to have_http_status(:success)
       expect(json[:applied_rate_card][:lago_id]).to be_present
-      expect(json[:applied_rate_card][:external_subscription_id]).to eq(subscription.external_id)
+      expect(json[:applied_rate_card][:external_contract_id]).to eq(subscription.external_id)
       expect(json[:applied_rate_card][:rate_card_code]).to eq(rate_card.code)
-      expect(json[:applied_rate_card][:external_subscription_id]).to eq(subscription.external_id)
+      expect(json[:applied_rate_card][:external_contract_id]).to eq(subscription.external_id)
       expect(json[:applied_rate_card][:rate_card_code]).to eq(rate_card.code)
       expect(json[:applied_rate_card][:rate_phases_count]).to eq(1)
     end
@@ -57,7 +57,7 @@ RSpec.describe Api::V2::SubscriptionRateCardsController do
       it "returns a not found error" do
         subject
 
-        expect(response).to be_not_found_error("subscription")
+        expect(response).to be_not_found_error("contract")
       end
     end
 
@@ -89,32 +89,32 @@ RSpec.describe Api::V2::SubscriptionRateCardsController do
     end
 
     it "stays addressable during the authoring window" do
-      get_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{rate_card.code}")
+      get_with_token(organization, "/api/v2/contracts/#{subscription.external_id}/applied_rate_cards/#{rate_card.code}")
       expect(response).to have_http_status(:success)
 
       put_with_token(
         organization,
-        "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{rate_card.code}",
+        "/api/v2/contracts/#{subscription.external_id}/applied_rate_cards/#{rate_card.code}",
         {applied_rate_card: {units: "3"}}
       )
       expect(response).to have_http_status(:success)
       expect(subscription_rate_card.reload.units).to eq(3)
 
-      delete_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{rate_card.code}")
+      delete_with_token(organization, "/api/v2/contracts/#{subscription.external_id}/applied_rate_cards/#{rate_card.code}")
       expect(response).to have_http_status(:success)
       expect(subscription_rate_card.reload).to be_discarded
     end
   end
 
-  describe "GET /api/v2/subscriptions/:external_id/applied_rate_cards" do
-    subject { get_with_token(organization, "/api/v2/subscriptions/#{external_id}/applied_rate_cards") }
+  describe "GET /api/v2/contracts/:external_id/applied_rate_cards" do
+    subject { get_with_token(organization, "/api/v2/contracts/#{external_id}/applied_rate_cards") }
 
     let(:external_id) { subscription.external_id }
     let!(:subscription_rate_card) { create(:subscription_rate_card, organization:, subscription:) }
 
     before { create(:subscription_rate_card, organization:) }
 
-    include_examples "requires API permission", "subscription_rate_card", "read"
+    include_examples "requires API permission", "contract_rate_card", "read"
 
     it "returns the subscription's entries only" do
       subject
@@ -142,17 +142,17 @@ RSpec.describe Api::V2::SubscriptionRateCardsController do
       it "returns a not found error" do
         subject
 
-        expect(response).to be_not_found_error("subscription")
+        expect(response).to be_not_found_error("contract")
       end
     end
   end
 
-  describe "GET /api/v2/subscriptions/:external_id/applied_rate_cards/:code" do
-    subject { get_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}") }
+  describe "GET /api/v2/contracts/:external_id/applied_rate_cards/:code" do
+    subject { get_with_token(organization, "/api/v2/contracts/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}") }
 
     let(:subscription_rate_card) { create(:subscription_rate_card, organization:, subscription:) }
 
-    include_examples "requires API permission", "subscription_rate_card", "read"
+    include_examples "requires API permission", "contract_rate_card", "read"
 
     it "returns the subscription product" do
       subject
@@ -162,7 +162,7 @@ RSpec.describe Api::V2::SubscriptionRateCardsController do
     end
 
     context "when it does not exist" do
-      subject { get_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/unknown") }
+      subject { get_with_token(organization, "/api/v2/contracts/#{subscription.external_id}/applied_rate_cards/unknown") }
 
       it "returns a not found error" do
         subject
@@ -172,12 +172,12 @@ RSpec.describe Api::V2::SubscriptionRateCardsController do
     end
   end
 
-  describe "PUT /api/v2/subscriptions/:external_id/applied_rate_cards/:code" do
-    subject { put_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}", {applied_rate_card: {units: "12"}}) }
+  describe "PUT /api/v2/contracts/:external_id/applied_rate_cards/:code" do
+    subject { put_with_token(organization, "/api/v2/contracts/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}", {applied_rate_card: {units: "12"}}) }
 
     let(:subscription_rate_card) { create(:subscription_rate_card, organization:, subscription:, units: 5) }
 
-    include_examples "requires API permission", "subscription_rate_card", "write"
+    include_examples "requires API permission", "contract_rate_card", "write"
 
     it "updates the entry" do
       subject
@@ -197,7 +197,7 @@ RSpec.describe Api::V2::SubscriptionRateCardsController do
     end
 
     context "when it does not exist" do
-      subject { put_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/unknown", {applied_rate_card: {units: "12"}}) }
+      subject { put_with_token(organization, "/api/v2/contracts/#{subscription.external_id}/applied_rate_cards/unknown", {applied_rate_card: {units: "12"}}) }
 
       it "returns a not found error" do
         subject
@@ -207,12 +207,12 @@ RSpec.describe Api::V2::SubscriptionRateCardsController do
     end
   end
 
-  describe "DELETE /api/v2/subscriptions/:external_id/applied_rate_cards/:code" do
-    subject { delete_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}") }
+  describe "DELETE /api/v2/contracts/:external_id/applied_rate_cards/:code" do
+    subject { delete_with_token(organization, "/api/v2/contracts/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}") }
 
     let(:subscription_rate_card) { create(:subscription_rate_card, organization:, subscription:) }
 
-    include_examples "requires API permission", "subscription_rate_card", "write"
+    include_examples "requires API permission", "contract_rate_card", "write"
 
     it "soft deletes the entry" do
       subject

--- a/spec/requests/api/v2/contracts_controller_spec.rb
+++ b/spec/requests/api/v2/contracts_controller_spec.rb
@@ -2,14 +2,14 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V2::SubscriptionsController do
+RSpec.describe Api::V2::ContractsController do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:, pricing_type: "product_catalog") }
   let(:subscription) { create(:subscription, customer:, plan:, organization:) }
 
-  describe "GET /api/v2/subscriptions" do
-    subject { get_with_token(organization, "/api/v2/subscriptions") }
+  describe "GET /api/v2/contracts" do
+    subject { get_with_token(organization, "/api/v2/contracts") }
 
     before do
       create(:subscription_rate_card, organization:, subscription:)
@@ -17,14 +17,14 @@ RSpec.describe Api::V2::SubscriptionsController do
       create(:subscription_rate_card, organization:, subscription:, started_at: 10.days.ago, ended_at: 1.day.ago)
     end
 
-    include_examples "requires API permission", "subscription", "read"
+    include_examples "requires API permission", "contract", "read"
 
     it "returns subscriptions in the v2 shape" do
       subject
 
       expect(response).to have_http_status(:success)
 
-      result = json[:subscriptions].sole
+      result = json[:contracts].sole
       expect(result[:lago_id]).to eq(subscription.id)
       expect(result[:plan_code]).to eq(plan.code)
       expect(result[:applied_rate_cards_count]).to eq(1)
@@ -38,30 +38,30 @@ RSpec.describe Api::V2::SubscriptionsController do
       it "lists only active subscriptions by default" do
         subject
 
-        expect(json[:subscriptions].map { |s| s[:lago_id] }).to eq([subscription.id])
+        expect(json[:contracts].map { |s| s[:lago_id] }).to eq([subscription.id])
       end
 
       it "lists pending subscriptions when the status filter asks for them" do
-        get_with_token(organization, "/api/v2/subscriptions?status[]=pending")
+        get_with_token(organization, "/api/v2/contracts?status[]=pending")
 
-        expect(json[:subscriptions].map { |s| s[:lago_id] }).to eq([pending_subscription.id])
+        expect(json[:contracts].map { |s| s[:lago_id] }).to eq([pending_subscription.id])
       end
     end
   end
 
-  describe "GET /api/v2/subscriptions/:external_id" do
-    subject { get_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}") }
+  describe "GET /api/v2/contracts/:external_id" do
+    subject { get_with_token(organization, "/api/v2/contracts/#{subscription.external_id}") }
 
     let!(:subscription_rate_card) { create(:subscription_rate_card, organization:, subscription:) }
 
-    include_examples "requires API permission", "subscription", "read"
+    include_examples "requires API permission", "contract", "read"
 
     it "returns the subscription with its rate card entries" do
       subject
 
       expect(response).to have_http_status(:success)
-      expect(json[:subscription][:lago_id]).to eq(subscription.id)
-      expect(json[:subscription][:applied_rate_cards].sole[:lago_id]).to eq(subscription_rate_card.id)
+      expect(json[:contract][:lago_id]).to eq(subscription.id)
+      expect(json[:contract][:applied_rate_cards].sole[:lago_id]).to eq(subscription_rate_card.id)
     end
 
     context "with an ended version of an entry" do
@@ -72,8 +72,8 @@ RSpec.describe Api::V2::SubscriptionsController do
       it "excludes it from the count and the list" do
         subject
 
-        expect(json[:subscription][:applied_rate_cards_count]).to eq(1)
-        expect(json[:subscription][:applied_rate_cards].sole[:lago_id]).to eq(subscription_rate_card.id)
+        expect(json[:contract][:applied_rate_cards_count]).to eq(1)
+        expect(json[:contract][:applied_rate_cards].sole[:lago_id]).to eq(subscription_rate_card.id)
       end
     end
 
@@ -84,17 +84,17 @@ RSpec.describe Api::V2::SubscriptionsController do
         subject
 
         expect(response).to have_http_status(:success)
-        expect(json[:subscription][:external_id]).to eq("sub.2026-01")
+        expect(json[:contract][:external_id]).to eq("sub.2026-01")
       end
     end
 
     context "when it does not exist" do
-      subject { get_with_token(organization, "/api/v2/subscriptions/unknown") }
+      subject { get_with_token(organization, "/api/v2/contracts/unknown") }
 
       it "returns a not found error" do
         subject
 
-        expect(response).to be_not_found_error("subscription")
+        expect(response).to be_not_found_error("contract")
       end
     end
   end


### PR DESCRIPTION
## Context

The v2 runtime object has outgrown the name *subscription*: billing anchor, its own applied rate cards with overrides and phases, and upcoming invoice schedules, commitments, contract-scoped wallets — plus the plan-less shape where nothing is subscribed to. **Contract** names both shapes honestly and matches the sales-led segment's vocabulary. Pre-GA is the only cheap window.

## Description

**The boundary rule (D1)**: database, models, jobs and internal services keep `subscription`; everything a v2 customer sees says `contract` — same discipline as `amount_currency` exposed as `currency`.

- Routes: `/api/v2/contracts` (index, show) and `/api/v2/contracts/:external_id/applied_rate_cards` + nested `rate_phases`. Hard cut, no aliases (pre-GA).
- Controllers: `Api::V2::ContractsController`, `Api::V2::ContractRateCardsController` (+ nested rate phases). 404s say `contract_not_found`; the boundary owns the lookup so internal services keep their vocabulary.
- Serializers: `V2::ContractSerializer`, `V2::ContractAppliedRateCardSerializer` (`external_contract_id`). Response roots `contract(s)`.
- API key permission resources: `subscription_rate_card` → `contract_rate_card` (v2-only, safe pre-merge), new `contract` resource for the contracts endpoints. Legacy `subscription` permission untouched for v1.
- Unchanged: `subscriptions`/`subscription_rate_cards` tables, `Subscription`/`SubscriptionRateCard` models, `Subscriptions::*` / `SubscriptionRateCards::*` services, all of v1.

## Follow-ups (per the dive-in)

- Engine-side endpoints (`cycles`, `bill`, `terminate`) live on `miguel-engine-v2` and pick the rename up when that branch rebases over this one — cycle payload keys (`contract_external_id`, `contract_started_at`) included
- PR 2: GraphQL `Contract` type + queries/mutations (catalog-gated)
- PR 3: events ingestion alias — accept `external_contract_id` alongside `external_subscription_id` (never break the hot path)
- Error-code grammar beyond 404s (`subscription_locked` → `contract_locked`) — touches services shared with the phase PRs, deferred until the train lands
- Open: `subscription_at` field name on the contract payload (see dive-in §7)