### PR TITLE
feat(products): query a single rate card rate

### DIFF
--- a/app/graphql/resolvers/rate_card_rate_resolver.rb
+++ b/app/graphql/resolvers/rate_card_rate_resolver.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class RateCardRateResolver < Resolvers::BaseResolver
+    include RequiresProductCatalog
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    REQUIRED_PERMISSION = "rate_cards:view"
+
+    description "Query a single rate of a rate card"
+
+    argument :id, ID, required: true, description: "Uniq ID of the rate"
+
+    type Types::RateCardRates::Object, null: true
+
+    def resolve(id: nil)
+      current_organization.rate_card_rates.find(id)
+    rescue ActiveRecord::RecordNotFound
+      not_found_error(resource: "rate_card_rate")
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -103,6 +103,7 @@ module Types
     field :quote_version, resolver: Resolvers::QuoteVersionResolver
     field :quotes, resolver: Resolvers::QuotesResolver
     field :rate_card, resolver: Resolvers::RateCardResolver
+    field :rate_card_rate, resolver: Resolvers::RateCardRateResolver
     field :rate_card_rates, resolver: Resolvers::RateCardRatesResolver
     field :rate_cards, resolver: Resolvers::RateCardsResolver
     field :role, resolver: Resolvers::RoleResolver

--- a/schema.graphql
+++ b/schema.graphql
@@ -12158,6 +12158,16 @@ type Query {
   ): RateCard
 
   """
+  Query a single rate of a rate card
+  """
+  rateCardRate(
+    """
+    Uniq ID of the rate
+    """
+    id: ID!
+  ): RateCardRate
+
+  """
   Query the rates of a rate card
   """
   rateCardRates(limit: Int, page: Int, rateCardId: ID!): RateCardRateCollection!

--- a/schema.json
+++ b/schema.json
@@ -65401,6 +65401,35 @@
               "deprecationReason": null
             },
             {
+              "name": "rateCardRate",
+              "description": "Query a single rate of a rate card",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Uniq ID of the rate",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "RateCardRate",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "rateCardRates",
               "description": "Query the rates of a rate card",
               "args": [

--- a/spec/graphql/resolvers/rate_card_rate_resolver_spec.rb
+++ b/spec/graphql/resolvers/rate_card_rate_resolver_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::RateCardRateResolver do
+  subject(:execution) do
+    execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query:,
+      variables: {rateId: rate.id}
+    )
+  end
+
+  let(:required_permission) { "rate_cards:view" }
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:rate_card) { create(:rate_card, organization:) }
+  let(:rate) { create(:rate_card_rate, organization:, rate_card:) }
+
+  let(:query) do
+    <<~GQL
+      query($rateId: ID!) {
+        rateCardRate(id: $rateId) {
+          id code rateModel status
+        }
+      }
+    GQL
+  end
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "rate_cards:view"
+
+  it "returns a single rate" do
+    response = execution["data"]["rateCardRate"]
+
+    expect(response["id"]).to eq(rate.id)
+    expect(response["code"]).to eq(rate.code)
+  end
+
+  context "when the rate belongs to another organization" do
+    let(:rate) { create(:rate_card_rate) }
+
+    it "returns a not found error" do
+      expect_graphql_error(result: execution, message: "Resource not found")
+    end
+  end
+end


### PR DESCRIPTION
## Context

The graphql schema has `rateCardRates` (per-card list) but no single-rate query, which the rate edit form needs.

## Description

`rateCardRate(id: ID!)` query, mirroring `rateCard`: org-scoped, `rate_cards:view` permission, catalog-gated