### PR TITLE
feat(products): add the catalog subscription runtime

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -167,6 +167,7 @@ module Api
             :external_id,
             :billing_time,
             :subscription_at,
+            :billing_anchor_date,
             :ending_at,
             :progressive_billing_disabled,
             :consolidate_invoice,

--- a/app/controllers/api/v2/subscriptions_controller.rb
+++ b/app/controllers/api/v2/subscriptions_controller.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    class SubscriptionsController < Api::BaseController
+      include Api::RequiresProductCatalog
+
+      def index
+        filters = params.permit(:plan_code, :external_customer_id, :external_id, status: [])
+        filters[:status] = ["active"] if filters[:status].blank?
+
+        result = ::SubscriptionsQuery.call(
+          organization: current_organization,
+          pagination: {
+            page: params[:page],
+            limit: params[:per_page] || PER_PAGE
+          },
+          filters:
+        )
+
+        if result.success?
+          subscriptions = result.subscriptions.includes(:plan, customer: :billing_entity)
+
+          # One grouped query instead of one COUNT per row in the serializer.
+          applied_rate_cards_counts = SubscriptionRateCard.current_and_scheduled
+            .where(subscription_id: subscriptions.map(&:id))
+            .group(:subscription_id)
+            .count
+
+          render(
+            json: ::CollectionSerializer.new(
+              subscriptions,
+              ::V2::SubscriptionSerializer,
+              collection_name: "subscriptions",
+              meta: pagination_metadata(subscriptions),
+              applied_rate_cards_counts:
+            )
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
+      def show
+        subscription = current_organization.subscriptions
+          .order("terminated_at DESC NULLS FIRST, started_at DESC")
+          .find_by(
+            external_id: params[:external_id],
+            status: params[:status] || :active
+          )
+        return not_found_error(resource: "subscription") unless subscription
+
+        render(
+          json: ::V2::SubscriptionSerializer.new(
+            subscription,
+            root_name: "subscription",
+            includes: %i[applied_rate_cards]
+          )
+        )
+      end
+
+      private
+
+      def resource_name
+        "subscription"
+      end
+    end
+  end
+end

--- a/app/models/concerns/rate_phaseable.rb
+++ b/app/models/concerns/rate_phaseable.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Shared by the two rate-phase parents (plan_rate_card and
+# subscription_rate_card): walking the ordered phase sequence to find the
+# one covering a billing cycle.
+module RatePhaseable
+  extend ActiveSupport::Concern
+
+  # Returns the rate phase covering the given zero-based billing cycle index.
+  # Phases (ordered by position) partition the timeline by their cumulative
+  # billing_interval_cycle_count; the final phase may carry a nil count,
+  # meaning it runs indefinitely. Returns nil when no phase covers the cycle.
+  def rate_phase_for_cycle(cycle_index)
+    cursor = 0
+
+    rate_phases.order(:position).each do |phase|
+      count = phase.billing_interval_cycle_count
+      return phase if count.nil?
+
+      cursor += count
+      return phase if cycle_index < cursor
+    end
+
+    nil
+  end
+end

--- a/app/models/plan_rate_card.rb
+++ b/app/models/plan_rate_card.rb
@@ -3,6 +3,7 @@
 class PlanRateCard < ApplicationRecord
   include PaperTrailTraceable
   include Discard::Model
+  include RatePhaseable
 
   self.discard_column = :deleted_at
 

--- a/app/models/rate_card.rb
+++ b/app/models/rate_card.rb
@@ -100,6 +100,14 @@ class RateCard < ApplicationRecord
   def active_rate
     rates.effective.order(effective_from: :desc).first
   end
+
+  # The rate that was active at a given time — how billing resolves the rate
+  # for a period (the rate effective at the period start). Rates are
+  # append-only and locked once the card has subscriptions, so only rates
+  # scheduled before signing can change a subscriber's price.
+  def rate_active_at(datetime)
+    rates.where(effective_from: ..datetime).order(effective_from: :desc).first
+  end
 end
 
 # == Schema Information

--- a/app/models/rate_card_rate.rb
+++ b/app/models/rate_card_rate.rb
@@ -69,6 +69,17 @@ class RateCardRate < ApplicationRecord
     rate_properties
   end
 
+  # The charge-model calculators (ChargeModels::*) read the pricing model from
+  # a `charge_model` attribute and check `prorated?`; expose both so a rate can
+  # be priced through the same calculators as charges.
+  def charge_model
+    rate_model
+  end
+
+  def prorated?
+    rate_card.proration?
+  end
+
   # Status is derived from the card's append-only timeline rather than stored:
   # the latest effective rate is active, future rates are pending, and earlier
   # effective rates have been superseded and are terminated.

--- a/app/models/rate_override.rb
+++ b/app/models/rate_override.rb
@@ -38,6 +38,21 @@ class RateOverride < ApplicationRecord
     rate_properties
   end
 
+  # The charge-model calculators (ChargeModels::*) read the pricing model from
+  # a `charge_model` attribute and check `prorated?`; expose both so an
+  # override can be priced through the same calculators as charges.
+  def charge_model
+    rate_model
+  end
+
+  # Proration is structural and never overridable: it is always inherited from
+  # the card the override's phase prices. An override not yet attached to a
+  # phase cannot be priced, so false is only the safe default there.
+  def prorated?
+    card_entry = rate_phase&.plan_rate_card || rate_phase&.subscription_rate_card
+    card_entry&.rate_card&.proration? || false
+  end
+
   private
 
   def validate_properties

--- a/app/models/subscription_rate_card.rb
+++ b/app/models/subscription_rate_card.rb
@@ -3,6 +3,7 @@
 class SubscriptionRateCard < ApplicationRecord
   include PaperTrailTraceable
   include Discard::Model
+  include RatePhaseable
 
   self.discard_column = :deleted_at
 
@@ -21,7 +22,16 @@ class SubscriptionRateCard < ApplicationRecord
 
   validate :validate_started_before_ended
 
+  validates :units, numericality: {greater_than_or_equal_to: 0}, allow_nil: true
+
   default_scope -> { kept }
+
+  # An entry is versioned on units changes: rows are time-bounded by
+  # [started_at, ended_at). active_at picks the version in force at a given
+  # time; current_and_scheduled hides superseded history but keeps upcoming
+  # versions visible.
+  scope :active_at, ->(time) { where(started_at: ..time).where("ended_at IS NULL OR ended_at > ?", time) }
+  scope :current_and_scheduled, -> { where("ended_at IS NULL OR ended_at > ?", Time.current) }
 
   private
 

--- a/app/serializers/v1/subscription_rate_card_serializer.rb
+++ b/app/serializers/v1/subscription_rate_card_serializer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module V1
+  class SubscriptionRateCardSerializer < ModelSerializer
+    def serialize
+      {
+        lago_id: model.id,
+        external_subscription_id: model.subscription.external_id,
+        rate_card_code: model.rate_card.code,
+        units: model.units,
+        started_at: model.started_at.iso8601,
+        ended_at: model.ended_at&.iso8601,
+        billing_anchor_date: model.billing_anchor_date.iso8601,
+        next_billing_at: model.next_billing_at.iso8601,
+        # size counts the loaded collection when the caller preloaded it.
+        rate_phases_count: model.rate_phases.size,
+        created_at: model.created_at.iso8601,
+        updated_at: model.updated_at.iso8601
+      }
+    end
+  end
+end

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -15,6 +15,7 @@ module V1
         status: model.status,
         billing_time: model.billing_time,
         subscription_at: model.subscription_at&.iso8601,
+        billing_anchor_date: model.effective_billing_anchor_date&.iso8601,
         started_at: model.started_at&.iso8601(3),
         trial_ended_at: model.trial_ended_at&.iso8601,
         ending_at: model.ending_at&.iso8601,

--- a/app/serializers/v2/subscription_serializer.rb
+++ b/app/serializers/v2/subscription_serializer.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module V2
+  # The v2 shape drops the plan-interval fields (amounts, billing periods,
+  # trial): a product-catalog subscription prices through its rate card
+  # entries, each carrying its own billing cycle.
+  class SubscriptionSerializer < ModelSerializer
+    def serialize
+      payload = {
+        lago_id: model.id,
+        external_id: model.external_id,
+        lago_customer_id: model.customer_id,
+        external_customer_id: model.customer.external_id,
+        name: model.name,
+        plan_code: model.plan.code,
+        status: model.status,
+        billing_time: model.billing_time,
+        subscription_at: model.subscription_at&.iso8601,
+        started_at: model.started_at&.iso8601,
+        ending_at: model.ending_at&.iso8601,
+        terminated_at: model.terminated_at&.iso8601,
+        canceled_at: model.canceled_at&.iso8601,
+        created_at: model.created_at.iso8601,
+        updated_at: model.updated_at.iso8601,
+        # Ended versions (closed by units changes) are history, not cards the
+        # subscription currently carries.
+        applied_rate_cards_count: applied_rate_cards_count
+      }
+
+      payload[:applied_rate_cards] = applied_rate_cards if include?(:applied_rate_cards)
+
+      payload
+    end
+
+    private
+
+    # The index passes one grouped count for the whole page; show falls back
+    # to the scoped count on the single record.
+    def applied_rate_cards_count
+      counts = options[:applied_rate_cards_counts]
+      return counts.fetch(model.id, 0) if counts
+
+      model.applied_rate_cards.current_and_scheduled.count
+    end
+
+    def applied_rate_cards
+      ::CollectionSerializer.new(
+        model.applied_rate_cards.current_and_scheduled.includes(:rate_phases, :rate_card, :subscription),
+        ::V1::SubscriptionRateCardSerializer,
+        collection_name: "applied_rate_cards"
+      ).serialize[:applied_rate_cards]
+    end
+  end
+end

--- a/app/services/organizations/create_service.rb
+++ b/app/services/organizations/create_service.rb
@@ -14,6 +14,9 @@ module Organizations
         params.slice(:name, :document_numbering, :premium_integrations)
       )
 
+      # New organizations default to the product catalog (billing v2).
+      organization.feature_flags = organization.feature_flags.to_a | ["product_catalog"]
+
       if ActiveModel::Type::Boolean.new.cast(ENV["LAGO_CLICKHOUSE_ENABLED"]) && ENV["LAGO_DEFAULT_EVENT_STORE"] == "clickhouse"
         organization.clickhouse_events_store = true
         organization.clickhouse_deduplication_enabled = true

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -27,6 +27,7 @@ module Subscriptions
         plan:,
         subscription_at:,
         ending_at: params[:ending_at],
+        billing_anchor_date: params[:billing_anchor_date],
         payment_method: params[:payment_method],
         activation_rules: params[:activation_rules],
         subscription_type:
@@ -112,7 +113,21 @@ module Subscriptions
       Subscriptions::ValidateService.new(result, **args).valid?
     end
 
+    def product_catalog_plan_change?
+      return false unless current_subscription
+      return false if plan.id == current_subscription.plan.id
+
+      plan.product_catalog? || current_subscription.plan.product_catalog?
+    end
+
     def handle_subscription
+      # Product-catalog plan changes go through the dedicated upgrade and
+      # downgrade flows once they exist; the legacy amount comparison cannot
+      # price catalog plans, so the change is rejected instead of crashing.
+      if product_catalog_plan_change?
+        result.single_validation_failure!(field: :plan, error_code: "plan_change_not_available").raise_if_error!
+      end
+
       return upgrade_subscription if upgrade?
       return downgrade_subscription if downgrade?
 
@@ -143,6 +158,7 @@ module Subscriptions
         external_id:,
         billing_time: billing_time || :calendar,
         ending_at: params[:ending_at],
+        billing_anchor_date: params[:billing_anchor_date],
         purchase_order_number: params[:purchase_order_number],
         progressive_billing_disabled: params[:progressive_billing_disabled] || false,
         consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : true,
@@ -172,7 +188,15 @@ module Subscriptions
         handle_future_subscription(new_subscription)
       end
 
+      materialize_product_catalog_rate_cards(new_subscription)
+
       new_subscription
+    end
+
+    def materialize_product_catalog_rate_cards(new_subscription)
+      return unless new_subscription.plan.product_catalog?
+
+      Subscriptions::ProductCatalog::MaterializeService.call!(subscription: new_subscription)
     end
 
     def handle_today_subscription(new_subscription)

--- a/app/services/subscriptions/product_catalog/materialize_service.rb
+++ b/app/services/subscriptions/product_catalog/materialize_service.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  module ProductCatalog
+    # Materializes the plan's rate cards onto the subscription: one
+    # subscription_rate_card per plan_rate_card, carrying the billing
+    # lifecycle (anchor, clock, units). Pricing is not copied — a plan is
+    # immutable once it has subscriptions, so phases and rates resolve by
+    # reference through the plan entry.
+    class MaterializeService < BaseService
+      Result = BaseResult[:subscription_rate_cards]
+
+      def initialize(subscription:)
+        @subscription = subscription
+        super
+      end
+
+      def call
+        return result unless subscription.plan.product_catalog?
+
+        materialized = []
+        ActiveRecord::Base.transaction do
+          subscription.plan.applied_rate_cards.find_each do |plan_rate_card|
+            materialized << SubscriptionRateCard.create!(
+              organization: subscription.organization,
+              subscription:,
+              rate_card: plan_rate_card.rate_card,
+              units: plan_rate_card.units,
+              billing_anchor_date: subscription.effective_billing_anchor_date,
+              next_billing_at: started_at,
+              started_at:
+            )
+          end
+        end
+
+        result.subscription_rate_cards = materialized
+        result
+      end
+
+      private
+
+      attr_reader :subscription
+
+      def started_at
+        @started_at ||= subscription.started_at || subscription.subscription_at
+      end
+    end
+  end
+end

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -101,8 +101,10 @@ module Subscriptions
         end
 
         if subscription.starting_in_the_future? && params.key?(:subscription_at)
+          previous_subscription_at = subscription.subscription_at
           subscription.subscription_at = params[:subscription_at]
 
+          resync_product_catalog_rate_cards(subscription, previous_subscription_at)
           process_subscription_at_change(subscription)
         else
           subscription.save!
@@ -150,6 +152,22 @@ module Subscriptions
       return false unless params.key?(:subscription_at)
 
       DateTime.parse(params[:subscription_at]).to_date < Date.current
+    end
+
+    # Materialized and default-dated entries follow the subscription's new
+    # start; entries authored with their own explicit dates keep them.
+    def resync_product_catalog_rate_cards(subscription, previous_subscription_at)
+      return unless subscription.plan&.product_catalog?
+
+      new_start = subscription.subscription_at
+      subscription.applied_rate_cards.where(started_at: previous_subscription_at).find_each do |card|
+        card.started_at = new_start
+        card.next_billing_at = new_start
+        if subscription.billing_anchor_date.nil? && card.billing_anchor_date == previous_subscription_at.to_date
+          card.billing_anchor_date = new_start.to_date
+        end
+        card.save!
+      end
     end
 
     def process_subscription_at_change(subscription)

--- a/app/services/subscriptions/validate_service.rb
+++ b/app/services/subscriptions/validate_service.rb
@@ -8,6 +8,7 @@ module Subscriptions
 
       valid_subscription_at?
       valid_ending_at?
+      valid_billing_anchor_date?
       valid_on_termination_credit_note?
       valid_on_termination_invoice?
       valid_payment_method?
@@ -58,6 +59,17 @@ module Subscriptions
       end
 
       add_error(field: :ending_at, error_code: "invalid_date")
+      false
+    end
+
+    # The column is a date, so a malformed value would silently cast to nil
+    # and the subscription would anchor on its start date instead of failing.
+    def valid_billing_anchor_date?
+      return true if args[:billing_anchor_date].blank?
+      return true if Utils::Datetime.valid_format?(args[:billing_anchor_date])
+
+      add_error(field: :billing_anchor_date, error_code: "value_is_invalid")
+
       false
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,8 +30,8 @@ Rails.application.routes.draw do
       draw(:shared_api)
     end
 
-    # Drawn first so catalog routes win recognition; everything else on /api/v2
-    # falls through to v1.
+    # Catalog-specific v2 routes are drawn before the v1 fallback: for the
+    # paths defined here (e.g. GET /api/v2/subscriptions) the first match wins.
     namespace :v2 do
       resources :products, param: :code, code: /.*/, only: %i[index show create update destroy] do
         resources :filters, param: :code, code: /.*/, only: %i[index show create update destroy], controller: "products/filters"
@@ -48,6 +48,9 @@ Rails.application.routes.draw do
         end
         draw(:plan_nested_api)
       end
+      # The constraint mirrors v1: without it, an external id containing a
+      # dot is truncated at the format separator.
+      resources :subscriptions, only: %i[index show], param: :external_id, constraints: {external_id: /[^\/]+/}
     end
 
     namespace :v2, module: :v1 do

--- a/spec/models/plan_rate_card_spec.rb
+++ b/spec/models/plan_rate_card_spec.rb
@@ -55,4 +55,11 @@ RSpec.describe PlanRateCard do
       end
     end
   end
+
+  it_behaves_like "a rate phase parent" do
+    let(:item) { create(:plan_rate_card) }
+    let(:create_rate_phase) do
+      ->(attributes) { create(:rate_phase, plan_rate_card: item, **attributes) }
+    end
+  end
 end

--- a/spec/models/rate_card_rate_spec.rb
+++ b/spec/models/rate_card_rate_spec.rb
@@ -300,4 +300,17 @@ RSpec.describe RateCardRate do
       end
     end
   end
+
+  describe "#charge_model" do
+    it "exposes the rate model under the calculators' expected name" do
+      expect(build(:rate_card_rate).charge_model).to eq("standard")
+    end
+  end
+
+  describe "#prorated?" do
+    it "reflects the card's proration mode" do
+      expect(build(:rate_card_rate, rate_card: build(:rate_card, proration: true)).prorated?).to be(true)
+      expect(build(:rate_card_rate, rate_card: build(:rate_card, proration: false)).prorated?).to be(false)
+    end
+  end
 end

--- a/spec/models/rate_card_spec.rb
+++ b/spec/models/rate_card_spec.rb
@@ -204,4 +204,20 @@ RSpec.describe RateCard do
       expect(rate_card.attached_to_subscriptions?).to be(true)
     end
   end
+
+  describe "#rate_active_at" do
+    subject(:rate_card) { create(:rate_card) }
+
+    let!(:old_rate) { create(:rate_card_rate, rate_card:, effective_from: 10.days.ago.beginning_of_day) }
+    let!(:new_rate) { create(:rate_card_rate, rate_card:, effective_from: 2.days.ago.beginning_of_day) }
+
+    it "returns the rate that was active at the given time" do
+      expect(rate_card.rate_active_at(5.days.ago)).to eq(old_rate)
+      expect(rate_card.rate_active_at(1.day.ago)).to eq(new_rate)
+    end
+
+    it "returns nil before the first rate" do
+      expect(rate_card.rate_active_at(11.days.ago)).to be_nil
+    end
+  end
 end

--- a/spec/models/rate_override_spec.rb
+++ b/spec/models/rate_override_spec.rb
@@ -60,4 +60,27 @@ RSpec.describe RateOverride do
       end
     end
   end
+
+  describe "#charge_model" do
+    it "exposes the rate model under the calculators' expected name" do
+      expect(build(:rate_override).charge_model).to eq("standard")
+    end
+  end
+
+  describe "#prorated?" do
+    it "inherits the structural proration of the card its phase prices" do
+      organization = create(:organization)
+      product = create(:product, :fixed, organization:)
+      rate_card = create(:rate_card, organization:, product:, proration: true)
+      plan_rate_card = create(:plan_rate_card, organization:, rate_card:)
+      override = create(:rate_override, organization:)
+      create(:rate_phase, organization:, plan_rate_card:, position: 1, rate_override: override)
+
+      expect(override.prorated?).to be(true)
+    end
+
+    it "defaults to false when not attached to a phase yet" do
+      expect(build(:rate_override).prorated?).to be(false)
+    end
+  end
 end

--- a/spec/models/subscription_rate_card_spec.rb
+++ b/spec/models/subscription_rate_card_spec.rb
@@ -61,4 +61,11 @@ RSpec.describe SubscriptionRateCard do
       end
     end
   end
+
+  it_behaves_like "a rate phase parent" do
+    let(:item) { create(:subscription_rate_card) }
+    let(:create_rate_phase) do
+      ->(attributes) { create(:rate_phase, :subscription_level, subscription_rate_card: item, **attributes) }
+    end
+  end
 end

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -63,6 +63,71 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
 
     include_examples "requires API permission", "subscription", "write"
 
+    context "when changing the plan of a product-catalog subscription" do
+      let(:plan) { create(:plan, :product_catalog, organization:) }
+      let(:other_plan) { create(:plan, :product_catalog, organization:) }
+
+      it "rejects the change instead of crashing on the legacy comparison" do
+        post_with_token(organization, "/api/v1/subscriptions", {subscription: {
+          external_customer_id: customer.external_id, plan_code: plan.code, external_id: "cat-sub-1"
+        }})
+        expect(response).to have_http_status(:ok)
+
+        post_with_token(organization, "/api/v1/subscriptions", {subscription: {
+          external_customer_id: customer.external_id, plan_code: other_plan.code, external_id: "cat-sub-1"
+        }})
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json.dig(:error_details, :plan)).to eq(["plan_change_not_available"])
+      end
+    end
+
+    context "with a billing_anchor_date" do
+      let(:params) do
+        {
+          external_customer_id: customer.external_id,
+          plan_code:,
+          external_id: SecureRandom.uuid,
+          billing_anchor_date: "2026-01-01"
+        }
+      end
+
+      it "stores and returns it" do
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:subscription][:billing_anchor_date]).to eq("2026-01-01")
+      end
+    end
+
+    context "without a billing_anchor_date" do
+      it "returns the effective anchor instead of null" do
+        freeze_time do
+          subject
+
+          expect(response).to have_http_status(:ok)
+          expect(json[:subscription][:billing_anchor_date]).to eq(Time.current.to_date.iso8601)
+        end
+      end
+    end
+
+    context "with a malformed billing_anchor_date" do
+      let(:params) do
+        {
+          external_customer_id: customer.external_id,
+          plan_code:,
+          external_id: SecureRandom.uuid,
+          billing_anchor_date: "hello"
+        }
+      end
+
+      it "returns a validation error instead of silently dropping it" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json.dig(:error_details, :billing_anchor_date)).to eq(["value_is_invalid"])
+      end
+    end
+
     it "returns a success" do
       create(:plan, code: plan.code, parent_id: plan.id, organization:, description: "foo")
       create(:entitlement, organization:, plan:)

