### PR TITLE
fix(stripe-customer-balance): implement auto payment retry for canceled intent with customer balance

### DIFF
--- a/app/models/payment_providers/stripe_provider.rb
+++ b/app/models/payment_providers/stripe_provider.rb
@@ -19,6 +19,7 @@ module PaymentProviders
       charge.refund.updated
       customer.updated
       charge.dispute.closed
+      customer_cash_balance_transaction.created
     ].freeze
 
     PROCESSING_STATUSES = %w[

--- a/app/services/payment_providers/stripe/handle_event_service.rb
+++ b/app/services/payment_providers/stripe/handle_event_service.rb
@@ -9,7 +9,9 @@ module PaymentProviders
         "payment_intent.payment_failed" => PaymentProviders::Stripe::Webhooks::PaymentIntentPaymentFailedService,
         "customer.updated" => PaymentProviders::Stripe::Webhooks::CustomerUpdatedService,
         "charge.dispute.closed" => PaymentProviders::Stripe::Webhooks::ChargeDisputeClosedService,
-        "payment_intent.canceled" => PaymentProviders::Stripe::Webhooks::PaymentIntentPaymentFailedService
+        "payment_intent.canceled" => PaymentProviders::Stripe::Webhooks::PaymentIntentPaymentFailedService,
+        "customer_cash_balance_transaction.created" =>
+          PaymentProviders::Stripe::Webhooks::CustomerCashBalanceTransactionCreatedService
       }.freeze
 
       def initialize(organization:, event_json:)

