### PR TITLE
feat: add flag to skip the payment delay

### DIFF
--- a/app/config/feature_flags.yaml
+++ b/app/config/feature_flags.yaml
@@ -45,3 +45,7 @@ product_catalog:
 invoice_search_terms:
   description: "Search the invoice list on the denormalized invoices.search_terms column instead of joining customers"
   owners: ["@toommz"]
+
+skip_checkout_auto_payment_delay:
+  description: "Trigger the first auto-payment immediately instead of delaying it, for organizations that don't rely on the hosted checkout URL"
+  owners: ["@brunomiguelpinto"]

--- a/app/config/feature_flags.yaml
+++ b/app/config/feature_flags.yaml
@@ -46,6 +46,6 @@ invoice_search_terms:
   description: "Search the invoice list on the denormalized invoices.search_terms column instead of joining customers"
   owners: ["@toommz"]
 
-skip_checkout_auto_payment_delay:
-  description: "Trigger the first auto-payment immediately instead of delaying it, for organizations that don't rely on the hosted checkout URL"
+skip_credit_invoice_auto_payment_delay:
+  description: "Trigger the auto-payment of credit invoices (wallet top-ups) immediately instead of delaying it behind a possible hosted checkout payment"
   owners: ["@brunomiguelpinto"]

--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -130,6 +130,7 @@ module Invoices
       # Delay the first auto-payment for orgs using hosted checkout so it can't race a manual checkout
       # and double-charge; skip flows that pay synchronously (gated subs, auto wallet top-ups).
       def defer_for_checkout_organization?
+        return false if invoice.organization.feature_flag_enabled?(:skip_checkout_auto_payment_delay)
         return false unless invoice.payment_attempts.zero?
         return false if invoice.subscription? && invoice.subscription_payment_gated?
         return false if non_manual_wallet_topup?

--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -130,12 +130,16 @@ module Invoices
       # Delay the first auto-payment for orgs using hosted checkout so it can't race a manual checkout
       # and double-charge; skip flows that pay synchronously (gated subs, auto wallet top-ups).
       def defer_for_checkout_organization?
-        return false if invoice.organization.feature_flag_enabled?(:skip_checkout_auto_payment_delay)
         return false unless invoice.payment_attempts.zero?
+        return false if invoice.credit? && skip_credit_invoice_delay?
         return false if invoice.subscription? && invoice.subscription_payment_gated?
         return false if non_manual_wallet_topup?
 
         PaymentIntent.where(organization_id: invoice.organization_id).exists?
+      end
+
+      def skip_credit_invoice_delay?
+        invoice.organization.feature_flag_enabled?(:skip_credit_invoice_auto_payment_delay)
       end
 
       def non_manual_wallet_topup?

--- a/schema.graphql
+++ b/schema.graphql
@@ -6485,6 +6485,7 @@ enum FeatureFlagEnum {
   payment_gated_subscriptions
   postgres_enriched_events
   product_catalog
+  skip_checkout_auto_payment_delay
   stripe_shared_payment_token
   wallet_traceability
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -6485,7 +6485,7 @@ enum FeatureFlagEnum {
   payment_gated_subscriptions
   postgres_enriched_events
   product_catalog
-  skip_checkout_auto_payment_delay
+  skip_credit_invoice_auto_payment_delay
   stripe_shared_payment_token
   wallet_traceability
 }

--- a/schema.json
+++ b/schema.json
@@ -31413,7 +31413,7 @@
               "deprecationReason": null
             },
             {
-              "name": "skip_checkout_auto_payment_delay",
+              "name": "skip_credit_invoice_auto_payment_delay",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/schema.json
+++ b/schema.json
@@ -31411,6 +31411,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "skip_checkout_auto_payment_delay",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -875,6 +875,17 @@ RSpec.describe Invoices::Payments::CreateService do
         end
       end
 
+      context "when the organization skips the checkout auto-payment delay" do
+        before { organization.enable_feature_flag!(:skip_checkout_auto_payment_delay) }
+
+        it "enqueues the payment immediately" do
+          expect { ApplicationRecord.transaction { create_service.call_async } }
+            .to have_enqueued_job(Invoices::Payments::CreateJob)
+            .with(invoice:, payment_provider: :stripe, payment_method_params: {})
+            .at(:no_wait)
+        end
+      end
+
       context "when it is not the first payment attempt (retry)" do
         before { invoice.update!(payment_attempts: 1) }
 

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -875,14 +875,16 @@ RSpec.describe Invoices::Payments::CreateService do
         end
       end
 
-      context "when the organization skips the checkout auto-payment delay" do
-        before { organization.enable_feature_flag!(:skip_checkout_auto_payment_delay) }
+      context "when the organization skips the credit invoice auto-payment delay" do
+        before { organization.enable_feature_flag!(:skip_credit_invoice_auto_payment_delay) }
 
-        it "enqueues the payment immediately" do
-          expect { ApplicationRecord.transaction { create_service.call_async } }
-            .to have_enqueued_job(Invoices::Payments::CreateJob)
-            .with(invoice:, payment_provider: :stripe, payment_method_params: {})
-            .at(:no_wait)
+        it "still delays a non-credit invoice" do
+          freeze_time do
+            expect { ApplicationRecord.transaction { create_service.call_async } }
+              .to have_enqueued_job(Invoices::Payments::CreateJob)
+              .with(invoice:, payment_provider: :stripe, payment_method_params: {})
+              .at(described_class::CHECKOUT_AUTO_PAYMENT_DELAY.from_now)
+          end
         end
       end
 
@@ -942,6 +944,17 @@ RSpec.describe Invoices::Payments::CreateService do
               .to have_enqueued_job(Invoices::Payments::CreateJob)
               .with(invoice:, payment_provider: :stripe, payment_method_params: {})
               .at(described_class::CHECKOUT_AUTO_PAYMENT_DELAY.from_now)
+          end
+        end
+
+        context "when the organization skips the credit invoice auto-payment delay" do
+          before { organization.enable_feature_flag!(:skip_credit_invoice_auto_payment_delay) }
+
+          it "enqueues the payment immediately" do
+            expect { ApplicationRecord.transaction { create_service.call_async } }
+              .to have_enqueued_job(Invoices::Payments::CreateJob)
+              .with(invoice:, payment_provider: :stripe, payment_method_params: {})
+              .at(:no_wait)
           end
         end
       end


### PR DESCRIPTION
## Context

The first auto-payment of an invoice is delayed by 10 minutes for
organizations that have used a hosted checkout URL, so an in-flight
manual payment settles before Lago charges the customer again.
Organizations that never use the hosted checkout gain nothing from that
delay and only see their payments land later than necessary.

## Description

Add the `skip_checkout_auto_payment_delay` feature flag. When an
organization enables it, the first auto-payment is enqueued immediately
instead of being deferred. All other conditions guarding the delay stay
as they are, and the flag is disabled by default so existing behaviour
is unchanged.