--- a/spec/requests/api/v2/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v2/subscriptions_controller_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V2::SubscriptionsController do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:, pricing_type: "product_catalog") }
+  let(:subscription) { create(:subscription, customer:, plan:, organization:) }
+
+  describe "GET /api/v2/subscriptions" do
+    subject { get_with_token(organization, "/api/v2/subscriptions") }
+
+    before do
+      create(:subscription_rate_card, organization:, subscription:)
+      # An ended version must not inflate the grouped count.
+      create(:subscription_rate_card, organization:, subscription:, started_at: 10.days.ago, ended_at: 1.day.ago)
+    end
+
+    include_examples "requires API permission", "subscription", "read"
+
+    it "returns subscriptions in the v2 shape" do
+      subject
+
+      expect(response).to have_http_status(:success)
+
+      result = json[:subscriptions].sole
+      expect(result[:lago_id]).to eq(subscription.id)
+      expect(result[:plan_code]).to eq(plan.code)
+      expect(result[:applied_rate_cards_count]).to eq(1)
+      expect(result).not_to have_key(:current_billing_period_started_at)
+      expect(result).not_to have_key(:plan_amount_cents)
+    end
+
+    context "with a pending subscription" do
+      let!(:pending_subscription) { create(:subscription, :pending, customer:, plan:, organization:) }
+
+      it "lists only active subscriptions by default" do
+        subject
+
+        expect(json[:subscriptions].map { |s| s[:lago_id] }).to eq([subscription.id])
+      end
+
+      it "lists pending subscriptions when the status filter asks for them" do
+        get_with_token(organization, "/api/v2/subscriptions?status[]=pending")
+
+        expect(json[:subscriptions].map { |s| s[:lago_id] }).to eq([pending_subscription.id])
+      end
+    end
+  end
+
+  describe "GET /api/v2/subscriptions/:external_id" do
+    subject { get_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}") }
+
+    let!(:subscription_rate_card) { create(:subscription_rate_card, organization:, subscription:) }
+
+    include_examples "requires API permission", "subscription", "read"
+
+    it "returns the subscription with its rate card entries" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:subscription][:lago_id]).to eq(subscription.id)
+      expect(json[:subscription][:applied_rate_cards].sole[:lago_id]).to eq(subscription_rate_card.id)
+    end
+
+    context "with an ended version of an entry" do
+      before do
+        create(:subscription_rate_card, organization:, subscription:, started_at: 10.days.ago, ended_at: 1.day.ago)
+      end
+
+      it "excludes it from the count and the list" do
+        subject
+
+        expect(json[:subscription][:applied_rate_cards_count]).to eq(1)
+        expect(json[:subscription][:applied_rate_cards].sole[:lago_id]).to eq(subscription_rate_card.id)
+      end
+    end
+
+    context "when the external id contains a dot" do
+      let(:subscription) { create(:subscription, customer:, plan:, organization:, external_id: "sub.2026-01") }
+
+      it "matches the full id instead of truncating at the format separator" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:subscription][:external_id]).to eq("sub.2026-01")
+      end
+    end
+
+    context "when it does not exist" do
+      subject { get_with_token(organization, "/api/v2/subscriptions/unknown") }
+
+      it "returns a not found error" do
+        subject
+
+        expect(response).to be_not_found_error("subscription")
+      end
+    end
+  end
+end

