### PR TITLE
refactor(fees): introduce metered items

### DIFF
--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -4,69 +4,51 @@ module Fees
   class ChargeService < BaseService
     Result = BaseResult[:fees, :cached_aggregations]
 
-    # optional params:
-    # | usage_filters - UsageFilters
-    #  - context (:current_usage, :invoice_preview, :recurring) - to be moved in usage_filters
-    # | results_adjustments - to be implemented as a class to pass the following inside:
-    #  - with_zero_units_filters
-    #  - calculate_projected_usage
-    #  - apply_taxes
-    #  - filtered_aggregations
     def initialize(
       invoice:,
-      charge:,
+      metered_item:,
       subscription:,
-      boundaries:,
-      context: nil,
       cache_middleware: nil,
       filtered_aggregations: nil,
-      apply_taxes: false,
-      calculate_projected_usage: false,
-      with_zero_units_filters: true,
-      usage_filters: UsageFilters::NONE,
-      skip_adjusted_fees: false,
+      options: nil,
       plan: nil,
       customer: nil
     )
       @invoice = invoice
-      @charge = charge
+      @metered_item = metered_item
       @subscription = subscription
-      @boundaries = boundaries
-      @currency = subscription.plan.amount.currency
-      @apply_taxes = apply_taxes
-      @calculate_projected_usage = calculate_projected_usage
-      @with_zero_units_filters = with_zero_units_filters
-      @context = context
-      @current_usage = context == :current_usage
-      @cache_middleware = cache_middleware || Subscriptions::ChargeCacheMiddleware.new(
-        subscription:, charge:, to_datetime: boundaries.charges_to_datetime, cache: false
-      )
-
-      # Allow the service to ignore events aggregation
-      @filtered_aggregations = filtered_aggregations
-      @usage_filters = usage_filters
-      @skip_adjusted_fees = skip_adjusted_fees
-
+      @options = options || Options.default
       @plan = plan
       @customer = customer
+
+      validate!
+
+      @cache_middleware = cache_middleware || Subscriptions::ChargeCacheMiddleware.new(
+        subscription:,
+        charge: metered_item.charge,
+        to_datetime: metered_item.boundaries.charges_to_datetime,
+        cache: false
+      )
+      @filtered_aggregations = filtered_aggregations
 
       super(nil)
     end
 
     def call
-      return result if !current_usage && already_billed?
+      return result if !options.current_usage? && already_billed?
 
-      init_fees
-      return result if current_usage
+      init_metered_items_fees
+      return result if options.current_usage?
 
       if invoice.nil? || !invoice.progressive_billing?
         init_true_up_fee
       end
+
       return result unless result.success?
 
       ActiveRecord::Base.transaction do
         result.fees.reject! { |f| !should_persist_fee?(f, result.fees) }
-        next if context == :invoice_preview
+        next if options.invoice_preview?
 
         result.fees.each do |fee|
           fee.save!
@@ -87,46 +69,53 @@ module Fees
 
     private
 
-    attr_accessor :invoice, :charge, :subscription, :boundaries, :context, :current_usage, :currency, :cache_middleware,
-      :filtered_aggregations, :apply_taxes, :calculate_projected_usage, :with_zero_units_filters, :usage_filters
+    attr_reader :invoice, :metered_item, :subscription, :cache_middleware, :filtered_aggregations, :options, :plan, :customer
 
-    delegate :billable_metric, to: :charge
-    delegate :organization, to: :subscription
-    delegate :plan, to: :subscription
-
-    def init_fees
+    def init_metered_items_fees
       result.fees = []
 
-      return init_charge_fees(properties: charge.properties) unless charge.filters.any?
+      return init_fees(selected_metered_item: metered_item) unless metered_item.charge.filters.any?
 
       # NOTE: Create a fee for each filters defined on the charge.
-      charge.filters.each do |charge_filter|
-        init_charge_fees(properties: charge_filter.properties, charge_filter:)
+      metered_item.charge.filters.each do |charge_filter|
+        filter_metered_item = metered_item.with_charge_filter(charge_filter)
+        init_fees(selected_metered_item: filter_metered_item)
       end
 
       # NOTE: Create a fee for events not matching any filters.
-      charge_filter = ChargeFilter.new(charge:, properties: {"pricing_group_keys" => charge.pricing_group_keys})
-      init_charge_fees(properties: charge.properties, charge_filter:)
+      charge_filter = ChargeFilter.new(
+        charge: metered_item.charge,
+        properties: {"pricing_group_keys" => metered_item.charge.pricing_group_keys}
+      )
+
+      init_fees(
+        selected_metered_item: metered_item.with_charge_filter(
+          charge_filter,
+          properties: metered_item.charge.properties
+        )
+      )
     end
 
-    def init_charge_fees(properties:, charge_filter: nil)
-      if skip_unused_filter?(charge_filter)
+    def init_fees(selected_metered_item:)
+      if skip_unused_filter?(selected_metered_item)
         fees = []
       else
-        fees = compute_fees_with_cache(properties:, charge_filter:)
+        fees = compute_fees_with_cache(selected_metered_item:)
         # NOTE: nil means the aggregation or the charge model failed, result carries the error
         return if fees.nil?
       end
 
       if fees.empty? && skip_caching_of_non_persistable_fee?
-        fees = hydrate_non_persistable_fees(properties:, charge_filter:)
+        fees = hydrate_non_persistable_fees(selected_metered_item:)
       end
 
       # Preserve preloaded associations on all fees (including cached ones) to avoid N+1 queries
       fees.each do |fee|
-        fee.association(:billable_metric).target = billable_metric
-        fee.association(:charge_filter).target = charge_filter if charge_filter&.id
-        fee.association(:charge).target = charge
+        fee.association(:billable_metric).target = selected_metered_item.billable_metric
+        if selected_metered_item.charge_filter&.id
+          fee.association(:charge_filter).target = selected_metered_item.charge_filter
+        end
+        fee.association(:charge).target = selected_metered_item.charge
       end
 
       result.fees.concat(fees.compact)
@@ -138,24 +127,26 @@ module Fees
     #       is hydrated in memory instead. Scoped to current usage: on invoicing, adjusted fees
     #       on draft invoices can target filters without any usage.
     #       Recurring metrics always aggregate as usage carries over from previous periods.
-    def skip_unused_filter?(charge_filter)
-      return false unless current_usage
+    def skip_unused_filter?(selected_metered_item)
+      return false unless options.current_usage?
       return false if filtered_aggregations.nil?
-      return false if billable_metric.recurring?
+      return false if selected_metered_item.billable_metric.recurring?
 
-      !filtered_aggregations.include?(charge_filter&.id)
+      !filtered_aggregations.include?(selected_metered_item.charge_filter&.id)
     end
 
-    def compute_fees_with_cache(properties:, charge_filter:)
-      cache_middleware.call(charge_filter:) do
-        aggregation_result = aggregator(charge_filter:).aggregate(options: options(properties))
+    def compute_fees_with_cache(selected_metered_item:)
+      cache_middleware.call(charge_filter: selected_metered_item.charge_filter) do
+        aggregation_result = aggregator(selected_metered_item:).aggregate(
+          options: selected_metered_item.aggregation_options(current_usage: options.current_usage?)
+        )
 
         unless aggregation_result.success?
           result.fail_with_error!(aggregation_result.error)
           return
         end
 
-        charge_model_result = apply_charge_model(aggregation_result:, properties:)
+        charge_model_result = apply_charge_model(aggregation_result:, selected_metered_item:)
         unless charge_model_result.success?
           result.fail_with_error!(charge_model_result.error)
           return
