### PR TITLE
fix(analytics): return integer amounts and counts

### DIFF
--- a/app/serializers/v1/analytics/gross_revenue_serializer.rb
+++ b/app/serializers/v1/analytics/gross_revenue_serializer.rb
@@ -6,9 +6,9 @@ module V1
       def serialize
         {
           month: model["month"],
-          amount_cents: model["amount_cents"],
+          amount_cents: model["amount_cents"]&.to_i,
           currency: model["currency"],
-          invoices_count: model["invoices_count"],
+          invoices_count: model["invoices_count"]&.to_i,
           billing_entity_id: model["billing_entity_id"]
         }
       end

--- a/app/serializers/v1/analytics/invoice_collection_serializer.rb
+++ b/app/serializers/v1/analytics/invoice_collection_serializer.rb
@@ -8,7 +8,7 @@ module V1
           month: model["month"],
           payment_status: model["payment_status"],
           invoices_count: model["invoices_count"],
-          amount_cents: model["amount_cents"],
+          amount_cents: model["amount_cents"]&.to_i,
           currency: model["currency"]
         }
       end

--- a/app/serializers/v1/analytics/invoiced_usage_serializer.rb
+++ b/app/serializers/v1/analytics/invoiced_usage_serializer.rb
@@ -8,7 +8,7 @@ module V1
           month: model["month"],
           code: model["code"],
           currency: model["currency"],
-          amount_cents: model["amount_cents"]
+          amount_cents: model["amount_cents"]&.to_i
         }
       end
     end

--- a/app/serializers/v1/analytics/mrr_serializer.rb
+++ b/app/serializers/v1/analytics/mrr_serializer.rb
@@ -6,7 +6,7 @@ module V1
       def serialize
         {
           month: model["month"],
-          amount_cents: model["amount_cents"],
+          amount_cents: model["amount_cents"]&.to_i,
           currency: model["currency"]
         }
       end