--- a/spec/services/organizations/create_service_spec.rb
+++ b/spec/services/organizations/create_service_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe Organizations::CreateService do
           )
       end
 
+      it "enables the product catalog for the new organization" do
+        expect(service_result.organization).to be_product_catalog_enabled
+      end
+
       it "creates an API key for created organization" do
         expect { service_result }.to change(ApiKey, :count).by(1)
 

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -2198,4 +2198,28 @@ RSpec.describe Subscriptions::CreateService do
       end
     end
   end
+
+  describe "product catalog materialization" do
+    before do
+      allow(Subscriptions::ProductCatalog::MaterializeService).to receive(:call!).and_call_original
+    end
+
+    context "when the plan uses the product catalog" do
+      let(:plan) { create(:plan, organization:, pricing_type: "product_catalog") }
+
+      it "materializes the plan's rate cards onto the subscription" do
+        create_service.call
+
+        expect(Subscriptions::ProductCatalog::MaterializeService).to have_received(:call!)
+      end
+    end
+
+    context "when the plan is legacy" do
+      it "does not materialize rate cards" do
+        create_service.call
+
+        expect(Subscriptions::ProductCatalog::MaterializeService).not_to have_received(:call!)
+      end
+    end
+  end
 end

--- a/spec/services/subscriptions/product_catalog/materialize_service_spec.rb
+++ b/spec/services/subscriptions/product_catalog/materialize_service_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::ProductCatalog::MaterializeService do
+  subject(:result) { described_class.call(subscription:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:, pricing_type: "product_catalog") }
+  let(:subscription) { create(:subscription, customer:, plan:, started_at: Time.current) }
+
+  let(:rate_card) { create(:rate_card, organization:) }
+
+  before do
+    create(:plan_rate_card, organization:, plan:, rate_card:, units: 5)
+  end
+
+  it "materializes the plan's rate cards onto the subscription" do
+    expect { result }.to change(SubscriptionRateCard, :count).by(1)
+
+    item = subscription.reload.applied_rate_cards.sole
+    expect(item.rate_card).to eq(rate_card)
+    expect(item.units).to eq(5)
+    expect(item.started_at).to eq(subscription.started_at)
+    expect(item.billing_anchor_date).to eq(subscription.started_at.to_date)
+    expect(item.next_billing_at).to eq(subscription.started_at)
+    expect(result.subscription_rate_cards).to eq([item])
+  end
+
+  context "when the subscription carries its own billing anchor" do
+    let(:subscription) do
+      create(:subscription, customer:, plan:, started_at: Time.zone.parse("2026-01-15"), billing_anchor_date: Date.new(2026, 1, 1))
+    end
+
+    it "materializes cards on the subscription's anchor, not its start date" do
+      result
+
+      expect(subscription.reload.applied_rate_cards.sole.billing_anchor_date).to eq(Date.new(2026, 1, 1))
+    end
+  end
+
+  it "does not copy the plan entry's phases: pricing resolves by reference" do
+    plan_rate_card = plan.applied_rate_cards.sole
+    create(:rate_phase, organization:, plan_rate_card:, position: 1)
+
+    expect { result }.not_to change(RatePhase, :count)
+    expect(subscription.reload.applied_rate_cards.sole.rate_phases).to be_empty
+  end
+
+  context "when the plan is not a product catalog plan" do
+    let(:plan) { create(:plan, organization:, pricing_type: "legacy") }
+
+    it "does not materialize anything" do
+      expect { result }.not_to change(SubscriptionRateCard, :count)
+      expect(result.subscription_rate_cards).to be_nil
+    end
+  end
+end

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -1668,4 +1668,40 @@ RSpec.describe Subscriptions::UpdateService do
       end
     end
   end