@@ -163,14 +154,17 @@ module Fees
 
         breakdowns_by_group = breakdowns_by_grouped_by(aggregation_result.breakdowns, charge_model_result)
 
-        if billable_metric.recurring?
-          persist_recurring_value(aggregation_result.aggregations || [aggregation_result], charge_filter, breakdowns_by_group)
+        if selected_metered_item.billable_metric.recurring?
+          persist_recurring_value(
+            aggregation_result.aggregations || [aggregation_result],
+            selected_metered_item,
+            breakdowns_by_group
+          )
         end
 
         charge_fees = fees_from_charge_model_result(
           charge_model_result,
-          properties:,
-          charge_filter:,
+          selected_metered_item:,
           breakdowns_by_group:
         )
 
@@ -179,29 +173,31 @@ module Fees
     end
 
     def skip_caching_of_non_persistable_fee?
-      current_usage
+      options.current_usage?
     end
 
-    def hydrate_non_persistable_fees(properties:, charge_filter:)
-      zero_aggregation = aggregator(charge_filter:).empty_results
+    def hydrate_non_persistable_fees(selected_metered_item:)
+      zero_aggregation = aggregator(selected_metered_item:).empty_results
 
       charge_model_result = ChargeModels::Factory.new_instance(
-        pricing_structure: ChargeModels::PricingStructure.from_charge(charge).with(properties:),
+        pricing_structure: selected_metered_item.pricing_structure,
         aggregation_result: zero_aggregation,
-        period_ratio: calculate_period_ratio,
-        calculate_projected_usage:
+        period_ratio: selected_metered_item.period_ratio,
+        calculate_projected_usage: options.calculate_projected_usage
       ).apply
 
-      fees_from_charge_model_result(charge_model_result, properties:, charge_filter:, breakdowns_by_group: {})
+      fees_from_charge_model_result(charge_model_result, selected_metered_item:, breakdowns_by_group: {})
     end
 
-    def fees_from_charge_model_result(charge_model_result, properties:, charge_filter:, breakdowns_by_group:)
+    def fees_from_charge_model_result(charge_model_result, selected_metered_item:, breakdowns_by_group:)
       charge_model_result.grouped_results.map do |amount_result|
         # TODO: check if this is still needed as we now skip certain zero units fees
-        next if current_usage && charge_filter && amount_result.units.zero? && !with_zero_units_filters
+        if options.current_usage? && selected_metered_item.charge_filter && amount_result.units.zero? && !options.with_zero_units_filters
+          next
+        end
 
-        adjusted = applicable_adjusted_fee(amount_result:, charge_filter:)
-        fee = init_fee(amount_result, properties:, charge_filter:, adjusted:)
+        adjusted = applicable_adjusted_fee(amount_result:, selected_metered_item:)
+        fee = init_fee(amount_result, selected_metered_item:, adjusted:)
         next if fee.nil?
 
         if adjusted.nil? || amount_result.units == fee.units
@@ -212,11 +208,11 @@ module Fees
       end.compact
     end
 
-    def applicable_adjusted_fee(amount_result:, charge_filter:)
-      return nil if current_usage
+    def applicable_adjusted_fee(amount_result:, selected_metered_item:)
+      return nil if options.current_usage?
       return nil unless invoice&.draft?
 
-      adjusted = adjusted_fee(charge_filter:, grouped_by: amount_result.grouped_by)
+      adjusted = adjusted_fee(charge_filter: selected_metered_item.charge_filter, grouped_by: amount_result.grouped_by)
       return nil if adjusted.nil? || adjusted.adjusted_display_name?
 
       adjusted
@@ -229,7 +225,7 @@ module Fees
         fee.presentation_breakdowns.build(
           presentation_by: breakdown[:groups],
           units: breakdown[:value],
-          organization_id: charge.organization_id
+          organization_id: metered_item.organization_id
         )
       end
     end
@@ -254,14 +250,14 @@ module Fees
       charge_fees.filter { |f| should_persist_fee?(f, charge_fees) }
     end
 
-    def init_fee(amount_result, properties:, charge_filter:, adjusted:)
+    def init_fee(amount_result, selected_metered_item:, adjusted:)
       # NOTE: Build fee for case when there is adjusted fee and units or amount has been adjusted (see applicable_adjusted_fee method).
       # Base fee creation flow handles case when only name has been adjusted
       if adjusted
         adjustement_result = Fees::InitFromAdjustedChargeFeeService.call(
           adjusted_fee: adjusted,
-          boundaries:,
-          properties:
+          boundaries: selected_metered_item.boundaries,
+          properties: selected_metered_item.properties
         )
         unless adjustement_result.success?
           result.fail_with_error!(adjustement_result.error)
@@ -279,28 +275,28 @@ module Fees
 
       # NOTE: amount_result should be a BigDecimal, we need to round it
       # to the currency decimals and transform it into currency cents
-      if charge.applied_pricing_unit
+      if selected_metered_item.applied_pricing_unit
         pricing_unit_usage = PricingUnitUsage.build_from_fiat_amounts(
           amount: amount_result.amount,
           unit_amount: amount_result.unit_amount,
-          applied_pricing_unit: charge.applied_pricing_unit
+          applied_pricing_unit: selected_metered_item.applied_pricing_unit
         )
 
         amount_cents, precise_amount_cents, unit_amount_cents, precise_unit_amount = pricing_unit_usage
-          .to_fiat_currency_cents(currency)
+          .to_fiat_currency_cents(selected_metered_item.currency)
           .values_at(:amount_cents, :precise_amount_cents, :unit_amount_cents, :precise_unit_amount)
       else
         pricing_unit_usage = nil
-        rounded_amount = amount_result.amount.round(currency.exponent)
-        amount_cents = rounded_amount * currency.subunit_to_unit
-        precise_amount_cents = amount_result.amount * currency.subunit_to_unit.to_d
-        unit_amount_cents = amount_result.unit_amount * currency.subunit_to_unit
+        rounded_amount = amount_result.amount.round(selected_metered_item.currency.exponent)
+        amount_cents = rounded_amount * selected_metered_item.currency.subunit_to_unit
+        precise_amount_cents = amount_result.amount * selected_metered_item.currency.subunit_to_unit.to_d
+        unit_amount_cents = amount_result.unit_amount * selected_metered_item.currency.subunit_to_unit
         precise_unit_amount = amount_result.unit_amount
       end
 
-      units = if current_usage && (charge.pay_in_advance? || charge.prorated?)
+      units = if options.current_usage? && (selected_metered_item.pay_in_advance? || selected_metered_item.prorated?)
         amount_result.current_usage_units
-      elsif charge.prorated?
+      elsif selected_metered_item.prorated?
         amount_result.full_units_number.nil? ? amount_result.units : amount_result.full_units_number
       else
         amount_result.units
@@ -311,16 +307,16 @@ module Fees
         organization_id: subscription.organization_id,
         billing_entity_id: subscription.applicable_billing_entity_id,
         subscription:,
-        charge:,
+        charge: selected_metered_item.charge,
         amount_cents:,
         precise_amount_cents:,
-        amount_currency: currency,
+        amount_currency: selected_metered_item.currency,
         fee_type: :charge,
         invoiceable_type: "Charge",
-        invoiceable: charge,
+        invoiceable: selected_metered_item.charge,
         units:,
         total_aggregated_units: amount_result.total_aggregated_units || units,
-        properties: filtered_for_charge_boundaries(boundaries.to_h),
+        properties: selected_metered_item.filtered_for_charge_boundaries,
         events_count: amount_result.count,
         payment_status: :pending,
         taxes_amount_cents: 0,
@@ -329,20 +325,20 @@ module Fees
         precise_unit_amount:,
         amount_details: amount_result.amount_details,
         grouped_by: amount_result.grouped_by || {},
