### PR TITLE
perf(specs): Clean up factories usage in spec/models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -167,6 +167,8 @@ group :test do
   # HTML testing (invoice rendering)
   gem "rspec-snapshot", "~> 2.0"
   gem "htmlbeautifier", "~> 1.4"
+
+  gem "test-prof", "~> 1.0"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1004,6 +1004,8 @@ GEM
     temple (0.10.4)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
+    test-prof (1.6.3)
+      logger
     thor (1.5.0)
     throttling (0.4.1)
       logger
@@ -1181,6 +1183,7 @@ DEPENDENCIES
   stripe
   strong_migrations
   super_diff (~> 0.19.0)
+  test-prof (~> 1.0)
   throttling
   timecop
   tzinfo-data

--- a/spec/models/analytics/gross_revenue_spec.rb
+++ b/spec/models/analytics/gross_revenue_spec.rb
@@ -79,9 +79,10 @@ RSpec.describe Analytics::GrossRevenue do
   describe ".find_all_by" do
     subject(:gross_revenues) { described_class.find_all_by(organization.id, **args) }
 
-    let(:organization) { create(:organization, created_at: 3.months.ago) }
+    let_it_be(:customer) { create_default(:customer) }
+    let_it_be(:organization) { create_default(:organization, created_at: 3.months.ago) }
     let(:billing_entity1) { organization.default_billing_entity }