+
+  context "when moving a pending product-catalog subscription's date" do
+    let(:organization) { membership.organization }
+    let(:customer) { create(:customer, organization:) }
+    let(:plan) { create(:plan, :product_catalog, organization:) }
+    let(:subscription) do
+      create(:subscription, :pending, organization:, customer:, plan:, subscription_at: 1.month.from_now, started_at: nil)
+    end
+
+    let!(:materialized_card) do
+      create(
+        :subscription_rate_card,
+        organization:,
+        subscription:,
+        started_at: subscription.subscription_at,
+        next_billing_at: subscription.subscription_at,
+        billing_anchor_date: subscription.subscription_at.to_date
+      )
+    end
+
+    let!(:custom_card) do
+      create(:subscription_rate_card, organization:, subscription:, started_at: 2.months.from_now)
+    end
+
+    it "resyncs the cards that followed the subscription date" do
+      new_date = 6.weeks.from_now.change(usec: 0)
+
+      result = described_class.call(subscription:, params: {subscription_at: new_date.iso8601})
+
+      expect(result).to be_success
+      expect(materialized_card.reload.started_at).to eq(new_date)
+      expect(materialized_card.next_billing_at).to eq(new_date)
+      expect(materialized_card.billing_anchor_date).to eq(new_date.to_date)
+      expect(custom_card.reload.started_at).to be_within(1.second).of(2.months.from_now)
+    end
+  end
 end

--- a/spec/services/subscriptions/validate_service_spec.rb
+++ b/spec/services/subscriptions/validate_service_spec.rb
@@ -98,6 +98,43 @@ RSpec.describe Subscriptions::ValidateService do
       end
     end
 
+    context "with invalid billing_anchor_date" do
+      let(:args) do
+        {
+          customer:,
+          plan:,
+          subscription_at:,
+          ending_at:,
+          billing_anchor_date: "hello",
+          subscription:,
+          subscription_type:
+        }
+      end
+
+      it "returns false and result has errors" do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:billing_anchor_date]).to eq(["value_is_invalid"])
+      end
+    end
+
+    context "with a valid billing_anchor_date" do
+      let(:args) do
+        {
+          customer:,
+          plan:,
+          subscription_at:,
+          ending_at:,
+          billing_anchor_date: "2026-01-01",
+          subscription:,
+          subscription_type:
+        }
+      end
+
+      it "returns true" do
+        expect(validate_service).to be_valid
+      end
+    end
+
     context "with invalid subscription_at" do
       context "when string is not a valid iso8601 datetime" do
         let(:subscription_at) { "2022-12-13 12:00:00Z" }

--- a/spec/support/shared_examples/rate_phaseable.rb
+++ b/spec/support/shared_examples/rate_phaseable.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Expects the including spec to define:
+#   let(:item) { ... }              - the rate-phase parent
+#   let(:create_rate_phase) { ... } - ->(attributes) { create(:rate_phase, ...) }
+RSpec.shared_examples "a rate phase parent" do
+  describe "#rate_phase_for_cycle" do
+    context "with a terminal (indefinite) phase" do
+      let!(:first) { create_rate_phase.call(position: 1, billing_interval_cycle_count: 2) }
+      let!(:terminal) { create_rate_phase.call(position: 2, billing_interval_cycle_count: nil) }
+
+      it "returns the phase covering each cycle" do
+        expect(item.rate_phase_for_cycle(0)).to eq(first)
+        expect(item.rate_phase_for_cycle(1)).to eq(first)
+        expect(item.rate_phase_for_cycle(2)).to eq(terminal)
+        expect(item.rate_phase_for_cycle(99)).to eq(terminal)
+      end
+    end
+
+    context "when all phases are finite" do
+      before do
+        create_rate_phase.call(position: 1, billing_interval_cycle_count: 2)
+        create_rate_phase.call(position: 2, billing_interval_cycle_count: 3)
+      end
+
+      it "returns nil for cycles past the defined window" do
+        expect(item.rate_phase_for_cycle(5)).to be_nil
+      end
+    end
+
+    context "without any phase" do
+      it "returns nil" do
+        expect(item.rate_phase_for_cycle(0)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

- Materialize a plan's rate cards onto the subscription at creation, inheriting the subscription billing anchor and validating `billing_anchor_date`.
- Add phase-aware rate resolution helpers on the catalog models.
- Serve product-catalog subscriptions on the v2 API (index and show) with a v2 shape that drops the plan-interval fields and only counts current and scheduled rate cards.
- Guard sibling v1 flows: reject plan changes involving catalog plans and resync card dates when a pending subscription moves.
- Default new organizations to the product catalog.