-        charge_filter: charge_filter&.persisted? ? charge_filter : nil,
+        charge_filter: selected_metered_item.charge_filter&.persisted? ? selected_metered_item.charge_filter : nil,
         pricing_unit_usage:
       )
 
-      unless charge.invoiceable?
-        new_fee.pay_in_advance = charge.pay_in_advance?
+      unless selected_metered_item.invoiceable?
+        new_fee.pay_in_advance = selected_metered_item.pay_in_advance?
       end
 
-      if !current_usage && (adjusted = adjusted_fee(charge_filter:, grouped_by: amount_result.grouped_by))&.adjusted_display_name?
+      if !options.current_usage? && (adjusted = adjusted_fee(charge_filter: selected_metered_item.charge_filter, grouped_by: amount_result.grouped_by))&.adjusted_display_name?
         new_fee.invoice_display_name = adjusted.invoice_display_name
       end
 
-      if apply_taxes
-        taxes_result = Fees::ApplyTaxesService.call(fee: new_fee, plan: @plan, customer: @customer)
+      if options.apply_taxes
+        taxes_result = Fees::ApplyTaxesService.call(fee: new_fee, plan:, customer:)
         taxes_result.raise_if_error!
       end
 
@@ -350,7 +346,7 @@ module Fees
     end
 
     def should_persist_fee?(fee, fees)
-      return true if context == :recurring
+      return true if options.recurring?
       return true if fee.units != 0 || fee.amount_cents != 0 || fee.events_count != 0
       return true if adjusted_fee(charge_filter: fee.charge_filter, grouped_by: fee.grouped_by).present?
       return true if fee.true_up_parent_fee.present?
@@ -359,7 +355,7 @@ module Fees
     end
 
     def adjusted_fee(charge_filter:, grouped_by:)
