### PR TITLE
chore(invoices): remove the invoice_search_terms flag

### DIFF
--- a/app/config/feature_flags.yaml
+++ b/app/config/feature_flags.yaml
@@ -42,10 +42,6 @@ product_catalog:
   description: "Use the product catalog (billing v2): product_categories, products, rate cards and plan rate phases"
   owners: ["@rsempe"]
 
-invoice_search_terms:
-  description: "Search the invoice list on the denormalized invoices.search_terms column instead of joining customers"
-  owners: ["@toommz"]
-
 skip_credit_invoice_auto_payment_delay:
   description: "Trigger the auto-payment of credit invoices (wallet top-ups) immediately instead of delaying it behind a possible hosted checkout payment"
   owners: ["@brunomiguelpinto"]

--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -89,7 +89,8 @@ module Resolvers
       return result_error(result) unless result.success?
 
       invoices = result.invoices
-      invoices = invoices.without_count.extend(BaseQuery::CappedTotalCount) if capped_count?(invoices)
+      # Meilisearch returns a paginated array, which has no `without_count` and carries its own total.
+      invoices = invoices.without_count.extend(BaseQuery::CappedTotalCount) if invoices.respond_to?(:without_count)
 
       ActiveRecord::Associations::Preloader.new(
         records: invoices.to_a,
@@ -104,15 +105,6 @@ module Resolvers
       ).call
 
       Invoice.preload_offset_amounts(invoices)
-    end
-
-    private
-
-    # Meilisearch returns a paginated array, which has no `without_count`. An organization
-    # can have both feature flags enabled, so the flag alone is not enough to tell them apart.
-    def capped_count?(invoices)
-      invoices.respond_to?(:without_count) &&
-        current_organization.feature_flag_enabled?(:invoice_search_terms)
     end
   end
 end

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -198,18 +198,8 @@ class InvoicesQuery < BaseQuery
   def base_scope
     scope = organization.invoices
     return scope if search_term.blank?
-    return search_terms_scope(scope) if search_terms_enabled?
 
-    scope = scope.with(matching_customers: matching_customers) if search_customers?
-    scope
-      .with(matching_invoices: matching_invoices)
-      .where("invoices.id IN (SELECT id FROM matching_invoices)")
-  end
-
-  # The customer portal passes a Customer as `organization`, and only Organization
-  # carries feature flags.
-  def search_terms_enabled?
-    organization.is_a?(Organization) && organization.feature_flag_enabled?(:invoice_search_terms)
+    search_terms_scope(scope)
   end
 
   def search_terms_scope(scope)
@@ -223,37 +213,6 @@ class InvoicesQuery < BaseQuery
 
   def search_customers?
     filters.customer_id.blank? && filters.customer_external_id.blank?
-  end
-
-  def matching_customers
-    escaped_term = "%#{Customer.sanitize_sql_like(search_term)}%"
-
-    organization.customers
-      .where(
-        "customers.name ILIKE :term OR customers.firstname ILIKE :term " \
-        "OR customers.lastname ILIKE :term OR customers.external_id ILIKE :term " \
-        "OR customers.email ILIKE :term",
-        term: escaped_term
-      )
-      .select(:id)
-  end
-
-  def matching_invoices
-    escaped_term = "%#{Invoice.sanitize_sql_like(search_term)}%"
-    search_base = organization.invoices
-
-    branches = [
-      search_base.where("invoices.number ILIKE ?", escaped_term).select(:id)
-    ]
-
-    branches << search_base.where(id: search_term).select(:id) if search_term.match?(BaseQuery::UUID_REGEX)
-
-    if search_customers?
-      branches << search_base.where("invoices.customer_id IN (SELECT id FROM matching_customers)").select(:id)
-    end
-
-    union_sql = branches.map(&:to_sql).join(" UNION ")
-    Invoice.unscoped.from("(#{union_sql}) AS invoices").select(:id)
   end
 
   def with_billing_entity_ids(scope)

--- a/schema.graphql
+++ b/schema.graphql
@@ -6477,7 +6477,6 @@ Organization Feature Flag Values
 enum FeatureFlagEnum {
   enriched_events_aggregation
   fixed_charge_usage_delta_migration
-  invoice_search_terms
   lazy_charge_usage_cache
   meilisearch
   multi_connection

--- a/schema.json
+++ b/schema.json
@@ -31407,12 +31407,6 @@
               "deprecationReason": null
             },
             {
-              "name": "invoice_search_terms",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "skip_credit_invoice_auto_payment_delay",
               "description": null,
               "isDeprecated": false,

--- a/spec/graphql/resolvers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoices_resolver_spec.rb
@@ -867,11 +867,8 @@ RSpec.describe Resolvers::InvoicesResolver do
       )
     end
 