--- a/app/serializers/v1/analytics/overdue_balance_serializer.rb
+++ b/app/serializers/v1/analytics/overdue_balance_serializer.rb
@@ -6,7 +6,7 @@ module V1
       def serialize
         {
           month: model["month"],
-          amount_cents: model["amount_cents"],
+          amount_cents: model["amount_cents"]&.to_i,
           currency: model["currency"],
           lago_invoice_ids: JSON.parse(model["lago_invoice_ids"]).flatten,
           billing_entity_id: model["billing_entity_id"]

--- a/spec/requests/api/v1/analytics/gross_revenues_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/gross_revenues_controller_spec.rb
@@ -26,6 +26,30 @@ RSpec.describe Api::V1::Analytics::GrossRevenuesController do
         expect(Analytics::GrossRevenuesService).to have_received(:call).with(organization, billing_entity_id: nil, currency: nil, months: nil, external_customer_id: nil)
       end
 
+      context "when the organization has finalized invoices" do
+        it "returns integer amounts and counts" do
+          travel_to(DateTime.new(2024, 1, 15)) do
+            create(:invoice, customer:, organization:, status: :finalized, total_amount_cents: 1000, issuing_date: DateTime.new(2024, 1, 5))
+            create(:invoice, customer:, organization:, status: :finalized, total_amount_cents: 2000, issuing_date: DateTime.new(2024, 1, 6))
+
+            subject
+
+            expect(response).to have_http_status(:success)
+            expect(json[:gross_revenues]).to eq(
+              [
+                {
+                  month: "2024-01-01T00:00:00.000Z",
+                  amount_cents: 3000,
+                  currency: "EUR",
+                  invoices_count: 2,
+                  billing_entity_id: organization.default_billing_entity.id
+                }
+              ]
+            )
+          end
+        end
+      end
+
       context "when sending params" do
         let(:params) { {billing_entity_code: billing_entity.code} }
 

--- a/spec/requests/api/v1/analytics/invoice_collections_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/invoice_collections_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Api::V1::Analytics::InvoiceCollectionsController do # rubocop:dis
         expect(month).to eq(DateTime.current.beginning_of_month)
         expect(json[:invoice_collections].first[:payment_status]).to eq(nil)
         expect(json[:invoice_collections].first[:invoices_count]).to eq(0)
-        expect(json[:invoice_collections].first[:amount_cents]).to eq(0.0)
+        expect(json[:invoice_collections].first[:amount_cents]).to eq(0)
         expect(json[:invoice_collections].first[:currency]).to eq(nil)
         expect(Analytics::InvoiceCollectionsService).to have_received(:call).with(organization, billing_entity_id: nil, currency: nil, months: nil)
       end

--- a/spec/requests/api/v1/analytics/overdue_balances_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/overdue_balances_controller_spec.rb
@@ -31,14 +31,14 @@ RSpec.describe Api::V1::Analytics::OverdueBalancesController do
           [
             {
               month: "2023-11-01T00:00:00.000Z",
-              amount_cents: "1000.0",
+              amount_cents: 1000,
               currency: "EUR",
               lago_invoice_ids: [i1.id],
               billing_entity_id: organization.default_billing_entity.id
             },
             {
               month: "2024-01-01T00:00:00.000Z",
-              amount_cents: "5000.0",
+              amount_cents: 5000,
               currency: "EUR",
               lago_invoice_ids: match_array([i2.id, i3.id]),
               billing_entity_id: organization.default_billing_entity.id

--- a/spec/serializers/v1/analytics/gross_revenue_serializer_spec.rb
+++ b/spec/serializers/v1/analytics/gross_revenue_serializer_spec.rb
@@ -28,4 +28,36 @@ RSpec.describe ::V1::Analytics::GrossRevenueSerializer do
       }
     )
   end
+
+  context "when amount_cents is a BigDecimal" do
+    before { gross_revenue["amount_cents"] = BigDecimal("1000.0") }
+
+    it "serializes it as an integer" do
+      expect(result["gross_revenue"]["amount_cents"]).to be(1000)
+    end
+  end
+
+  context "when amount_cents is a float" do
+    before { gross_revenue["amount_cents"] = 1000.0 }
+
+    it "serializes it as an integer" do
+      expect(result["gross_revenue"]["amount_cents"]).to be(1000)
+    end
+  end
+
+  context "when amount_cents is nil" do
+    before { gross_revenue["amount_cents"] = nil }
+
+    it "serializes it as nil" do
+      expect(result["gross_revenue"]["amount_cents"]).to be_nil
+    end
+  end
+
+  context "when invoices_count is a BigDecimal" do
+    before { gross_revenue["invoices_count"] = BigDecimal("2.0") }
+
+    it "serializes it as an integer" do
+      expect(result["gross_revenue"]["invoices_count"]).to be(2)
+    end
+  end
 end

--- a/spec/serializers/v1/analytics/invoice_collection_serializer_spec.rb
+++ b/spec/serializers/v1/analytics/invoice_collection_serializer_spec.rb
@@ -24,4 +24,28 @@ RSpec.describe ::V1::Analytics::InvoiceCollectionSerializer do
     expect(result["invoice_collection"]["currency"]).to eq("EUR")
     expect(result["invoice_collection"]["amount_cents"]).to eq(100)
   end
+
+  context "when amount_cents is a BigDecimal" do
+    before { invoice_collection["amount_cents"] = BigDecimal("1000.0") }
+
+    it "serializes it as an integer" do
+      expect(result["invoice_collection"]["amount_cents"]).to be(1000)
+    end
+  end
+
+  context "when amount_cents is a float" do
+    before { invoice_collection["amount_cents"] = 1000.0 }
+
+    it "serializes it as an integer" do
+      expect(result["invoice_collection"]["amount_cents"]).to be(1000)
+    end
+  end
+
+  context "when amount_cents is nil" do
+    before { invoice_collection["amount_cents"] = nil }
+
+    it "serializes it as nil" do
+      expect(result["invoice_collection"]["amount_cents"]).to be_nil
+    end
+  end
 end

--- a/spec/serializers/v1/analytics/invoiced_usage_serializer_spec.rb
+++ b/spec/serializers/v1/analytics/invoiced_usage_serializer_spec.rb
@@ -22,4 +22,28 @@ RSpec.describe ::V1::Analytics::InvoicedUsageSerializer do
     expect(result["invoiced_usage"]["currency"]).to eq("EUR")
     expect(result["invoiced_usage"]["amount_cents"]).to eq(100)
   end
+
+  context "when amount_cents is a BigDecimal" do
+    before { invoiced_usage["amount_cents"] = BigDecimal("1000.0") }
+
+    it "serializes it as an integer" do
+      expect(result["invoiced_usage"]["amount_cents"]).to be(1000)
+    end
+  end
+
+  context "when amount_cents is a float" do
+    before { invoiced_usage["amount_cents"] = 1000.0 }
+
+    it "serializes it as an integer" do
+      expect(result["invoiced_usage"]["amount_cents"]).to be(1000)
+    end
+  end
+
+  context "when amount_cents is nil" do
+    before { invoiced_usage["amount_cents"] = nil }
+
+    it "serializes it as nil" do
+      expect(result["invoiced_usage"]["amount_cents"]).to be_nil
+    end
+  end
 end

--- a/spec/serializers/v1/analytics/mrr_serializer_spec.rb
+++ b/spec/serializers/v1/analytics/mrr_serializer_spec.rb
@@ -20,4 +20,28 @@ RSpec.describe ::V1::Analytics::MrrSerializer do
     expect(result["mrr"]["amount_cents"]).to eq(100)
     expect(result["mrr"]["currency"]).to eq("EUR")
   end
+
+  context "when amount_cents is a BigDecimal" do
+    before { mrr["amount_cents"] = BigDecimal("1000.0") }
+
+    it "serializes it as an integer" do
+      expect(result["mrr"]["amount_cents"]).to be(1000)
+    end
+  end
+
+  context "when amount_cents is a float" do
+    before { mrr["amount_cents"] = 1000.0 }
+
+    it "serializes it as an integer" do
+      expect(result["mrr"]["amount_cents"]).to be(1000)
+    end
+  end
+
+  context "when amount_cents is nil" do
+    before { mrr["amount_cents"] = nil }
+
+    it "serializes it as nil" do
+      expect(result["mrr"]["amount_cents"]).to be_nil
+    end
+  end
 end

--- a/spec/serializers/v1/analytics/overdue_balance_serializer_spec.rb
+++ b/spec/serializers/v1/analytics/overdue_balance_serializer_spec.rb
@@ -28,4 +28,28 @@ RSpec.describe ::V1::Analytics::OverdueBalanceSerializer do
       }
     )
   end