-      return if @skip_adjusted_fees
+      return if options.skip_adjusted_fees
       @adjusted_fee ||= {}
 
       key = [
@@ -373,9 +369,9 @@ module Fees
       return @adjusted_fee[key] if @adjusted_fee.key?(key)
 
       scope = AdjustedFee
-        .where(invoice:, subscription:, charge:, charge_filter:, fee_type: :charge)
-        .where("(properties->>'charges_from_datetime')::timestamptz = ?", boundaries.charges_from_datetime&.iso8601(3))
-        .where("(properties->>'charges_to_datetime')::timestamptz = ?", boundaries.charges_to_datetime&.iso8601(3))
+        .where(invoice:, subscription:, charge: metered_item.charge, charge_filter:, fee_type: :charge)
+        .where("(properties->>'charges_from_datetime')::timestamptz = ?", metered_item.boundaries.charges_from_datetime&.iso8601(3))
+        .where("(properties->>'charges_to_datetime')::timestamptz = ?", metered_item.boundaries.charges_to_datetime&.iso8601(3))
 
       scope = if grouped_by.present?
         scope.where(grouped_by:)
@@ -389,7 +385,7 @@ module Fees
     def init_true_up_fee
       fee = result.fees.find { |f| f.charge_filter_id.nil? }
 
-      if charge.applied_pricing_unit
+      if metered_item.applied_pricing_unit
         used_amount_cents = result.fees.map(&:pricing_unit_usage).sum(&:amount_cents)
         used_precise_amount_cents = result.fees.map(&:pricing_unit_usage).sum(&:precise_amount_cents)
       else
@@ -401,37 +397,28 @@ module Fees
       result.fees << true_up_fee if true_up_fee
     end
 
-    def apply_charge_model(aggregation_result:, properties:)
+    def apply_charge_model(aggregation_result:, selected_metered_item:)
       ChargeModels::Factory.new_instance(
-        pricing_structure: ChargeModels::PricingStructure.from_charge(charge).with(properties:),
+        pricing_structure: selected_metered_item.pricing_structure,
         aggregation_result:,
-        period_ratio: calculate_period_ratio,
-        calculate_projected_usage:
+        period_ratio: selected_metered_item.period_ratio,
+        calculate_projected_usage: options.calculate_projected_usage
       ).apply
-    end
-
-    def options(properties)
-      {
-        free_units_per_events: properties["free_units_per_events"].to_i,
-        free_units_per_total_aggregation: BigDecimal(properties["free_units_per_total_aggregation"] || 0),
-        is_current_usage: current_usage,
-        is_pay_in_advance: charge.pay_in_advance?
-      }
     end
 
     def already_billed?
       existing_fees = if invoice
-        invoice.fees.where(charge_id: charge.id, subscription_id: subscription.id)
+        invoice.fees.where(charge_id: metered_item.charge.id, subscription_id: subscription.id)
       else
         Fee.where(
-          charge_id: charge.id,
+          charge_id: metered_item.charge.id,
           subscription_id: subscription.id,
           invoice_id: nil,
           pay_in_advance_event_id: nil
         ).where(
-          "(properties->>'charges_from_datetime')::timestamptz = ?", boundaries.charges_from_datetime&.iso8601(3)
+          "(properties->>'charges_from_datetime')::timestamptz = ?", metered_item.boundaries.charges_from_datetime&.iso8601(3)
         ).where(
-          "(properties->>'charges_to_datetime')::timestamptz = ?", boundaries.charges_to_datetime&.iso8601(3)
+          "(properties->>'charges_to_datetime')::timestamptz = ?", metered_item.boundaries.charges_to_datetime&.iso8601(3)
         )
       end
 
@@ -441,27 +428,27 @@ module Fees
       true
     end
 
-    def aggregator(charge_filter:)
+    def aggregator(selected_metered_item:)
       aggregate = true
-      aggregate = filtered_aggregations.include?(charge_filter&.id) unless filtered_aggregations.nil?
+      aggregate = filtered_aggregations.include?(selected_metered_item.charge_filter&.id) unless filtered_aggregations.nil?
 
       BillableMetrics::AggregationFactory.new_instance(
-        charge:,
-        current_usage:,
+        charge: selected_metered_item.charge,
+        current_usage: options.current_usage?,
         subscription:,
         boundaries: {
-          from_datetime: boundaries.charges_from_datetime,
-          to_datetime: boundaries.charges_to_datetime,
-          charges_duration: boundaries.charges_duration,
-          max_timestamp: boundaries.max_timestamp
+          from_datetime: selected_metered_item.boundaries.charges_from_datetime,
+          to_datetime: selected_metered_item.boundaries.charges_to_datetime,
+          charges_duration: selected_metered_item.boundaries.charges_duration,
+          max_timestamp: selected_metered_item.boundaries.max_timestamp
         },
-        filters: aggregation_filters(charge_filter:, bypass_aggregation: !aggregate),
+        filters: aggregation_filters(selected_metered_item:, bypass_aggregation: !aggregate),
         bypass_aggregation: !aggregate
       )
     end
 
-    def persist_recurring_value(aggregation_results, charge_filter, breakdowns_by_group)
-      return if current_usage
+    def persist_recurring_value(aggregation_results, selected_metered_item, breakdowns_by_group)
+      return if options.current_usage?
 
       # NOTE: Only weighted sum and custom aggregations are setting this value
       return unless aggregation_results.first&.recurring_updated_at
@@ -473,10 +460,10 @@ module Fees
         grouped_by = aggregation_result.grouped_by || {}
 
         result.cached_aggregations << CachedAggregation.find_or_initialize_by(
-          organization_id: billable_metric.organization_id,
+          organization_id: selected_metered_item.organization_id,
           external_subscription_id: subscription.external_id,
-          charge_id: charge.id,
-          charge_filter_id: charge_filter&.id,
+          charge_id: selected_metered_item.charge.id,
+          charge_filter_id: selected_metered_item.charge_filter&.id,
           grouped_by:,
           timestamp: aggregation_result.recurring_updated_at
         ) do |aggregation|
@@ -488,76 +475,66 @@ module Fees
       end
     end
 
-    def grouped_by_keys(charge_filter: nil)
-      model = charge_filter.presence || charge
-      grouped_by_keys = model.pricing_group_keys&.dup || []
-      if charge.accepts_target_wallet && !grouped_by_keys.include?("target_wallet_code")
-        grouped_by_keys << "target_wallet_code"
-      end
-      grouped_by_keys if grouped_by_keys.present? && !usage_filters.skip_grouping
+    def grouped_by_keys(selected_metered_item:)
+      grouped_by_keys = selected_metered_item.pricing_group_keys
+      grouped_by_keys if grouped_by_keys.present? && !options.usage_filters.skip_grouping
     end
 
-    def aggregation_filters(charge_filter: nil, bypass_aggregation: false)
-      filters = {charge_id: charge.id}
+    def aggregation_filters(selected_metered_item:, bypass_aggregation: false)
+      filters = {charge_id: selected_metered_item.charge.id}
 
-      grouped_by_keys = grouped_by_keys(charge_filter:)
+      grouped_by_keys = grouped_by_keys(selected_metered_item:)
       filters[:grouped_by] = grouped_by_keys if grouped_by_keys.present?
 
-      presentation_group_keys_values = charge.presentation_group_keys_values
+      presentation_group_keys_values = selected_metered_item.presentation_group_keys_values
       if presentation_group_keys_values.present?
-        filters[:presentation_by] = presentation_group_keys_values & (usage_filters.filter_by_presentation || presentation_group_keys_values)
+        filters[:presentation_by] = presentation_group_keys_values & (options.usage_filters.filter_by_presentation || presentation_group_keys_values)
       end
 
-      if charge_filter.present?
-        filters[:charge_filter] = charge_filter
+      if selected_metered_item.charge_filter.present?
+        filters[:charge_filter] = selected_metered_item.charge_filter
 
         # NOTE: Matching and ignored filters are only used to filter events when querying the store.
         #       When the aggregation is bypassed, no event is queried, so computing them is a waste
         #       (see BillableMetrics::Aggregations::BaseService#should_bypass_aggregation?).
-        if !bypass_aggregation || billable_metric.recurring?
-          result = ChargeFilters::MatchingAndIgnoredService.call(charge:, filter: charge_filter)
-          filters[:matching_filters] = result.matching_filters
-          filters[:ignored_filters] = result.ignored_filters
+        if !bypass_aggregation || selected_metered_item.billable_metric.recurring?
+          matching_and_ignored_filters = selected_metered_item.matching_and_ignored_filters
+          filters[:matching_filters] = matching_and_ignored_filters.matching_filters
+          filters[:ignored_filters] = matching_and_ignored_filters.ignored_filters
         end
       end
 
-      if usage_filters.filter_by_group.present?
+      if options.usage_filters.filter_by_group.present?
         # when pricing group keys on a charge are "workspace" and "user", and filter_by_group is {"workspace" => ["A"]},
         # we want to remove the grouping keys "workspace", but keep the grouping key "user", so the usage will still be granular within the workspace
-        usage_filters.filter_by_group.keys.each { |key| filters[:grouped_by]&.delete(key) }
+        options.usage_filters.filter_by_group.keys.each { |key| filters[:grouped_by]&.delete(key) }
         # NOTE: filters[:matching_filters] may come from ChargeFilter#to_h_with_all_values
         # which returns a frozen hash, so we must not mutate it in place.
         # expected matching_filters format is { "workspace" => ["A", "B"], "user" => ["U1", "U2"] }
-        filters[:matching_filters] = (filters[:matching_filters] || {}).merge(usage_filters.filter_by_group)
+        filters[:matching_filters] = (filters[:matching_filters] || {}).merge(options.usage_filters.filter_by_group)
       end
 
       filters
     end
 
-    def calculate_period_ratio
-      from_date = boundaries.charges_from_datetime.to_date
-      to_date = boundaries.charges_to_datetime.to_date
-      current_date = Time.current.to_date
+    def validate!
+      unless metered_item.is_a?(MeteredItem)
+        raise ArgumentError, "metered_item must be a Fees::ChargeService::MeteredItem"
+      end
 
-      total_days = (to_date - from_date).to_i + 1
+      unless options.is_a?(Options)
+        raise ArgumentError, "options must be a Fees::ChargeService::Options"
+      end
 
-      charges_duration = boundaries.charges_duration || total_days
+      return unless options.apply_taxes
 
-      return 1.0 if current_date >= to_date
-      return 0.0 if current_date < from_date
+      unless plan
+        raise ArgumentError, "plan is required when applying taxes"
+      end
 
-      days_passed = (current_date - from_date).to_i + 1
-
-      ratio = days_passed.fdiv(charges_duration)
-      ratio.clamp(0.0, 1.0)
-    end
-
-    def filtered_for_charge_boundaries(boundaries)
-      properties = boundaries.to_h
-      properties["fixed_charges_from_datetime"] = nil
-      properties["fixed_charges_to_datetime"] = nil
-      properties["fixed_charges_duration"] = nil
-      properties
+      unless customer
+        raise ArgumentError, "customer is required when applying taxes"
+      end
     end
   end
 end

--- a/app/services/fees/charge_service/metered_item.rb
+++ b/app/services/fees/charge_service/metered_item.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Fees
+  class ChargeService
+    MeteredItem = Data.define(:source) do
+      def self.from_charge(charge:, boundaries:, charge_filter: nil, properties: nil)
+        new(
+          source: Sources::Charge.new(
+            charge:,
+            boundaries:,
+            charge_filter:,
+            properties_override: properties
+          )
+        )
+      end
+
+      delegate :charge,
+        :charge_filter,
+        :billable_metric,
+        :organization_id,
+        :currency,
+        :boundaries,
+        :properties,
+        :pricing_structure,
+        :period_ratio,
+        :pricing_group_keys,
+        :presentation_group_keys_values,
+        :matching_filters,
+        :ignored_filters,
+        :matching_and_ignored_filters,
+        :aggregation_options,
+        :accepts_target_wallet?,
+        :pay_in_advance?,
+        :prorated?,
+        :invoiceable?,
+        :applied_pricing_unit,
+        to: :source
+
+      def with_charge_filter(charge_filter, properties: nil)
+        self.class.new(source: source.with_charge_filter(charge_filter, properties:))
+      end
+
+      def filtered_for_charge_boundaries
+        properties = boundaries.to_h
+        properties["fixed_charges_from_datetime"] = nil
+        properties["fixed_charges_to_datetime"] = nil
+        properties["fixed_charges_duration"] = nil
+        properties
+      end
+    end
+  end
+end

--- a/app/services/fees/charge_service/options.rb
+++ b/app/services/fees/charge_service/options.rb
@@ -3,6 +3,8 @@
 module Fees
   class ChargeService
     CONTEXTS = [nil, :current_usage, :invoice_preview, :recurring, :finalize].freeze
+    # NOTE: Accepted for callers that still use invoice-level contexts with charge fee calculation.
+    DEPRECATED_CONTEXTS = [:refresh, :draft].freeze
 
     Options = Data.define(
       :context,
@@ -53,9 +55,10 @@ module Fees
       private
 
       def validate_context!(context)
-        return if CONTEXTS.include?(context)
+        accepted_contexts = CONTEXTS + DEPRECATED_CONTEXTS
+        return if accepted_contexts.include?(context)
 
-        raise ArgumentError, "context must be one of: #{CONTEXTS.compact.join(", ")}"
+        raise ArgumentError, "context '#{context}' must be one of: #{accepted_contexts.compact.join(", ")}"
       end
 
       def validate_usage_filters!(usage_filters)

--- a/app/services/fees/charge_service/options.rb
+++ b/app/services/fees/charge_service/options.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Fees
+  class ChargeService
+    CONTEXTS = [nil, :current_usage, :invoice_preview, :recurring, :finalize].freeze
+
+    Options = Data.define(
+      :context,
+      :apply_taxes,
+      :calculate_projected_usage,
+      :with_zero_units_filters,
+      :usage_filters,
+      :skip_adjusted_fees
+    ) do
+      def self.default
+        new
+      end
+
+      def initialize(
+        context: nil,
+        apply_taxes: false,
+        calculate_projected_usage: false,
+        with_zero_units_filters: true,
+        usage_filters: UsageFilters::NONE,
+        skip_adjusted_fees: false
+      )
+        validate_context!(context)
+        validate_usage_filters!(usage_filters)
+        validate_boolean!(:apply_taxes, apply_taxes)
+        validate_boolean!(:calculate_projected_usage, calculate_projected_usage)
+        validate_boolean!(:with_zero_units_filters, with_zero_units_filters)
+        validate_boolean!(:skip_adjusted_fees, skip_adjusted_fees)
+
+        super
+      end
+
+      def current_usage?
+        context == :current_usage
+      end
+
+      def invoice_preview?
+        context == :invoice_preview
+      end
+
+      def recurring?
+        context == :recurring
+      end
+
+      def finalize?
+        context == :finalize
+      end
+
+      private
+
+      def validate_context!(context)
+        return if CONTEXTS.include?(context)
+
+        raise ArgumentError, "context must be one of: #{CONTEXTS.compact.join(", ")}"
+      end
+
+      def validate_usage_filters!(usage_filters)
+        return if usage_filters.is_a?(UsageFilters)
+
+        raise ArgumentError, "usage_filters must be a UsageFilters"
+      end
+
+      def validate_boolean!(name, value)
+        return if value == true || value == false
+
+        raise ArgumentError, "#{name} must be a boolean"
+      end
+    end
+  end
+end

--- a/app/services/fees/charge_service/sources/charge.rb
+++ b/app/services/fees/charge_service/sources/charge.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+module Fees
+  class ChargeService
+    module Sources
+      Charge = Data.define(:charge, :boundaries, :charge_filter, :properties_override) do
+        def initialize(charge:, boundaries:, charge_filter: nil, properties_override: nil)
+          validate_charge!(charge)
+          validate_boundaries!(boundaries)
+          validate_charge_filter!(charge, charge_filter)
+
+          super
+        end
+
+        delegate :billable_metric,
+          :pay_in_advance?,
+          :prorated?,
+          :invoiceable?,
+          :applied_pricing_unit,
+          :organization_id,
+          :presentation_group_keys_values,
+          to: :charge
+
+        def with_charge_filter(charge_filter, properties: nil)
+          self.class.new(
+            charge:,
+            boundaries:,
+            charge_filter:,
+            properties_override: properties
+          )
+        end
+
+        def properties
+          properties_override || charge_filter&.properties || charge.properties
+        end
+
+        def pricing_structure
+          ChargeModels::PricingStructure.from_charge(charge).with(properties:)
+        end
+
+        def period_ratio
+          from_date = boundaries.charges_from_datetime.to_date
+          to_date = boundaries.charges_to_datetime.to_date
+          current_date = Time.current.to_date
+
+          total_days = (to_date - from_date).to_i + 1
+          charges_duration = boundaries.charges_duration || total_days
+
+          return 1.0 if current_date >= to_date
+          return 0.0 if current_date < from_date
+
+          days_passed = (current_date - from_date).to_i + 1
+          days_passed.fdiv(charges_duration).clamp(0.0, 1.0)
+        end
+
+        def pricing_group_keys
+          keys = (charge_filter.presence || charge).pricing_group_keys&.dup || []
+
+          if charge.accepts_target_wallet && !keys.include?(::Charge::EVENT_TARGET_WALLET_CODE)
+            keys << ::Charge::EVENT_TARGET_WALLET_CODE
+          end
+
+          keys
+        end
+
+        def matching_filters
+          return {} unless charge_filter
+
+          matching_and_ignored_filters.matching_filters
+        end
+
+        def ignored_filters
+          return [] unless charge_filter
+
+          matching_and_ignored_filters.ignored_filters
+        end
+
+        def matching_and_ignored_filters
+          ChargeFilters::MatchingAndIgnoredService.call(
+            charge:,
+            filter: charge_filter
+          )
+        end
+
+        def aggregation_options(current_usage:)
+          {
+            free_units_per_events: properties["free_units_per_events"].to_i,
+            free_units_per_total_aggregation: BigDecimal(properties["free_units_per_total_aggregation"] || 0),
+            is_current_usage: current_usage,
+            is_pay_in_advance: pay_in_advance?
+          }
+        end
+
+        def accepts_target_wallet?
+          charge.accepts_target_wallet
+        end
+
+        def currency
+          charge.plan.amount.currency
+        end
+
+        private
+
+        def validate_charge!(charge)
+          return if charge.is_a?(::Charge)
+
+          raise ArgumentError, "charge must be a Charge"
+        end
+
+        def validate_boundaries!(boundaries)
+          if boundaries&.charges_from_datetime && boundaries.charges_to_datetime
+            return
+          end
+
+          raise ArgumentError, "charge boundaries are mandatory"
+        end
+
+        def validate_charge_filter!(charge, charge_filter)
+          return unless charge_filter
+
+          unless charge_filter.is_a?(::ChargeFilter)
+            raise ArgumentError, "charge_filter must be a ChargeFilter"
+          end
+
+          return if charge_filter.charge.nil? || charge_filter.charge == charge
+
+          raise ArgumentError, "charge_filter must belong to charge"
+        end
+      end
+    end
+  end
+end

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -3,7 +3,6 @@
 module Invoices
   class CalculateFeesService < BaseService
     Result = BaseResult[:invoice, :non_invoiceable_fees]
-    CHARGE_SERVICE_CONTEXTS = [nil, :current_usage, :invoice_preview, :recurring, :finalize].freeze
 
     def initialize(invoice:, recurring: false, context: nil)
       @invoice = invoice
@@ -244,7 +243,7 @@ module Invoices
     end
 
     def charge_service_context
-      return context if CHARGE_SERVICE_CONTEXTS.include?(context)
+      return context if Fees::ChargeService::CONTEXTS.include?(context)
 
       nil
     end

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -136,7 +136,7 @@ module Invoices
             metered_item: Fees::ChargeService::MeteredItem.from_charge(charge:, boundaries:),
             subscription:,
             options: Fees::ChargeService::Options.new(
-              context: charge_service_context,
+              context:,
               skip_adjusted_fees: !adjusted_fee_exists
             ),
             filtered_aggregations: filters[charge.id]&.keys || []
@@ -240,12 +240,6 @@ module Invoices
 
           result.non_invoiceable_fees.concat(fee_result.fees)
       end
-    end
-
-    def charge_service_context
-      return context if Fees::ChargeService::CONTEXTS.include?(context)
-
-      nil
     end
 
     def should_create_minimum_commitment_true_up_fee?(invoice_subscription)

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -3,6 +3,7 @@
 module Invoices
   class CalculateFeesService < BaseService
     Result = BaseResult[:invoice, :non_invoiceable_fees]
+    CHARGE_SERVICE_CONTEXTS = [nil, :current_usage, :invoice_preview, :recurring, :finalize].freeze
 
     def initialize(invoice:, recurring: false, context: nil)
       @invoice = invoice
@@ -118,8 +119,6 @@ module Invoices
       return unless charge_boundaries_valid?(boundaries)
 
       filters = event_filters(subscription, boundaries).charges
-      plan = subscription.plan
-      customer = subscription.customer
       adjusted_fee_exists = AdjustedFee.where(invoice:, subscription:).matching_charge_boundaries(boundaries).exists?
 
       subscription
@@ -135,13 +134,12 @@ module Invoices
 
           Fees::ChargeService.call!(
             invoice:,
-            charge:,
+            metered_item: Fees::ChargeService::MeteredItem.from_charge(charge:, boundaries:),
             subscription:,
-            boundaries:,
-            context:,
-            plan:,
-            customer:,
-            skip_adjusted_fees: !adjusted_fee_exists,
+            options: Fees::ChargeService::Options.new(
+              context: charge_service_context,
+              skip_adjusted_fees: !adjusted_fee_exists
+            ),
             filtered_aggregations: filters[charge.id]&.keys || []
           )
         end
@@ -231,17 +229,24 @@ module Invoices
 
           fee_result = Fees::ChargeService.call!(
             invoice: nil,
-            charge:,
+            metered_item: Fees::ChargeService::MeteredItem.from_charge(charge:, boundaries:),
             subscription:,
-            context: :recurring,
-            boundaries:,
             plan: subscription.plan,
             customer: subscription.customer,
-            apply_taxes: invoice.customer.tax_customer.blank?
+            options: Fees::ChargeService::Options.new(
+              context: :recurring,
+              apply_taxes: invoice.customer.tax_customer.blank?
+            )
           )
 
           result.non_invoiceable_fees.concat(fee_result.fees)
       end
+    end
+
+    def charge_service_context
+      return context if CHARGE_SERVICE_CONTEXTS.include?(context)
+
+      nil
     end
 
     def should_create_minimum_commitment_true_up_fee?(invoice_subscription)

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -141,17 +141,18 @@ module Invoices
       Fees::ChargeService
         .call!(
           invoice:,
-          charge:,
+          metered_item: Fees::ChargeService::MeteredItem.from_charge(charge:, boundaries: applied_boundaries),
           subscription:,
-          boundaries: applied_boundaries,
-          context: :current_usage,
           cache_middleware:,
-          calculate_projected_usage:,
-          with_zero_units_filters:,
-          # NOTE: current usage is computed on a non-persisted invoice, so adjusted fees never apply
-          skip_adjusted_fees: true,
           filtered_aggregations: applied_filters.keys,
-          usage_filters:
+          options: Fees::ChargeService::Options.new(
+            context: :current_usage,
+            calculate_projected_usage:,
+            with_zero_units_filters:,
+            usage_filters:,
+            # NOTE: current usage is computed on a non-persisted invoice, so adjusted fees never apply
+            skip_adjusted_fees: true
+          )
         )
         .fees
     end

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -217,12 +217,11 @@ module Invoices
             Fees::ChargeService
               .call!(
                 invoice:,
-                charge:,
+                metered_item: Fees::ChargeService::MeteredItem.from_charge(charge:, boundaries:),
                 subscription:,
-                boundaries:,
-                context: :invoice_preview,
                 cache_middleware:,
-                filtered_aggregations: applied_filters.keys
+                filtered_aggregations: applied_filters.keys,
+                options: Fees::ChargeService::Options.new(context: :invoice_preview)
               )
               .fees
           end

--- a/app/services/invoices/progressive_billing_service.rb
+++ b/app/services/invoices/progressive_billing_service.rb
@@ -97,10 +97,9 @@ module Invoices
       charges.find_each do |charge|
         Fees::ChargeService.call!(
           invoice:,
-          charge:,
+          metered_item: Fees::ChargeService::MeteredItem.from_charge(charge:, boundaries:),
           subscription:,
-          context: :finalize,
-          boundaries:,
+          options: Fees::ChargeService::Options.new(context: :finalize),
           filtered_aggregations: filters[charge.id]&.keys || []
         )
       end

--- a/spec/services/fees/charge_service/metered_item_spec.rb
+++ b/spec/services/fees/charge_service/metered_item_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Fees::ChargeService::MeteredItem do
+  subject(:metered_item) { described_class.from_charge(charge:, boundaries:) }
+
+  let(:organization) { create(:organization) }
+  let(:subscription) { create(:subscription, organization:) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric:) }
+  let(:boundaries) do
+    BillingPeriodBoundaries.new(
+      from_datetime: Time.zone.parse("2022-03-01"),
+      to_datetime: Time.zone.parse("2022-03-31").end_of_day,
+      charges_from_datetime: Time.zone.parse("2022-03-01"),
+      charges_to_datetime: Time.zone.parse("2022-03-31").end_of_day,
+      charges_duration: 31,
+      timestamp: Time.zone.parse("2022-04-01")
+    )
+  end
+
+  describe ".from_charge" do
+    it "builds a metered item backed by a charge source" do
+      expect(metered_item.charge).to eq(charge)
+      expect(metered_item.boundaries).to eq(boundaries)
+      expect(metered_item.billable_metric).to eq(billable_metric)
+    end
+  end
+
+  describe "delegations" do
+    it "exposes charge source behavior" do
+      expect(metered_item.organization_id).to eq(charge.organization_id)
+      expect(metered_item.currency).to eq(charge.plan.amount.currency)
+      expect(metered_item.properties).to eq(charge.properties)
+      expect(metered_item.pricing_structure).to be_a(ChargeModels::PricingStructure)
+      expect(metered_item).to have_attributes(
+        charge_filter: nil,
+        pay_in_advance?: false,
+        prorated?: false,
+        invoiceable?: true,
+        applied_pricing_unit: nil
+      )
+    end
+  end
+
+  describe "#with_charge_filter" do
+    let(:charge_filter) { create(:charge_filter, charge:, properties: {amount: "30"}) }
+
+    it "returns a new metered item with the selected charge filter" do
+      filtered_item = metered_item.with_charge_filter(charge_filter)
+
+      expect(filtered_item).not_to eq(metered_item)
+      expect(filtered_item.charge).to eq(charge)
+      expect(filtered_item.charge_filter).to eq(charge_filter)
+      expect(filtered_item.properties).to eq(charge_filter.properties)
+    end
+  end
+
+  describe "#filtered_for_charge_boundaries" do
+    it "returns fee properties without fixed charge boundaries" do
+      expect(metered_item.filtered_for_charge_boundaries).to include(
+        "charges_from_datetime" => Time.zone.parse("2022-03-01"),
+        "charges_to_datetime" => Time.zone.parse("2022-03-31").end_of_day,
+        "charges_duration" => 31,
+        "fixed_charges_from_datetime" => nil,
+        "fixed_charges_to_datetime" => nil,
+        "fixed_charges_duration" => nil
+      )
+    end
+  end
+end

--- a/spec/services/fees/charge_service/options_spec.rb
+++ b/spec/services/fees/charge_service/options_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Fees::ChargeService::Options do
+  describe ".default" do
+    it "returns default options" do
+      expect(described_class.default).to have_attributes(
+        context: nil,
+        apply_taxes: false,
+        calculate_projected_usage: false,
+        with_zero_units_filters: true,
+        usage_filters: UsageFilters::NONE,
+        skip_adjusted_fees: false
+      )
+    end
+  end
+
+  describe "validations" do
+    it "validates context" do
+      expect { described_class.new(context: :current_usage) }.not_to raise_error
+      expect { described_class.new(context: :unknown) }
+        .to raise_error(ArgumentError, "context must be one of: current_usage, invoice_preview, recurring, finalize")
+    end
+
+    it "validates usage filters" do
+      expect { described_class.new(usage_filters: UsageFilters.new) }.not_to raise_error
+      expect { described_class.new(usage_filters: nil) }
+        .to raise_error(ArgumentError, "usage_filters must be a UsageFilters")
+    end
+
+    it "validates booleans" do
+      expect { described_class.new(apply_taxes: nil) }
+        .to raise_error(ArgumentError, "apply_taxes must be a boolean")
+      expect { described_class.new(calculate_projected_usage: nil) }
+        .to raise_error(ArgumentError, "calculate_projected_usage must be a boolean")
+      expect { described_class.new(with_zero_units_filters: nil) }
+        .to raise_error(ArgumentError, "with_zero_units_filters must be a boolean")
+      expect { described_class.new(skip_adjusted_fees: nil) }
+        .to raise_error(ArgumentError, "skip_adjusted_fees must be a boolean")
+    end
+  end
+
+  describe "context predicates" do
+    it "returns whether the option matches a context" do
+      expect(described_class.new(context: :current_usage)).to be_current_usage
+      expect(described_class.new(context: :invoice_preview)).to be_invoice_preview
+      expect(described_class.new(context: :recurring)).to be_recurring
+      expect(described_class.new(context: :finalize)).to be_finalize
+    end
+  end
+end

--- a/spec/services/fees/charge_service/options_spec.rb
+++ b/spec/services/fees/charge_service/options_spec.rb
@@ -19,8 +19,10 @@ RSpec.describe Fees::ChargeService::Options do
   describe "validations" do
     it "validates context" do
       expect { described_class.new(context: :current_usage) }.not_to raise_error
+      expect { described_class.new(context: :refresh) }.not_to raise_error
+      expect { described_class.new(context: :draft) }.not_to raise_error
       expect { described_class.new(context: :unknown) }
-        .to raise_error(ArgumentError, "context must be one of: current_usage, invoice_preview, recurring, finalize")
+        .to raise_error(ArgumentError, "context 'unknown' must be one of: current_usage, invoice_preview, recurring, finalize, refresh, draft")
     end
 
     it "validates usage filters" do

--- a/spec/services/fees/charge_service/sources/charge_spec.rb
+++ b/spec/services/fees/charge_service/sources/charge_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Fees::ChargeService::Sources::Charge do
+  subject(:source) { described_class.new(charge:, boundaries:) }
+
+  let(:organization) { create(:organization) }
+  let(:subscription) { create(:subscription, organization:) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:charge) do
+    create(
+      :standard_charge,
+      plan: subscription.plan,
+      billable_metric:,
+      properties: {amount: "20", free_units_per_events: "2", free_units_per_total_aggregation: "3"}
+    )
+  end
+  let(:boundaries) do
+    BillingPeriodBoundaries.new(
+      from_datetime: Time.zone.parse("2022-03-01"),
+      to_datetime: Time.zone.parse("2022-03-31").end_of_day,
+      charges_from_datetime: Time.zone.parse("2022-03-01"),
+      charges_to_datetime: Time.zone.parse("2022-03-31").end_of_day,
+      charges_duration: 31,
+      timestamp: Time.zone.parse("2022-04-01")
+    )
+  end
+
+  describe "validations" do
+    it "validates source inputs" do
+      expect { described_class.new(charge: nil, boundaries:) }
+        .to raise_error(ArgumentError, "charge must be a Charge")
+      expect { described_class.new(charge:, boundaries: nil) }
+        .to raise_error(ArgumentError, "charge boundaries are mandatory")
+      expect { described_class.new(charge:, boundaries:, charge_filter: nil) }.not_to raise_error
+      expect { described_class.new(charge:, boundaries:, charge_filter: Object.new) }
+        .to raise_error(ArgumentError, "charge_filter must be a ChargeFilter")
+    end
+
+    it "validates the charge filter belongs to the charge" do
+      other_charge = create(:standard_charge, plan: subscription.plan, billable_metric:)
+      charge_filter = create(:charge_filter, charge: other_charge)
+
+      expect { described_class.new(charge:, boundaries:, charge_filter:) }
+        .to raise_error(ArgumentError, "charge_filter must belong to charge")
+    end
+  end
+
+  describe "#with_charge_filter" do
+    let(:charge_filter) { create(:charge_filter, charge:, properties: {amount: "30"}) }
+
+    it "returns a source with the selected filter" do
+      filtered_source = source.with_charge_filter(charge_filter)
+
+      expect(filtered_source.charge).to eq(charge)
+      expect(filtered_source.boundaries).to eq(boundaries)
+      expect(filtered_source.charge_filter).to eq(charge_filter)
+      expect(filtered_source.properties).to eq(charge_filter.properties)
+    end
+  end
+
+  describe "#properties" do
+    it "uses explicit properties before filter and charge properties" do
+      charge_filter = create(:charge_filter, charge:, properties: {amount: "30"})
+
+      expect(source.properties).to eq(charge.properties)
+      expect(source.with_charge_filter(charge_filter).properties).to eq(charge_filter.properties)
+      expect(source.with_charge_filter(charge_filter, properties: {amount: "40"}).properties).to eq({amount: "40"})
+    end
+  end
+
+  describe "#aggregation_options" do
+    it "returns aggregation options from properties" do
+      expect(source.aggregation_options(current_usage: true)).to eq(
+        free_units_per_events: 2,
+        free_units_per_total_aggregation: 3.to_d,
+        is_current_usage: true,
+        is_pay_in_advance: false
+      )
+    end
+  end
+
+  describe "#period_ratio" do
+    around { |test| travel_to(Time.zone.parse("2022-03-16")) { test.run } }
+
+    it "returns the elapsed charge period ratio" do
+      expect(source.period_ratio).to eq(16.fdiv(31))
+    end
+  end
+
+  describe "#pricing_group_keys" do
+    it "returns charge pricing group keys" do
+      charge.update!(properties: charge.properties.merge("pricing_group_keys" => ["region"]))
+
+      expect(source.pricing_group_keys).to eq(["region"])
+    end
+  end
+end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe Fees::ChargeService, :premium do
   subject(:charge_subscription_service) do
     described_class.new(
       invoice:,
-      charge:,
+      metered_item:,
       subscription:,
-      boundaries:,
-      context:,
-      apply_taxes:,
+      options:,
+      plan: subscription.plan,
+      customer:,
       filtered_aggregations:
     )
   end
@@ -26,6 +26,8 @@ RSpec.describe Fees::ChargeService, :premium do
   let(:context) { :finalize }
   let(:apply_taxes) { false }
   let(:filtered_aggregations) { nil }
+  let(:metered_item) { described_class::MeteredItem.from_charge(charge:, boundaries:) }
+  let(:options) { described_class::Options.new(context:, apply_taxes:) }
 
   let(:subscription) do
     create(
@@ -64,6 +66,32 @@ RSpec.describe Fees::ChargeService, :premium do
         amount: "20"
       }
     )