-    context "when the organization reads from search terms" do
-      before do
-        stub_const("BaseQuery::CappedTotalCount::MAX_COUNTED_RECORDS", 1)
-        organization.enable_feature_flag!(:invoice_search_terms)
-      end
+    context "when the result set exceeds the cap" do
+      before { stub_const("BaseQuery::CappedTotalCount::MAX_COUNTED_RECORDS", 1) }
 
       it "caps the total and keeps advertising the next page" do
         expect(metadata).to eq(

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -399,7 +399,14 @@ RSpec.describe InvoicesQuery do
     end
   end
 
-  shared_examples "invoice search" do
+  context "when searching" do
+    # Refreshed here rather than in a before hook so that fixtures created by an inner
+    # let! are covered too: the factory does not go through the services.
+    let(:returned_ids) do
+      organization.invoices.find_each { |invoice| Invoices::RefreshSearchTermsService.call!(invoice:) }
+      result.invoices.pluck(:id)
+    end
+
     context "when searching for a full invoice id (UUID)" do
       let(:search_term) { invoice_fourth.id }
 
@@ -548,50 +555,13 @@ RSpec.describe InvoicesQuery do
         )
       end
     end
-  end
-
-  context "with the CTE search path" do
-    it_behaves_like "invoice search"
 
     context "when the term only matches a customer legal name" do
       let(:search_term) { "Sanchez Holdings" }
 
       before { customer_first.update!(legal_name: "Sanchez Holdings") }
 
-      it "does not match, the CTE does not search legal_name" do
-        expect(returned_ids).to be_empty
-      end
-    end
-
-    context "when the term only matches a purchase order number" do
-      let(:search_term) { "PO-4242" }
-
-      before { invoice_first.update!(purchase_order_number: "PO-4242") }
-
-      it "does not match, the CTE does not search purchase_order_number" do
-        expect(returned_ids).to be_empty
-      end
-    end
-  end
-
-  context "with the search_terms path" do
-    before { organization.enable_feature_flag!(:invoice_search_terms) }
-
-    # Refreshed here rather than in a before hook so that fixtures created by an inner
-    # let! are covered too: the factory does not go through the services.
-    let(:returned_ids) do
-      organization.invoices.find_each { |invoice| Invoices::RefreshSearchTermsService.call!(invoice:) }
-      result.invoices.pluck(:id)
-    end
-
-    it_behaves_like "invoice search"
-
-    context "when the term only matches a customer legal name" do
-      let(:search_term) { "Sanchez Holdings" }
-
-      before { customer_first.update!(legal_name: "Sanchez Holdings") }
-
-      it "matches, unlike the CTE path" do
+      it "returns the matching invoices" do
         expect(returned_ids).to contain_exactly(invoice_first.id, invoice_third.id, invoice_fifth.id, invoice_sixth.id)
       end
     end
@@ -601,7 +571,7 @@ RSpec.describe InvoicesQuery do
 
       before { invoice_first.update!(purchase_order_number: "PO-4242") }
 
-      it "matches, unlike the CTE path" do
+      it "returns the matching invoices" do
         expect(returned_ids).to eq([invoice_first.id])
       end
     end
@@ -1004,8 +974,8 @@ RSpec.describe InvoicesQuery do
     end
 
     before do
-      ms_invoice_first
-      ms_invoice_second
+      # The factory does not go through the services, so the denormalized column is empty.
+      [ms_invoice_first, ms_invoice_second].each { |invoice| Invoices::RefreshSearchTermsService.call!(invoice:) }
       organization.enable_feature_flag!(:meilisearch)
       stub_const(
         "ENV",

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -461,10 +461,9 @@ RSpec.describe Api::V1::InvoicesController do
       end
     end
 
-    context "when the organization reads from search terms" do
+    context "when the result set exceeds the graphql cap" do
       before do
         stub_const("BaseQuery::CappedTotalCount::MAX_COUNTED_RECORDS", 1)
-        organization.enable_feature_flag!(:invoice_search_terms)
         create(:invoice, customer:, organization:)
         create(:invoice, customer:, organization:)
       end

--- a/spec/support/shared_examples/invoice_index.rb
+++ b/spec/support/shared_examples/invoice_index.rb
@@ -241,7 +241,11 @@ RSpec.shared_examples "an invoice index endpoint" do
       create(:invoice, customer:, number: SecureRandom.uuid, organization:)
     end
 
-    before { create(:invoice, customer:, number: "not-relevant-number", organization:) }
+    before do
+      create(:invoice, customer:, number: "not-relevant-number", organization:)
+      # The factory does not go through the services, so the denormalized column is empty.
+      organization.invoices.find_each { |invoice| Invoices::RefreshSearchTermsService.call!(invoice:) }
+    end
 
     it "returns invoices matching the search terms" do
       subject


### PR DESCRIPTION
## Context

`invoice_search_terms` flag gated two things: reading the invoice list search from the denormalized `invoices.search_terms` column instead of CTE-ing over `customers` (#6156), and the capped GraphQL total count (#6165). The rollout and the backfill are done, so the flag and the legacy CTE path can go.