+
+  context "when amount_cents is a BigDecimal" do
+    before { overdue_balance["amount_cents"] = BigDecimal("1000.0") }
+
+    it "serializes it as an integer" do
+      expect(result["overdue_balance"]["amount_cents"]).to be(1000)
+    end
+  end
+
+  context "when amount_cents is a float" do
+    before { overdue_balance["amount_cents"] = 1000.0 }
+
+    it "serializes it as an integer" do
+      expect(result["overdue_balance"]["amount_cents"]).to be(1000)
+    end
+  end
+
+  context "when amount_cents is nil" do
+    before { overdue_balance["amount_cents"] = nil }
+
+    it "serializes it as nil" do
+      expect(result["overdue_balance"]["amount_cents"]).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
> Reported as [lago-go-client#358](https://github.com/getlago/lago-go-client/pull/358), which works around this client-side.

## Context

The analytics endpoints document `amount_cents` and `invoices_count` as integers, but the
serializers forward whatever the SQL produced. Those queries cast amounts to `float` for the
arithmetic they perform, and `SUM` widens counts to `numeric`, so what reaches the payload is a
Float or a BigDecimal — and Rails renders BigDecimal as a quoted string.

```
# one organization, three finalized invoices in Jan 2024, one of them overdue

GET /analytics/gross_revenue
before: {"amount_cents":6000.0,"invoices_count":"3.0"}   # numeric -> BigDecimal -> quoted, undecodable as an int
after:  {"amount_cents":6000,"invoices_count":3}

GET /analytics/overdue_balance
before: {"amount_cents":"3000.0"}                        # same, on the amount itself
after:  {"amount_cents":3000}
```

GraphQL is unaffected: its `BigInt` scalar already runs `value.to_i` over these same rows, which is
why only REST clients ever saw it.

## Description

The serializers now apply that same coercion, so both APIs agree on the value. Fixing the casts in
SQL was rejected: the intermediate `::float` and `::numeric` are load-bearing for the division and
proration those queries perform, and only the final output is contractually an integer.

`nil` is preserved rather than coerced, because the MRR query left-joins a generated month series
and returns no amount for months it never measured; `0` would claim a zero MRR. That row still
deviates from a schema which marks the field required and non-nullable, but the padding row is the
defect there, not the amount.

`overdue_balances_controller_spec` expected `"3000.0"` and `invoice_collections_controller_spec`
expected `0.0`: both were pinning the bug rather than the contract. `gross_revenues_controller_spec`
only ever asserted an empty list, which is how the string count survived, so it now exercises a
populated payload. Not covered: `billing_entity_id` is returned by two of these endpoints but
missing from their OpenAPI schemas, documented separately in [lago-openapi#573](https://github.com/getlago/lago-openapi/pull/573).

## Behavior change to be aware of

Integrators polling these five endpoints will see the JSON type of `amount_cents` and
`invoices_count` change — `"3000.0"` and `0.0` become `3000` and `0` — so anything parsing them as
strings or floats has to accept integers. Nothing to backfill. Values are unchanged except where the
underlying figure was genuinely fractional, which is MRR proration and usage net of precise coupon
amounts: those are now truncated, matching what GraphQL has always returned for the same row.