+  end
+
+  describe "validations" do
+    it "validates the metered item" do
+      expect do
+        described_class.new(invoice:, metered_item: nil, subscription:)
+      end.to raise_error(ArgumentError, "metered_item must be a Fees::ChargeService::MeteredItem")
+    end
+
+    it "validates the options" do
+      expect do
+        described_class.new(invoice:, metered_item:, subscription:, options: Object.new)
+      end.to raise_error(ArgumentError, "options must be a Fees::ChargeService::Options")
+    end
+
+    it "requires plan and customer when applying taxes" do
+      tax_options = described_class::Options.new(apply_taxes: true)
+
+      expect do
+        described_class.new(invoice:, metered_item:, subscription:, options: tax_options, customer:)
+      end.to raise_error(ArgumentError, "plan is required when applying taxes")
+
+      expect do
+        described_class.new(invoice:, metered_item:, subscription:, options: tax_options, plan: subscription.plan)
+      end.to raise_error(ArgumentError, "customer is required when applying taxes")
+    end
   end
 
   describe ".call" do
@@ -1140,12 +1168,9 @@ RSpec.describe Fees::ChargeService, :premium do
           subject(:charge_subscription_service) do
             described_class.new(
               invoice:,
-              charge:,
+              metered_item:,
               subscription:,
-              boundaries:,
-              context:,
-              apply_taxes:,
-              skip_adjusted_fees: true,
+              options: described_class::Options.new(context:, apply_taxes:, skip_adjusted_fees: true),
               filtered_aggregations:
             )
           end
@@ -3462,11 +3487,9 @@ RSpec.describe Fees::ChargeService, :premium do
           subject(:charge_subscription_service) do
             described_class.new(
               invoice:,
-              charge:,
+              metered_item:,
               subscription:,
-              boundaries:,
-              context: :current_usage,
-              apply_taxes: false,
+              options: described_class::Options.new(context: :current_usage),
               filtered_aggregations: nil,
               cache_middleware:
             )
@@ -4118,13 +4141,13 @@ RSpec.describe Fees::ChargeService, :premium do
         subject(:charge_subscription_service) do
           described_class.new(
             invoice:,
-            charge:,
+            metered_item:,
             subscription:,
-            boundaries:,
-            context: :current_usage,
-            apply_taxes: false,
+            options: described_class::Options.new(
+              context: :current_usage,
+              with_zero_units_filters:
+            ),
             filtered_aggregations:,
-            with_zero_units_filters:,
             cache_middleware:
           )
         end
@@ -4199,13 +4222,13 @@ RSpec.describe Fees::ChargeService, :premium do
       subject(:charge_subscription_service) do
         described_class.new(
           invoice:,
-          charge:,
+          metered_item:,
           subscription:,
-          boundaries:,
-          context: :current_usage,
-          apply_taxes: false,
           filtered_aggregations: nil,
-          usage_filters: UsageFilters.new(filter_by_group:)
+          options: described_class::Options.new(
+            context: :current_usage,
+            usage_filters: UsageFilters.new(filter_by_group:)
+          )
         )
       end
 
@@ -4306,13 +4329,13 @@ RSpec.describe Fees::ChargeService, :premium do
       subject(:charge_subscription_service) do
         described_class.new(
           invoice:,
-          charge:,
+          metered_item:,
           subscription:,
-          boundaries:,
-          context: :current_usage,
-          apply_taxes: false,
           filtered_aggregations: nil,
-          usage_filters: UsageFilters.new(filter_by_presentation: filter_by_presentation)
+          options: described_class::Options.new(
+            context: :current_usage,
+            usage_filters: UsageFilters.new(filter_by_presentation: filter_by_presentation)
+          )
         )
       end
 
@@ -4452,13 +4475,13 @@ RSpec.describe Fees::ChargeService, :premium do
       subject(:charge_subscription_service) do
         described_class.new(
           invoice:,
-          charge:,
+          metered_item:,
           subscription:,
-          boundaries:,
-          context: :current_usage,
-          apply_taxes: false,
           filtered_aggregations: nil,
-          usage_filters: UsageFilters.new(skip_grouping: true)
+          options: described_class::Options.new(
+            context: :current_usage,
+            usage_filters: UsageFilters.new(skip_grouping: true)
+          )
         )
       end
 

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -184,7 +184,8 @@ RSpec.describe Invoices::CalculateFeesService do
             invoice_service.call
 
             expect(AdjustedFee).to have_received(:matching_charge_boundaries)
