### PR TITLE
fix(charges): guard missing graduated percentage ranges

### DIFF
--- a/app/services/charges/validators/graduated_percentage_service.rb
+++ b/app/services/charges/validators/graduated_percentage_service.rb
@@ -36,7 +36,7 @@ module Charges
       end
 
       def ranges
-        properties["graduated_percentage_ranges"].map(&:with_indifferent_access)
+        (properties["graduated_percentage_ranges"] || []).map(&:with_indifferent_access)
       end
 
       def validate_rate_and_amounts(range)

--- a/spec/services/charges/validators/graduated_percentage_service_spec.rb
+++ b/spec/services/charges/validators/graduated_percentage_service_spec.rb
@@ -61,6 +61,16 @@ RSpec.describe Charges::Validators::GraduatedPercentageService do
           .to include("missing_graduated_percentage_ranges")
       end
 
+      context "when the ranges key is absent" do
+        let(:charge) { build(:graduated_percentage_charge, properties: {}) }
+
+        it "fails validation instead of raising" do
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error.messages[:graduated_percentage_ranges])
+            .to include("missing_graduated_percentage_ranges")
+        end
+      end
+
       context "when ranges does not starts at 0" do
         let(:ranges) { [{from_value: -1, to_value: 100}] }
 

--- a/spec/services/rate_card_rates/create_service_spec.rb
+++ b/spec/services/rate_card_rates/create_service_spec.rb
@@ -186,4 +186,21 @@ RSpec.describe RateCardRates::CreateService do
       expect(result.rate_card_rate).to be_persisted
     end
   end
+
+  context "when a graduated percentage rate has no ranges" do
+    let(:params) do
+      {
+        code: "gp",
+        effective_from: Time.current,
+        rate_model: "graduated_percentage",
+        rate_properties: {},
+        billing_interval_unit: "month"
+      }
+    end
+
+    it "returns a validation failure instead of raising" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:rate_properties]).to be_present
+    end
+  end
 end


### PR DESCRIPTION
## Context

`Charges::Validators::GraduatedPercentageService#ranges` maps over `properties["graduated_percentage_ranges"]` before the `blank?` presence check can run, so a payload without the key raises `NoMethodError` instead of failing validation.