-    let(:billing_entity2) { create(:billing_entity, organization: organization) }
+    let_it_be(:billing_entity2) { create(:billing_entity, organization: organization) }
     let(:invoices) {
       [
         create(:invoice, organization:, total_amount_cents: 1000, issuing_date: 1.month.ago, billing_entity: billing_entity1),

--- a/spec/models/analytics/gross_revenue_spec.rb
+++ b/spec/models/analytics/gross_revenue_spec.rb
@@ -82,7 +82,6 @@ RSpec.describe Analytics::GrossRevenue do
     let_it_be(:customer) { create_default(:customer) }
     let_it_be(:organization) { create_default(:organization, created_at: 3.months.ago) }
     let(:billing_entity1) { organization.default_billing_entity }
-    let_it_be(:billing_entity2) { create(:billing_entity, organization: organization) }
     let(:invoices) {
       [
         create(:invoice, organization:, total_amount_cents: 1000, issuing_date: 1.month.ago, billing_entity: billing_entity1),
@@ -91,6 +90,8 @@ RSpec.describe Analytics::GrossRevenue do
         create(:invoice, organization:, total_amount_cents: 4000, issuing_date: 2.months.ago, billing_entity: billing_entity2)
       ]
     }
+
+    let_it_be(:billing_entity2) { create(:billing_entity, organization: organization) }
 
     before { invoices }
 

--- a/spec/models/analytics/invoice_collection_spec.rb
+++ b/spec/models/analytics/invoice_collection_spec.rb
@@ -90,7 +90,6 @@ RSpec.describe Analytics::InvoiceCollection do
 
     let_it_be(:organization) { create_default(:organization, created_at: 3.months.ago) }
     let(:billing_entity1) { organization.default_billing_entity }
-    let_it_be(:billing_entity2) { create(:billing_entity, organization: organization) }
     let(:invoices) {
       [
         create(:invoice, organization:, customer: customer1, billing_entity: billing_entity1, issuing_date: 2.months.ago, total_amount_cents: 100, status: :pending),
@@ -99,6 +98,9 @@ RSpec.describe Analytics::InvoiceCollection do
         create(:invoice, organization:, customer: customer2, billing_entity: billing_entity2, issuing_date: 1.month.ago, total_amount_cents: 400, status: :finalized)
       ]
     }
+
+    let_it_be(:billing_entity2) { create(:billing_entity, organization: organization) }
+
     let_it_be(:customer1) { create(:customer, organization:, tax_identification_number: nil) }
     let_it_be(:customer2) { create(:customer, organization:, tax_identification_number: "123456789") }
 

--- a/spec/models/analytics/invoice_collection_spec.rb
+++ b/spec/models/analytics/invoice_collection_spec.rb
@@ -88,9 +88,9 @@ RSpec.describe Analytics::InvoiceCollection do
   describe ".find_all_by" do
     subject(:invoice_collections) { described_class.find_all_by(organization.id, **args) }
 
-    let(:organization) { create(:organization, created_at: 3.months.ago) }
+    let_it_be(:organization) { create_default(:organization, created_at: 3.months.ago) }
     let(:billing_entity1) { organization.default_billing_entity }
-    let(:billing_entity2) { create(:billing_entity, organization: organization) }
+    let_it_be(:billing_entity2) { create(:billing_entity, organization: organization) }
     let(:invoices) {
       [
         create(:invoice, organization:, customer: customer1, billing_entity: billing_entity1, issuing_date: 2.months.ago, total_amount_cents: 100, status: :pending),
@@ -99,9 +99,8 @@ RSpec.describe Analytics::InvoiceCollection do
         create(:invoice, organization:, customer: customer2, billing_entity: billing_entity2, issuing_date: 1.month.ago, total_amount_cents: 400, status: :finalized)
       ]
     }
-
-    let(:customer1) { create(:customer, organization:, tax_identification_number: nil) }
-    let(:customer2) { create(:customer, organization:, tax_identification_number: "123456789") }
+    let_it_be(:customer1) { create(:customer, organization:, tax_identification_number: nil) }
+    let_it_be(:customer2) { create(:customer, organization:, tax_identification_number: "123456789") }
 
     before { invoices }
 

--- a/spec/models/analytics/invoiced_usage_spec.rb
+++ b/spec/models/analytics/invoiced_usage_spec.rb
@@ -78,13 +78,13 @@ RSpec.describe Analytics::InvoicedUsage do
   describe ".find_all_by" do
     subject(:invoiced_usages) { described_class.find_all_by(organization.id, **args) }
 
-    let(:organization) { create(:organization, created_at: 3.months.ago) }
-    let(:customer) { create(:customer, organization:) }
+    let_it_be(:plan) { create_default(:plan) }
+    let_it_be(:organization) { create_default(:organization, created_at: 3.months.ago) }
+    let_it_be(:customer) { create_default(:customer, organization:) }
     let(:subscription) { create(:subscription, customer:) }
     let(:billing_entity1) { organization.default_billing_entity }
-    let(:billing_entity2) { create(:billing_entity, organization: organization) }
-
-    let(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
+    let_it_be(:billing_entity2) { create(:billing_entity, organization: organization) }
+    let_it_be(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
     let(:charge) { create(:standard_charge, billable_metric:) }
 
     let(:fee1) do

--- a/spec/models/analytics/invoiced_usage_spec.rb
+++ b/spec/models/analytics/invoiced_usage_spec.rb
@@ -82,34 +82,29 @@ RSpec.describe Analytics::InvoicedUsage do
     let_it_be(:organization) { create_default(:organization, created_at: 3.months.ago) }
     let_it_be(:customer) { create_default(:customer, organization:) }
     let(:subscription) { create(:subscription, customer:) }
-    let(:billing_entity1) { organization.default_billing_entity }
-    let_it_be(:billing_entity2) { create(:billing_entity, organization: organization) }
-    let_it_be(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
     let(:charge) { create(:standard_charge, billable_metric:) }
-
     let(:fee1) do
       create(:charge_fee, charge:, subscription:, amount_cents: 100, amount_currency: "EUR", created_at: 2.months.ago)
     end
-
     let(:fee2) do
       create(:charge_fee, charge:, subscription:, amount_cents: 200, amount_currency: "EUR", created_at: 2.months.ago)
     end
-
     let(:fee3) do
       create(:charge_fee, charge:, subscription:, amount_cents: 300, amount_currency: "EUR", created_at: 1.month.ago)
     end
-
     let(:fee4) do
       create(:charge_fee, charge:, subscription:, amount_cents: 400, amount_currency: "EUR", created_at: 1.month.ago)
     end
-
     let(:invoice1) do
       create(:invoice, organization:, billing_entity: billing_entity1, issuing_date: 2.months.ago, status: :finalized, fees: [fee1, fee2])
     end
-
     let(:invoice2) do
       create(:invoice, organization:, billing_entity: billing_entity2, issuing_date: 1.month.ago, status: :finalized, fees: [fee3, fee4])
     end
+    let(:billing_entity1) { organization.default_billing_entity }
+
+    let_it_be(:billing_entity2) { create(:billing_entity, organization: organization) }
+    let_it_be(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
 
     before do
       invoice1

--- a/spec/models/analytics/mrr_spec.rb
+++ b/spec/models/analytics/mrr_spec.rb
@@ -75,11 +75,12 @@ RSpec.describe Analytics::Mrr do
   describe ".find_all_by" do
     subject(:mrrs) { described_class.find_all_by(organization.id, **args) }
 
-    let(:organization) { create(:organization, created_at: 3.months.ago) }
-    let(:customer) { create(:customer, organization:) }
+    let_it_be(:plan) { create_default(:plan) }
+    let_it_be(:organization) { create_default(:organization, created_at: 3.months.ago) }
+    let_it_be(:customer) { create_default(:customer, organization:) }
     let(:subscription) { create(:subscription, customer:) }
     let(:billing_entity1) { organization.default_billing_entity }
-    let(:billing_entity2) { create(:billing_entity, organization: organization) }
+    let_it_be(:billing_entity2) { create(:billing_entity, organization: organization) }
 
     let(:fee1) do
       create(:fee, subscription:, amount_cents: 100, amount_currency: "EUR", created_at: 2.months.ago, taxes_amount_cents: 10)

--- a/spec/models/analytics/mrr_spec.rb
+++ b/spec/models/analytics/mrr_spec.rb
@@ -79,32 +79,27 @@ RSpec.describe Analytics::Mrr do
     let_it_be(:organization) { create_default(:organization, created_at: 3.months.ago) }
     let_it_be(:customer) { create_default(:customer, organization:) }
     let(:subscription) { create(:subscription, customer:) }
-    let(:billing_entity1) { organization.default_billing_entity }
-    let_it_be(:billing_entity2) { create(:billing_entity, organization: organization) }
-
     let(:fee1) do
       create(:fee, subscription:, amount_cents: 100, amount_currency: "EUR", created_at: 2.months.ago, taxes_amount_cents: 10)
     end
-
     let(:fee2) do
       create(:fee, subscription:, amount_cents: 200, amount_currency: "EUR", created_at: 2.months.ago, taxes_amount_cents: 20)
     end
-
     let(:fee3) do
       create(:fee, subscription:, amount_cents: 300, amount_currency: "EUR", created_at: 1.month.ago, taxes_amount_cents: 30)
     end
-
     let(:fee4) do
       create(:fee, subscription:, amount_cents: 400, amount_currency: "EUR", created_at: 1.month.ago, taxes_amount_cents: 40)
     end
-
     let(:invoice1) do
       create(:invoice, organization:, billing_entity: billing_entity1, issuing_date: 2.months.ago, status: :finalized, fees: [fee1, fee2], customer: customer)
     end
-
     let(:invoice2) do
       create(:invoice, organization:, billing_entity: billing_entity2, issuing_date: 1.month.ago, status: :finalized, fees: [fee3, fee4], customer: customer)
     end
+    let(:billing_entity1) { organization.default_billing_entity }
+
+    let_it_be(:billing_entity2) { create(:billing_entity, organization: organization) }
 
     before do
       invoice1

--- a/spec/models/applied_coupon_spec.rb
+++ b/spec/models/applied_coupon_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe AppliedCoupon do
   subject(:applied_coupon) { create(:applied_coupon) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   it_behaves_like "paper_trail traceable"
 

--- a/spec/models/applied_coupon_spec.rb
+++ b/spec/models/applied_coupon_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe AppliedCoupon do
   subject(:applied_coupon) { create(:applied_coupon) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it_behaves_like "paper_trail traceable"
 
   describe "associations" do

--- a/spec/models/billable_metric_spec.rb
+++ b/spec/models/billable_metric_spec.rb
@@ -3,7 +3,9 @@
 require "rails_helper"
 
 RSpec.describe BillableMetric do
-  subject(:billable_metric) { create(:billable_metric) }
+  subject(:billable_metric) { create_default(:billable_metric) }
+
+  let_it_be(:organization) { create_default(:organization) }
 
   it_behaves_like "paper_trail traceable"
 
@@ -144,8 +146,8 @@ RSpec.describe BillableMetric do
   describe "#attached_subscriptions" do
     subject(:billable_metric) { create(:billable_metric, organization:) }
 
-    let(:organization) { create(:organization) }
-    let(:plan) { create(:plan, organization:) }
+    let_it_be(:organization) { create_default(:organization) }
+    let_it_be(:plan) { create_default(:plan, organization:) }
     let(:other_plan) { create(:plan, organization:) }
 
     it "returns subscriptions of plans that have a charge for this billable metric" do

--- a/spec/models/billing_entity/applied_invoice_custom_section_spec.rb
+++ b/spec/models/billing_entity/applied_invoice_custom_section_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe BillingEntity::AppliedInvoiceCustomSection do
     create(:billing_entity_applied_invoice_custom_section)
   end
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:billing_entity) }
   it { is_expected.to belong_to(:invoice_custom_section) }

--- a/spec/models/billing_entity/applied_tax_spec.rb
+++ b/spec/models/billing_entity/applied_tax_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe BillingEntity::AppliedTax do
   subject(:billing_entity_applied_tax) { create(:billing_entity_applied_tax) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it { is_expected.to belong_to(:billing_entity) }
   it { is_expected.to belong_to(:tax) }
   it { is_expected.to belong_to(:organization) }

--- a/spec/models/billing_entity/applied_tax_spec.rb
+++ b/spec/models/billing_entity/applied_tax_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe BillingEntity::AppliedTax do
   subject(:billing_entity_applied_tax) { create(:billing_entity_applied_tax) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billing_entity) { create_default(:billing_entity) }
 
   it { is_expected.to belong_to(:billing_entity) }
   it { is_expected.to belong_to(:tax) }

--- a/spec/models/charge/applied_tax_spec.rb
+++ b/spec/models/charge/applied_tax_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Charge::AppliedTax do
   subject(:charge_applied_tax) { create(:charge_applied_tax) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:plan) { create_default(:plan) }
 
   it { is_expected.to belong_to(:charge) }
   it { is_expected.to belong_to(:tax) }

--- a/spec/models/charge/applied_tax_spec.rb
+++ b/spec/models/charge/applied_tax_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe Charge::AppliedTax do
   subject(:charge_applied_tax) { create(:charge_applied_tax) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it { is_expected.to belong_to(:charge) }
   it { is_expected.to belong_to(:tax) }
   it { is_expected.to belong_to(:organization) }

--- a/spec/models/charge_filter_spec.rb
+++ b/spec/models/charge_filter_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe ChargeFilter do
   subject(:charge_filter) { build(:charge_filter) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it_behaves_like "paper_trail traceable"
 
   describe "associations" do

--- a/spec/models/charge_filter_spec.rb
+++ b/spec/models/charge_filter_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe ChargeFilter do
   subject(:charge_filter) { build(:charge_filter) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:plan) { create_default(:plan) }
 
   it_behaves_like "paper_trail traceable"
 

--- a/spec/models/charge_filter_value_spec.rb
+++ b/spec/models/charge_filter_value_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe ChargeFilterValue do
   subject { build(:charge_filter_value) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it_behaves_like "paper_trail traceable"
 
   describe "associations" do

--- a/spec/models/charge_filter_value_spec.rb
+++ b/spec/models/charge_filter_value_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe ChargeFilterValue do
   subject { build(:charge_filter_value) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:plan) { create_default(:plan) }
 
   it_behaves_like "paper_trail traceable"
 

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -5,6 +5,11 @@ require "rails_helper"
 RSpec.describe Charge do
   subject(:charge) { create(:standard_charge) }
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
+
   describe "plan pricing type validation" do
     it "rejects a charge on a product-catalog plan" do
       plan = create(:plan, pricing_type: "product_catalog", interval: nil, amount_cents: nil, pay_in_advance: nil)
@@ -814,7 +819,8 @@ RSpec.describe Charge do
       end
 
       it "allows same code on different plans" do
-        create(:standard_charge, code: "my_code")
+        plan = create(:plan)
+        create(:standard_charge, code: "my_code", plan:)
         new_charge = build(:standard_charge, code: "my_code")
         expect(new_charge).to be_valid
       end
@@ -926,10 +932,6 @@ RSpec.describe Charge do
   end
 
   describe "#validate_accepts_target_wallet" do
-    let(:organization) { create(:organization) }
-    let(:plan) { create(:plan, organization:) }
-    let(:billable_metric) { create(:billable_metric, organization:) }
-
     context "when accepts_target_wallet is false" do
       it "is valid" do
         charge = build(:standard_charge, plan:, billable_metric:, accepts_target_wallet: false)
@@ -957,9 +959,9 @@ RSpec.describe Charge do
       end
 
       context "when feature is enabled", :premium do
-        before do
-          organization.update!(premium_integrations: ["events_targeting_wallets"])
-        end
+        let(:organization) { create(:organization, premium_integrations: ["events_targeting_wallets"]) }
+        let(:billable_metric) { create(:billable_metric, organization:) }
+        let(:plan) { create(:plan, organization:) }
 
         it "is valid" do
           charge = build(:standard_charge, plan:, billable_metric:, accepts_target_wallet: true)

--- a/spec/models/clickhouse/activity_log_spec.rb
+++ b/spec/models/clickhouse/activity_log_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Clickhouse::ActivityLog, clickhouse: true do
   subject(:activity_log) { create(:clickhouse_activity_log) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:resource) }
   it { is_expected.to belong_to(:customer).optional }

--- a/spec/models/clickhouse/activity_log_spec.rb
+++ b/spec/models/clickhouse/activity_log_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe Clickhouse::ActivityLog, clickhouse: true do
   subject(:activity_log) { create(:clickhouse_activity_log) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
 
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:resource) }

--- a/spec/models/clickhouse/api_log_spec.rb
+++ b/spec/models/clickhouse/api_log_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Clickhouse::ApiLog, clickhouse: true do
   subject(:api_log) { create(:clickhouse_api_log) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:api_key) }
 

--- a/spec/models/clickhouse/security_log_spec.rb
+++ b/spec/models/clickhouse/security_log_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Clickhouse::SecurityLog, clickhouse: true do
   subject(:security_log) { create(:clickhouse_security_log) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   describe "associations" do
     it do
       expect(security_log).to belong_to(:organization)

--- a/spec/models/concerns/has_feature_flags_spec.rb
+++ b/spec/models/concerns/has_feature_flags_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe HasFeatureFlags do
-  subject(:organization) { create(:organization, feature_flags: []) }
+  subject(:organization) { create_default(:organization, feature_flags: []) }
 
   let(:valid_flag) { FeatureFlag::DEFINITION.keys.first }
 

--- a/spec/models/concerns/organizations/authentication_methods_spec.rb
+++ b/spec/models/concerns/organizations/authentication_methods_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Organizations::AuthenticationMethods do
   describe "authentication_methods" do
-    let(:organization) { create(:organization) }
+    let_it_be(:organization) { create_default(:organization) }
 
     before do
       organization

--- a/spec/models/credit_note/applied_tax_spec.rb
+++ b/spec/models/credit_note/applied_tax_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe CreditNote::AppliedTax do
   subject(:applied_tax) { create(:credit_note_applied_tax) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   describe "associations" do
     it { is_expected.to belong_to(:credit_note) }

--- a/spec/models/credit_note/applied_tax_spec.rb
+++ b/spec/models/credit_note/applied_tax_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe CreditNote::AppliedTax do
   subject(:applied_tax) { create(:credit_note_applied_tax) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   describe "associations" do
     it { is_expected.to belong_to(:credit_note) }
     it { is_expected.to belong_to(:tax).optional }

--- a/spec/models/credit_note_item_spec.rb
+++ b/spec/models/credit_note_item_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe CreditNoteItem do
   subject(:credit_note_item) { create(:credit_note_item) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
 
   it { is_expected.to belong_to(:credit_note) }
   it { is_expected.to belong_to(:fee) }

--- a/spec/models/credit_note_item_spec.rb
+++ b/spec/models/credit_note_item_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe CreditNoteItem do
   subject(:credit_note_item) { create(:credit_note_item) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it { is_expected.to belong_to(:credit_note) }
   it { is_expected.to belong_to(:fee) }
   it { is_expected.to belong_to(:organization) }

--- a/spec/models/credit_note_spec.rb
+++ b/spec/models/credit_note_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe CreditNote do
   end
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:add_on) { create_default(:add_on) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
 
   let(:item) { create(:credit_note_item, credit_note:, precise_amount_cents: 10000, amount_cents: 1000) }
 

--- a/spec/models/credit_note_spec.rb
+++ b/spec/models/credit_note_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe CreditNote do
       taxes_rate: 10.0, precise_taxes_amount_cents: 1000
   end
 
+  let_it_be(:organization) { create_default(:organization) }
+
   let(:item) { create(:credit_note_item, credit_note:, precise_amount_cents: 10000, amount_cents: 1000) }
 
   it_behaves_like "paper_trail traceable"
@@ -518,7 +520,8 @@ RSpec.describe CreditNote do
     subject(:method_call) { credit_note.should_sync_credit_note? }
 
     let(:credit_note) { create(:credit_note, customer:, organization:, status:) }
-    let(:organization) { create(:organization) }
+
+    let_it_be(:organization) { create_default(:organization) }
 
     context "when credit note is not finalized" do
       let(:status) { :draft }
@@ -534,7 +537,8 @@ RSpec.describe CreditNote do
       context "with integration customer" do
         let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
         let(:integration) { create(:netsuite_integration, organization:, sync_credit_notes:) }
-        let(:customer) { create(:customer, organization:) }
+
+        let_it_be(:customer) { create_default(:customer, organization:) }
 
         before { integration_customer }
 
@@ -570,7 +574,8 @@ RSpec.describe CreditNote do
       context "with integration customer" do
         let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
         let(:integration) { create(:netsuite_integration, organization:, sync_credit_notes:) }
-        let(:customer) { create(:customer, organization:) }
+
+        let_it_be(:customer) { create_default(:customer, organization:) }
 
         before { integration_customer }
 

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Credit do
   subject(:credit) { create(:credit) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   describe "associations" do
     it { is_expected.to belong_to(:invoice) }

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Credit do
   subject(:credit) { create(:credit) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   describe "associations" do
     it { is_expected.to belong_to(:invoice) }
     it { is_expected.to belong_to(:applied_coupon).optional }

--- a/spec/models/customer/applied_invoice_custom_section_spec.rb
+++ b/spec/models/customer/applied_invoice_custom_section_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Customer::AppliedInvoiceCustomSection do
   end
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:billing_entity) }

--- a/spec/models/customer/applied_invoice_custom_section_spec.rb
+++ b/spec/models/customer/applied_invoice_custom_section_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Customer::AppliedInvoiceCustomSection do
     create(:customer_applied_invoice_custom_section)
   end
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:billing_entity) }
   it { is_expected.to belong_to(:customer) }

--- a/spec/models/customer/applied_tax_spec.rb
+++ b/spec/models/customer/applied_tax_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Customer::AppliedTax do
   subject(:applied_tax) { create(:customer_applied_tax) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   it_behaves_like "paper_trail traceable"
 

--- a/spec/models/customer/applied_tax_spec.rb
+++ b/spec/models/customer/applied_tax_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Customer::AppliedTax do
   subject(:applied_tax) { create(:customer_applied_tax) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it_behaves_like "paper_trail traceable"
 
   it { is_expected.to belong_to(:organization) }

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Customer do
   subject(:customer) { create(:customer) }
 
-  let(:organization) { create(:organization) }
-  let(:billing_entity) { create(:billing_entity, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billing_entity) { create_default(:billing_entity, organization:) }
 
   it_behaves_like "paper_trail traceable"
 
@@ -1183,7 +1183,7 @@ RSpec.describe Customer do
   describe "#overdue_balance_cents" do
     subject(:overdue_balance_cents) { customer.overdue_balance_cents }
 
-    let(:customer) { create(:customer, currency: "USD") }
+    let_it_be(:customer) { create(:customer, currency: "USD") }
 
     context "when there are no overdue invoices" do
       before do
@@ -1249,7 +1249,7 @@ RSpec.describe Customer do
   end
 
   describe "#overdue_balances" do
-    let(:customer) { create(:customer, currency: "USD") }
+    let_it_be(:customer) { create(:customer, currency: "USD") }
 
     context "when there are no overdue invoices" do
       it "returns an empty hash" do
@@ -1312,8 +1312,8 @@ RSpec.describe Customer do
   end
 
   describe "#reset_dunning_campaign_for_currency!" do
-    let(:last_dunning_campaign_attempt_at) { 1.day.ago }
-    let(:customer) do
+    let_it_be(:last_dunning_campaign_attempt_at) { 1.day.ago }
+    let_it_be(:customer) do
       create(
         :customer,
         last_dunning_campaign_attempt: 5,
@@ -1427,7 +1427,7 @@ RSpec.describe Customer do
   end
 
   describe "#payment_connection" do
-    let(:customer) { create(:customer) }
+    let_it_be(:customer) { create(:customer) }
     let!(:default_connection) { create(:stripe_customer, customer:, code: "stripe_eu", is_default: true) }
     let!(:other_connection) { create(:gocardless_customer, customer:, code: "gc") }
 
@@ -1445,7 +1445,7 @@ RSpec.describe Customer do
   end
 
   describe "#payment_connection_status" do
-    let(:customer) { create(:customer) }
+    let_it_be(:customer) { create(:customer) }
 
     context "when no connection is the default" do
       it "returns not_connected" do

--- a/spec/models/dunning_campaign_spec.rb
+++ b/spec/models/dunning_campaign_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe DunningCampaign do
   subject(:dunning_campaign) { create(:dunning_campaign) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it_behaves_like "paper_trail traceable"
 
   it do

--- a/spec/models/dunning_campaign_threshold_spec.rb
+++ b/spec/models/dunning_campaign_threshold_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe DunningCampaignThreshold do
   subject(:dunning_campaign_threshold) { create(:dunning_campaign_threshold) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it_behaves_like "paper_trail traceable"
 
   it { is_expected.to belong_to(:dunning_campaign) }

--- a/spec/models/enriched_event_spec.rb
+++ b/spec/models/enriched_event_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe EnrichedEvent do
   subject { build(:enriched_event) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
 
   it { is_expected.to belong_to(:event) }
 

--- a/spec/models/enriched_event_spec.rb
+++ b/spec/models/enriched_event_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe EnrichedEvent do
   subject { build(:enriched_event) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it { is_expected.to belong_to(:event) }
 
   it { is_expected.to validate_presence_of(:code) }

--- a/spec/models/enriched_store_migration_spec.rb
+++ b/spec/models/enriched_store_migration_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe EnrichedStoreMigration do
   subject(:migration) { create(:enriched_store_migration) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   describe "enums" do
     it do
       expect(subject).to define_enum_for(:status)

--- a/spec/models/enriched_store_subscription_migration_spec.rb
+++ b/spec/models/enriched_store_subscription_migration_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe EnrichedStoreSubscriptionMigration do
   subject(:subscription_migration) { create(:enriched_store_subscription_migration) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
 
   describe "enums" do
     it do

--- a/spec/models/enriched_store_subscription_migration_spec.rb
+++ b/spec/models/enriched_store_subscription_migration_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe EnrichedStoreSubscriptionMigration do
   subject(:subscription_migration) { create(:enriched_store_subscription_migration) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   describe "enums" do
     it do
       expect(subject).to define_enum_for(:status)

--- a/spec/models/entitlement/entitlement_spec.rb
+++ b/spec/models/entitlement/entitlement_spec.rb
@@ -19,9 +19,10 @@ RSpec.describe Entitlement::Entitlement do
 
   describe "validations" do
     describe "exactly_one_parent_present validation" do
-      let(:organization) { create(:organization) }
+      let_it_be(:organization) { create_default(:organization) }
+      let_it_be(:plan) { create_default(:plan, organization:) }
+
       let(:feature) { create(:feature, organization:) }
-      let(:plan) { create(:plan, organization:) }
       let(:subscription) { create(:subscription, organization:) }
 
       it "is valid when only plan_id is present" do

--- a/spec/models/entitlement/entitlement_spec.rb
+++ b/spec/models/entitlement/entitlement_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Entitlement::Entitlement do
     describe "exactly_one_parent_present validation" do
       let_it_be(:organization) { create_default(:organization) }
       let_it_be(:plan) { create_default(:plan, organization:) }
+      let_it_be(:customer) { create_default(:customer) }
 
       let(:feature) { create(:feature, organization:) }
       let(:subscription) { create(:subscription, organization:) }

--- a/spec/models/entitlement/entitlement_value_spec.rb
+++ b/spec/models/entitlement/entitlement_value_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Entitlement::EntitlementValue do
   subject { create(:entitlement_value) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it { expect(described_class).to be_soft_deletable }
 
   describe "associations" do

--- a/spec/models/entitlement/entitlement_value_spec.rb
+++ b/spec/models/entitlement/entitlement_value_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Entitlement::EntitlementValue do
   subject { create(:entitlement_value) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
 
   it { expect(described_class).to be_soft_deletable }
 

--- a/spec/models/error_detail_spec.rb
+++ b/spec/models/error_detail_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ErrorDetail do
   it { is_expected.to belong_to(:organization) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   context "when creating an invoice generation error for an invoice" do
     let(:invoice) { create(:invoice, :generating) }

--- a/spec/models/error_detail_spec.rb
+++ b/spec/models/error_detail_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe ErrorDetail do
   it { is_expected.to belong_to(:owner) }
   it { is_expected.to belong_to(:organization) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   context "when creating an invoice generation error for an invoice" do
     let(:invoice) { create(:invoice, :generating) }
     let(:result) { BaseService::Result.new }

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -5,14 +5,17 @@ require "rails_helper"
 RSpec.describe Event do
   subject { build(:event) }
 
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:plan) { create_default(:plan) }
+
   it { is_expected.to have_many(:enriched_events) }
 
   it { is_expected.to validate_presence_of(:transaction_id) }
   it { is_expected.to validate_presence_of(:code) }
 
   describe "#customer" do
-    let(:organization) { create(:organization) }
-    let(:customer) { create(:customer, organization:) }
+    let_it_be(:organization) { create_default(:organization) }
+    let_it_be(:customer) { create_default(:customer, organization:) }
     let(:subscription) { create(:subscription, organization:, customer:) }
     let(:external_customer_id) { customer.external_id }
     let(:external_subscription_id) { subscription.external_id }
@@ -56,9 +59,9 @@ RSpec.describe Event do
   end
 
   describe "#subscription" do
-    let(:organization) { create(:organization) }
-    let(:customer) { create(:customer, organization:) }
-    let(:plan) { create(:plan, organization:) }
+    let_it_be(:organization) { create_default(:organization) }
+    let_it_be(:customer) { create_default(:customer, organization:) }
+    let_it_be(:plan) { create_default(:plan, organization:) }
     let(:subscription) { create(:subscription, organization:, customer:, plan:, started_at:) }
 
     let(:started_at) { Time.current - 3.days }

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe Event do
   subject { build(:event) }
 
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:customer) { create_default(:customer) }
   let_it_be(:plan) { create_default(:plan) }
 

--- a/spec/models/events/common_spec.rb
+++ b/spec/models/events/common_spec.rb
@@ -15,14 +15,13 @@ RSpec.describe Events::Common do
     )
   end
 
-  let(:organization) { create(:organization) }
-  let(:billable_metric) { create(:billable_metric, organization: organization) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization: organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
+
   let(:timestamp) { Time.current - 1.second }
-
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, organization:, customer:, plan:, started_at:) }
-
   let(:started_at) { Time.current - 3.days }
   let(:external_subscription_id) { subscription.external_id }
 

--- a/spec/models/feature_flag_spec.rb
+++ b/spec/models/feature_flag_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe FeatureFlag do
-  let(:valid_flag) { "test_flag" }
+  let_it_be(:valid_flag) { "test_flag" }
 
   before do
     stub_const(
@@ -46,10 +46,10 @@ RSpec.describe FeatureFlag do
   end
 
   describe ".sanitize!" do
-    let(:organization_with_valid_flags) { create(:organization, feature_flags: [valid_flag]) }
-    let(:organization_with_invalid_flags) { create(:organization, feature_flags: ["invalid_flag", "another_invalid"]) }
-    let(:organization_with_mixed_flags) { create(:organization, feature_flags: [valid_flag, "invalid_flag"]) }
-    let(:organization_without_flags) { create(:organization, feature_flags: []) }
+    let_it_be(:organization_with_valid_flags) { create(:organization, feature_flags: [valid_flag]) }
+    let_it_be(:organization_with_invalid_flags) { create(:organization, feature_flags: ["invalid_flag", "another_invalid"]) }
+    let_it_be(:organization_with_mixed_flags) { create(:organization, feature_flags: [valid_flag, "invalid_flag"]) }
+    let_it_be(:organization_without_flags) { create(:organization, feature_flags: []) }
 
     before do
       organization_with_valid_flags

--- a/spec/models/fee/applied_tax_spec.rb
+++ b/spec/models/fee/applied_tax_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Fee::AppliedTax do
   subject(:applied_tax) { create(:fee_applied_tax) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
 
   it_behaves_like "paper_trail traceable"
 

--- a/spec/models/fee/applied_tax_spec.rb
+++ b/spec/models/fee/applied_tax_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Fee::AppliedTax do
   subject(:applied_tax) { create(:fee_applied_tax) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it_behaves_like "paper_trail traceable"
 
   it { is_expected.to belong_to(:organization) }

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Fee do
   subject { build(:fee) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it { is_expected.to belong_to(:add_on).optional }
   it { is_expected.to belong_to(:charge).optional }
   it { is_expected.to belong_to(:fixed_charge).optional }

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe Fee do
   subject { build(:fee) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:add_on) { create_default(:add_on) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
 
   it { is_expected.to belong_to(:add_on).optional }
   it { is_expected.to belong_to(:charge).optional }

--- a/spec/models/fixed_charge_spec.rb
+++ b/spec/models/fixed_charge_spec.rb
@@ -5,6 +5,9 @@ require "rails_helper"
 RSpec.describe FixedCharge do
   subject { build(:fixed_charge) }
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:add_on) { create_default(:add_on) }
+
   describe "plan pricing type validation" do
     it "rejects a fixed charge on a product-catalog plan" do
       plan = create(:plan, pricing_type: "product_catalog", interval: nil, amount_cents: nil, pay_in_advance: nil)

--- a/spec/models/integration_collection_mappings/base_collection_mapping_spec.rb
+++ b/spec/models/integration_collection_mappings/base_collection_mapping_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe IntegrationCollectionMappings::BaseCollectionMapping do
   subject(:mapping) { build(:netsuite_collection_mapping, settings: {}) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   let(:mapping_types) do
     %i[fallback_item coupon subscription_fee minimum_commitment tax prepaid_credit credit_note account currencies]
   end
@@ -20,11 +22,13 @@ RSpec.describe IntegrationCollectionMappings::BaseCollectionMapping do
   describe "validations" do
     describe "of mapping type uniqueness" do
       let(:mapping_type) { :fallback_item }
-      let(:organization) { create(:organization) }
       let(:integration) { create(:netsuite_integration, organization:) }
       let(:other_integration) { create(:netsuite_integration, organization: organization) }
-      let(:billing_entity) { create(:billing_entity, organization: organization) }
-      let(:other_billing_entity) { create(:billing_entity, organization: organization) }
+
+      let_it_be(:organization) { create_default(:organization) }
+
+      let_it_be(:billing_entity) { create_default(:billing_entity, organization: organization) }
+      let_it_be(:other_billing_entity) { create_default(:billing_entity, organization: organization) }
 
       context "when billing entity is nil" do
         subject(:mapping) do

--- a/spec/models/integration_collection_mappings/netsuite_collection_mapping_spec.rb
+++ b/spec/models/integration_collection_mappings/netsuite_collection_mapping_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe IntegrationCollectionMappings::NetsuiteCollectionMapping do
   subject(:mapping) { build(:netsuite_collection_mapping) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   describe "#external_id" do
     let(:external_id) { SecureRandom.uuid }
 

--- a/spec/models/integration_mappings/base_mapping_spec.rb
+++ b/spec/models/integration_mappings/base_mapping_spec.rb
@@ -21,15 +21,16 @@ RSpec.describe IntegrationMappings::BaseMapping do
       let(:mapping) do
         build(:netsuite_mapping, integration:, organization:, mappable: add_on, billing_entity:)
       end
-      let(:organization) { create(:organization) }
       let(:integration) { create(:netsuite_integration, organization: organization) }
-      let(:add_on) { create(:add_on, organization: organization) }
-      let(:other_add_on) { create(:add_on, organization: organization) }
-      let(:billable_metric) { create(:billable_metric, id: add_on.id, organization: organization) }
       let(:other_integration) { create(:netsuite_integration, organization: organization) }
-      let(:billing_entity) { create(:billing_entity, organization: organization) }
-      let(:other_billing_entity) { create(:billing_entity, organization: organization) }
       let(:other_organization) { create(:organization) }
+
+      let_it_be(:organization) { create_default(:organization) }
+      let_it_be(:add_on) { create_default(:add_on, organization: organization) }
+      let_it_be(:other_add_on) { create_default(:add_on, organization: organization) }
+      let_it_be(:billable_metric) { create_default(:billable_metric, id: add_on.id, organization: organization) }
+      let_it_be(:billing_entity) { create_default(:billing_entity, organization: organization) }
+      let_it_be(:other_billing_entity) { create(:billing_entity, organization: organization) }
 
       context "without billing entity" do
         let(:mapping) do
@@ -95,11 +96,12 @@ RSpec.describe IntegrationMappings::BaseMapping do
     end
 
     describe "billing entity organization validation" do
-      let(:organization) { create(:organization) }
-      let(:different_organization) { create(:organization) }
+      let_it_be(:organization) { create_default(:organization) }
+      let_it_be(:different_organization) { create_default(:organization) }
       let(:integration) { create(:netsuite_integration, organization: organization) }
-      let(:billing_entity) { create(:billing_entity, organization: different_organization) }
-      let(:add_on) { create(:add_on, organization: organization) }
+
+      let_it_be(:billing_entity) { create_default(:billing_entity, organization: different_organization) }
+      let_it_be(:add_on) { create_default(:add_on, organization: organization) }
 
       it "validates billing entity belongs to same organization" do
         mapping = build(

--- a/spec/models/integration_mappings/base_mapping_spec.rb
+++ b/spec/models/integration_mappings/base_mapping_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe IntegrationMappings::BaseMapping do
 
       let_it_be(:organization) { create_default(:organization) }
       let_it_be(:add_on) { create_default(:add_on, organization: organization) }
-      let_it_be(:other_add_on) { create_default(:add_on, organization: organization) }
+      let_it_be(:other_add_on) { create(:add_on, organization: organization) }
       let_it_be(:billable_metric) { create_default(:billable_metric, id: add_on.id, organization: organization) }
       let_it_be(:billing_entity) { create_default(:billing_entity, organization: organization) }
       let_it_be(:other_billing_entity) { create(:billing_entity, organization: organization) }

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Invite do
   subject(:invite) { create(:invite) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it_behaves_like "paper_trail traceable"
 
   describe "#mark_as_revoked" do
@@ -37,7 +39,7 @@ RSpec.describe Invite do
   describe "validations" do
     subject(:invite) { build(:invite, organization:) }
 
-    let(:organization) { create(:organization) }
+    let_it_be(:organization) { create_default(:organization) }
     let!(:role) { create(:role, :custom, organization:) }
 
     before { create(:role, :admin) }

--- a/spec/models/invoice/applied_tax_spec.rb
+++ b/spec/models/invoice/applied_tax_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Invoice::AppliedTax do
   subject(:applied_tax) { create(:invoice_applied_tax) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   it_behaves_like "paper_trail traceable"
 

--- a/spec/models/invoice/applied_tax_spec.rb
+++ b/spec/models/invoice/applied_tax_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Invoice::AppliedTax do
   subject(:applied_tax) { create(:invoice_applied_tax) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it_behaves_like "paper_trail traceable"
 
   it { is_expected.to belong_to(:organization) }

--- a/spec/models/invoice_custom_section_spec.rb
+++ b/spec/models/invoice_custom_section_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe InvoiceCustomSection do
   subject(:invoice_custom_section) { create(:invoice_custom_section) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to have_many(:customer_applied_invoice_custom_sections).dependent(:destroy) }
   it { is_expected.to have_many(:billing_entity_applied_invoice_custom_sections).dependent(:destroy) }

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -5,7 +5,9 @@ require "rails_helper"
 RSpec.describe Invoice do
   subject(:invoice) { create(:invoice, organization:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:add_on) { create_default(:add_on) }
 
   it_behaves_like "paper_trail traceable"
   it_behaves_like "a model with a purchase order number"

--- a/spec/models/invoice_subscription_spec.rb
+++ b/spec/models/invoice_subscription_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe InvoiceSubscription do
     )
   end
 
+  let_it_be(:organization) { create_default(:organization) }
+
   let(:invoice) { invoice_subscription.invoice }
   let(:subscription) { invoice_subscription.subscription }
 
@@ -28,17 +30,16 @@ RSpec.describe InvoiceSubscription do
   it { is_expected.to belong_to(:organization) }
 
   describe ".order_by_subscription_invoice_name" do
-    let(:organization) { create(:organization) }
-    let(:customer) { create(:customer, organization:) }
+    let_it_be(:organization) { create_default(:organization) }
+    let_it_be(:customer) { create_default(:customer, organization:) }
     let(:invoice) { create(:invoice, customer:, organization:) }
-
-    let(:plan_zebra) { create(:plan, organization:, name: "Zebra Plan", invoice_display_name: nil) }
-    let(:plan_alpha) { create(:plan, organization:, name: "Alpha Plan", invoice_display_name: nil) }
-    let(:plan_beta) { create(:plan, organization:, name: "Beta Plan", invoice_display_name: "Custom Beta") }
-
     let(:subscription_zebra) { create(:subscription, customer:, plan: plan_zebra, name: nil) }
     let(:subscription_alpha) { create(:subscription, customer:, plan: plan_alpha, name: nil) }
     let(:subscription_custom) { create(:subscription, customer:, plan: plan_beta, name: "AAA Custom Name") }
+
+    let_it_be(:plan_zebra) { create(:plan, organization:, name: "Zebra Plan", invoice_display_name: nil) }
+    let_it_be(:plan_alpha) { create(:plan, organization:, name: "Alpha Plan", invoice_display_name: nil) }
+    let_it_be(:plan_beta) { create(:plan, organization:, name: "Beta Plan", invoice_display_name: "Custom Beta") }
 
     before do
       create(:invoice_subscription, invoice:, subscription: subscription_zebra)
@@ -107,14 +108,12 @@ RSpec.describe InvoiceSubscription do
         timestamp: Time.current
       )
     end
-
     let(:base_from_datetime) { "2022-01-01 00:00:00" }
     let(:base_to_datetime) { "2022-01-31 23:59:59" }
     let(:base_charges_from_datetime) { "2022-01-01 00:00:00" }
     let(:base_charges_to_datetime) { "2022-01-31 23:59:59" }
     let(:base_fixed_charges_from_datetime) { "2022-01-01 00:00:00" }
     let(:base_fixed_charges_to_datetime) { "2022-01-31 23:59:59" }
-
     let(:from_datetime) { base_from_datetime }
     let(:to_datetime) { base_to_datetime }
     let(:charges_from_datetime) { base_charges_from_datetime }

--- a/spec/models/invoice_subscription_spec.rb
+++ b/spec/models/invoice_subscription_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe InvoiceSubscription do
   end
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
 
   let(:invoice) { invoice_subscription.invoice }
   let(:subscription) { invoice_subscription.subscription }
@@ -30,8 +32,6 @@ RSpec.describe InvoiceSubscription do
   it { is_expected.to belong_to(:organization) }
 
   describe ".order_by_subscription_invoice_name" do
-    let_it_be(:organization) { create_default(:organization) }
-    let_it_be(:customer) { create_default(:customer, organization:) }
     let(:invoice) { create(:invoice, customer:, organization:) }
     let(:subscription_zebra) { create(:subscription, customer:, plan: plan_zebra, name: nil) }
     let(:subscription_alpha) { create(:subscription, customer:, plan: plan_alpha, name: nil) }

--- a/spec/models/lifetime_usage_spec.rb
+++ b/spec/models/lifetime_usage_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe LifetimeUsage do
   subject(:lifetime_usage) { create(:lifetime_usage) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
 
   it { is_expected.to belong_to(:organization) }
 

--- a/spec/models/lifetime_usage_spec.rb
+++ b/spec/models/lifetime_usage_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe LifetimeUsage do
   subject(:lifetime_usage) { create(:lifetime_usage) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it { is_expected.to belong_to(:organization) }
 
   describe "default scope" do

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Membership do
   subject(:membership) { create(:membership) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it { is_expected.to have_many(:data_exports) }
   it { is_expected.to have_many(:membership_roles) }
   it { is_expected.to have_many(:roles).through(:membership_roles) }
@@ -100,7 +102,7 @@ RSpec.describe Membership do
     end
 
     context "with custom role" do
-      let(:organization) { create(:organization) }
+      let_it_be(:organization) { create_default(:organization) }
       let(:role) { create(:role, :custom, organization:, permissions: %w[foo addons:view]) }
       let(:membership) { create(:membership, organization:, role:) }
 
@@ -122,7 +124,7 @@ RSpec.describe Membership do
     end
 
     context "with mixed roles" do
-      let(:organization) { create(:organization) }
+      let_it_be(:organization) { create_default(:organization) }
       let(:role) { create(:role, :custom, organization:, permissions: %w[foo addons:view]) }
       let(:membership) { create(:membership, organization:, role:, roles: %i[finance]) }
 

--- a/spec/models/metadata/customer_metadata_spec.rb
+++ b/spec/models/metadata/customer_metadata_spec.rb
@@ -5,7 +5,9 @@ require "rails_helper"
 RSpec.describe Metadata::CustomerMetadata do
   subject(:metadata) { described_class.new(attributes) }
 
-  let(:customer) { create(:customer) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+
   let(:key) { "hello" }
   let(:value) { "abcdef" }
   let(:attributes) do

--- a/spec/models/metadata/invoice_metadata_spec.rb
+++ b/spec/models/metadata/invoice_metadata_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Metadata::InvoiceMetadata do
   subject(:metadata) { described_class.new(attributes) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   let(:invoice) { create(:invoice) }
   let(:key) { "hello" }
   let(:value) { "abcdef" }

--- a/spec/models/metadata/invoice_metadata_spec.rb
+++ b/spec/models/metadata/invoice_metadata_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Metadata::InvoiceMetadata do
   subject(:metadata) { described_class.new(attributes) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   let(:invoice) { create(:invoice) }
   let(:key) { "hello" }

--- a/spec/models/metadata/item_metadata_spec.rb
+++ b/spec/models/metadata/item_metadata_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Metadata::ItemMetadata do
   subject(:item_metadata) { described_class.new(organization:, owner:, value:) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
   let(:invoice) { create(:invoice, organization:) }
-  let(:customer) { invoice.customer }
   let(:owner) { create(:credit_note, invoice:, customer:, organization:) }
   let(:value) { {"key1" => "value1"} }
 

--- a/spec/models/metadata/item_metadata_spec.rb
+++ b/spec/models/metadata/item_metadata_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Metadata::ItemMetadata do
   subject(:item_metadata) { described_class.new(organization:, owner:, value:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:invoice) { create(:invoice, organization:) }
   let(:customer) { invoice.customer }
   let(:owner) { create(:credit_note, invoice:, customer:, organization:) }

--- a/spec/models/order_form_spec.rb
+++ b/spec/models/order_form_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe OrderForm do
 
   describe "Scopes" do
     describe ".expirable" do
-      let(:organization) { create(:organization) }
+      let_it_be(:organization) { create_default(:organization) }
       let(:customer) { create(:customer, organization:) }
 
       let!(:expired_yesterday) { create(:order_form, :expired_yesterday, organization:, customer:) }
@@ -55,7 +55,7 @@ RSpec.describe OrderForm do
       end
 
       context "with customer timezone" do
-        let(:customer) { create(:customer, organization:, timezone: "America/New_York") }
+        let_it_be(:customer) { create_default(:customer, organization:, timezone: "America/New_York") }
 
         it "includes a form whose expiry day has started in the customer timezone but not in UTC" do
           # 2026-01-16 02:00 UTC is 2026-01-15 21:00 in New York

--- a/spec/models/payment_intent_spec.rb
+++ b/spec/models/payment_intent_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe PaymentIntent do
+  let_it_be(:organization) { create_default(:organization) }
+
   it { is_expected.to define_enum_for(:status).with_values(described_class::STATUSES) }
 
   it { is_expected.to belong_to(:invoice) }

--- a/spec/models/payment_intent_spec.rb
+++ b/spec/models/payment_intent_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe PaymentIntent do
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   it { is_expected.to define_enum_for(:status).with_values(described_class::STATUSES) }
 

--- a/spec/models/payment_providers/stripe_provider_spec.rb
+++ b/spec/models/payment_providers/stripe_provider_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviders::StripeProvider do
   subject(:stripe_provider) { build(:stripe_provider, attributes) }
 
+  let_it_be(:organization) { create_default(:organization) }
   let(:attributes) {}
 
   it { is_expected.to validate_length_of(:success_redirect_url).is_at_most(1024).allow_nil }

--- a/spec/models/payment_providers/stripe_provider_spec.rb
+++ b/spec/models/payment_providers/stripe_provider_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe PaymentProviders::StripeProvider do
   subject(:stripe_provider) { build(:stripe_provider, attributes) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
   let(:attributes) {}
 
   it { is_expected.to validate_length_of(:success_redirect_url).is_at_most(1024).allow_nil }

--- a/spec/models/payment_request_spec.rb
+++ b/spec/models/payment_request_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe PaymentRequest do
     )
   end
 
-  let(:customer) { create(:customer) }
-  let(:organization) { customer.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
   let(:payment) { create(:payment) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -5,6 +5,9 @@ require "rails_helper"
 RSpec.describe Payment do
   subject(:payment) { build(:payment, payable:, payment_type:, provider_payment_id:, reference:, amount_cents:) }
 
+  let_it_be(:organization) { create_default(:organization) }
+  let(:customer) { create_default(:customer) }
+
   let(:payable) { create(:invoice, invoice_type:, total_amount_cents: 10000) }
   let(:invoice_type) { :subscription }
   let(:payment_type) { "provider" }
@@ -530,7 +533,6 @@ RSpec.describe Payment do
 
     let(:payment) { create(:payment, payable: invoice) }
     let(:invoice) { create(:invoice, customer:, organization:, status:) }
-    let(:organization) { create(:organization) }
 
     context "when invoice is not finalized" do
       let(:status) { %i[draft voided generating].sample }
@@ -546,7 +548,6 @@ RSpec.describe Payment do
       context "with integration customer" do
         let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
         let(:integration) { create(:netsuite_integration, organization:, sync_payments:) }
-        let(:customer) { create(:customer, organization:) }
 
         before { integration_customer }
 
@@ -582,7 +583,6 @@ RSpec.describe Payment do
       context "with integration customer" do
         let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
         let(:integration) { create(:netsuite_integration, organization:, sync_payments:) }
-        let(:customer) { create(:customer, organization:) }
 
         before { integration_customer }
 

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Plan do
   subject(:plan) { build(:plan, trial_period: 3) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it { expect(described_class).to be_soft_deletable }
 
   it do
@@ -84,7 +86,7 @@ RSpec.describe Plan do
   end
 
   describe "#applicable_usage_thresholds" do
-    let(:plan) { create(:plan) }
+    let_it_be(:plan) { create_default(:plan) }
 
     it "returns usage thresholds plan is a parent" do
       threshold = create(:usage_threshold, plan: plan)

--- a/spec/models/product_category_spec.rb
+++ b/spec/models/product_category_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe ProductCategory do
   subject(:product_category) { build(:product_category) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it_behaves_like "paper_trail traceable"
 
   describe "associations" do

--- a/spec/models/quote_spec.rb
+++ b/spec/models/quote_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Quote do
   subject(:quote) { create(:quote) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   describe "enums" do
     it do

--- a/spec/models/quote_spec.rb
+++ b/spec/models/quote_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Quote do
   subject(:quote) { create(:quote) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   describe "enums" do
     it do
       expect(subject).to define_enum_for(:order_type)

--- a/spec/models/quote_version_spec.rb
+++ b/spec/models/quote_version_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe QuoteVersion do
   subject(:quote_version) { create(:quote_version) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   describe "enums" do
     it do

--- a/spec/models/quote_version_spec.rb
+++ b/spec/models/quote_version_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe QuoteVersion do
   subject(:quote_version) { create(:quote_version) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   describe "enums" do
     it do
       expect(subject).to define_enum_for(:status)
@@ -119,9 +121,10 @@ RSpec.describe QuoteVersion do
 
     # The plan change carries the target's binding over, so the document has to name the same issuer.
     context "when the quote amends a subscription bound to another entity" do
-      let(:organization) { create(:organization) }
-      let(:customer) { create(:customer, organization:) }
-      let(:target_entity) { create(:billing_entity, organization:) }
+      let_it_be(:plan) { create_default(:plan) }
+      let_it_be(:organization) { create_default(:organization) }
+      let_it_be(:customer) { create_default(:customer, organization:) }
+      let_it_be(:target_entity) { create_default(:billing_entity, organization:) }
       let(:subscription) { create(:subscription, organization:, customer:, billing_entity: target_entity) }
       let(:quote) do
         create(:quote, organization:, customer:, subscription:, order_type: :subscription_amendment)

--- a/spec/models/rate_card_rate_spec.rb
+++ b/spec/models/rate_card_rate_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe RateCardRate do
   subject(:rate_card_rate) { build(:rate_card_rate) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it_behaves_like "paper_trail traceable"
 
   describe "enums" do
@@ -127,7 +129,7 @@ RSpec.describe RateCardRate do
     end
 
     describe "rate_model compatibility" do
-      let(:organization) { create(:organization) }
+      let_it_be(:organization) { create_default(:organization) }
 
       def rate_for(product_type:, rate_model:, billing_timing: "arrears", proration: false, metric: nil)
         item = create(:product, organization:, product_type:, billable_metric: metric)

--- a/spec/models/rate_card_rate_spec.rb
+++ b/spec/models/rate_card_rate_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe RateCardRate do
   subject(:rate_card_rate) { build(:rate_card_rate) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
 
   it_behaves_like "paper_trail traceable"
 

--- a/spec/models/recurring_transaction_rule/applied_invoice_custom_section_spec.rb
+++ b/spec/models/recurring_transaction_rule/applied_invoice_custom_section_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe RecurringTransactionRule::AppliedInvoiceCustomSection do
   end
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:recurring_transaction_rule) }

--- a/spec/models/recurring_transaction_rule/applied_invoice_custom_section_spec.rb
+++ b/spec/models/recurring_transaction_rule/applied_invoice_custom_section_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe RecurringTransactionRule::AppliedInvoiceCustomSection do
     create(:recurring_rule_applied_invoice_custom_section)
   end
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:recurring_transaction_rule) }
   it { is_expected.to belong_to(:invoice_custom_section) }

--- a/spec/models/recurring_transaction_rule_spec.rb
+++ b/spec/models/recurring_transaction_rule_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe RecurringTransactionRule do
   it_behaves_like "a model with a purchase order number"
 
+  let_it_be(:organization) { create_default(:organization) }
+
   describe "associations" do
     it { is_expected.to belong_to(:wallet) }
     it { is_expected.to belong_to(:organization) }

--- a/spec/models/recurring_transaction_rule_spec.rb
+++ b/spec/models/recurring_transaction_rule_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe RecurringTransactionRule do
   it_behaves_like "a model with a purchase order number"
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   describe "associations" do
     it { is_expected.to belong_to(:wallet) }

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Role do
     end
   end
 
-
   describe "scopes" do
     describe ".with_code" do
       let!(:developer) { create(:role, code: :developer, organization:) }

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Role do
   subject(:role) { build(:role) }
 
+  let_it_be(:organization) { create(:organization) }
+
   it { expect(described_class).to be_soft_deletable }
 
   describe "associations" do
@@ -21,9 +23,9 @@ RSpec.describe Role do
     end
   end
 
+
   describe "scopes" do
     describe ".with_code" do
-      let(:organization) { create(:organization) }
       let!(:developer) { create(:role, code: :developer, organization:) }
 
       before { create(:role, code: :designer, organization:) }
@@ -38,8 +40,7 @@ RSpec.describe Role do
     end
 
     describe ".with_organization" do
-      let(:organization) { create(:organization) }
-      let(:other_organization) { create(:organization) }
+      let_it_be(:other_organization) { create(:organization) }
       let!(:system_role) { create(:role, :admin) }
       let!(:org_role) { create(:role, organization:) }
 
@@ -133,8 +134,6 @@ RSpec.describe Role do
   end
 
   describe "database constraints" do
-    let!(:organization) { create(:organization) }
-
     it "rejects empty name" do
       expect {
         described_class.connection.execute(<<~SQL)

--- a/spec/models/subscription/activation_rule/payment_spec.rb
+++ b/spec/models/subscription/activation_rule/payment_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Subscription::ActivationRule::Payment do
   subject(:rule) { build(:subscription_activation_rule, subscription:, timeout_hours:) }
 
   let_it_be(:organization) { create_default(:organization) }
-  let_it_be(:customer) { create_default(:customer, :with_stripe_payment_provider, organization:) }
   let_it_be(:plan) { create_default(:plan, organization:) }
+  let_it_be(:customer) { create_default(:customer, :with_stripe_payment_provider, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:, organization:) }
   let(:timeout_hours) { 48 }
 

--- a/spec/models/subscription/activation_rule/payment_spec.rb
+++ b/spec/models/subscription/activation_rule/payment_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Subscription::ActivationRule::Payment do
   subject(:rule) { build(:subscription_activation_rule, subscription:, timeout_hours:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, :with_stripe_payment_provider, organization:) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, :with_stripe_payment_provider, organization:) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:, organization:) }
   let(:timeout_hours) { 48 }
 

--- a/spec/models/subscription/activation_rule_spec.rb
+++ b/spec/models/subscription/activation_rule_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Subscription::ActivationRule do
   subject(:activation_rule) { create(:subscription_activation_rule) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   describe "enums" do
     it do
       expect(subject).to define_enum_for(:status)

--- a/spec/models/subscription/activation_rule_spec.rb
+++ b/spec/models/subscription/activation_rule_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Subscription::ActivationRule do
   subject(:activation_rule) { create(:subscription_activation_rule) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
 
   describe "enums" do
     it do

--- a/spec/models/subscription/applied_invoice_custom_section_spec.rb
+++ b/spec/models/subscription/applied_invoice_custom_section_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Subscription::AppliedInvoiceCustomSection do
   end
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
 
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:subscription) }

--- a/spec/models/subscription/applied_invoice_custom_section_spec.rb
+++ b/spec/models/subscription/applied_invoice_custom_section_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Subscription::AppliedInvoiceCustomSection do
     create(:subscription_applied_invoice_custom_section)
   end
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:subscription) }
   it { is_expected.to belong_to(:invoice_custom_section) }

--- a/spec/models/subscription/fixed_charge_presenter_spec.rb
+++ b/spec/models/subscription/fixed_charge_presenter_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Subscription::FixedChargePresenter do
   subject(:presenter) { described_class.new(fixed_charge, subscription, effective_units:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
   let(:fixed_charge) { create(:fixed_charge, plan:, organization:, units: 10) }
   let(:subscription) { create(:subscription, plan:, customer:) }
 

--- a/spec/models/subscription/fixed_charge_presenter_spec.rb
+++ b/spec/models/subscription/fixed_charge_presenter_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Subscription::FixedChargePresenter do
   subject(:presenter) { described_class.new(fixed_charge, subscription, effective_units:) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:add_on) { create_default(:add_on) }
   let_it_be(:customer) { create_default(:customer, organization:) }
   let_it_be(:plan) { create_default(:plan, organization:) }
   let(:fixed_charge) { create(:fixed_charge, plan:, organization:, units: 10) }

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Subscription do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
+
   subject(:subscription) { create(:subscription, plan:) }
 
   let(:plan) { create(:plan) }

--- a/spec/models/tax_spec.rb
+++ b/spec/models/tax_spec.rb
@@ -5,6 +5,9 @@ require "rails_helper"
 RSpec.describe Tax do
   subject(:tax) { create(:tax, applied_to_organization:) }
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+
   let(:organization) { tax.organization }
   let(:applied_to_organization) { false }
 

--- a/spec/models/usage_monitoring/alert_spec.rb
+++ b/spec/models/usage_monitoring/alert_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe UsageMonitoring::Alert do
   let(:alert) { create(:alert, code: "my-code", thresholds: [10, 30, 50], recurring_threshold: 100) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   describe "enums" do
     it do
       expect(subject).to define_enum_for(:direction)

--- a/spec/models/usage_monitoring/alert_spec.rb
+++ b/spec/models/usage_monitoring/alert_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe UsageMonitoring::Alert do
   let(:alert) { create(:alert, code: "my-code", thresholds: [10, 30, 50], recurring_threshold: 100) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
 
   describe "enums" do
     it do

--- a/spec/models/usage_threshold_spec.rb
+++ b/spec/models/usage_threshold_spec.rb
@@ -23,8 +23,9 @@ RSpec.describe UsageThreshold do
     it { is_expected.to validate_numericality_of(:amount_cents).is_greater_than(0) }
 
     describe "exactly_one_parent_present validation" do
-      let(:organization) { create(:organization) }
-      let(:plan) { create(:plan, organization:) }
+      let_it_be(:customer) { create_default(:customer) }
+      let_it_be(:organization) { create_default(:organization) }
+      let_it_be(:plan) { create_default(:plan, organization:) }
       let(:subscription) { create(:subscription, organization:) }
 
       it "is valid when only plan_id is present" do
@@ -52,7 +53,7 @@ RSpec.describe UsageThreshold do
   end
 
   describe "#currency" do
-    let(:organization) { create(:organization, default_currency: "USD") }
+    let_it_be(:organization) { create_default(:organization, default_currency: "USD") }
 
     context "when threshold belongs to a plan" do
       let(:plan) { create(:plan, organization:, amount_currency: "GBP") }

--- a/spec/models/usage_threshold_spec.rb
+++ b/spec/models/usage_threshold_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe UsageThreshold do
     it { is_expected.to validate_numericality_of(:amount_cents).is_greater_than(0) }
 
     describe "exactly_one_parent_present validation" do
-      let_it_be(:customer) { create_default(:customer) }
       let_it_be(:organization) { create_default(:organization) }
       let_it_be(:plan) { create_default(:plan, organization:) }
+      let_it_be(:customer) { create_default(:customer) }
       let(:subscription) { create(:subscription, organization:) }
 
       it "is valid when only plan_id is present" do

--- a/spec/models/wallet/applied_invoice_custom_section_spec.rb
+++ b/spec/models/wallet/applied_invoice_custom_section_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Wallet::AppliedInvoiceCustomSection do
     create(:wallet_applied_invoice_custom_section)
   end
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:wallet) }
   it { is_expected.to belong_to(:invoice_custom_section) }

--- a/spec/models/wallet/applied_invoice_custom_section_spec.rb
+++ b/spec/models/wallet/applied_invoice_custom_section_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Wallet::AppliedInvoiceCustomSection do
   end
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:wallet) }

--- a/spec/models/wallet_credit_spec.rb
+++ b/spec/models/wallet_credit_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe WalletCredit do
   subject { described_class.new(wallet:, credit_amount:, invoiceable:) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   let(:wallet) { create(:wallet, rate_amount:, currency:) }
   let(:currency) { "EUR" }
   let(:credit_amount) { 1000 }

--- a/spec/models/wallet_credit_spec.rb
+++ b/spec/models/wallet_credit_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe WalletCredit do
   subject { described_class.new(wallet:, credit_amount:, invoiceable:) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   let(:wallet) { create(:wallet, rate_amount:, currency:) }
   let(:currency) { "EUR" }

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Wallet do
   end
 
   describe "#billing_entity" do
-    let(:organization) { create(:organization) }
-    let(:customer) { create(:customer, organization:) }
+    let_it_be(:organization) { create_default(:organization) }
+    let_it_be(:customer) { create_default(:customer, organization:) }
 
     context "when wallet has a billing_entity" do
       let(:billing_entity) { create(:billing_entity, organization:) }

--- a/spec/models/wallet_transaction/applied_invoice_custom_section_spec.rb
+++ b/spec/models/wallet_transaction/applied_invoice_custom_section_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe WalletTransaction::AppliedInvoiceCustomSection do
     create(:wallet_transaction_applied_invoice_custom_section)
   end
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:wallet_transaction) }
   it { is_expected.to belong_to(:invoice_custom_section) }

--- a/spec/models/wallet_transaction/applied_invoice_custom_section_spec.rb
+++ b/spec/models/wallet_transaction/applied_invoice_custom_section_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe WalletTransaction::AppliedInvoiceCustomSection do
   end
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:wallet_transaction) }

--- a/spec/models/wallet_transaction_consumption_spec.rb
+++ b/spec/models/wallet_transaction_consumption_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe WalletTransactionConsumption do
+  let_it_be(:organization) { create_default(:organization) }
+
   describe "associations" do
     it do
       expect(subject).to belong_to(:organization)

--- a/spec/models/wallet_transaction_consumption_spec.rb
+++ b/spec/models/wallet_transaction_consumption_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe WalletTransactionConsumption do
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   describe "associations" do
     it do

--- a/spec/models/wallet_transaction_spec.rb
+++ b/spec/models/wallet_transaction_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe WalletTransaction do
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   it_behaves_like "a model with a purchase order number"
 

--- a/spec/models/wallet_transaction_spec.rb
+++ b/spec/models/wallet_transaction_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe WalletTransaction do
+  let_it_be(:organization) { create_default(:organization) }
+
   it_behaves_like "a model with a purchase order number"
 
   describe "validations" do

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Webhook do
   subject(:webhook) { build(:webhook) }
 
+  let_it_be(:organization) { create_default(:organization) }
+
   it { is_expected.to belong_to(:webhook_endpoint) }
   it { is_expected.to belong_to(:object).optional }
   it { is_expected.to belong_to(:organization) }

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Webhook do
   subject(:webhook) { build(:webhook) }
 
   let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   it { is_expected.to belong_to(:webhook_endpoint) }
   it { is_expected.to belong_to(:object).optional }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,6 +76,10 @@ Sentry.init do |config|
   config.transport.transport_class = Sentry::DummyTransport
 end
 
+require "test_prof/recipes/rspec/sample"
+require "test_prof/recipes/rspec/let_it_be"
+require "test_prof/recipes/rspec/factory_default"
+
 RSpec.configure do |config|
   config.include ActiveJob::TestHelper
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
## Context

Currently, around **50% of the spec runtime** is spent preparing data and creating factories. A lot of this data is either duplicated or recreates the same objects multiple times, so we can get rid of a good chunk of it and significantly speed up the specs.

To avoid creating unnecessary factories, we can use `let_it_be`, `before_all`, and `create_default` from `test-prof`. More info [here](https://test-prof.evilmartians.io/guide/recipes/let_it_be).

## Description

This PR cleans up the model specs and removes unnecessary factory usage.

Here are the numbers before and after the cleanup. The times below are for running the specs in a single process:

| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 9,849 | 5,789 |
| Total time spent creating factories | 01:03.776 | 00:25.564 |
| Total time | 01:24.615 | 00:45.682 |

## Overall results

This PR is part of a series of PRs focused on cleaning up factory usage across different specs.

Once all the changes are merged, we expect to:

- Reduce the number of factories by **~50k**
- Cut spec runtime by around **20%**
- Shave off roughly **1:15 min** from the CI runtime


| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 157,949 | 103,761 |
| Total time spent creating factories | 17:59.851  | 11:14.739 |
| Total time | 34:41.482 | 27:03.658 |

Here is [the CI run](https://github.com/getlago/lago-api/actions/runs/33399605547/job/99512391170?pr=6255) with all the changes merged together: