### PR TITLE
feat(payment_terms): Add payment_term to subscriptions and wallets

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -331,6 +331,7 @@ end
 #  on_termination_credit_note   :enum
 #  on_termination_invoice       :enum             default("generate"), not null
 #  payment_method_type          :enum             default("provider"), not null
+#  payment_term                 :jsonb
 #  progressive_billing_disabled :boolean          default(FALSE), not null
 #  purchase_order_number        :string
 #  skip_daily_usage             :boolean          default(FALSE), not null

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -158,6 +158,7 @@ end
 #  paid_top_up_max_amount_cents        :bigint
 #  paid_top_up_min_amount_cents        :bigint
 #  payment_method_type                 :enum             default("provider"), not null
+#  payment_term                        :jsonb
 #  priority                            :integer          default(50), not null
 #  purchase_order_number               :string
 #  rate_amount                         :decimal(30, 5)   default(0.0), not null

--- a/db/migrate/20260826191346_add_payment_term_to_subscriptions_and_wallets.rb
+++ b/db/migrate/20260826191346_add_payment_term_to_subscriptions_and_wallets.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddPaymentTermToSubscriptionsAndWallets < ActiveRecord::Migration[8.0]
+  def change
+    add_column :subscriptions, :payment_term, :jsonb
+    add_column :wallets, :payment_term, :jsonb
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3955,7 +3955,8 @@ CREATE TABLE public.subscriptions (
     skip_daily_usage boolean DEFAULT false NOT NULL,
     cancellation_reason public.subscription_cancellation_reasons,
     purchase_order_number character varying,
-    billing_anchor_date date
+    billing_anchor_date date,
+    payment_term jsonb
 );
 
 
@@ -4881,7 +4882,8 @@ CREATE TABLE public.wallets (
     traceable boolean DEFAULT false NOT NULL,
     code character varying,
     billing_entity_id uuid,
-    purchase_order_number character varying
+    purchase_order_number character varying,
+    payment_term jsonb
 );
 
 
@@ -15063,6 +15065,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260826235314'),
 ('20260826235313'),
 ('20260826235312'),
+('20260826191346'),
 ('20260824115446'),
 ('20260819134550'),
 ('20260819134021'),

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -286,6 +286,7 @@ RSpec.describe Wallet do
       paid_top_up_max_amount_cents
       paid_top_up_min_amount_cents
       payment_method_type
+      payment_term
       rate_amount
       ready_to_be_refreshed
       skip_invoice_custom_sections


### PR DESCRIPTION
## Context

Subscriptions and wallets need optional structured payment-term overrides in the flexible payment terms stack. This PR depends on #6201.

## Description

Add nullable JSONB `payment_term` columns to subscriptions and wallets. Classify the wallet column as unrelated to balance refresh in the exhaustive attribute coverage spec.

## Validation

GitHub RSpec, lint, and migration checks pass. [RSpec run](https://github.com/getlago/lago-api/actions/runs/34230986547). No tests were run locally for this follow-up.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>