### PR TITLE
fix(storage): pin multi_json to keep the GCS adapter loadable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,10 @@ gem "datadog", require: false
 # Storage
 gem "aws-sdk-s3", require: false
 gem "google-cloud-storage", require: false
+# google-apis-core < 1.2.1 loads representable/json, which calls `gem "multi_json"`
+# without declaring the dependency. googleauth 1.17 and signet 0.22 both migrated to
+# stdlib json, so multi_json is no longer pulled in transitively and must be pinned.
+gem "multi_json", require: false
 
 # Templating
 gem "slim"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -497,6 +497,7 @@ GEM
       money (~> 7.0)
       railties (>= 7.0)
     msgpack (1.8.2)
+    multi_json (1.21.1)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
     multipart-post (2.4.1)
@@ -1132,6 +1133,7 @@ DEPENDENCIES
   logstash-event
   meilisearch-rails
   money-rails
+  multi_json
   multipart-post
   mutex_m
   newrelic_rpm

--- a/spec/active_storage/service/configurator_spec.rb
+++ b/spec/active_storage/service/configurator_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ActiveStorage::Service::Configurator do
+  # `#resolve` rescues LoadError and re-raises it as `Missing service adapter for "GCS"`,
+  # so a gem missing from the bundle anywhere in an adapter's require chain stays invisible
+  # until a boot actually selects that adapter. Nothing else in dev or test loads these
+  # adapters, since both storage gems are declared with `require: false`.
+  it "can load the GCS adapter" do
+    expect { require "active_storage/service/gcs_service" }.not_to raise_error
+  end
+
+  it "can load the S3 adapter" do
+    expect { require "active_storage/service/s3_service" }.not_to raise_error
+  end
+end


### PR DESCRIPTION
## Context

Since 1.52, production images configured with `LAGO_USE_GCS=true` fail to boot:

```
Missing service adapter for "GCS" (RuntimeError)
...
multi_json is not part of the bundle. Add it to your Gemfile. (Gem::LoadError)
```

## Root cause

`representable-3.2.0/lib/representable/json.rb` opens with a literal `gem "multi_json", '>= 1.14.1'`. Bundler raises on that call as soon as multi_json is absent from the lock, whether or not the gem is on disk. `google-apis-core 0.18.0` pulls in `representable (~> 3.0)` but never declared multi_json, so it free-rode on googleauth and signet for years.

#6064 (googleauth `~> 1.16.2` to `~> 1.17.0`) ended that ride. googleauth 1.17.0 and signet 0.22.0 both migrated to stdlib `json`, so multi_json dropped out of `Gemfile.lock` entirely:

```
-    googleauth (1.16.2)
-      multi_json (~> 1.11)
+    googleauth (1.17.3)
+      pstore (~> 0.1)
-    multi_json (1.21.1)
-    signet (0.21.0)
-      multi_json (~> 1.10)
+    signet (0.22.0)
```

## Changes

- Pin `multi_json` explicitly in the Gemfile. The only lockfile movement is `multi_json (1.21.1)` returning; no other gem version changes.
- Add `spec/active_storage/service/configurator_spec.rb`, which loads the GCS and S3 adapters the same way the configurator does, so this class of failure breaks CI instead of a production boot.