-            expect(Fees::ChargeService).to have_received(:call!).with(hash_including(skip_adjusted_fees: false))
+            expect(Fees::ChargeService).to have_received(:call!)
+              .with(hash_including(options: have_attributes(skip_adjusted_fees: false)))
           end
         end
 
@@ -195,7 +196,8 @@ RSpec.describe Invoices::CalculateFeesService do
             invoice_service.call
 
             expect(AdjustedFee).to have_received(:matching_charge_boundaries).once
-            expect(Fees::ChargeService).to have_received(:call!).with(hash_including(skip_adjusted_fees: true))
+            expect(Fees::ChargeService).to have_received(:call!)
+              .with(hash_including(options: have_attributes(skip_adjusted_fees: true)))
           end
         end
 

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
 
       expect(AdjustedFee).not_to have_received(:matching_charge_boundaries)
       expect(Fees::ChargeService).to have_received(:call!)
-        .with(hash_including(skip_adjusted_fees: true))
+        .with(hash_including(options: have_attributes(skip_adjusted_fees: true)))
     end
 
     context "when initializes an invoice" do


### PR DESCRIPTION
## Context

This PR refactors `Fees::ChargeService` to introduce a clearer boundary between invoice fee computation and the source of metered pricing data.

The current service is tightly coupled to `Charge` and `ChargeFilter` inputs. That makes it harder to extend the same billing computation flow to future metered sources, especially product-catalog-backed objects, without adding more conditional logic directly inside `ChargeService`.

The goal of this refactor is to keep the existing legacy charge behavior unchanged while preparing the service API for additional metered inputs.

## What Changed

- Introduced `Fees::ChargeService::MeteredItem` as the main input object for metered fee calculation.
- Introduced `Fees::ChargeService::Options` to group execution flags and context-specific behavior.
- Introduced `Fees::ChargeService::Sources::Charge` as the legacy `Charge` / `ChargeFilter` adapter.
- Updated `Fees::ChargeService` to consume `metered_item` instead of receiving `charge`, `boundaries`, `charge_filter`, and properties directly.
- Updated invoice services to build `MeteredItem.from_charge(...)` before calling `Fees::ChargeService`.
- Added validation around `metered_item`, `options`, tax inputs, and supported contexts.
- Added unit coverage for `MeteredItem`, `Options`, and the charge-backed source.
- Updated existing charge and invoice specs to assert the new interface.

## Important Decisions

### Naming: `MeteredItem`

The new abstraction is called `MeteredItem` because it describes the billing behavior rather than the underlying persistence model.

A `Charge` is the current source, but the service is really computing fees for something metered. This keeps the naming aligned with the product terminology around fixed vs metered pricing and avoids baking the legacy `Charge` model into the new abstraction.

### Legacy Charge Support Only

This PR intentionally keeps the runtime scope limited to existing `Charge` and `ChargeFilter` behavior.

It does not yet wire product-catalog objects into fee computation. Instead, it creates the adapter shape needed for that future work while keeping this PR focused and safer to review.

### Source Adapter

`Fees::ChargeService::Sources::Charge` owns all charge-specific behavior, including:

- charge properties vs charge filter properties
- pricing structure construction
- period ratio calculation
- pricing group keys
- aggregation filters
- charge filter matching and ignored filters

This keeps `Fees::ChargeService` focused on fee computation rather than charge-model translation.

### Options Object

`Options` groups service flags that were previously separate keyword arguments, including:

- `context`
- `apply_taxes`
- `calculate_projected_usage`
- `with_zero_units_filters`
- `usage_filters`
- `skip_adjusted_fees`

This makes the call signature smaller and makes validation of execution options explicit.

### Deprecated Contexts

`Fees::ChargeService::CONTEXTS` now contains only active charge-service contexts.

`DEPRECATED_CONTEXTS` contains `:refresh` and `:draft`, which are still accepted because some invoice-level flows pass those contexts through charge fee calculation. They are preserved for compatibility but kept separate to make the distinction explicit.