--- a/app/services/payment_providers/stripe/webhooks/customer_cash_balance_transaction_created_service.rb
+++ b/app/services/payment_providers/stripe/webhooks/customer_cash_balance_transaction_created_service.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Stripe
+    module Webhooks
+      class CustomerCashBalanceTransactionCreatedService < BaseService
+        Result = BaseResult[:invoice]
+
+        FUNDED_TYPE = "funded"
+
+        def call
+          return result unless funded?
+          return result unless stripe_customer
+          return result unless customer_balance_only?
+          return result unless unallocated_funds?
+
+          invoice = oldest_collectible_invoice
+          return result unless invoice
+          return result unless last_payment_failed?(invoice)
+
+          Invoices::Payments::CreateJob.perform_later(invoice:, payment_provider: :stripe)
+
+          result.invoice = invoice
+          result
+        end
+
+        private
+
+        def transaction
+          event.data.object
+        end
+
+        def funded?
+          transaction[:type] == FUNDED_TYPE
+        end
+
+        def stripe_customer
+          return @stripe_customer if defined?(@stripe_customer)
+
+          @stripe_customer = PaymentProviderCustomers::StripeCustomer
+            .by_provider_id_from_organization(organization.id, transaction[:customer])
+            .first
+        end
+
+        def customer_balance_only?
+          stripe_customer.provider_payment_methods == ["customer_balance"]
+        end
+
+        def unallocated_funds?
+          transaction[:ending_balance].to_i.positive?
+        end
+
+        def last_payment_failed?(invoice)
+          last_payment = invoice
+            .payments
+            .where(payment_type: :provider)
+            .order(:created_at, :id)
+            .last
+
+          last_payment&.payable_payment_status == "failed"
+        end
+
+        def oldest_collectible_invoice
+          stripe_customer
+            .customer
+            .invoices
+            .finalized
+            .non_self_billed
+            .where(payment_status: %w[pending failed], currency: currency)
+            .order(:issuing_date, :created_at)
+            .first
+        end
+
+        def currency
+          transaction[:currency].to_s.upcase
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/stripe/2020-08-27/webhooks/customer_cash_balance_transaction_created.json
+++ b/spec/fixtures/stripe/2020-08-27/webhooks/customer_cash_balance_transaction_created.json
@@ -1,0 +1,37 @@
+{
+  "id": "evt_1RWGXCQ8iJWBZFaMVlV0UVdh",
+  "object": "event",
+  "api_version": "2020-08-27",
+  "created": 1749040510,
+  "data": {
+    "object": {
+      "id": "ccsbtxn_1RWGXCQ8iJWBZFaMkO5jYqHt",
+      "object": "customer_cash_balance_transaction",
+      "created": 1749040510,
+      "currency": "eur",
+      "customer": "cus_SR8o2vcGRkVb6v",
+      "ending_balance": 10000,
+      "funded": {
+        "bank_transfer": {
+          "eu_bank_transfer": {
+            "bic": "DABAIE2D",
+            "iban_last4": "3000",
+            "sender_name": "Acme Corp"
+          },
+          "reference": "INV-0001",
+          "type": "eu_bank_transfer"
+        }
+      },
+      "livemode": false,
+      "net_amount": 10000,
+      "type": "funded"
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 1,
+  "request": {
+    "id": null,
+    "idempotency_key": null
+  },
+  "type": "customer_cash_balance_transaction.created"
+}

--- a/spec/fixtures/stripe/2025-04-30.basil/webhooks/customer_cash_balance_transaction_created.json
+++ b/spec/fixtures/stripe/2025-04-30.basil/webhooks/customer_cash_balance_transaction_created.json
@@ -1,0 +1,37 @@
+{
+  "id": "evt_1RWGXCQ8iJWBZFaMVlV0UVdh",
+  "object": "event",
+  "api_version": "2025-04-30.basil",
+  "created": 1749040510,
+  "data": {
+    "object": {
+      "id": "ccsbtxn_1RWGXCQ8iJWBZFaMkO5jYqHt",
+      "object": "customer_cash_balance_transaction",
+      "created": 1749040510,
+      "currency": "eur",
+      "customer": "cus_SR8o2vcGRkVb6v",
+      "ending_balance": 10000,
+      "funded": {
+        "bank_transfer": {
+          "eu_bank_transfer": {
+            "bic": "DABAIE2D",
+            "iban_last4": "3000",
+            "sender_name": "Acme Corp"
+          },
+          "reference": "INV-0001",
+          "type": "eu_bank_transfer"
+        }
+      },
+      "livemode": false,
+      "net_amount": 10000,
+      "type": "funded"
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 1,
+  "request": {
+    "id": null,
+    "idempotency_key": null
+  },
+  "type": "customer_cash_balance_transaction.created"
+}

--- a/spec/services/payment_providers/stripe/webhooks/customer_cash_balance_transaction_created_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/customer_cash_balance_transaction_created_service_spec.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerCashBalanceTransactionCreatedService do
+  subject(:webhook_service) { described_class.new(organization_id: organization.id, event:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:, currency: "EUR") }
+  let(:stripe_provider) { create(:stripe_provider, organization:) }
+
+  let(:provider_payment_methods) { ["customer_balance"] }
+  let(:stripe_customer) do
+    create(
+      :stripe_customer,
+      payment_provider: stripe_provider,
+      customer:,
+      provider_customer_id: "cus_SR8o2vcGRkVb6v",
+      provider_payment_methods:
+    )
+  end
+
+  let(:event) { Stripe::Event.construct_from(JSON.parse(event_json)) }
+  let(:event_json) { get_stripe_fixtures("webhooks/customer_cash_balance_transaction_created.json") }
+
+  let(:invoice) do
+    create(:invoice, organization:, customer:, currency: "EUR", status: :finalized, payment_status: :failed)
+  end
+
+  def create_payment(payable, payable_payment_status, status)
+    create(
+      :payment,
+      payable:,
+      customer:,
+      payment_provider: stripe_provider,
+      payment_provider_customer: stripe_customer,
+      payable_payment_status:,
+      status:
+    )
+  end
+
+  before do
+    stripe_customer
+    create_payment(invoice, :failed, "failed")
+    allow(Invoices::Payments::CreateJob).to receive(:perform_later)
+  end
+
+  describe "#call" do
+    it "opens a payment intent on the invoice whose intent died" do
+      result = webhook_service.call
+
+      expect(result).to be_success
+      expect(result.invoice).to eq(invoice)
+      expect(Invoices::Payments::CreateJob).to have_received(:perform_later)
+        .with(invoice:, payment_provider: :stripe)
+    end
+
+    context "when several invoices had their intent canceled" do
+      let(:older_invoice) do
+        create(
+          :invoice,
+          organization:,
+          customer:,
+          currency: "EUR",
+          status: :finalized,
+          payment_status: :failed,
+          issuing_date: invoice.issuing_date - 1.month
+        )
+      end
+
+      before { create_payment(older_invoice, :failed, "failed") }
+
+      it "targets the oldest one" do
+        result = webhook_service.call
+
+        expect(result.invoice).to eq(older_invoice)
+        expect(Invoices::Payments::CreateJob).to have_received(:perform_later)
+          .with(invoice: older_invoice, payment_provider: :stripe)
+      end
+    end
+
+    context "when only a newer invoice has an awaiting-funds payment open" do
+      let(:older_invoice) do
+        create(
+          :invoice,
+          organization:,
+          customer:,
+          currency: "EUR",
+          status: :finalized,
+          payment_status: :failed,
+          issuing_date: invoice.issuing_date - 1.month
+        )
+      end
+
+      before do
+        create_payment(older_invoice, :failed, "failed")
+        create_payment(invoice, :processing, "requires_action")
+      end
+
+      it "still opens an intent on the older invoice" do
+        result = webhook_service.call
+
+        expect(result.invoice).to eq(older_invoice)
+        expect(Invoices::Payments::CreateJob).to have_received(:perform_later)
+          .with(invoice: older_invoice, payment_provider: :stripe)
+      end
+    end
+
+    context "when a new intent already replaced the failed one" do
+      before { create_payment(invoice, :processing, "requires_action") }
+
+      it "does not open another intent" do
+        result = webhook_service.call
+
+        expect(result).to be_success
+        expect(result.invoice).to be_nil
+        expect(Invoices::Payments::CreateJob).not_to have_received(:perform_later)
+      end
+    end
+
+    context "when the invoice never had a payment attempt" do
+      let(:invoice) do
+        create(:invoice, organization:, customer:, currency: "EUR", status: :finalized, payment_status: :pending)
+      end
+
+      before { Payment.where(payable: invoice).delete_all }
+
+      it "does not open an intent" do
+        result = webhook_service.call
+
+        expect(result).to be_success
+        expect(Invoices::Payments::CreateJob).not_to have_received(:perform_later)
+      end
+    end
+
+    context "when the customer does not use customer_balance" do
+      let(:provider_payment_methods) { %w[card] }
+
+      it "does not open an intent" do
+        result = webhook_service.call
+
+        expect(result).to be_success
+        expect(Invoices::Payments::CreateJob).not_to have_received(:perform_later)
+      end
+    end
+
+    context "when the transaction is not a funding" do
+      let(:event_json) do
+        get_stripe_fixtures("webhooks/customer_cash_balance_transaction_created.json") do |h|
+          h[:data][:object][:type] = "applied_to_payment"
+        end
+      end
+
+      it "does not open an intent" do
+        result = webhook_service.call
+
+        expect(result).to be_success
+        expect(Invoices::Payments::CreateJob).not_to have_received(:perform_later)
+      end
+    end
+
+    context "when the funds are already fully allocated" do
+      let(:event_json) do
+        get_stripe_fixtures("webhooks/customer_cash_balance_transaction_created.json") do |h|
+          h[:data][:object][:ending_balance] = 0
+        end
+      end
+
+      it "does not open an intent" do
+        result = webhook_service.call
+
+        expect(result).to be_success
+        expect(Invoices::Payments::CreateJob).not_to have_received(:perform_later)
+      end
+    end
+
+    context "when no unpaid invoice matches the funded currency" do
+      let(:event_json) do
+        get_stripe_fixtures("webhooks/customer_cash_balance_transaction_created.json") do |h|
+          h[:data][:object][:currency] = "usd"
+        end
+      end
+
+      it "does not open an intent" do
+        result = webhook_service.call
+
+        expect(result).to be_success
+        expect(Invoices::Payments::CreateJob).not_to have_received(:perform_later)
+      end
+    end
+
+    context "when the invoice is already paid" do
+      let(:invoice) do
+        create(:invoice, organization:, customer:, currency: "EUR", status: :finalized, payment_status: :succeeded)
+      end
+
+      it "does not open an intent" do
+        result = webhook_service.call
+
+        expect(result).to be_success
+        expect(Invoices::Payments::CreateJob).not_to have_received(:perform_later)
+      end
+    end
+
+    context "when the stripe customer is unknown" do
+      let(:event_json) do
+        get_stripe_fixtures("webhooks/customer_cash_balance_transaction_created.json") do |h|
+          h[:data][:object][:customer] = "cus_unknown"
+        end
+      end
+
+      it "does not open an intent" do
+        result = webhook_service.call
+
+        expect(result).to be_success
+        expect(Invoices::Payments::CreateJob).not_to have_received(:perform_later)
+      end
+    end
+  end
+end

--- a/spec/services/payment_providers/stripe/webhooks/customer_cash_balance_transaction_created_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/customer_cash_balance_transaction_created_service_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerCashBalanceTransactio
   before do
     stripe_customer
     create_payment(invoice, :failed, "failed")
-    allow(Invoices::Payments::CreateJob).to receive(:perform_later)
   end
 
   describe "#call" do
@@ -51,7 +50,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerCashBalanceTransactio
 
       expect(result).to be_success
       expect(result.invoice).to eq(invoice)
-      expect(Invoices::Payments::CreateJob).to have_received(:perform_later)
+      expect(Invoices::Payments::CreateJob).to have_been_enqueued
         .with(invoice:, payment_provider: :stripe)
     end
 
@@ -74,7 +73,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerCashBalanceTransactio
         result = webhook_service.call
 
         expect(result.invoice).to eq(older_invoice)
-        expect(Invoices::Payments::CreateJob).to have_received(:perform_later)
+        expect(Invoices::Payments::CreateJob).to have_been_enqueued
           .with(invoice: older_invoice, payment_provider: :stripe)
       end
     end
@@ -101,7 +100,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerCashBalanceTransactio
         result = webhook_service.call
 
         expect(result.invoice).to eq(older_invoice)
-        expect(Invoices::Payments::CreateJob).to have_received(:perform_later)
+        expect(Invoices::Payments::CreateJob).to have_been_enqueued
           .with(invoice: older_invoice, payment_provider: :stripe)
       end
     end
@@ -114,7 +113,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerCashBalanceTransactio
 
         expect(result).to be_success
         expect(result.invoice).to be_nil
-        expect(Invoices::Payments::CreateJob).not_to have_received(:perform_later)
+        expect(Invoices::Payments::CreateJob).not_to have_been_enqueued
       end
     end
 
@@ -129,7 +128,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerCashBalanceTransactio
         result = webhook_service.call
 
         expect(result).to be_success
-        expect(Invoices::Payments::CreateJob).not_to have_received(:perform_later)
+        expect(Invoices::Payments::CreateJob).not_to have_been_enqueued
       end
     end
 
@@ -140,7 +139,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerCashBalanceTransactio
         result = webhook_service.call
 
         expect(result).to be_success
-        expect(Invoices::Payments::CreateJob).not_to have_received(:perform_later)
+        expect(Invoices::Payments::CreateJob).not_to have_been_enqueued
       end
     end
 
@@ -155,7 +154,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerCashBalanceTransactio
         result = webhook_service.call
 
         expect(result).to be_success
-        expect(Invoices::Payments::CreateJob).not_to have_received(:perform_later)
+        expect(Invoices::Payments::CreateJob).not_to have_been_enqueued
       end
     end
 
@@ -170,7 +169,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerCashBalanceTransactio
         result = webhook_service.call
 
         expect(result).to be_success
-        expect(Invoices::Payments::CreateJob).not_to have_received(:perform_later)
+        expect(Invoices::Payments::CreateJob).not_to have_been_enqueued
       end
     end
 
@@ -185,7 +184,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerCashBalanceTransactio
         result = webhook_service.call
 
         expect(result).to be_success
-        expect(Invoices::Payments::CreateJob).not_to have_received(:perform_later)
+        expect(Invoices::Payments::CreateJob).not_to have_been_enqueued
       end
     end
 
@@ -198,7 +197,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerCashBalanceTransactio
         result = webhook_service.call
 
         expect(result).to be_success
-        expect(Invoices::Payments::CreateJob).not_to have_received(:perform_later)
+        expect(Invoices::Payments::CreateJob).not_to have_been_enqueued
       end
     end
 
@@ -213,7 +212,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerCashBalanceTransactio
         result = webhook_service.call
 
         expect(result).to be_success
-        expect(Invoices::Payments::CreateJob).not_to have_received(:perform_later)
+        expect(Invoices::Payments::CreateJob).not_to have_been_enqueued
       end
     end
   end


### PR DESCRIPTION
## Context

For Stripe `customer_balance` (V-BAN) customers, a wire lands in the Stripe cash balance,
which is attached to the customer and not to an invoice. If the invoice's PaymentIntent was
canceled or failed, the funds have nothing to attach to — Lago never learns of them, and
Stripe later applies them to whichever invoice opens the next intent, marking an invoice paid
that the customer never funded.

## Description

Subscribe to Stripe's `customer_cash_balance_transaction.created` event. When a funding leaves
an unallocated balance and the oldest unpaid invoice's last payment attempt failed, open a new
intent on that invoice so Stripe applies the funds to the invoice they were meant for. Oldest
first, and only in the funded currency, since targeting a later invoice is the bug itself.