### PR TITLE
perf(specs): Clean up factories usage in spec/graphql

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -167,6 +167,8 @@ group :test do
   # HTML testing (invoice rendering)
   gem "rspec-snapshot", "~> 2.0"
   gem "htmlbeautifier", "~> 1.4"
+
+  gem "test-prof", "~> 1.0"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1004,6 +1004,8 @@ GEM
     temple (0.10.4)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
+    test-prof (1.6.3)
+      logger
     thor (1.5.0)
     throttling (0.4.1)
       logger
@@ -1181,6 +1183,7 @@ DEPENDENCIES
   stripe
   strong_migrations
   super_diff (~> 0.19.0)
+  test-prof (~> 1.0)
   throttling
   timecop
   tzinfo-data

--- a/spec/graphql/mutations/add_ons/update_spec.rb
+++ b/spec/graphql/mutations/add_ons/update_spec.rb
@@ -3,12 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Mutations::AddOns::Update do
+  let_it_be(:organization) { create_default(:organization) }
   let(:required_permission) { "addons:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:tax) { create(:tax, organization:) }
   let(:tax2) { create(:tax, organization:) }
-  let(:add_on) { create(:add_on, organization:) }
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateAddOnInput!) {
@@ -25,6 +23,9 @@ RSpec.describe Mutations::AddOns::Update do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:add_on) { create_default(:add_on, organization:) }
 
   before { create(:add_on_applied_tax, add_on:, tax:) }
 

--- a/spec/graphql/mutations/adjusted_fees/create_spec.rb
+++ b/spec/graphql/mutations/adjusted_fees/create_spec.rb
@@ -4,15 +4,9 @@ require "rails_helper"
 
 RSpec.describe Mutations::AdjustedFees::Create, :premium do
   let(:required_permission) { "invoices:update" }
-  let(:organization) { create(:organization) }
-  let(:membership) { create(:membership, organization:) }
   let(:invoice) { create(:invoice, invoice_type: :subscription, organization:, customer:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, plan:, billable_metric:) }
-  let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:, started_at: Time.current - 1.year) }
-
   let(:invoice_subscription) do
     create(
       :invoice_subscription,
@@ -25,7 +19,6 @@ RSpec.describe Mutations::AdjustedFees::Create, :premium do
       charges_to_datetime: (Time.current - 1.month).end_of_month
     )
   end
-
   let(:fee) do
     create(
       :charge_fee,
@@ -41,7 +34,6 @@ RSpec.describe Mutations::AdjustedFees::Create, :premium do
       }
     )
   end
-
   let(:input) do
     {
       feeId: fee.id,
@@ -51,7 +43,6 @@ RSpec.describe Mutations::AdjustedFees::Create, :premium do
       invoiceDisplayName: "Hello"
     }
   end
-
   let(:mutation) do
     <<-GQL
       mutation($input: CreateAdjustedFeeInput!) {
@@ -64,6 +55,12 @@ RSpec.describe Mutations::AdjustedFees::Create, :premium do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership, organization:) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
+  let(:customer) { create(:customer, organization:) }
 
   before { fee.invoice.draft! }
 

--- a/spec/graphql/mutations/adjusted_fees/create_spec.rb
+++ b/spec/graphql/mutations/adjusted_fees/create_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe Mutations::AdjustedFees::Create, :premium do
   let(:required_permission) { "invoices:update" }
+  let(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, invoice_type: :subscription, organization:, customer:) }
   let(:charge) { create(:standard_charge, plan:, billable_metric:) }
   let(:subscription) { create(:subscription, customer:, plan:, started_at: Time.current - 1.year) }
@@ -60,7 +61,6 @@ RSpec.describe Mutations::AdjustedFees::Create, :premium do
   let_it_be(:membership) { create_default(:membership, organization:) }
   let_it_be(:plan) { create_default(:plan, organization:) }
   let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
-  let(:customer) { create(:customer, organization:) }
 
   before { fee.invoice.draft! }
 

--- a/spec/graphql/mutations/adjusted_fees/destroy_spec.rb
+++ b/spec/graphql/mutations/adjusted_fees/destroy_spec.rb
@@ -3,13 +3,15 @@
 require "rails_helper"
 
 RSpec.describe Mutations::AdjustedFees::Destroy do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let(:customer) { create(:customer) }
   let(:required_permission) { "invoices:update" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:invoice) { create(:invoice, status: :draft, organization:) }
   let(:fee) { create(:charge_fee, invoice:) }
   let(:adjusted_fee) { create(:adjusted_fee, invoice:, fee:) }
-
   let(:mutation) do
     <<-GQL
       mutation($input: DestroyAdjustedFeeInput!) {
@@ -17,6 +19,8 @@ RSpec.describe Mutations::AdjustedFees::Destroy do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before { adjusted_fee }
 

--- a/spec/graphql/mutations/ai_conversations/create_spec.rb
+++ b/spec/graphql/mutations/ai_conversations/create_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Mutations::AiConversations::Create do
+  let_it_be(:organization) { create_default(:organization) }
   subject(:result) do
     execute_graphql(
       current_user: membership.user,
@@ -20,10 +21,11 @@ RSpec.describe Mutations::AiConversations::Create do
       }
     GQL
   end
+  let(:message) { Faker::Lorem.word }
 
   let(:required_permission) { "ai_conversations:create" }
-  let!(:membership) { create(:membership) }
-  let(:message) { Faker::Lorem.word }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/api_keys/create_spec.rb
+++ b/spec/graphql/mutations/api_keys/create_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Mutations::ApiKeys::Create do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   subject(:result) do
     execute_graphql(
       current_user: membership.user,
@@ -20,10 +22,11 @@ RSpec.describe Mutations::ApiKeys::Create do
       }
     GQL
   end
+  let(:name) { Faker::Lorem.word }
 
   let(:required_permission) { "developers:keys:manage" }
-  let!(:membership) { create(:membership) }
-  let(:name) { Faker::Lorem.word }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   include_context "with mocked security logger"
 

--- a/spec/graphql/mutations/api_keys/destroy_spec.rb
+++ b/spec/graphql/mutations/api_keys/destroy_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Mutations::ApiKeys::Destroy do
   end
 
   let(:required_permission) { "developers:keys:manage" }
-  let!(:membership) { create(:membership) }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   include_context "with mocked security logger"
 

--- a/spec/graphql/mutations/api_keys/rotate_spec.rb
+++ b/spec/graphql/mutations/api_keys/rotate_spec.rb
@@ -20,11 +20,12 @@ RSpec.describe Mutations::ApiKeys::Rotate do
       }
     GQL
   end
-
-  let(:required_permission) { "developers:keys:manage" }
-  let!(:membership) { create(:membership) }
   let(:expires_at) { generate(:future_date).iso8601 }
   let(:name) { Faker::Lorem.words.join(" ") }
+
+  let(:required_permission) { "developers:keys:manage" }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   include_context "with mocked security logger"
 

--- a/spec/graphql/mutations/api_keys/update_spec.rb
+++ b/spec/graphql/mutations/api_keys/update_spec.rb
@@ -20,12 +20,13 @@ RSpec.describe Mutations::ApiKeys::Update, :premium do
       }
     GQL
   end
-
-  let(:required_permission) { "developers:keys:manage" }
-  let!(:membership) { create(:membership) }
   let(:input_params) { {id: api_key.id, permissions:, name:} }
   let(:permissions) { api_key.permissions.merge("add_on" => ["read"]) }
   let(:name) { Faker::Lorem.words.join(" ") }
+
+  let(:required_permission) { "developers:keys:manage" }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   include_context "with mocked security logger"
 

--- a/spec/graphql/mutations/applied_coupons/create_spec.rb
+++ b/spec/graphql/mutations/applied_coupons/create_spec.rb
@@ -3,8 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Mutations::AppliedCoupons::Create do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "coupons:attach" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:mutation) do
     <<-GQL
@@ -19,9 +20,11 @@ RSpec.describe Mutations::AppliedCoupons::Create do
       }
     GQL
   end
-
   let(:coupon) { create(:coupon, organization:) }
-  let(:customer) { create(:customer, organization:) }
+
+  let_it_be(:membership) { create_default(:membership) }
+
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     create(:subscription, customer:)

--- a/spec/graphql/mutations/applied_coupons/terminate_spec.rb
+++ b/spec/graphql/mutations/applied_coupons/terminate_spec.rb
@@ -4,12 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::AppliedCoupons::Terminate do
   let(:required_permission) { "coupons:detach" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:coupon) { create(:coupon, organization:) }
   let(:applied_coupon) { create(:applied_coupon, coupon:, customer:) }
-
   let(:mutation) do
     <<-GQL
       mutation($input: TerminateAppliedCouponInput!) {
@@ -19,6 +15,10 @@ RSpec.describe Mutations::AppliedCoupons::Terminate do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before { applied_coupon }
 

--- a/spec/graphql/mutations/auth/entra_id/accept_invite_spec.rb
+++ b/spec/graphql/mutations/auth/entra_id/accept_invite_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Mutations::Auth::EntraId::AcceptInvite, :premium, cache: :memory do
-  let(:organization) { create(:organization, premium_integrations: ["entra_id"]) }
+  let_it_be(:organization) { create_default(:organization, premium_integrations: ["entra_id"]) }
   let(:invite) { create(:invite, email: "foo@bar.com", organization:) }
   let(:entra_id_integration) { create(:entra_id_integration, domain: "bar.com", organization:) }
   let(:lago_http_client) { instance_double(LagoHttpClient::Client) }

--- a/spec/graphql/mutations/auth/entra_id/authorize_spec.rb
+++ b/spec/graphql/mutations/auth/entra_id/authorize_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Mutations::Auth::EntraId::Authorize do
+  let_it_be(:organization) { create_default(:organization) }
   let(:user) { create(:user) }
   let(:entra_id_integration) { create(:entra_id_integration) }
 

--- a/spec/graphql/mutations/auth/google/accept_invite_spec.rb
+++ b/spec/graphql/mutations/auth/google/accept_invite_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Mutations::Auth::Google::AcceptInvite do
+  let_it_be(:organization) { create_default(:organization) }
   let(:user) { create(:user) }
   let(:invite) { create(:invite) }
 

--- a/spec/graphql/mutations/auth/google/login_user_spec.rb
+++ b/spec/graphql/mutations/auth/google/login_user_spec.rb
@@ -3,7 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Mutations::Auth::Google::LoginUser do
-  let(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
   let(:user) { membership.user }
 
   let(:login_result) do

--- a/spec/graphql/mutations/auth/google/register_user_spec.rb
+++ b/spec/graphql/mutations/auth/google/register_user_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Mutations::Auth::Google::RegisterUser do
-  let(:user) { create(:user) }
+  let_it_be(:user) { create_default(:user) }
 
   let(:register_user_result) do
     result = Auth::GoogleService::RESULTS.fetch(:register_user).new

--- a/spec/graphql/mutations/auth/okta/accept_invite_spec.rb
+++ b/spec/graphql/mutations/auth/okta/accept_invite_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Mutations::Auth::Okta::AcceptInvite, :premium, cache: :memory do
-  let(:organization) { create(:organization, premium_integrations: ["okta"]) }
+  let_it_be(:organization) { create_default(:organization, premium_integrations: ["okta"]) }
   let(:invite) { create(:invite, email: "foo@bar.com", organization:) }
   let(:okta_integration) { create(:okta_integration, domain: "bar.com", organization_name: "foo", organization:) }
   let(:lago_http_client) { instance_double(LagoHttpClient::Client) }

--- a/spec/graphql/mutations/auth/okta/authorize_spec.rb
+++ b/spec/graphql/mutations/auth/okta/authorize_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Mutations::Auth::Okta::Authorize do
+  let_it_be(:organization) { create_default(:organization) }
   let(:user) { create(:user) }
   let(:okta_integration) { create(:okta_integration) }
 

--- a/spec/graphql/mutations/billing_entities/apply_taxes_spec.rb
+++ b/spec/graphql/mutations/billing_entities/apply_taxes_spec.rb
@@ -3,12 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Mutations::BillingEntities::ApplyTaxes do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "billing_entities:update" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:billing_entity) { organization.default_billing_entity }
   let(:tax_codes) { ["TAX_CODE_1", "TAX_CODE_2"] }
-
   let(:mutation) do
     <<~GQL
       mutation($input: ApplyTaxesInput!) {
@@ -21,6 +21,8 @@ RSpec.describe Mutations::BillingEntities::ApplyTaxes do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     allow(::BillingEntities::Taxes::ApplyTaxesService).to receive(:call).and_call_original

--- a/spec/graphql/mutations/billing_entities/create_spec.rb
+++ b/spec/graphql/mutations/billing_entities/create_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Mutations::BillingEntities::Create, :premium do
+  let_it_be(:user) { create_default(:user) }
   include_context "with mocked security logger"
 
   let(:required_permission) { "billing_entities:create" }
@@ -108,7 +109,7 @@ RSpec.describe Mutations::BillingEntities::Create, :premium do
   end
 
   context "when the organization can create billing entities" do
-    let(:organization) { create(:organization, premium_integrations: %w[multi_entities_enterprise]) }
+    let_it_be(:organization) { create_default(:organization, premium_integrations: %w[multi_entities_enterprise]) }
 
     let!(:result) do
       execute_graphql(

--- a/spec/graphql/mutations/billing_entities/remove_taxes_spec.rb
+++ b/spec/graphql/mutations/billing_entities/remove_taxes_spec.rb
@@ -3,12 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Mutations::BillingEntities::RemoveTaxes do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "billing_entities:update" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:billing_entity) { organization.default_billing_entity }
   let(:tax_codes) { ["TAX_CODE_1", "TAX_CODE_2"] }
-
   let(:mutation) do
     <<~GQL
       mutation($input: RemoveTaxesInput!) {
@@ -21,6 +21,8 @@ RSpec.describe Mutations::BillingEntities::RemoveTaxes do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     allow(BillingEntities::Taxes::RemoveTaxesService).to receive(:call).and_call_original

--- a/spec/graphql/mutations/billing_entities/update_applied_dunning_campaign_spec.rb
+++ b/spec/graphql/mutations/billing_entities/update_applied_dunning_campaign_spec.rb
@@ -4,9 +4,7 @@ require "rails_helper"
 
 RSpec.describe Mutations::BillingEntities::UpdateAppliedDunningCampaign do
   let(:required_permission) { "billing_entities:update" }
-  let(:membership) { create(:membership, organization:) }
-  let(:organization) { create(:organization) }
-  let(:billing_entity) { create(:billing_entity, organization:, applied_dunning_campaign:) }
+  let(:billing_entity) { create_default(:billing_entity, organization:, applied_dunning_campaign:) }
   let(:dunning_campaign) { create(:dunning_campaign, organization:) }
   let(:applied_dunning_campaign) { create(:dunning_campaign, organization:) }
   let(:mutation) do
@@ -21,6 +19,10 @@ RSpec.describe Mutations::BillingEntities::UpdateAppliedDunningCampaign do
       }
     GQL
   end
+
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/billing_entities/update_spec.rb
+++ b/spec/graphql/mutations/billing_entities/update_spec.rb
@@ -3,14 +3,13 @@
 require "rails_helper"
 
 RSpec.describe Mutations::BillingEntities::Update, :premium do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   include_context "with mocked security logger"
 
   let(:required_permission) { "billing_entities:update" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:billing_entity) { create(:billing_entity, organization:) }
   let(:invoice_custom_sections) { create_list(:invoice_custom_section, 2, organization:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: UpdateBillingEntityInput!) {
@@ -50,14 +49,12 @@ RSpec.describe Mutations::BillingEntities::Update, :premium do
       }
     GQL
   end
-
   let(:logo) do
     logo_file = File.read(Rails.root.join("spec/factories/images/logo.png"))
     base64_logo = Base64.encode64(logo_file)
 
     "data:image/png;base64,#{base64_logo}"
   end
-
   let(:input) do
     {
       id: billing_entity.id,
@@ -93,6 +90,9 @@ RSpec.describe Mutations::BillingEntities::Update, :premium do
       invoiceCustomSectionIds: invoice_custom_sections.map(&:id)
     }
   end
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:billing_entity) { create_default(:billing_entity, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/catalog_plans/create_spec.rb
+++ b/spec/graphql/mutations/catalog_plans/create_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Mutations::CatalogPlans::Create do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   subject(:result) do
     execute_graphql(
       current_user: membership.user,
@@ -13,7 +15,7 @@ RSpec.describe Mutations::CatalogPlans::Create do
     )
   end
 
-  let(:membership) { create(:membership) }
+  let_it_be(:membership) { create_default(:membership) }
   let(:organization) { membership.organization }
   let(:required_permission) { "plans:create" }
   let(:input) { {name: "Growth", code: "growth", currency: "EUR"} }

--- a/spec/graphql/mutations/catalog_plans/update_spec.rb
+++ b/spec/graphql/mutations/catalog_plans/update_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Mutations::CatalogPlans::Update do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   subject(:result) do
     execute_graphql(
       current_user: membership.user,
@@ -13,12 +15,9 @@ RSpec.describe Mutations::CatalogPlans::Update do
     )
   end
 
-  let(:membership) { create(:membership) }
+  let_it_be(:membership) { create_default(:membership) }
   let(:organization) { membership.organization }
-  let(:required_permission) { "plans:update" }
-  let(:plan) { create(:plan, :product_catalog, organization:) }
   let(:input) { {id: plan.id, name: "Renamed"} }
-
   let(:query) do
     <<~GQL
       mutation($input: UpdateCatalogPlanInput!) {
@@ -26,6 +25,9 @@ RSpec.describe Mutations::CatalogPlans::Update do
       }
     GQL
   end
+  let(:required_permission) { "plans:update" }
+
+  let_it_be(:plan) { create_default(:plan, :product_catalog, organization:) }
 
   before { organization.enable_feature_flag!(:product_catalog) }
 

--- a/spec/graphql/mutations/charge_filters/create_spec.rb
+++ b/spec/graphql/mutations/charge_filters/create_spec.rb
@@ -3,14 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Mutations::ChargeFilters::Create, type: :graphql do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "charges:create" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
   let(:billable_metric_filter) { create(:billable_metric_filter, billable_metric:, values: %w[value1 value2 value3]) }
   let(:charge) { create(:standard_charge, plan:, billable_metric:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: ChargeFilterCreateInput!) {
@@ -26,6 +24,10 @@ RSpec.describe Mutations::ChargeFilters::Create, type: :graphql do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/charge_filters/destroy_spec.rb
+++ b/spec/graphql/mutations/charge_filters/destroy_spec.rb
@@ -3,14 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Mutations::ChargeFilters::Destroy, type: :graphql do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "charges:delete" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, plan:, billable_metric:) }
   let(:charge_filter) { create(:charge_filter, charge:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: DestroyChargeFilterInput!) {
@@ -20,6 +18,10 @@ RSpec.describe Mutations::ChargeFilters::Destroy, type: :graphql do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/charge_filters/update_spec.rb
+++ b/spec/graphql/mutations/charge_filters/update_spec.rb
@@ -3,14 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Mutations::ChargeFilters::Update, type: :graphql do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "charges:update" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, plan:, billable_metric:) }
   let(:charge_filter) { create(:charge_filter, charge:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: ChargeFilterUpdateInput!) {
@@ -24,6 +22,10 @@ RSpec.describe Mutations::ChargeFilters::Update, type: :graphql do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/charges/create_spec.rb
+++ b/spec/graphql/mutations/charges/create_spec.rb
@@ -3,12 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Mutations::Charges::Create, type: :graphql do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "charges:create" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: ChargeCreateInput!) {
@@ -31,6 +29,10 @@ RSpec.describe Mutations::Charges::Create, type: :graphql do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/charges/destroy_spec.rb
+++ b/spec/graphql/mutations/charges/destroy_spec.rb
@@ -3,13 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Mutations::Charges::Destroy, type: :graphql do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "charges:delete" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, plan:, billable_metric:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: DestroyChargeInput!) {
@@ -19,6 +17,10 @@ RSpec.describe Mutations::Charges::Destroy, type: :graphql do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/charges/update_spec.rb
+++ b/spec/graphql/mutations/charges/update_spec.rb
@@ -3,13 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Mutations::Charges::Update, type: :graphql do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "charges:update" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, plan:, billable_metric:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: ChargeUpdateInput!) {
@@ -27,6 +25,10 @@ RSpec.describe Mutations::Charges::Update, type: :graphql do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/coupons/create_spec.rb
+++ b/spec/graphql/mutations/coupons/create_spec.rb
@@ -3,8 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Mutations::Coupons::Create do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "coupons:create" }
-  let(:membership) { create(:membership) }
   let(:expiration_at) { Time.current + 3.days }
   let(:plan) { create(:plan, organization: membership.organization) }
   let(:billable_metric) { create(:billable_metric, organization: membership.organization) }
@@ -30,6 +31,8 @@ RSpec.describe Mutations::Coupons::Create do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/coupons/update_spec.rb
+++ b/spec/graphql/mutations/coupons/update_spec.rb
@@ -4,8 +4,6 @@ require "rails_helper"
 
 RSpec.describe Mutations::Coupons::Update do
   let(:required_permission) { "coupons:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:coupon) { create(:coupon, organization:) }
   let(:expiration_at) { Time.current + 3.days }
   let(:plan) { create(:plan, organization:) }
@@ -32,6 +30,9 @@ RSpec.describe Mutations::Coupons::Update do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/credit_notes/create_spec.rb
+++ b/spec/graphql/mutations/credit_notes/create_spec.rb
@@ -3,14 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Mutations::CreditNotes::Create, :premium do
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "credit_notes:create" }
-  let(:organization) { create(:organization) }
-  let(:membership) { create(:membership, organization:) }
-  let(:customer) { create(:customer, organization:) }
-
   let(:fee1) { create(:fee, invoice:) }
   let(:fee2) { create(:charge_fee, invoice:) }
-
   let(:invoice) do
     create(
       :invoice,
@@ -24,7 +20,6 @@ RSpec.describe Mutations::CreditNotes::Create, :premium do
       total_paid_amount_cents: 110
     )
   end
-
   let(:mutation) do
     <<~GQL
       mutation($input: CreateCreditNoteInput!) {
@@ -50,6 +45,12 @@ RSpec.describe Mutations::CreditNotes::Create, :premium do
       }
     GQL
   end
+
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership, organization:) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/credit_notes/download_xml_spec.rb
+++ b/spec/graphql/mutations/credit_notes/download_xml_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Mutations::CreditNotes::DownloadXml do
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:required_permission) { "credit_notes:view" }
   let(:credit_note) { create(:credit_note) }
   let(:organization) { credit_note.organization }

--- a/spec/graphql/mutations/credit_notes/resend_email_spec.rb
+++ b/spec/graphql/mutations/credit_notes/resend_email_spec.rb
@@ -3,14 +3,13 @@
 require "rails_helper"
 
 RSpec.describe Mutations::CreditNotes::ResendEmail do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "credit_notes:send" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:, email: "customer@example.com") }
   let(:billing_entity) { customer.billing_entity }
   let(:invoice) { create(:invoice, customer:, organization:, status: :finalized) }
   let(:credit_note) { create(:credit_note, invoice:, customer:, status: :finalized) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: ResendCreditNoteEmailInput!) {
@@ -20,6 +19,9 @@ RSpec.describe Mutations::CreditNotes::ResendEmail do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:, email: "customer@example.com") }
 
   before do
     billing_entity.update!(email: "billing@example.com")

--- a/spec/graphql/mutations/credit_notes/retry_tax_reporting_spec.rb
+++ b/spec/graphql/mutations/credit_notes/retry_tax_reporting_spec.rb
@@ -3,12 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Mutations::CreditNotes::RetryTaxReporting do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "credit_notes:update" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:user) { membership.user }
-
   let(:invoice) do
     create(
       :invoice,
@@ -19,7 +18,6 @@ RSpec.describe Mutations::CreditNotes::RetryTaxReporting do
       currency: "EUR"
     )
   end
-
   let(:credit_note) do
     create(
       :credit_note,
@@ -29,7 +27,6 @@ RSpec.describe Mutations::CreditNotes::RetryTaxReporting do
       invoice:
     )
   end
-
   let(:subscription) do
     create(
       :subscription,
@@ -39,10 +36,8 @@ RSpec.describe Mutations::CreditNotes::RetryTaxReporting do
       created_at: started_at
     )
   end
-
   let(:timestamp) { Time.zone.now - 1.year }
   let(:started_at) { Time.zone.now - 2.years }
-  let(:plan) { create(:plan, organization:, interval: "monthly") }
   let(:fee_subscription) do
     create(
       :fee,
@@ -52,7 +47,6 @@ RSpec.describe Mutations::CreditNotes::RetryTaxReporting do
       amount_cents: 2_000
     )
   end
-
   let(:integration) { create(:anrok_integration, organization:) }
   let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
   let(:response) { instance_double(Net::HTTPOK) }
@@ -79,6 +73,11 @@ RSpec.describe Mutations::CreditNotes::RetryTaxReporting do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+
+  let_it_be(:plan) { create_default(:plan, organization:, interval: "monthly") }
 
   before do
     integration_collection_mapping

--- a/spec/graphql/mutations/credit_notes/update_spec.rb
+++ b/spec/graphql/mutations/credit_notes/update_spec.rb
@@ -4,12 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::CreditNotes::Update do
   let(:required_permission) { "credit_notes:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, organization:, customer:) }
   let(:credit_note) { create(:credit_note, customer:, invoice:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: UpdateCreditNoteInput!) {
@@ -20,6 +16,10 @@ RSpec.describe Mutations::CreditNotes::Update do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/credit_notes/void_spec.rb
+++ b/spec/graphql/mutations/credit_notes/void_spec.rb
@@ -4,12 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::CreditNotes::Void do
   let(:required_permission) { "credit_notes:void" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, organization:, customer:) }
   let(:credit_note) { create(:credit_note, customer:, invoice:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: VoidCreditNoteInput!) {
@@ -21,6 +17,10 @@ RSpec.describe Mutations::CreditNotes::Void do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/customer_portal/download_invoice_spec.rb
+++ b/spec/graphql/mutations/customer_portal/download_invoice_spec.rb
@@ -3,11 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Mutations::CustomerPortal::DownloadInvoice do
-  let(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: DownloadCustomerPortalInvoiceInput!) {
@@ -17,6 +17,8 @@ RSpec.describe Mutations::CustomerPortal::DownloadInvoice do
       }
     GQL
   end
+
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before { stub_pdf_generation }
 

--- a/spec/graphql/mutations/customer_portal/update_customer_spec.rb
+++ b/spec/graphql/mutations/customer_portal/update_customer_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Mutations::CustomerPortal::UpdateCustomer do
     )
   end
 
+  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, legal_name: nil) }
 
   let(:mutation) do

--- a/spec/graphql/mutations/customer_portal/wallet_transactions/create_spec.rb
+++ b/spec/graphql/mutations/customer_portal/wallet_transactions/create_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Mutations::CustomerPortal::WalletTransactions::Create do
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:wallet) { create(:wallet, balance: 10.0, credits_balance: 10.0) }
 
   let(:mutation) do

--- a/spec/graphql/mutations/customers/create_spec.rb
+++ b/spec/graphql/mutations/customers/create_spec.rb
@@ -3,13 +3,13 @@
 require "rails_helper"
 
 RSpec.describe Mutations::Customers::Create do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permissions) { "customers:create" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:billing_entity) { create(:billing_entity, organization:) }
   let(:stripe_provider) { create(:stripe_provider, organization:) }
   let(:tax) { create(:tax, organization:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: CreateCustomerInput!) {
@@ -45,13 +45,14 @@ RSpec.describe Mutations::Customers::Create do
       }
     GQL
   end
-
   let(:body) do
     {
       object: "event",
       data: {url: "test.url"}
     }
   end
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     stub_request(:post, "https://api.stripe.com/v1/checkout/sessions")

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -4,15 +4,11 @@ require "rails_helper"
 
 RSpec.describe Mutations::Customers::Update do
   let(:required_permission) { "customers:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:billing_entity) { create(:billing_entity, organization:) }
   let(:customer) { create(:customer, organization:, legal_name: nil) }
   let(:stripe_provider) { create(:stripe_provider, organization:) }
   let(:tax) { create(:tax, organization:) }
   let(:external_id) { SecureRandom.uuid }
   let(:invoice_custom_sections) { create_list(:invoice_custom_section, 2, organization:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: UpdateCustomerInput!) {
@@ -47,14 +43,12 @@ RSpec.describe Mutations::Customers::Update do
       }
     GQL
   end
-
   let(:body) do
     {
       object: "event",
       data: {}
     }
   end
-
   let(:input) do
     {
       id: customer.id,
@@ -89,6 +83,10 @@ RSpec.describe Mutations::Customers::Update do
       configurableInvoiceCustomSectionIds: invoice_custom_sections.map(&:id)
     }
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:billing_entity) { create_default(:billing_entity, organization:) }
 
   before do
     stub_request(:post, "https://api.stripe.com/v1/checkout/sessions")

--- a/spec/graphql/mutations/data_exports/credit_notes/create_spec.rb
+++ b/spec/graphql/mutations/data_exports/credit_notes/create_spec.rb
@@ -3,12 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Mutations::DataExports::CreditNotes::Create do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   include_context "with mocked security logger"
 
   let(:required_permission) { "credit_notes:export" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-
   let(:mutation) do
     <<-GQL
       mutation($input: CreateDataExportsCreditNotesInput!) {
@@ -19,7 +19,6 @@ RSpec.describe Mutations::DataExports::CreditNotes::Create do
       }
     GQL
   end
-
   let(:variables) do
     {
       input: {
@@ -41,6 +40,8 @@ RSpec.describe Mutations::DataExports::CreditNotes::Create do
       }
     }
   end
+
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/data_exports/invoices/create_spec.rb
+++ b/spec/graphql/mutations/data_exports/invoices/create_spec.rb
@@ -3,12 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Mutations::DataExports::Invoices::Create do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   include_context "with mocked security logger"
 
   let(:required_permission) { "invoices:export" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-
   let(:mutation) do
     <<-GQL
       mutation($input: CreateDataExportsInvoicesInput!) {
@@ -19,6 +19,8 @@ RSpec.describe Mutations::DataExports::Invoices::Create do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before { membership }
 

--- a/spec/graphql/mutations/dunning_campaigns/destroy_spec.rb
+++ b/spec/graphql/mutations/dunning_campaigns/destroy_spec.rb
@@ -4,10 +4,7 @@ require "rails_helper"
 
 RSpec.describe Mutations::DunningCampaigns::Destroy, :premium do
   let(:required_permissions) { "dunning_campaigns:delete" }
-  let(:membership) { create(:membership, organization:) }
-  let(:organization) { create(:organization, premium_integrations: ["auto_dunning"]) }
   let(:dunning_campaign) { create(:dunning_campaign, organization:) }
-
   let(:mutation) do
     <<-GQL
       mutation($input: DestroyDunningCampaignInput!) {
@@ -17,6 +14,9 @@ RSpec.describe Mutations::DunningCampaigns::Destroy, :premium do
       }
     GQL
   end
+  let(:membership) { create(:membership, organization:) }
+
+  let_it_be(:organization) { create(:organization, premium_integrations: ["auto_dunning"]) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/dunning_campaigns/update_spec.rb
+++ b/spec/graphql/mutations/dunning_campaigns/update_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe Mutations::DunningCampaigns::Update, :premium do
   let(:required_permission) { "dunning_campaigns:update" }
-  let(:organization) { create(:organization, premium_integrations: ["auto_dunning"]) }
   let(:membership) { create(:membership, organization:) }
   let(:dunning_campaign) do
     create(:dunning_campaign, organization:)
@@ -12,7 +11,6 @@ RSpec.describe Mutations::DunningCampaigns::Update, :premium do
   let(:dunning_campaign_threshold) do
     create(:dunning_campaign_threshold, dunning_campaign:)
   end
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateDunningCampaignInput!) {
@@ -25,7 +23,6 @@ RSpec.describe Mutations::DunningCampaigns::Update, :premium do
       }
     GQL
   end
-
   let(:input) do
     {
       id: dunning_campaign.id,
@@ -44,6 +41,8 @@ RSpec.describe Mutations::DunningCampaigns::Update, :premium do
       ]
     }
   end
+
+  let_it_be(:organization) { create_default(:organization, premium_integrations: ["auto_dunning"]) }
 
   before do
     organization.default_billing_entity.update!(applied_dunning_campaign: dunning_campaign)

--- a/spec/graphql/mutations/entitlement/create_feature_spec.rb
+++ b/spec/graphql/mutations/entitlement/create_feature_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe Mutations::Entitlement::CreateFeature, :premium do
   subject { execute_query(query:, input:) }
 
   let(:required_permission) { "features:create" }
-
-  let(:organization) { create(:organization) }
   let(:query) do
     <<-GQL
       mutation($input: CreateFeatureInput!) {
@@ -25,7 +23,6 @@ RSpec.describe Mutations::Entitlement::CreateFeature, :premium do
       }
     GQL
   end
-
   let(:input) do
     {
       code: "test_feature",
@@ -34,6 +31,8 @@ RSpec.describe Mutations::Entitlement::CreateFeature, :premium do
       privileges: []
     }
   end
+
+  let_it_be(:organization) { create_default(:organization) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/entitlement/create_or_update_subscription_entitlement_spec.rb
+++ b/spec/graphql/mutations/entitlement/create_or_update_subscription_entitlement_spec.rb
@@ -6,14 +6,10 @@ RSpec.describe Mutations::Entitlement::CreateOrUpdateSubscriptionEntitlement, :p
   subject { execute_query(query:, input:) }
 
   let(:required_permission) { "subscriptions:update" }
-  let(:organization) { create(:organization) }
-
-  let(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, organization:, plan:) }
   let(:feature) { create(:feature, organization:, code: "seats", name: "SEATS") }
   let(:privilege) { create(:privilege, feature:, code: "max", value_type: "integer") }
   let(:privilege2) { create(:privilege, feature:, code: "reset", value_type: "select", config: {select_options: %w[email slack]}) }
-
   let(:query) do
     <<~GQL
       mutation($input: CreateOrUpdateSubscriptionEntitlementInput!) {
@@ -25,7 +21,6 @@ RSpec.describe Mutations::Entitlement::CreateOrUpdateSubscriptionEntitlement, :p
       }
     GQL
   end
-
   let(:input) do
     {
       subscriptionId: subscription.id,
@@ -37,6 +32,11 @@ RSpec.describe Mutations::Entitlement::CreateOrUpdateSubscriptionEntitlement, :p
       }
     }
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/entitlement/destroy_feature_spec.rb
+++ b/spec/graphql/mutations/entitlement/destroy_feature_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe Mutations::Entitlement::DestroyFeature, :premium do
   subject { execute_query(query:, input:) }
 
   let(:required_permission) { "features:delete" }
-
-  let(:organization) { create(:organization) }
   let(:feature) { create(:feature, organization:) }
   let(:input) { {id: feature.id} }
   let(:query) do
@@ -22,6 +20,8 @@ RSpec.describe Mutations::Entitlement::DestroyFeature, :premium do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/entitlement/remove_subscription_entitlement_spec.rb
+++ b/spec/graphql/mutations/entitlement/remove_subscription_entitlement_spec.rb
@@ -6,13 +6,9 @@ RSpec.describe Mutations::Entitlement::RemoveSubscriptionEntitlement, :premium d
   subject { execute_query(query:, input:) }
 
   let(:required_permission) { "subscriptions:update" }
-  let(:organization) { create(:organization) }
-
   let(:feature) { create(:feature, organization:, code: "seats") }
-  let(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, organization:, plan:) }
   let(:privilege) { create(:privilege, feature:, code: "max") }
-
   let(:query) do
     <<~GQL
       mutation($input: RemoveSubscriptionEntitlementInput!) {
@@ -22,13 +18,17 @@ RSpec.describe Mutations::Entitlement::RemoveSubscriptionEntitlement, :premium d
       }
     GQL
   end
-
   let(:input) do
     {
       subscriptionId: subscription.id,
       featureCode: feature.code
     }
   end
+
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/entitlement/update_feature_spec.rb
+++ b/spec/graphql/mutations/entitlement/update_feature_spec.rb
@@ -6,11 +6,9 @@ RSpec.describe Mutations::Entitlement::UpdateFeature, :premium do
   subject { execute_query(query:, input:) }
 
   let(:required_permission) { "features:update" }
-  let(:organization) { create(:organization) }
   let(:feature) do
     create(:feature, organization:)
   end
-
   let(:query) do
     <<-GQL
       mutation($input: UpdateFeatureInput!) {
@@ -32,6 +30,8 @@ RSpec.describe Mutations::Entitlement::UpdateFeature, :premium do
       privileges: []
     }
   end
+
+  let_it_be(:organization) { create_default(:organization) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/finance_assistant/ask_spec.rb
+++ b/spec/graphql/mutations/finance_assistant/ask_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Mutations::FinanceAssistant::Ask do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   subject(:result) do
     execute_graphql(
       current_user: membership.user,
@@ -27,9 +29,6 @@ RSpec.describe Mutations::FinanceAssistant::Ask do
       }
     GQL
   end
-
-  let(:required_permission) { "ai_conversations:create" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:question) { "Show MRR for the past 3 months" }
   let(:session_id) { SecureRandom.uuid }
@@ -46,6 +45,10 @@ RSpec.describe Mutations::FinanceAssistant::Ask do
       }
     end
   end
+
+  let(:required_permission) { "ai_conversations:create" }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     allow(FinanceAssistant::AskService).to receive(:call).and_return(service_result)

--- a/spec/graphql/mutations/finance_assistant/export_spec.rb
+++ b/spec/graphql/mutations/finance_assistant/export_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Mutations::FinanceAssistant::Export do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   subject(:result) do
     execute_graphql(
       current_user: membership.user,
@@ -23,9 +25,6 @@ RSpec.describe Mutations::FinanceAssistant::Export do
       }
     GQL
   end
-
-  let(:required_permission) { "ai_conversations:view" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:message_id) { SecureRandom.uuid }
   let(:file_url) { "http://api.lago.test/rails/active_storage/blobs/redirect/abc/finance_export.csv" }
@@ -33,6 +32,10 @@ RSpec.describe Mutations::FinanceAssistant::Export do
   let(:service_result) do
     BaseResult[:export].new.tap { |r| r.export = {file_url:, filename:} }
   end
+
+  let(:required_permission) { "ai_conversations:view" }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     allow(FinanceAssistant::ExportService).to receive(:call).and_return(service_result)

--- a/spec/graphql/mutations/fixed_charges/create_spec.rb
+++ b/spec/graphql/mutations/fixed_charges/create_spec.rb
@@ -3,12 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Mutations::FixedCharges::Create, type: :graphql do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "charges:create" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:plan) { create(:plan, organization:) }
-  let(:add_on) { create(:add_on, organization:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: FixedChargeCreateInput!) {
@@ -30,6 +29,9 @@ RSpec.describe Mutations::FixedCharges::Create, type: :graphql do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:add_on) { create_default(:add_on, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/fixed_charges/destroy_spec.rb
+++ b/spec/graphql/mutations/fixed_charges/destroy_spec.rb
@@ -3,13 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Mutations::FixedCharges::Destroy, type: :graphql do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "charges:delete" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
-  let(:add_on) { create(:add_on, organization:) }
   let(:fixed_charge) { create(:fixed_charge, plan:, add_on:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: DestroyFixedChargeInput!) {
@@ -19,6 +17,10 @@ RSpec.describe Mutations::FixedCharges::Destroy, type: :graphql do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
+  let_it_be(:add_on) { create_default(:add_on, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/fixed_charges/update_spec.rb
+++ b/spec/graphql/mutations/fixed_charges/update_spec.rb
@@ -3,13 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Mutations::FixedCharges::Update, type: :graphql do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "charges:update" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
-  let(:add_on) { create(:add_on, organization:) }
   let(:fixed_charge) { create(:fixed_charge, plan:, add_on:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: FixedChargeUpdateInput!) {
@@ -26,6 +24,10 @@ RSpec.describe Mutations::FixedCharges::Update, type: :graphql do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
+  let_it_be(:add_on) { create_default(:add_on, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/integration_collection_mappings/create_spec.rb
+++ b/spec/graphql/mutations/integration_collection_mappings/create_spec.rb
@@ -6,14 +6,9 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Create do
   subject { execute_query(query:, input:) }
 
   let(:required_permission) { "organization:integrations:update" }
-  let(:integration) { create(:netsuite_integration, organization:) }
-  let(:mapping_type) { %i[fallback_item coupon subscription_fee minimum_commitment tax prepaid_credit].sample.to_s }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
   let(:external_account_code) { Faker::Barcode.ean }
   let(:external_id) { SecureRandom.uuid }
   let(:external_name) { Faker::Commerce.department }
-
   let(:query) do
     <<-GQL
       mutation($input: CreateIntegrationCollectionMappingInput!) {
@@ -40,6 +35,11 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Create do
     }
   end
   let(:billing_entity_id) { nil }
+  let(:integration) { create(:netsuite_integration, organization:) }
+  let(:mapping_type) { %i[fallback_item coupon subscription_fee minimum_commitment tax prepaid_credit].sample.to_s }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   def create_integration_collection_mapping(input:, raw: false)
     result = execute_query(query:, input:)

--- a/spec/graphql/mutations/integration_collection_mappings/destroy_spec.rb
+++ b/spec/graphql/mutations/integration_collection_mappings/destroy_spec.rb
@@ -4,11 +4,6 @@ require "rails_helper"
 
 RSpec.describe Mutations::IntegrationCollectionMappings::Destroy do
   let(:required_permission) { "organization:integrations:update" }
-  let(:integration_collection_mapping) { create(:netsuite_collection_mapping, integration:) }
-  let(:integration) { create(:netsuite_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
-
   let(:mutation) do
     <<-GQL
       mutation($input: DestroyIntegrationCollectionMappingInput!) {
@@ -16,6 +11,12 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Destroy do
       }
     GQL
   end
+  let(:integration_collection_mapping) { create(:netsuite_collection_mapping, integration:) }
+  let(:integration) { create(:netsuite_integration, organization:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before { integration_collection_mapping }
 

--- a/spec/graphql/mutations/integration_collection_mappings/update_spec.rb
+++ b/spec/graphql/mutations/integration_collection_mappings/update_spec.rb
@@ -6,15 +6,9 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Update do
   subject { execute_query(query:, input:) }
 
   let(:required_permission) { "organization:integrations:update" }
-  let(:integration_collection_mapping) { create(:netsuite_collection_mapping, integration:) }
-  let(:integration) { create(:netsuite_integration, organization:) }
-  let(:mapping_type) { %i[fallback_item coupon subscription_fee minimum_commitment tax prepaid_credit].sample.to_s }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
   let(:external_account_code) { Faker::Barcode.ean }
   let(:external_id) { SecureRandom.uuid }
   let(:external_name) { Faker::Commerce.department }
-
   let(:query) do
     <<-GQL
       mutation($input: UpdateIntegrationCollectionMappingInput!) {
@@ -30,7 +24,6 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Update do
       }
     GQL
   end
-
   let(:input) do
     original_mapping_type = integration_collection_mapping.mapping_type
     different_integration = create(:netsuite_integration, organization:)
@@ -45,6 +38,12 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Update do
       externalName: external_name
     }
   end
+  let(:integration_collection_mapping) { create(:netsuite_collection_mapping, integration:) }
+  let(:integration) { create(:netsuite_integration, organization:) }
+  let(:mapping_type) { %i[fallback_item coupon subscription_fee minimum_commitment tax prepaid_credit].sample.to_s }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/integration_customers/create_spec.rb
+++ b/spec/graphql/mutations/integration_customers/create_spec.rb
@@ -4,12 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::IntegrationCustomers::Create do
   let(:required_permission) { "customers:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:integration) { create(:netsuite_integration, organization:, code: "ns_main") }
   let(:external_customer_id) { SecureRandom.uuid }
-
   let(:mutation) do
     <<-GQL
       mutation($input: CreateIntegrationCustomerInput!) {
@@ -28,6 +24,11 @@ RSpec.describe Mutations::IntegrationCustomers::Create do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before { integration }
 

--- a/spec/graphql/mutations/integration_customers/destroy_spec.rb
+++ b/spec/graphql/mutations/integration_customers/destroy_spec.rb
@@ -4,12 +4,6 @@ require "rails_helper"
 
 RSpec.describe Mutations::IntegrationCustomers::Destroy do
   let(:required_permission) { "customers:update" }
-  let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
-  let(:integration) { create(:netsuite_integration, organization:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
-
   let(:mutation) do
     <<-GQL
       mutation($input: DestroyIntegrationCustomerInput!) {
@@ -17,6 +11,13 @@ RSpec.describe Mutations::IntegrationCustomers::Destroy do
       }
     GQL
   end
+  let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
+  let(:integration) { create(:netsuite_integration, organization:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before { integration_customer }
 

--- a/spec/graphql/mutations/integration_items/fetch_accounts_spec.rb
+++ b/spec/graphql/mutations/integration_items/fetch_accounts_spec.rb
@@ -4,16 +4,13 @@ require "rails_helper"
 
 RSpec.describe Mutations::IntegrationItems::FetchAccounts do
   let(:required_permission) { "organization:integrations:update" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:integration_item) { create(:integration_item, integration:) }
   let(:sync_service) { instance_double(Integrations::Aggregator::SyncService) }
-
   let(:accounts_response) do
     File.read(Rails.root.join("spec/fixtures/integration_aggregator/accounts_response.json"))
   end
-
   let(:mutation) do
     <<~GQL
       mutation($input: FetchIntegrationAccountsInput!) {
@@ -23,10 +20,13 @@ RSpec.describe Mutations::IntegrationItems::FetchAccounts do
       }
     GQL
   end
-
   let(:account_ids) do
     %w[12ec4c59-ad56-4a4f-93eb-fb0a7740f4e2 6317441d-6547-417c-89e2-6e43ece791d8 80701036-73b5-4468-a4b3-a139262035b4]
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     allow(Integrations::Aggregator::SyncService).to receive(:call).and_return(BaseResult.new)

--- a/spec/graphql/mutations/integration_items/fetch_items_spec.rb
+++ b/spec/graphql/mutations/integration_items/fetch_items_spec.rb
@@ -4,16 +4,13 @@ require "rails_helper"
 
 RSpec.describe Mutations::IntegrationItems::FetchItems do
   let(:required_permission) { "organization:integrations:update" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:integration_item) { create(:integration_item, integration:) }
   let(:sync_service) { instance_double(Integrations::Aggregator::SyncService) }
-
   let(:items_response) do
     File.read(Rails.root.join("spec/fixtures/integration_aggregator/items_response.json"))
   end
-
   let(:mutation) do
     <<~GQL
       mutation($input: FetchIntegrationItemsInput!) {
@@ -23,6 +20,10 @@ RSpec.describe Mutations::IntegrationItems::FetchItems do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     allow(Integrations::Aggregator::SyncService).to receive(:call).and_return(true)

--- a/spec/graphql/mutations/integration_mappings/create_spec.rb
+++ b/spec/graphql/mutations/integration_mappings/create_spec.rb
@@ -4,10 +4,6 @@ require "rails_helper"
 
 RSpec.describe Mutations::IntegrationMappings::Create do
   let(:required_permission) { "organization:integrations:update" }
-  let(:integration) { create(:netsuite_integration, organization:) }
-  let(:mappable) { create(:add_on, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
   let(:external_account_code) { Faker::Barcode.ean }
   let(:external_id) { SecureRandom.uuid }
   let(:external_name) { Faker::Commerce.department }
@@ -39,6 +35,11 @@ RSpec.describe Mutations::IntegrationMappings::Create do
     }
   end
   let(:billing_entity_id) { nil }
+  let(:integration) { create(:netsuite_integration, organization:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:mappable) { create_default(:add_on, organization:) }
+  let_it_be(:membership) { create_default(:membership) }
 
   def create_integration_mapping(input:, raw: false)
     result = execute_query(query: mutation, input:)

--- a/spec/graphql/mutations/integration_mappings/destroy_spec.rb
+++ b/spec/graphql/mutations/integration_mappings/destroy_spec.rb
@@ -4,11 +4,6 @@ require "rails_helper"
 
 RSpec.describe Mutations::IntegrationMappings::Destroy do
   let(:required_permission) { "organization:integrations:update" }
-  let(:integration_mapping) { create(:netsuite_mapping, integration:) }
-  let(:integration) { create(:netsuite_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
-
   let(:mutation) do
     <<-GQL
       mutation($input: DestroyIntegrationMappingInput!) {
@@ -16,6 +11,13 @@ RSpec.describe Mutations::IntegrationMappings::Destroy do
       }
     GQL
   end
+  let(:integration_mapping) { create(:netsuite_mapping, integration:) }
+  let(:integration) { create(:netsuite_integration, organization:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:add_on) { create_default(:add_on) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before { integration_mapping }
 

--- a/spec/graphql/mutations/integration_mappings/update_spec.rb
+++ b/spec/graphql/mutations/integration_mappings/update_spec.rb
@@ -4,15 +4,9 @@ require "rails_helper"
 
 RSpec.describe Mutations::IntegrationMappings::Update do
   let(:required_permission) { "organization:integrations:update" }
-  let(:integration_mapping) { create(:netsuite_mapping, integration:) }
-  let(:integration) { create(:netsuite_integration, organization:) }
-  let(:mappable) { integration_mapping.mappable }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
   let(:external_account_code) { Faker::Barcode.ean }
   let(:external_id) { SecureRandom.uuid }
   let(:external_name) { Faker::Commerce.department }
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateIntegrationMappingInput!) {
@@ -28,6 +22,12 @@ RSpec.describe Mutations::IntegrationMappings::Update do
       }
     GQL
   end
+  let(:integration_mapping) { create(:netsuite_mapping, integration:) }
+  let(:integration) { create(:netsuite_integration, organization:) }
+  let(:mappable) { integration_mapping.mappable }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/integrations/anrok/create_spec.rb
+++ b/spec/graphql/mutations/integrations/anrok/create_spec.rb
@@ -6,10 +6,8 @@ RSpec.describe Mutations::Integrations::Anrok::Create, :premium do
   include_context "with mocked security logger"
 
   let(:required_permission) { "organization:integrations:create" }
-  let(:membership) { create(:membership) }
   let(:code) { "anrok1" }
   let(:name) { "Anrok 1" }
-
   let(:mutation) do
     <<-GQL
       mutation($input: CreateAnrokIntegrationInput!) {
@@ -23,6 +21,10 @@ RSpec.describe Mutations::Integrations::Anrok::Create, :premium do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/integrations/anrok/update_spec.rb
+++ b/spec/graphql/mutations/integrations/anrok/update_spec.rb
@@ -6,13 +6,9 @@ RSpec.describe Mutations::Integrations::Anrok::Update, :premium do
   include_context "with mocked security logger"
 
   let(:required_permission) { "organization:integrations:update" }
-  let(:integration) { create(:anrok_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
   let(:code) { "anrok1" }
   let(:name) { "Anrok 1" }
   let(:api_key) { "123456789" }
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateAnrokIntegrationInput!) {
@@ -25,6 +21,11 @@ RSpec.describe Mutations::Integrations::Anrok::Update, :premium do
       }
     GQL
   end
+  let(:integration) { create(:anrok_integration, organization:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     integration

--- a/spec/graphql/mutations/integrations/avalara/update_spec.rb
+++ b/spec/graphql/mutations/integrations/avalara/update_spec.rb
@@ -6,14 +6,10 @@ RSpec.describe Mutations::Integrations::Avalara::Update, :premium do
   include_context "with mocked security logger"
 
   let(:required_permission) { "organization:integrations:update" }
-  let(:integration) { create(:avalara_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
   let(:code) { "avalara1" }
   let(:name) { "Avalara 1" }
   let(:account_id) { "acc-id-1" }
   let(:license_key) { "123456789" }
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateAvalaraIntegrationInput!) {
@@ -27,6 +23,11 @@ RSpec.describe Mutations::Integrations::Avalara::Update, :premium do
       }
     GQL
   end
+  let(:integration) { create(:avalara_integration, organization:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     integration

--- a/spec/graphql/mutations/integrations/destroy_spec.rb
+++ b/spec/graphql/mutations/integrations/destroy_spec.rb
@@ -16,10 +16,7 @@ RSpec.describe Mutations::Integrations::Destroy do
   include_context "with mocked security logger"
 
   let(:required_permission) { "organization:integrations:delete" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:integration) { create(:netsuite_integration, organization:) }
-
   let(:mutation) do
     <<-GQL
       mutation($input: DestroyIntegrationInput!) {
@@ -27,6 +24,10 @@ RSpec.describe Mutations::Integrations::Destroy do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before { integration }
 

--- a/spec/graphql/mutations/integrations/entra_id/update_spec.rb
+++ b/spec/graphql/mutations/integrations/entra_id/update_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe Mutations::Integrations::EntraId::Update, :premium do
   include_context "with mocked security logger"
 
   let(:required_permission) { "organization:integrations:update" }
-  let(:integration) { create(:entra_id_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateEntraIdIntegrationInput!) {
@@ -25,6 +21,11 @@ RSpec.describe Mutations::Integrations::EntraId::Update, :premium do
       }
     GQL
   end
+  let(:integration) { create(:entra_id_integration, organization:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     integration

--- a/spec/graphql/mutations/integrations/fetch_draft_invoice_taxes_spec.rb
+++ b/spec/graphql/mutations/integrations/fetch_draft_invoice_taxes_spec.rb
@@ -4,14 +4,9 @@ require "rails_helper"
 
 RSpec.describe Mutations::Integrations::FetchDraftInvoiceTaxes do
   let(:required_permission) { "invoices:create" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:integration) { create(:anrok_integration, organization:) }
   let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
   let(:currency) { "EUR" }
-  let(:customer) { create(:customer, organization:) }
-  let(:add_on_first) { create(:add_on, organization:) }
-  let(:add_on_second) { create(:add_on, amount_cents: 400, organization:) }
   let(:response) { instance_double(Net::HTTPOK) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/anrok/draft_invoices" }
@@ -80,6 +75,13 @@ RSpec.describe Mutations::Integrations::FetchDraftInvoiceTaxes do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:add_on_first) { create_default(:add_on, organization:) }
+  let_it_be(:add_on_second) { create_default(:add_on, amount_cents: 400, organization:) }
 
   before do
     integration_customer

--- a/spec/graphql/mutations/integrations/hubspot/sync_invoice_spec.rb
+++ b/spec/graphql/mutations/integrations/hubspot/sync_invoice_spec.rb
@@ -16,13 +16,8 @@ RSpec.describe Mutations::Integrations::Hubspot::SyncInvoice do
   end
 
   let(:required_permission) { "organization:integrations:update" }
-  let(:invoice) { create(:invoice, customer:, organization:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
   let(:integration_customer) { create(:hubspot_customer, customer:, integration:) }
   let(:integration) { create(:hubspot_integration, organization:) }
-
   let(:mutation) do
     <<-GQL
       mutation($input: SyncHubspotIntegrationInvoiceInput!) {
@@ -30,14 +25,18 @@ RSpec.describe Mutations::Integrations::Hubspot::SyncInvoice do
       }
     GQL
   end
-
   let(:service) { instance_double(Integrations::Aggregator::Invoices::Hubspot::CreateService) }
-
   let(:result) do
     r = Integrations::Aggregator::Invoices::Hubspot::CreateService::Result.new
     r.invoice_id = invoice.id
     r
   end
+  let(:invoice) { create(:invoice, customer:, organization:) }
+  let(:customer) { create(:customer, organization:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     integration_customer

--- a/spec/graphql/mutations/integrations/hubspot/update_spec.rb
+++ b/spec/graphql/mutations/integrations/hubspot/update_spec.rb
@@ -6,12 +6,8 @@ RSpec.describe Mutations::Integrations::Hubspot::Update, :premium do
   include_context "with mocked security logger"
 
   let(:required_permission) { "organization:integrations:update" }
-  let(:integration) { create(:hubspot_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
   let(:code) { "hubspot1" }
   let(:name) { "Hubspot 1" }
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateHubspotIntegrationInput!) {
@@ -27,6 +23,11 @@ RSpec.describe Mutations::Integrations::Hubspot::Update, :premium do
       }
     GQL
   end
+  let(:integration) { create(:hubspot_integration, organization:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     integration

--- a/spec/graphql/mutations/integrations/netsuite/update_spec.rb
+++ b/spec/graphql/mutations/integrations/netsuite/update_spec.rb
@@ -6,13 +6,9 @@ RSpec.describe Mutations::Integrations::Netsuite::Update, :premium do
   include_context "with mocked security logger"
 
   let(:required_permission) { "organization:integrations:update" }
-  let(:integration) { create(:netsuite_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
   let(:code) { "netsuite1" }
   let(:name) { "Netsuite 1" }
   let(:script_endpoint_url) { Faker::Internet.url }
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateNetsuiteIntegrationInput!) {
@@ -30,6 +26,11 @@ RSpec.describe Mutations::Integrations::Netsuite::Update, :premium do
       }
     GQL
   end
+  let(:integration) { create(:netsuite_integration, organization:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     integration

--- a/spec/graphql/mutations/integrations/okta/update_spec.rb
+++ b/spec/graphql/mutations/integrations/okta/update_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe Mutations::Integrations::Okta::Update, :premium do
   include_context "with mocked security logger"
 
   let(:required_permission) { "organization:integrations:update" }
-  let(:integration) { create(:okta_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateOktaIntegrationInput!) {
@@ -25,6 +21,11 @@ RSpec.describe Mutations::Integrations::Okta::Update, :premium do
       }
     GQL
   end
+  let(:integration) { create(:okta_integration, organization:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     integration

--- a/spec/graphql/mutations/integrations/salesforce/sync_invoice_spec.rb
+++ b/spec/graphql/mutations/integrations/salesforce/sync_invoice_spec.rb
@@ -16,11 +16,6 @@ RSpec.describe Mutations::Integrations::Salesforce::SyncInvoice do
   end
 
   let(:required_permission) { "organization:integrations:update" }
-  let(:invoice) { create(:invoice, customer:, organization:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
-
   let(:mutation) do
     <<-GQL
       mutation($input: SyncSalesforceInvoiceInput!) {
@@ -28,6 +23,11 @@ RSpec.describe Mutations::Integrations::Salesforce::SyncInvoice do
       }
     GQL
   end
+  let(:invoice) { create(:invoice, customer:, organization:) }
+  let(:customer) { create(:customer, organization:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before { execute_graphql_call }
 

--- a/spec/graphql/mutations/integrations/salesforce/update_spec.rb
+++ b/spec/graphql/mutations/integrations/salesforce/update_spec.rb
@@ -6,13 +6,9 @@ RSpec.describe Mutations::Integrations::Salesforce::Update, :premium do
   include_context "with mocked security logger"
 
   let(:required_permission) { "organization:integrations:update" }
-  let(:integration) { create(:salesforce_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
   let(:name) { "Salesforce 1" }
   let(:code) { "salesforce_work" }
   let(:instance_id) { "salesforce_link" }
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateSalesforceIntegrationInput!) {
@@ -25,6 +21,11 @@ RSpec.describe Mutations::Integrations::Salesforce::Update, :premium do
       }
     GQL
   end
+  let(:integration) { create(:salesforce_integration, organization:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     integration

--- a/spec/graphql/mutations/integrations/sync_credit_note_spec.rb
+++ b/spec/graphql/mutations/integrations/sync_credit_note_spec.rb
@@ -16,13 +16,8 @@ RSpec.describe Mutations::Integrations::SyncCreditNote do
   end
 
   let(:required_permission) { "organization:integrations:update" }
-  let(:credit_note) { create(:credit_note, customer:, organization:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
   let(:integration_customer) { create(:netsuite_customer, customer:, integration:) }
   let(:integration) { create(:netsuite_integration, organization:) }
-
   let(:mutation) do
     <<-GQL
       mutation($input: SyncIntegrationCreditNoteInput!) {
@@ -30,14 +25,17 @@ RSpec.describe Mutations::Integrations::SyncCreditNote do
       }
     GQL
   end
-
   let(:service) { instance_double(Integrations::Aggregator::CreditNotes::CreateService) }
-
   let(:result) do
     r = Integrations::Aggregator::CreditNotes::CreateService::Result.new
     r.credit_note_id = credit_note.id
     r
   end
+  let(:credit_note) { create(:credit_note, customer:, organization:) }
+  let(:customer) { create(:customer, organization:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     integration_customer

--- a/spec/graphql/mutations/integrations/sync_invoice_spec.rb
+++ b/spec/graphql/mutations/integrations/sync_invoice_spec.rb
@@ -16,13 +16,8 @@ RSpec.describe Mutations::Integrations::SyncInvoice do
   end
 
   let(:required_permission) { "organization:integrations:update" }
-  let(:invoice) { create(:invoice, customer:, organization:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
   let(:integration_customer) { create(:netsuite_customer, customer:, integration:) }
   let(:integration) { create(:netsuite_integration, organization:) }
-
   let(:mutation) do
     <<-GQL
       mutation($input: SyncIntegrationInvoiceInput!) {
@@ -30,14 +25,18 @@ RSpec.describe Mutations::Integrations::SyncInvoice do
       }
     GQL
   end
-
   let(:service) { instance_double(Integrations::Aggregator::Invoices::CreateService) }
-
   let(:result) do
     r = Integrations::Aggregator::Invoices::CreateService::Result.new
     r.invoice_id = invoice.id
     r
   end
+  let(:invoice) { create(:invoice, customer:, organization:) }
+  let(:customer) { create(:customer, organization:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     integration_customer

--- a/spec/graphql/mutations/integrations/xero/update_spec.rb
+++ b/spec/graphql/mutations/integrations/xero/update_spec.rb
@@ -6,12 +6,8 @@ RSpec.describe Mutations::Integrations::Xero::Update, :premium do
   include_context "with mocked security logger"
 
   let(:required_permission) { "organization:integrations:update" }
-  let(:integration) { create(:xero_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
   let(:code) { "xero1" }
   let(:name) { "Xero 1" }
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateXeroIntegrationInput!) {
@@ -26,6 +22,11 @@ RSpec.describe Mutations::Integrations::Xero::Update, :premium do
       }
     GQL
   end
+  let(:integration) { create(:xero_integration, organization:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     integration

--- a/spec/graphql/mutations/invites/accept_spec.rb
+++ b/spec/graphql/mutations/invites/accept_spec.rb
@@ -3,8 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Mutations::Invites::Accept do
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
   let(:password) { Faker::Internet.password }
 
   let(:mutation) do

--- a/spec/graphql/mutations/invites/create_spec.rb
+++ b/spec/graphql/mutations/invites/create_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Mutations::Invites::Create do
   include_context "with mocked security logger"
 
   let(:required_permission) { "organization:members:create" }
-  let(:membership) { create(:membership) }
   let(:revoked_membership) do
     create(
       :membership,
@@ -14,10 +13,8 @@ RSpec.describe Mutations::Invites::Create do
       status: :revoked
     )
   end
-  let(:organization) { membership.organization }
   let(:email) { Faker::Internet.email }
   let(:roles) { %w[finance] }
-
   let(:mutation) do
     <<~GQL
       mutation($input: CreateInviteInput!) {
@@ -30,6 +27,9 @@ RSpec.describe Mutations::Invites::Create do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before { create(:role, :finance) }
 

--- a/spec/graphql/mutations/invites/revoke_spec.rb
+++ b/spec/graphql/mutations/invites/revoke_spec.rb
@@ -4,10 +4,7 @@ require "rails_helper"
 
 RSpec.describe Mutations::Invites::Revoke do
   let(:required_permission) { "organization:members:delete" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:user) { membership.user }
-
   let(:mutation) do
     <<-GQL
       mutation($input: RevokeInviteInput!) {
@@ -19,6 +16,10 @@ RSpec.describe Mutations::Invites::Revoke do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/invites/update_spec.rb
+++ b/spec/graphql/mutations/invites/update_spec.rb
@@ -4,10 +4,7 @@ require "rails_helper"
 
 RSpec.describe Mutations::Invites::Update do
   let(:required_permission) { "organization:members:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:user) { membership.user }
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateInviteInput!) {
@@ -18,6 +15,10 @@ RSpec.describe Mutations::Invites::Update do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/invoice_custom_sections/create_spec.rb
+++ b/spec/graphql/mutations/invoice_custom_sections/create_spec.rb
@@ -4,8 +4,6 @@ require "rails_helper"
 
 RSpec.describe Mutations::InvoiceCustomSections::Create do
   let(:required_permission) { "invoice_custom_sections:create" }
-  let(:membership) { create(:membership) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: CreateInvoiceCustomSectionInput!) {
@@ -20,6 +18,10 @@ RSpec.describe Mutations::InvoiceCustomSections::Create do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/invoice_custom_sections/update_spec.rb
+++ b/spec/graphql/mutations/invoice_custom_sections/update_spec.rb
@@ -4,9 +4,6 @@ require "rails_helper"
 
 RSpec.describe Mutations::InvoiceCustomSections::Update do
   let(:required_permission) { "invoice_custom_sections:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-
   let(:mutation) do
     <<~GQL
       mutation($input: UpdateInvoiceCustomSectionInput!) {
@@ -21,6 +18,10 @@ RSpec.describe Mutations::InvoiceCustomSections::Update do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/invoices/create_spec.rb
+++ b/spec/graphql/mutations/invoices/create_spec.rb
@@ -4,13 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::Invoices::Create do
   let(:required_permission) { "invoices:create" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:currency) { "EUR" }
-  let(:customer) { create(:customer, organization:) }
   let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
-  let(:add_on_first) { create(:add_on, organization:) }
-  let(:add_on_second) { create(:add_on, amount_cents: 400, organization:) }
   let(:current_time) { DateTime.new(2023, 7, 19, 12, 12) }
   let(:section_1) { create(:invoice_custom_section, organization:, code: "section_code_1") }
   let(:fees) do
@@ -58,6 +53,13 @@ RSpec.describe Mutations::Invoices::Create do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:add_on_first) { create_default(:add_on, organization:) }
+  let_it_be(:add_on_second) { create_default(:add_on, amount_cents: 400, organization:) }
 
   before { tax }
 
@@ -135,7 +137,7 @@ RSpec.describe Mutations::Invoices::Create do
   end
 
   context "when multi_entity_billing feature flag is enabled" do
-    let(:other_billing_entity) { create(:billing_entity, organization:) }
+    let_it_be(:other_billing_entity) { create_default(:billing_entity, organization:) }
     let(:mutation) do
       <<-GQL
         mutation($input: CreateInvoiceInput!) {

--- a/spec/graphql/mutations/invoices/delete_spec.rb
+++ b/spec/graphql/mutations/invoices/delete_spec.rb
@@ -4,11 +4,7 @@ require "rails_helper"
 
 RSpec.describe Mutations::Invoices::Delete do
   let(:required_permission) { "invoices:delete" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, :draft, customer:, organization:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: DeleteInvoiceInput!) {
@@ -19,6 +15,11 @@ RSpec.describe Mutations::Invoices::Delete do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/invoices/finalize_all_spec.rb
+++ b/spec/graphql/mutations/invoices/finalize_all_spec.rb
@@ -4,11 +4,6 @@ require "rails_helper"
 
 RSpec.describe Mutations::Invoices::FinalizeAll do
   let(:required_permission) { "invoices:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:user) { membership.user }
-  let(:customer) { create(:customer, organization:) }
-
   let(:invoice) do
     create(
       :invoice,
@@ -20,7 +15,6 @@ RSpec.describe Mutations::Invoices::FinalizeAll do
       currency: "EUR"
     )
   end
-
   let(:subscription) do
     create(
       :subscription,
@@ -30,10 +24,8 @@ RSpec.describe Mutations::Invoices::FinalizeAll do
       created_at: started_at
     )
   end
-
   let(:timestamp) { Time.zone.now - 1.year }
   let(:started_at) { Time.zone.now - 2.years }
-  let(:plan) { create(:plan, organization:, interval: "monthly") }
   let(:fee_subscription) do
     create(
       :fee,
@@ -43,7 +35,6 @@ RSpec.describe Mutations::Invoices::FinalizeAll do
       amount_cents: 2_000
     )
   end
-
   let(:mutation) do
     <<-GQL
       mutation($input: FinalizeAllInvoicesInput!) {
@@ -53,6 +44,13 @@ RSpec.describe Mutations::Invoices::FinalizeAll do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+
+  let_it_be(:plan) { create_default(:plan, organization:, interval: "monthly") }
 
   before do
     fee_subscription

--- a/spec/graphql/mutations/invoices/finalize_spec.rb
+++ b/spec/graphql/mutations/invoices/finalize_spec.rb
@@ -4,11 +4,7 @@ require "rails_helper"
 
 RSpec.describe Mutations::Invoices::Finalize do
   let(:required_permission) { "invoices:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, :draft, customer:, organization:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: FinalizeInvoiceInput!) {
@@ -20,6 +16,11 @@ RSpec.describe Mutations::Invoices::Finalize do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/invoices/generate_payment_url_spec.rb
+++ b/spec/graphql/mutations/invoices/generate_payment_url_spec.rb
@@ -4,11 +4,7 @@ require "rails_helper"
 
 RSpec.describe Mutations::Invoices::GeneratePaymentUrl do
   let(:required_permission) { "invoices:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: GeneratePaymentUrlInput!) {
@@ -18,12 +14,16 @@ RSpec.describe Mutations::Invoices::GeneratePaymentUrl do
       }
     GQL
   end
-
   let(:service_result) do
     result = Invoices::Payments::GeneratePaymentUrlService::Result.new
     result.payment_url = "https://payment.example.com/pay/123"
     result
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     allow(Invoices::Payments::GeneratePaymentUrlService).to receive(:call).and_return(service_result)

--- a/spec/graphql/mutations/invoices/regenerate_from_voided_spec.rb
+++ b/spec/graphql/mutations/invoices/regenerate_from_voided_spec.rb
@@ -4,10 +4,6 @@ require "rails_helper"
 
 RSpec.describe Mutations::Invoices::RegenerateFromVoided do
   let(:required_permission) { "invoices:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-
   let(:voided_invoice) do
     create(
       :invoice,
@@ -19,7 +15,6 @@ RSpec.describe Mutations::Invoices::RegenerateFromVoided do
       currency: "EUR"
     )
   end
-
   let(:subscription) do
     create(
       :subscription,
@@ -29,10 +24,8 @@ RSpec.describe Mutations::Invoices::RegenerateFromVoided do
       created_at: started_at
     )
   end
-
   let(:timestamp) { Time.zone.now - 1.year }
   let(:started_at) { Time.zone.now - 2.years }
-  let(:plan) { create(:plan, organization:, interval: "monthly") }
   let(:fee_subscription) do
     create(
       :fee,
@@ -42,7 +35,6 @@ RSpec.describe Mutations::Invoices::RegenerateFromVoided do
       amount_cents: 2_000
     )
   end
-
   let(:mutation) do
     <<~GQL
       mutation($input: RegenerateInvoiceInput!) {
@@ -61,7 +53,6 @@ RSpec.describe Mutations::Invoices::RegenerateFromVoided do
       }
     GQL
   end
-
   let(:fee_input) do
     {
       id: fee_subscription.id,
@@ -72,6 +63,13 @@ RSpec.describe Mutations::Invoices::RegenerateFromVoided do
       unitAmountCents: 5000
     }
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+
+  let_it_be(:plan) { create_default(:plan, organization:, interval: "monthly") }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/invoices/resend_email_spec.rb
+++ b/spec/graphql/mutations/invoices/resend_email_spec.rb
@@ -4,12 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::Invoices::ResendEmail do
   let(:required_permission) { "invoices:send" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:, email: "customer@example.com") }
   let(:billing_entity) { customer.billing_entity }
   let(:invoice) { create(:invoice, customer:, organization:, status: :finalized, fees_amount_cents: 1000) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: ResendInvoiceEmailInput!) {
@@ -19,6 +15,11 @@ RSpec.describe Mutations::Invoices::ResendEmail do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:, email: "customer@example.com") }
 
   before do
     billing_entity.update!(email: "billing@example.com")

--- a/spec/graphql/mutations/invoices/retry_all_spec.rb
+++ b/spec/graphql/mutations/invoices/retry_all_spec.rb
@@ -4,11 +4,6 @@ require "rails_helper"
 
 RSpec.describe Mutations::Invoices::RetryAll do
   let(:required_permission) { "invoices:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:user) { membership.user }
-  let(:customer) { create(:customer, organization:, payment_provider: "gocardless") }
-
   let(:invoice) do
     create(
       :invoice,
@@ -20,7 +15,6 @@ RSpec.describe Mutations::Invoices::RetryAll do
       currency: "EUR"
     )
   end
-
   let(:subscription) do
     create(
       :subscription,
@@ -30,10 +24,8 @@ RSpec.describe Mutations::Invoices::RetryAll do
       created_at: started_at
     )
   end
-
   let(:timestamp) { Time.zone.now - 1.year }
   let(:started_at) { Time.zone.now - 2.years }
-  let(:plan) { create(:plan, organization:, interval: "monthly") }
   let(:fee_subscription) do
     create(
       :fee,
@@ -43,7 +35,6 @@ RSpec.describe Mutations::Invoices::RetryAll do
       amount_cents: 2_000
     )
   end
-
   let(:integration) { create(:anrok_integration, organization:) }
   let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
   let(:response) { instance_double(Net::HTTPOK) }
@@ -76,6 +67,13 @@ RSpec.describe Mutations::Invoices::RetryAll do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:, payment_provider: "gocardless") }
+
+  let_it_be(:plan) { create_default(:plan, organization:, interval: "monthly") }
 
   before do
     integration_collection_mapping

--- a/spec/graphql/mutations/invoices/retry_payment_spec.rb
+++ b/spec/graphql/mutations/invoices/retry_payment_spec.rb
@@ -4,9 +4,6 @@ require "rails_helper"
 
 RSpec.describe Mutations::Invoices::RetryPayment do
   let(:required_permission) { "invoices:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:, payment_provider: "gocardless") }
   let(:gocardless_payment_provider) { create(:gocardless_provider, organization:) }
   let(:gocardless_customer) { create(:gocardless_customer, customer:) }
   let(:user) { membership.user }
@@ -30,6 +27,11 @@ RSpec.describe Mutations::Invoices::RetryPayment do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:, payment_provider: "gocardless") }
 
   before do
     gocardless_payment_provider

--- a/spec/graphql/mutations/invoices/retry_spec.rb
+++ b/spec/graphql/mutations/invoices/retry_spec.rb
@@ -4,11 +4,7 @@ require "rails_helper"
 
 RSpec.describe Mutations::Invoices::Retry do
   let(:required_permission) { "invoices:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:, payment_provider: "gocardless") }
   let(:user) { membership.user }
-
   let(:invoice) do
     create(
       :invoice,
@@ -20,7 +16,6 @@ RSpec.describe Mutations::Invoices::Retry do
       currency: "EUR"
     )
   end
-
   let(:subscription) do
     create(
       :subscription,
@@ -30,10 +25,8 @@ RSpec.describe Mutations::Invoices::Retry do
       created_at: started_at
     )
   end
-
   let(:timestamp) { Time.zone.now - 1.year }
   let(:started_at) { Time.zone.now - 2.years }
-  let(:plan) { create(:plan, organization:, interval: "monthly") }
   let(:fee_subscription) do
     create(
       :fee,
@@ -53,6 +46,13 @@ RSpec.describe Mutations::Invoices::Retry do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:, payment_provider: "gocardless") }
+
+  let_it_be(:plan) { create_default(:plan, organization:, interval: "monthly") }
 
   before do
     fee_subscription

--- a/spec/graphql/mutations/invoices/retry_tax_provider_voiding_spec.rb
+++ b/spec/graphql/mutations/invoices/retry_tax_provider_voiding_spec.rb
@@ -4,11 +4,7 @@ require "rails_helper"
 
 RSpec.describe Mutations::Invoices::RetryTaxProviderVoiding do
   let(:required_permission) { "invoices:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:, payment_provider: "gocardless") }
   let(:user) { membership.user }
-
   let(:invoice) do
     create(
       :invoice,
@@ -21,7 +17,6 @@ RSpec.describe Mutations::Invoices::RetryTaxProviderVoiding do
       currency: "EUR"
     )
   end
-
   let(:subscription) do
     create(
       :subscription,
@@ -31,10 +26,8 @@ RSpec.describe Mutations::Invoices::RetryTaxProviderVoiding do
       created_at: started_at
     )
   end
-
   let(:timestamp) { Time.zone.now - 1.year }
   let(:started_at) { Time.zone.now - 2.years }
-  let(:plan) { create(:plan, organization:, interval: "monthly") }
   let(:fee_subscription) do
     create(
       :fee,
@@ -44,7 +37,6 @@ RSpec.describe Mutations::Invoices::RetryTaxProviderVoiding do
       amount_cents: 2_000
     )
   end
-
   let(:integration) { create(:anrok_integration, organization:) }
   let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
   let(:response) { instance_double(Net::HTTPOK) }
@@ -72,6 +64,12 @@ RSpec.describe Mutations::Invoices::RetryTaxProviderVoiding do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:, payment_provider: "gocardless") }
+
+  let_it_be(:plan) { create_default(:plan, organization:, interval: "monthly") }
 
   before do
     integration_collection_mapping

--- a/spec/graphql/mutations/invoices/update_spec.rb
+++ b/spec/graphql/mutations/invoices/update_spec.rb
@@ -4,8 +4,6 @@ require "rails_helper"
 
 RSpec.describe Mutations::Invoices::Update do
   let(:required_permission) { "invoices:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:invoice) { create(:invoice, organization:) }
   let(:mutation) do
     <<~GQL
@@ -18,6 +16,9 @@ RSpec.describe Mutations::Invoices::Update do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires permission", "invoices:update"

--- a/spec/graphql/mutations/invoices/void_spec.rb
+++ b/spec/graphql/mutations/invoices/void_spec.rb
@@ -4,11 +4,7 @@ require "rails_helper"
 
 RSpec.describe Mutations::Invoices::Void do
   let(:required_permission) { "invoices:void" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, status: :finalized, customer:, organization:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: VoidInvoiceInput!) {
@@ -19,6 +15,10 @@ RSpec.describe Mutations::Invoices::Void do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/login_user_spec.rb
+++ b/spec/graphql/mutations/login_user_spec.rb
@@ -3,7 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Mutations::LoginUser do
-  let(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
   let(:user) { membership.user }
   let(:mutation) do
     <<~GQL

--- a/spec/graphql/mutations/memberships/revoke_spec.rb
+++ b/spec/graphql/mutations/memberships/revoke_spec.rb
@@ -6,11 +6,6 @@ RSpec.describe Mutations::Memberships::Revoke do
   include_context "with mocked security logger"
 
   let(:required_permission) { "organization:members:update" }
-  let(:admin_role) { create(:role, :admin) }
-  let(:finance_role) { create(:role, :finance) }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-
   let(:mutation) do
     <<-GQL
       mutation($input: RevokeMembershipInput!) {
@@ -21,6 +16,11 @@ RSpec.describe Mutations::Memberships::Revoke do
       }
     GQL
   end
+  let(:admin_role) { create(:role, :admin) }
+  let(:finance_role) { create(:role, :finance) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/memberships/update_spec.rb
+++ b/spec/graphql/mutations/memberships/update_spec.rb
@@ -6,12 +6,7 @@ RSpec.describe Mutations::Memberships::Update do
   include_context "with mocked security logger"
 
   let(:required_permission) { "organization:members:update" }
-  let(:admin_role) { create(:role, :admin) }
-  let(:finance_role) { create(:role, :finance) }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:user) { membership.user }
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateMembershipInput!) {
@@ -22,6 +17,11 @@ RSpec.describe Mutations::Memberships::Update do
       }
     GQL
   end
+  let(:admin_role) { create(:role, :admin) }
+  let(:finance_role) { create(:role, :finance) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"
@@ -43,7 +43,7 @@ RSpec.describe Mutations::Memberships::Update do
       )
     end
 
-    let(:membership_to_edit) { create(:membership, organization:) }
+    let_it_be(:membership_to_edit) { create_default(:membership, organization:) }
 
     before do
       create(:membership_role, membership: membership_to_edit, role: finance_role)

--- a/spec/graphql/mutations/order_forms/mark_as_signed_spec.rb
+++ b/spec/graphql/mutations/order_forms/mark_as_signed_spec.rb
@@ -3,13 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Mutations::OrderForms::MarkAsSigned do
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "order_forms:sign" }
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-  let(:membership) { create(:membership, organization:) }
-  let(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:order_form) { create(:order_form, organization:, customer:, quote:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: MarkOrderFormAsSignedInput!) {
@@ -22,6 +19,10 @@ RSpec.describe Mutations::OrderForms::MarkAsSigned do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
+  let_it_be(:membership) { create_default(:membership, organization:) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/order_forms/void_spec.rb
+++ b/spec/graphql/mutations/order_forms/void_spec.rb
@@ -3,12 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Mutations::OrderForms::Void do
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "order_forms:void" }
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-  let(:membership) { create(:membership, organization:) }
-  let(:customer) { create(:customer, organization:) }
   let(:order_form) { create(:order_form, organization:, customer:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: VoidOrderFormInput!) {
@@ -20,6 +17,10 @@ RSpec.describe Mutations::OrderForms::Void do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
+  let_it_be(:membership) { create_default(:membership, organization:) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/orders/execute_spec.rb
+++ b/spec/graphql/mutations/orders/execute_spec.rb
@@ -3,15 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Mutations::Orders::Execute do
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "orders:execute" }
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-  let(:membership) { create(:membership, organization:) }
-  let(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:, order_type: :one_off) }
   let(:quote_version) { create(:quote_version, :approved, quote:, organization:) }
   let(:order_form) { create(:order_form, :signed, organization:, customer:, quote_version:) }
   let(:order) { create(:order, organization:, customer:, order_form:, execution_mode: :order_only) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: ExecuteOrderInput!) {
@@ -23,6 +20,10 @@ RSpec.describe Mutations::Orders::Execute do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
+  let_it_be(:membership) { create_default(:membership, organization:) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/orders/update_spec.rb
+++ b/spec/graphql/mutations/orders/update_spec.rb
@@ -3,12 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Mutations::Orders::Update do
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "orders:update" }
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-  let(:membership) { create(:membership, organization:) }
-  let(:customer) { create(:customer, organization:) }
   let(:order) { create(:order, organization:, customer:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: UpdateOrderInput!) {
@@ -21,6 +18,10 @@ RSpec.describe Mutations::Orders::Update do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
+  let_it_be(:membership) { create_default(:membership, organization:) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/organizations/update_spec.rb
+++ b/spec/graphql/mutations/organizations/update_spec.rb
@@ -3,7 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Mutations::Organizations::Update do
-  let(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:membership) { create_default(:membership) }
   let(:mutation) do
     <<~GQL
       mutation($input: UpdateOrganizationInput!) {

--- a/spec/graphql/mutations/password_resets/create_spec.rb
+++ b/spec/graphql/mutations/password_resets/create_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Mutations::PasswordResets::Create do
   include_context "with mocked security logger"
 
-  let(:organization) { create(:organization) }
-  let(:membership) { create(:membership, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership, organization:) }
   let(:user) { membership.user }
   let(:email) { user.email }
 

--- a/spec/graphql/mutations/password_resets/reset_spec.rb
+++ b/spec/graphql/mutations/password_resets/reset_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Mutations::PasswordResets::Reset do
   include_context "with mocked security logger"
 
-  let(:organization) { create(:organization) }
-  let(:membership) { create(:membership, organization:, user: create(:user, password: "HelloLago!1")) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership, organization:, user: create(:user, password: "HelloLago!1")) }
   let(:user) { membership.user }
   let(:password_reset) { create(:password_reset, user:) }
 

--- a/spec/graphql/mutations/payment_methods/generate_checkout_url_spec.rb
+++ b/spec/graphql/mutations/payment_methods/generate_checkout_url_spec.rb
@@ -4,13 +4,10 @@ require "rails_helper"
 
 RSpec.describe Mutations::PaymentMethods::GenerateCheckoutUrl do
   let(:required_permission) { "payment_methods:create" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
   let(:stripe_provider) { create(:stripe_provider, organization:) }
   let(:user) { membership.user }
   let(:payment_method) { create(:payment_method, customer:, organization:, is_default: true) }
-
   let(:mutation) do
     <<-GQL
       mutation($input: GenerateCheckoutUrlInput!) {
@@ -20,6 +17,9 @@ RSpec.describe Mutations::PaymentMethods::GenerateCheckoutUrl do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     payment_method

--- a/spec/graphql/mutations/payment_methods/set_as_default_spec.rb
+++ b/spec/graphql/mutations/payment_methods/set_as_default_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe Mutations::PaymentMethods::SetAsDefault do
   let(:required_permission) { "payment_methods:update" }
+  let(:customer) { create(:customer, organization:) }
   let(:user) { membership.user }
   let(:payment_method) { create(:payment_method, customer:, organization:, is_default: false) }
   let(:payment_method2) { create(:payment_method, customer:, organization:, is_default: true) }
@@ -20,7 +21,6 @@ RSpec.describe Mutations::PaymentMethods::SetAsDefault do
 
   let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create_default(:membership) }
-  let(:customer) { create(:customer, organization:) }
 
   before do
     payment_method

--- a/spec/graphql/mutations/payment_methods/set_as_default_spec.rb
+++ b/spec/graphql/mutations/payment_methods/set_as_default_spec.rb
@@ -4,14 +4,10 @@ require "rails_helper"
 
 RSpec.describe Mutations::PaymentMethods::SetAsDefault do
   let(:required_permission) { "payment_methods:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:user) { membership.user }
   let(:payment_method) { create(:payment_method, customer:, organization:, is_default: false) }
   let(:payment_method2) { create(:payment_method, customer:, organization:, is_default: true) }
   let(:payment_method3) { create(:payment_method, customer:, organization:, is_default: false) }
-
   let(:mutation) do
     <<-GQL
       mutation($input: SetAsDefaultInput!) {
@@ -21,6 +17,10 @@ RSpec.describe Mutations::PaymentMethods::SetAsDefault do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let(:customer) { create(:customer, organization:) }
 
   before do
     payment_method

--- a/spec/graphql/mutations/payment_provider_customers/create_spec.rb
+++ b/spec/graphql/mutations/payment_provider_customers/create_spec.rb
@@ -4,11 +4,7 @@ require "rails_helper"
 
 RSpec.describe Mutations::PaymentProviderCustomers::Create do
   let(:required_permission) { "customers:update" }
-  let(:membership) { create(:membership, organization:) }
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
   let(:stripe_provider) { create(:stripe_provider, organization:, code: "stripe_eu") }
-
   let(:mutation) do
     <<-GQL
       mutation($input: CreatePaymentProviderCustomerInput!) {
@@ -23,6 +19,10 @@ RSpec.describe Mutations::PaymentProviderCustomers::Create do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership, organization:) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before { stripe_provider }
 

--- a/spec/graphql/mutations/payment_provider_customers/update_spec.rb
+++ b/spec/graphql/mutations/payment_provider_customers/update_spec.rb
@@ -4,13 +4,9 @@ require "rails_helper"
 
 RSpec.describe Mutations::PaymentProviderCustomers::Update do
   let(:required_permission) { "customers:update" }
-  let(:membership) { create(:membership, organization:) }
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
   let(:payment_provider_customer) do
     create(:stripe_customer, organization:, customer:, code: "old_code", provider_payment_methods: %w[card])
   end
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdatePaymentProviderCustomerInput!) {
@@ -23,6 +19,10 @@ RSpec.describe Mutations::PaymentProviderCustomers::Update do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership, organization:) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before { payment_provider_customer }
 

--- a/spec/graphql/mutations/payment_providers/adyen/update_spec.rb
+++ b/spec/graphql/mutations/payment_providers/adyen/update_spec.rb
@@ -4,10 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::PaymentProviders::Adyen::Update do
   let(:required_permission) { "organization:integrations:update" }
-  let(:membership) { create(:membership) }
   let(:adyen_provider) { create(:adyen_provider, organization: membership.organization) }
   let(:success_redirect_url) { Faker::Internet.url }
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateAdyenPaymentProviderInput!) {
@@ -18,6 +16,9 @@ RSpec.describe Mutations::PaymentProviders::Adyen::Update do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before { adyen_provider }
 

--- a/spec/graphql/mutations/payment_providers/cashfree/update_spec.rb
+++ b/spec/graphql/mutations/payment_providers/cashfree/update_spec.rb
@@ -4,10 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::PaymentProviders::Cashfree::Update do
   let(:required_permission) { "organization:integrations:update" }
-  let(:membership) { create(:membership) }
   let(:cashfree_provider) { create(:cashfree_provider, organization: membership.organization) }
   let(:success_redirect_url) { Faker::Internet.url }
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateCashfreePaymentProviderInput!) {
@@ -18,6 +16,9 @@ RSpec.describe Mutations::PaymentProviders::Cashfree::Update do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/payment_providers/flutterwave/update_spec.rb
+++ b/spec/graphql/mutations/payment_providers/flutterwave/update_spec.rb
@@ -4,10 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::PaymentProviders::Flutterwave::Update do
   let(:required_permission) { "organization:integrations:update" }
-  let(:membership) { create(:membership) }
   let(:flutterwave_provider) { create(:flutterwave_provider, organization: membership.organization) }
   let(:success_redirect_url) { Faker::Internet.url }
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateFlutterwavePaymentProviderInput!) {
@@ -18,6 +16,9 @@ RSpec.describe Mutations::PaymentProviders::Flutterwave::Update do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/payment_providers/gocardless/update_spec.rb
+++ b/spec/graphql/mutations/payment_providers/gocardless/update_spec.rb
@@ -4,13 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::PaymentProviders::Gocardless::Update do
   let(:required_permission) { "organization:integrations:update" }
-  let(:oauth_client) { instance_double(OAuth2::Client) }
-  let(:auth_code_strategy) { instance_double(OAuth2::Strategy::AuthCode) }
-  let(:access_token) { instance_double(OAuth2::AccessToken) }
-  let(:membership) { create(:membership) }
   let(:gocardless_provider) { create(:gocardless_provider, organization: membership.organization) }
   let(:success_redirect_url) { Faker::Internet.url }
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateGocardlessPaymentProviderInput!) {
@@ -21,6 +16,12 @@ RSpec.describe Mutations::PaymentProviders::Gocardless::Update do
       }
     GQL
   end
+  let(:oauth_client) { instance_double(OAuth2::Client) }
+  let(:auth_code_strategy) { instance_double(OAuth2::Strategy::AuthCode) }
+  let(:access_token) { instance_double(OAuth2::AccessToken) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     allow(OAuth2::Client).to receive(:new)

--- a/spec/graphql/mutations/payment_providers/stripe/update_spec.rb
+++ b/spec/graphql/mutations/payment_providers/stripe/update_spec.rb
@@ -4,10 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::PaymentProviders::Stripe::Update do
   let(:required_permission) { "organization:integrations:update" }
-  let(:membership) { create(:membership) }
   let(:stripe_provider) { create(:stripe_provider, organization: membership.organization) }
   let(:success_redirect_url) { Faker::Internet.url }
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateStripePaymentProviderInput!) {
@@ -20,6 +18,9 @@ RSpec.describe Mutations::PaymentProviders::Stripe::Update do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before { stripe_provider }
 

--- a/spec/graphql/mutations/payment_receipts/download_xml_spec.rb
+++ b/spec/graphql/mutations/payment_receipts/download_xml_spec.rb
@@ -4,14 +4,9 @@ require "rails_helper"
 
 RSpec.describe Mutations::PaymentReceipts::DownloadXml do
   let(:required_permission) { "invoices:view" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:billing_entity) { create(:billing_entity, country: "FR", einvoicing: true) }
-  let(:customer) { create(:customer, organization:, billing_entity:) }
   let(:invoice) { create(:invoice, customer:, organization:) }
   let(:payment) { create(:payment, payable: invoice, customer:) }
   let(:payment_receipt) { create(:payment_receipt, payment:, organization:, billing_entity:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: DownloadXMLPaymentReceiptInput!) {
@@ -22,6 +17,11 @@ RSpec.describe Mutations::PaymentReceipts::DownloadXml do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:billing_entity) { create_default(:billing_entity, country: "FR", einvoicing: true) }
+  let_it_be(:customer) { create_default(:customer, organization:, billing_entity:) }
 
   before { payment_receipt }
 

--- a/spec/graphql/mutations/payment_receipts/resend_email_spec.rb
+++ b/spec/graphql/mutations/payment_receipts/resend_email_spec.rb
@@ -4,14 +4,10 @@ require "rails_helper"
 
 RSpec.describe Mutations::PaymentReceipts::ResendEmail do
   let(:required_permission) { "payment_receipts:send" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:, email: "customer@example.com") }
   let(:billing_entity) { customer.billing_entity }
   let(:invoice) { create(:invoice, customer:, organization:, status: :finalized) }
   let(:payment) { create(:payment, payable: invoice) }
   let(:payment_receipt) { create(:payment_receipt, payment:, organization:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: ResendPaymentReceiptEmailInput!) {
@@ -21,6 +17,10 @@ RSpec.describe Mutations::PaymentReceipts::ResendEmail do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:, email: "customer@example.com") }
 
   before do
     billing_entity.update!(email: "billing@example.com")

--- a/spec/graphql/mutations/payments/create_spec.rb
+++ b/spec/graphql/mutations/payments/create_spec.rb
@@ -14,11 +14,8 @@ RSpec.describe Mutations::Payments::Create do
   end
 
   let(:required_permission) { "payments:create" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, organization:, total_amount_cents: 100) }
-
   let(:input) do
     {
       invoiceId: invoice.id,
@@ -27,7 +24,6 @@ RSpec.describe Mutations::Payments::Create do
       createdAt: 1.day.ago.iso8601
     }
   end
-
   let(:mutation) do
     <<-GQL
       mutation($input: CreatePaymentInput!) {
@@ -39,6 +35,10 @@ RSpec.describe Mutations::Payments::Create do
       }
     GQL
   end
+
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   context "with premium organization", :premium do
     it "creates a manual payment" do

--- a/spec/graphql/mutations/plan_applied_rate_cards/create_spec.rb
+++ b/spec/graphql/mutations/plan_applied_rate_cards/create_spec.rb
@@ -14,13 +14,7 @@ RSpec.describe Mutations::PlanAppliedRateCards::Create do
   end
 
   let(:input) { {planId: plan.id, rateCardCode: rate_card.code, units: 10.0} }
-
-  let(:required_permission) { "plans:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:plan) { create(:plan, :product_catalog, organization:) }
   let(:rate_card) { create(:rate_card, organization:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: CreatePlanAppliedRateCardInput!) {
@@ -34,6 +28,13 @@ RSpec.describe Mutations::PlanAppliedRateCards::Create do
       }
     GQL
   end
+
+  let(:required_permission) { "plans:update" }
+
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:plan) { create_default(:plan, :product_catalog, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/plans/create_spec.rb
+++ b/spec/graphql/mutations/plans/create_spec.rb
@@ -4,21 +4,17 @@ require "rails_helper"
 
 RSpec.describe Mutations::Plans::Create, :premium do
   let(:required_permission) { "plans:create" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:plan_tax) { create(:tax, organization:) }
   let(:charge_tax) { create(:tax, organization:) }
   let(:commitment_tax) { create(:tax, organization:) }
   let(:minimum_commitment_invoice_display_name) { "Minimum spending" }
   let(:minimum_commitment_amount_cents) { 100 }
-
   let(:feature) { create(:feature, code: :seats, organization:) }
   let(:privilege) { create(:privilege, feature:, code: "max", value_type: "integer") }
   let(:entitlement) { create(:entitlement, feature:, plan:) }
   let(:entitlement_value) { create(:entitlement_value, privilege:, entitlement:, value: "99") }
-
   let(:feature2) { create(:feature, code: "sso", organization:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: CreatePlanInput!) {
@@ -97,15 +93,6 @@ RSpec.describe Mutations::Plans::Create, :premium do
       }
     GQL
   end
-
-  let(:billable_metrics) do
-    create_list(:billable_metric, 6, organization:)
-  end
-
-  let(:add_ons) do
-    create_list(:add_on, 3, organization:)
-  end
-
   let(:billable_metric_filter) do
     create(
       :billable_metric_filter,
@@ -114,9 +101,19 @@ RSpec.describe Mutations::Plans::Create, :premium do
       values: %w[card sepa]
     )
   end
-
   let(:tax) { create(:tax, organization:) }
   let(:pricing_unit) { create(:pricing_unit, organization:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+
+  let_it_be(:billable_metrics) do
+    create_list(:billable_metric, 6, organization:)
+  end
+
+  let_it_be(:add_ons) do
+    create_list(:add_on, 3, organization:)
+  end
 
   before { organization.update!(premium_integrations: ["progressive_billing"]) }
 

--- a/spec/graphql/mutations/plans/destroy_spec.rb
+++ b/spec/graphql/mutations/plans/destroy_spec.rb
@@ -11,10 +11,6 @@ RSpec.describe Mutations::Plans::Destroy do
   end
 
   let(:required_permission) { "plans:delete" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization: membership.organization) }
-
   let(:mutation) do
     <<-GQL
       mutation($input: DestroyPlanInput!) {
@@ -24,6 +20,10 @@ RSpec.describe Mutations::Plans::Destroy do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:plan) { create_default(:plan, organization: membership.organization) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/plans/update_spec.rb
+++ b/spec/graphql/mutations/plans/update_spec.rb
@@ -4,20 +4,14 @@ require "rails_helper"
 
 RSpec.describe Mutations::Plans::Update do
   let(:required_permission) { "plans:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
   let(:minimum_commitment_invoice_display_name) { "Minimum spending" }
   let(:minimum_commitment_amount_cents) { 100 }
   let(:commitment_tax) { create(:tax, organization:) }
-
   let(:feature) { create(:feature, code: :seats, organization:) }
   let(:privilege) { create(:privilege, feature:, code: "max", value_type: "integer") }
   let(:entitlement) { create(:entitlement, feature:, plan:) }
   let(:entitlement_value) { create(:entitlement_value, privilege:, entitlement:, value: "99") }
-
   let(:feature2) { create(:feature, code: "sso", organization:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: UpdatePlanInput!) {
@@ -91,11 +85,6 @@ RSpec.describe Mutations::Plans::Update do
       }
     GQL
   end
-
-  let(:billable_metrics) do
-    create_list(:billable_metric, 5, organization:)
-  end
-
   let(:billable_metric_filter) do
     create(
       :billable_metric_filter,
@@ -104,10 +93,8 @@ RSpec.describe Mutations::Plans::Update do
       values: %w[card sepa]
     )
   end
-
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:) }
   let(:pricing_unit) { create(:pricing_unit, organization:) }
-
   let(:graphql) do
     {
       current_user: membership.user,
@@ -240,6 +227,14 @@ RSpec.describe Mutations::Plans::Update do
         }
       }
     }
+  end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
+
+  let_it_be(:billable_metrics) do
+    create_list(:billable_metric, 5, organization:)
   end
 
   before do
@@ -625,7 +620,7 @@ RSpec.describe Mutations::Plans::Update do
   end
 
   context "when fixed charges are provided" do
-    let(:add_ons) { create_list(:add_on, 5, organization:) }
+    let_it_be(:add_ons) { create_list(:add_on, 5, organization:) }
     let(:add_on_1) { add_ons[0] }
     let(:add_on_2) { add_ons[1] }
     let(:add_on_3) { add_ons[2] }

--- a/spec/graphql/mutations/pricing_units/create_spec.rb
+++ b/spec/graphql/mutations/pricing_units/create_spec.rb
@@ -20,10 +20,6 @@ RSpec.describe Mutations::PricingUnits::Create do
       }
     GQL
   end
-
-  let(:required_permission) { "pricing_units:create" }
-  let(:membership) { create(:membership) }
-
   let(:input_params) do
     {
       name: "Cloud token",
@@ -32,6 +28,11 @@ RSpec.describe Mutations::PricingUnits::Create do
       description: ""
     }
   end
+
+  let(:required_permission) { "pricing_units:create" }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/product_categories/create_spec.rb
+++ b/spec/graphql/mutations/product_categories/create_spec.rb
@@ -14,9 +14,7 @@ RSpec.describe Mutations::ProductCategories::Create do
   end
 
   let(:required_permission) { "product_categories:create" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-
   let(:input) do
     {
       name: "Cards",
@@ -25,7 +23,6 @@ RSpec.describe Mutations::ProductCategories::Create do
       invoiceDisplayName: "Cards"
     }
   end
-
   let(:mutation) do
     <<-GQL
       mutation($input: CreateProductCategoryInput!) {
@@ -35,6 +32,9 @@ RSpec.describe Mutations::ProductCategories::Create do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/product_filters/create_spec.rb
+++ b/spec/graphql/mutations/product_filters/create_spec.rb
@@ -14,13 +14,9 @@ RSpec.describe Mutations::ProductFilters::Create do
   end
 
   let(:required_permission) { "product_filters:create" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:billable_metric) { create(:billable_metric, organization:) }
   let(:product) { create(:product, organization:, billable_metric:) }
   let(:region_filter) { create(:billable_metric_filter, organization:, billable_metric:, key: "region", values: %w[us eu]) }
   let(:scheme_filter) { create(:billable_metric_filter, organization:, billable_metric:, key: "scheme", values: %w[visa]) }
-
   let(:input) do
     {
       productId: product.id,
@@ -32,7 +28,6 @@ RSpec.describe Mutations::ProductFilters::Create do
       ]
     }
   end
-
   let(:mutation) do
     <<-GQL
       mutation($input: CreateProductFilterInput!) {
@@ -44,6 +39,10 @@ RSpec.describe Mutations::ProductFilters::Create do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/products/create_spec.rb
+++ b/spec/graphql/mutations/products/create_spec.rb
@@ -14,11 +14,8 @@ RSpec.describe Mutations::Products::Create do
   end
 
   let(:required_permission) { "products:create" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:product_category) { create(:product_category, organization:) }
   let(:billable_metric) { create(:billable_metric, organization:) }
-
   let(:input) do
     {
       name: "Storage",
@@ -28,7 +25,6 @@ RSpec.describe Mutations::Products::Create do
       billableMetricId: billable_metric.id
     }
   end
-
   let(:mutation) do
     <<-GQL
       mutation($input: CreateProductInput!) {
@@ -40,6 +36,9 @@ RSpec.describe Mutations::Products::Create do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/quote_versions/approve_spec.rb
+++ b/spec/graphql/mutations/quote_versions/approve_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe Mutations::QuoteVersions::Approve do
   let(:required_permission) { "quotes:approve" }
-  let(:membership) { create(:membership) }
   let(:quote) { create(:quote, organization: membership.organization) }
   let(:quote_version) do
     create(
@@ -14,13 +13,11 @@ RSpec.describe Mutations::QuoteVersions::Approve do
       organization: membership.organization
     )
   end
-
   let(:input) do
     {
       id: quote_version.id
     }
   end
-
   let(:mutation) do
     <<-GQL
       mutation($input: ApproveQuoteVersionInput!) {
@@ -34,6 +31,11 @@ RSpec.describe Mutations::QuoteVersions::Approve do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let(:membership) { create(:membership) }
+  let(:customer) { create(:customer) }
+  let(:plan) { create(:plan) }
 
   before do
     membership.organization.enable_feature_flag!(:order_forms)

--- a/spec/graphql/mutations/quote_versions/approve_spec.rb
+++ b/spec/graphql/mutations/quote_versions/approve_spec.rb
@@ -4,6 +4,9 @@ require "rails_helper"
 
 RSpec.describe Mutations::QuoteVersions::Approve do
   let(:required_permission) { "quotes:approve" }
+  let(:membership) { create(:membership) }
+  let(:customer) { create(:customer) }
+  let(:plan) { create(:plan) }
   let(:quote) { create(:quote, organization: membership.organization) }
   let(:quote_version) do
     create(
@@ -33,9 +36,6 @@ RSpec.describe Mutations::QuoteVersions::Approve do
   end
 
   let_it_be(:organization) { create_default(:organization) }
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer) }
-  let(:plan) { create(:plan) }
 
   before do
     membership.organization.enable_feature_flag!(:order_forms)

--- a/spec/graphql/mutations/quote_versions/clone_spec.rb
+++ b/spec/graphql/mutations/quote_versions/clone_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::QuoteVersions::Clone do
   let(:required_permission) { "quotes:clone" }
+  let(:membership) { create(:membership) }
+  let(:customer) { create(:customer) }
   let(:quote_version) { create(:quote_version, organization: membership.organization) }
   let(:input) do
     {
@@ -26,8 +28,6 @@ RSpec.describe Mutations::QuoteVersions::Clone do
   end
 
   let_it_be(:organization) { create_default(:organization) }
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer) }
 
   before do
     membership.organization.enable_feature_flag!(:order_forms)

--- a/spec/graphql/mutations/quote_versions/clone_spec.rb
+++ b/spec/graphql/mutations/quote_versions/clone_spec.rb
@@ -4,15 +4,12 @@ require "rails_helper"
 
 RSpec.describe Mutations::QuoteVersions::Clone do
   let(:required_permission) { "quotes:clone" }
-  let(:membership) { create(:membership) }
   let(:quote_version) { create(:quote_version, organization: membership.organization) }
-
   let(:input) do
     {
       id: quote_version.id
     }
   end
-
   let(:mutation) do
     <<-GQL
       mutation($input: CloneQuoteVersionInput!) {
@@ -27,6 +24,10 @@ RSpec.describe Mutations::QuoteVersions::Clone do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let(:membership) { create(:membership) }
+  let(:customer) { create(:customer) }
 
   before do
     membership.organization.enable_feature_flag!(:order_forms)

--- a/spec/graphql/mutations/quote_versions/update_spec.rb
+++ b/spec/graphql/mutations/quote_versions/update_spec.rb
@@ -4,9 +4,7 @@ require "rails_helper"
 
 RSpec.describe Mutations::QuoteVersions::Update do
   let(:required_permission) { "quotes:update" }
-  let(:membership) { create(:membership) }
   let(:quote_version) { create(:quote_version, organization: membership.organization) }
-
   let(:input) do
     {
       id: quote_version.id,
@@ -15,7 +13,6 @@ RSpec.describe Mutations::QuoteVersions::Update do
       currency: "EUR"
     }
   end
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateQuoteVersionInput!) {
@@ -31,6 +28,10 @@ RSpec.describe Mutations::QuoteVersions::Update do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let(:membership) { create(:membership) }
+  let(:customer) { create(:customer) }
 
   before do
     membership.organization.enable_feature_flag!(:order_forms)
@@ -69,8 +70,6 @@ RSpec.describe Mutations::QuoteVersions::Update do
   # a currency change is asserted here rather than only at the service.
   context "when the currency change realigns the billing items", :premium do
     let(:organization) { membership.organization }
-    let(:quote) { create(:quote, organization:) }
-    let(:plan) { create(:plan, organization:, amount_currency: "EUR") }
     let(:overrides) { {"amountCurrency" => "USD"} }
     let(:quote_version) do
       create(
@@ -92,7 +91,6 @@ RSpec.describe Mutations::QuoteVersions::Update do
       )
     end
     let(:input) { {id: quote_version.id, currency: "EUR"} }
-
     let(:returned_overrides) do
       execute_graphql(
         current_user: membership.user,
@@ -102,6 +100,9 @@ RSpec.describe Mutations::QuoteVersions::Update do
         variables: {input:}
       ).dig("data", "updateQuoteVersion", "billingItems", "plans", 0, "overrides")
     end
+    let(:quote) { create(:quote, organization:) }
+
+    let(:plan) { create(:plan, organization:, amount_currency: "EUR") }
 
     it "returns an empty overrides object rather than dropping the key" do
       expect(returned_overrides).to eq({})

--- a/spec/graphql/mutations/quote_versions/update_spec.rb
+++ b/spec/graphql/mutations/quote_versions/update_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::QuoteVersions::Update do
   let(:required_permission) { "quotes:update" }
+  let(:membership) { create(:membership) }
+  let(:customer) { create(:customer) }
   let(:quote_version) { create(:quote_version, organization: membership.organization) }
   let(:input) do
     {
@@ -30,8 +32,6 @@ RSpec.describe Mutations::QuoteVersions::Update do
   end
 
   let_it_be(:organization) { create_default(:organization) }
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer) }
 
   before do
     membership.organization.enable_feature_flag!(:order_forms)

--- a/spec/graphql/mutations/quote_versions/void_spec.rb
+++ b/spec/graphql/mutations/quote_versions/void_spec.rb
@@ -4,15 +4,12 @@ require "rails_helper"
 
 RSpec.describe Mutations::QuoteVersions::Void do
   let(:required_permission) { "quotes:void" }
-  let(:membership) { create(:membership) }
   let(:quote_version) { create(:quote_version, organization: membership.organization) }
-
   let(:input) do
     {
       id: quote_version.id
     }
   end
-
   let(:mutation) do
     <<-GQL
       mutation($input: VoidQuoteVersionInput!) {
@@ -27,6 +24,10 @@ RSpec.describe Mutations::QuoteVersions::Void do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     membership.organization.enable_feature_flag!(:order_forms)

--- a/spec/graphql/mutations/quotes/add_image_spec.rb
+++ b/spec/graphql/mutations/quotes/add_image_spec.rb
@@ -4,19 +4,15 @@ require "rails_helper"
 
 RSpec.describe Mutations::Quotes::AddImage do
   let(:required_permission) { "quotes:update" }
-  let(:membership) { create(:membership) }
   let(:quote) { create(:quote, organization: membership.organization) }
-
   let(:png_bytes) { "\x89PNG\r\n\x1A\n".b }
   let(:image) { "data:image/png;base64,#{Base64.strict_encode64(png_bytes)}" }
-
   let(:input) do
     {
       id: quote.id,
       image:
     }
   end
-
   let(:mutation) do
     <<-GQL
       mutation($input: AddQuoteImageInput!) {
@@ -27,6 +23,10 @@ RSpec.describe Mutations::Quotes::AddImage do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     membership.organization.enable_feature_flag!(:order_forms)

--- a/spec/graphql/mutations/quotes/create_spec.rb
+++ b/spec/graphql/mutations/quotes/create_spec.rb
@@ -4,8 +4,6 @@ require "rails_helper"
 
 RSpec.describe Mutations::Quotes::Create do
   let(:required_permission) { "quotes:create" }
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer, organization: membership.organization) }
   let(:input) do
     {
       customerId: customer.id,
@@ -29,6 +27,10 @@ RSpec.describe Mutations::Quotes::Create do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization: membership.organization) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/quotes/update_spec.rb
+++ b/spec/graphql/mutations/quotes/update_spec.rb
@@ -4,16 +4,13 @@ require "rails_helper"
 
 RSpec.describe Mutations::Quotes::Update do
   let(:required_permission) { "quotes:update" }
-  let(:membership) { create(:membership) }
   let(:quote) { create(:quote, :with_version, organization: membership.organization) }
-
   let(:input) do
     {
       id: quote.id,
       owners: [membership.user.id]
     }
   end
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateQuoteInput!) {
@@ -25,6 +22,10 @@ RSpec.describe Mutations::Quotes::Update do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     membership.organization.enable_feature_flag!(:order_forms)

--- a/spec/graphql/mutations/rate_card_rates/destroy_spec.rb
+++ b/spec/graphql/mutations/rate_card_rates/destroy_spec.rb
@@ -14,13 +14,11 @@ RSpec.describe Mutations::RateCardRates::Destroy do
   end
 
   let(:required_permission) { "rate_cards:delete" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:rate_card) { create(:rate_card, organization:) }
   let(:rate_card_rate) do
     create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.from_now.beginning_of_day)
   end
-
   let(:mutation) do
     <<-GQL
       mutation($input: DestroyRateCardRateInput!) {
@@ -28,6 +26,10 @@ RSpec.describe Mutations::RateCardRates::Destroy do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/rate_cards/create_spec.rb
+++ b/spec/graphql/mutations/rate_cards/create_spec.rb
@@ -14,10 +14,7 @@ RSpec.describe Mutations::RateCards::Create do
   end
 
   let(:required_permission) { "rate_cards:create" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:product) { create(:product, organization:) }
-
   let(:input) do
     {
       productId: product.id,
@@ -27,7 +24,6 @@ RSpec.describe Mutations::RateCards::Create do
       billingTiming: "arrears"
     }
   end
-
   let(:mutation) do
     <<-GQL
       mutation($input: CreateRateCardInput!) {
@@ -40,6 +36,10 @@ RSpec.describe Mutations::RateCards::Create do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/rate_phases/create_spec.rb
+++ b/spec/graphql/mutations/rate_phases/create_spec.rb
@@ -14,16 +14,11 @@ RSpec.describe Mutations::RatePhases::Create do
   end
 
   let(:required_permission) { "plans:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:plan_rate_card) { create(:plan_rate_card, organization:) }
-
   let!(:terminal) { create(:rate_phase, organization:, plan_rate_card:, position: 1, billing_interval_cycle_count: nil) }
-
   let(:input) do
     {planAppliedRateCardId: plan_rate_card.id, code: "launch", name: "Launch", billingIntervalCycleCount: 3}
   end
-
   let(:mutation) do
     <<~GQL
       mutation($input: CreateRatePhaseInput!) {
@@ -33,6 +28,11 @@ RSpec.describe Mutations::RatePhases::Create do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/rate_phases/destroy_spec.rb
+++ b/spec/graphql/mutations/rate_phases/destroy_spec.rb
@@ -14,13 +14,9 @@ RSpec.describe Mutations::RatePhases::Destroy do
   end
 
   let(:required_permission) { "plans:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:plan_rate_card) { create(:plan_rate_card, organization:) }
-
   let!(:launch) { create(:rate_phase, organization:, plan_rate_card:, position: 1, billing_interval_cycle_count: 3) }
   let!(:terminal) { create(:rate_phase, organization:, plan_rate_card:, position: 2, billing_interval_cycle_count: nil) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: DestroyRatePhaseInput!) {
@@ -30,6 +26,11 @@ RSpec.describe Mutations::RatePhases::Destroy do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:plan) { create_default(:plan) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/rate_phases/update_spec.rb
+++ b/spec/graphql/mutations/rate_phases/update_spec.rb
@@ -14,13 +14,9 @@ RSpec.describe Mutations::RatePhases::Update do
   end
 
   let(:required_permission) { "plans:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:plan_rate_card) { create(:plan_rate_card, organization:) }
   let!(:rate_phase) { create(:rate_phase, organization:, plan_rate_card:, position: 1, code: "launch", name: "Before") }
-
   let(:input) { {planAppliedRateCardId: plan_rate_card.id, code: rate_phase.code, name: "After", newCode: "intro"} }
-
   let(:mutation) do
     <<~GQL
       mutation($input: UpdateRatePhaseInput!) {
@@ -30,6 +26,11 @@ RSpec.describe Mutations::RatePhases::Update do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/roles/create_spec.rb
+++ b/spec/graphql/mutations/roles/create_spec.rb
@@ -27,14 +27,15 @@ RSpec.describe Mutations::Roles::Create do
       }
     GQL
   end
-
-  let(:required_permission) { "roles:create" }
-  let(:organization) { create(:organization) }
-  let(:membership) { create(:membership, organization:) }
   let(:code) { "custom_role" }
   let(:name) { "Custom Role" }
   let(:description) { "A custom role" }
   let(:role_permissions) { %w[customers_view customers_create] }
+
+  let(:required_permission) { "roles:create" }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"
@@ -101,7 +102,7 @@ RSpec.describe Mutations::Roles::Create do
       )
     end
 
-    let!(:membership) { create(:membership, organization:, roles: [:admin]) }
+    let_it_be(:membership) { create_default(:membership, organization:, roles: [:admin]) }
 
     context "with premium organization and custom_roles integration", :premium do
       before { organization.update!(premium_integrations: ["custom_roles"]) }

--- a/spec/graphql/mutations/roles/destroy_spec.rb
+++ b/spec/graphql/mutations/roles/destroy_spec.rb
@@ -22,10 +22,11 @@ RSpec.describe Mutations::Roles::Destroy do
       }
     GQL
   end
-  let(:required_permission) { "roles:delete" }
-  let(:organization) { create(:organization) }
-  let(:membership) { create(:membership, organization:) }
   let(:role) { create(:role, organization:) }
+  let(:required_permission) { "roles:delete" }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership, organization:) }
 
   include_context "with mocked security logger"
 

--- a/spec/graphql/mutations/roles/update_spec.rb
+++ b/spec/graphql/mutations/roles/update_spec.rb
@@ -26,13 +26,14 @@ RSpec.describe Mutations::Roles::Update do
       }
     GQL
   end
-
-  let(:required_permission) { "roles:update" }
-  let(:organization) { create(:organization) }
-  let(:membership) { create(:membership, organization:) }
   let(:role) { create(:role, organization:, name: "Old Name", description: "Old description") }
   let(:new_name) { "New Name" }
   let(:new_description) { "New description" }
+
+  let(:required_permission) { "roles:update" }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/subscriptions/alerts/create_spec.rb
+++ b/spec/graphql/mutations/subscriptions/alerts/create_spec.rb
@@ -16,6 +16,19 @@ RSpec.describe Mutations::Subscriptions::Alerts::Create do
   end
 
   let(:required_permission) { "subscriptions:update" }
+  let(:subscription) { create(:subscription, customer:) }
+  let(:input) do
+    {
+      subscriptionId: subscription.id,
+      code: "global",
+      alertType: "current_usage_amount",
+      thresholds: [
+        {code: "warn", value: "10"},
+        {code: "alert", value: "50"},
+        {value: "20", recurring: true}
+      ]
+    }
+  end
   let(:mutation) do
     <<-GQL
     mutation ($input: CreateSubscriptionAlertInput!) {
@@ -33,22 +46,11 @@ RSpec.describe Mutations::Subscriptions::Alerts::Create do
     }
     GQL
   end
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer, organization: membership.organization) }
-  let(:subscription) { create(:subscription, customer:) }
 
-  let(:input) do
-    {
-      subscriptionId: subscription.id,
-      code: "global",
-      alertType: "current_usage_amount",
-      thresholds: [
-        {code: "warn", value: "10"},
-        {code: "alert", value: "50"},
-        {value: "20", recurring: true}
-      ]
-    }
-  end
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer, organization: membership.organization) }
 
   before do
     subscription

--- a/spec/graphql/mutations/subscriptions/alerts/destroy_spec.rb
+++ b/spec/graphql/mutations/subscriptions/alerts/destroy_spec.rb
@@ -4,11 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::Subscriptions::Alerts::Destroy do
   let(:required_permission) { "subscriptions:update" }
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer, organization: membership.organization) }
   let(:subscription) { create(:subscription, customer:) }
   let(:alert) { create(:usage_current_amount_alert, subscription_external_id: subscription.external_id, organization: membership.organization, recurring_threshold: 33, thresholds: [10, 20, 22]) }
-
   let(:mutation) do
     <<-GQL
     mutation ($input: DestroySubscriptionAlertInput!) {
@@ -25,6 +22,11 @@ RSpec.describe Mutations::Subscriptions::Alerts::Destroy do
     }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization: membership.organization) }
 
   before do
     alert

--- a/spec/graphql/mutations/subscriptions/alerts/update_spec.rb
+++ b/spec/graphql/mutations/subscriptions/alerts/update_spec.rb
@@ -4,11 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::Subscriptions::Alerts::Update do
   let(:required_permission) { "subscriptions:update" }
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer, organization: membership.organization) }
   let(:subscription) { create(:subscription, customer:, organization: membership.organization) }
   let(:alert) { create(:usage_current_amount_alert, subscription_external_id: subscription.external_id, organization: membership.organization, recurring_threshold: 33, thresholds: [10, 20, 22]) }
-
   let(:mutation) do
     <<-GQL
     mutation ($input: UpdateSubscriptionAlertInput!) {
@@ -22,6 +19,11 @@ RSpec.describe Mutations::Subscriptions::Alerts::Update do
     }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization: membership.organization) }
 
   before do
     subscription

--- a/spec/graphql/mutations/subscriptions/create_charge_filter_spec.rb
+++ b/spec/graphql/mutations/subscriptions/create_charge_filter_spec.rb
@@ -6,14 +6,9 @@ RSpec.describe Mutations::Subscriptions::CreateChargeFilter, :premium do
   subject { execute_query(query:, input:) }
 
   let(:required_permission) { "subscriptions:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
   let(:billable_metric_filter) { create(:billable_metric_filter, billable_metric:) }
   let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
   let(:subscription) { create(:subscription, organization:, plan:) }
-
   let(:query) do
     <<~GQL
       mutation($input: CreateSubscriptionChargeFilterInput!) {
@@ -28,7 +23,6 @@ RSpec.describe Mutations::Subscriptions::CreateChargeFilter, :premium do
       }
     GQL
   end
-
   let(:input) do
     {
       subscriptionId: subscription.id,
@@ -38,6 +32,12 @@ RSpec.describe Mutations::Subscriptions::CreateChargeFilter, :premium do
       values: {billable_metric_filter.key => [billable_metric_filter.values.first]}
     }
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
 
   before do
     charge

--- a/spec/graphql/mutations/subscriptions/create_spec.rb
+++ b/spec/graphql/mutations/subscriptions/create_spec.rb
@@ -4,22 +4,15 @@ require "rails_helper"
 
 RSpec.describe Mutations::Subscriptions::Create, :premium do
   let(:required_permission) { "subscriptions:create" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
   let(:charge) { create(:standard_charge, plan:) }
   let(:fixed_charge) { create(:fixed_charge, plan:) }
   let(:threshold) { create(:usage_threshold, plan:) }
   let(:ending_at) { Time.current.beginning_of_day + 1.year }
-  let(:customer) { create(:customer, organization:) }
-
   let(:feature) { create(:feature, code: :seats, organization:) }
   let(:privilege) { create(:privilege, feature:, code: "max", value_type: "integer") }
   let(:entitlement) { create(:entitlement, feature:, plan:) }
   let(:entitlement_value) { create(:entitlement_value, privilege:, entitlement:, value: "99") }
-
   let(:feature2) { create(:feature, code: "sso", organization:) }
-
   let(:mutation) do
     <<~GQL
       mutation($input: CreateSubscriptionInput!) {
@@ -53,6 +46,11 @@ RSpec.describe Mutations::Subscriptions::Create, :premium do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before { organization.update!(premium_integrations: ["progressive_billing"]) }
 

--- a/spec/graphql/mutations/subscriptions/destroy_charge_filter_spec.rb
+++ b/spec/graphql/mutations/subscriptions/destroy_charge_filter_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe Mutations::Subscriptions::DestroyChargeFilter, :premium do
   subject { execute_query(query:, input:) }
 
   let(:required_permission) { "subscriptions:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
   let(:billable_metric_filter) { create(:billable_metric_filter, billable_metric:) }
   let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
   let(:charge_filter) do
@@ -18,7 +14,6 @@ RSpec.describe Mutations::Subscriptions::DestroyChargeFilter, :premium do
     end
   end
   let(:subscription) { create(:subscription, organization:, plan:) }
-
   let(:query) do
     <<~GQL
       mutation($input: DestroySubscriptionChargeFilterInput!) {
@@ -28,7 +23,6 @@ RSpec.describe Mutations::Subscriptions::DestroyChargeFilter, :premium do
       }
     GQL
   end
-
   let(:input) do
     {
       subscriptionId: subscription.id,
@@ -36,6 +30,12 @@ RSpec.describe Mutations::Subscriptions::DestroyChargeFilter, :premium do
       values: {billable_metric_filter.key => [billable_metric_filter.values.first]}
     }
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
 
   before do
     charge_filter

--- a/spec/graphql/mutations/subscriptions/terminate_spec.rb
+++ b/spec/graphql/mutations/subscriptions/terminate_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe Mutations::Subscriptions::Terminate do
   end
 
   let(:required_permission) { "subscriptions:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:subscription) { create(:subscription, organization:) }
   let(:mutation) do
     <<~GQL
@@ -28,6 +26,10 @@ RSpec.describe Mutations::Subscriptions::Terminate do
     GQL
   end
   let(:input) { {id: subscription.id} }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"
@@ -67,7 +69,7 @@ RSpec.describe Mutations::Subscriptions::Terminate do
   end
 
   context "when plan is pay in advance" do
-    let(:subscription) { create(:subscription, organization:, plan: create(:plan, :pay_in_advance)) }
+    let_it_be(:subscription) { create(:subscription, organization:, plan: create_default(:plan, :pay_in_advance)) }
 
     it "terminates a subscription" do
       result_data = result["data"]["terminateSubscription"]

--- a/spec/graphql/mutations/subscriptions/update_charge_filter_spec.rb
+++ b/spec/graphql/mutations/subscriptions/update_charge_filter_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe Mutations::Subscriptions::UpdateChargeFilter, :premium do
   subject { execute_query(query:, input:) }
 
   let(:required_permission) { "subscriptions:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
   let(:billable_metric_filter) { create(:billable_metric_filter, billable_metric:) }
   let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
   let(:charge_filter) do
@@ -18,7 +14,6 @@ RSpec.describe Mutations::Subscriptions::UpdateChargeFilter, :premium do
     end
   end
   let(:subscription) { create(:subscription, organization:, plan:) }
-
   let(:query) do
     <<~GQL
       mutation($input: UpdateSubscriptionChargeFilterInput!) {
@@ -33,7 +28,6 @@ RSpec.describe Mutations::Subscriptions::UpdateChargeFilter, :premium do
       }
     GQL
   end
-
   let(:input) do
     {
       subscriptionId: subscription.id,
@@ -43,6 +37,12 @@ RSpec.describe Mutations::Subscriptions::UpdateChargeFilter, :premium do
       properties: {amount: "200"}
     }
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
 
   before do
     charge_filter

--- a/spec/graphql/mutations/subscriptions/update_charge_spec.rb
+++ b/spec/graphql/mutations/subscriptions/update_charge_spec.rb
@@ -6,13 +6,8 @@ RSpec.describe Mutations::Subscriptions::UpdateCharge, :premium do
   subject { execute_query(query:, input:) }
 
   let(:required_permission) { "subscriptions:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
   let(:subscription) { create(:subscription, organization:, plan:) }
-
   let(:query) do
     <<~GQL
       mutation($input: UpdateSubscriptionChargeInput!) {
@@ -28,7 +23,6 @@ RSpec.describe Mutations::Subscriptions::UpdateCharge, :premium do
       }
     GQL
   end
-
   let(:input) do
     {
       subscriptionId: subscription.id,
@@ -38,6 +32,12 @@ RSpec.describe Mutations::Subscriptions::UpdateCharge, :premium do
       properties: {amount: "200"}
     }
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
 
   before do
     charge

--- a/spec/graphql/mutations/subscriptions/update_fixed_charge_spec.rb
+++ b/spec/graphql/mutations/subscriptions/update_fixed_charge_spec.rb
@@ -6,13 +6,8 @@ RSpec.describe Mutations::Subscriptions::UpdateFixedCharge, :premium do
   subject { execute_query(query:, input:) }
 
   let(:required_permission) { "subscriptions:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
-  let(:add_on) { create(:add_on, organization:) }
   let(:fixed_charge) { create(:fixed_charge, plan:, organization:, add_on:) }
   let(:subscription) { create(:subscription, organization:, plan:) }
-
   let(:query) do
     <<~GQL
       mutation($input: UpdateSubscriptionFixedChargeInput!) {
@@ -25,7 +20,6 @@ RSpec.describe Mutations::Subscriptions::UpdateFixedCharge, :premium do
       }
     GQL
   end
-
   let(:input) do
     {
       subscriptionId: subscription.id,
@@ -34,6 +28,12 @@ RSpec.describe Mutations::Subscriptions::UpdateFixedCharge, :premium do
       units: "20"
     }
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
+  let_it_be(:add_on) { create_default(:add_on, organization:) }
 
   before do
     fixed_charge

--- a/spec/graphql/mutations/subscriptions/update_spec.rb
+++ b/spec/graphql/mutations/subscriptions/update_spec.rb
@@ -6,11 +6,7 @@ RSpec.describe Mutations::Subscriptions::Update, :premium do
   subject { execute_query(query:, input:) }
 
   let(:required_permission) { "subscriptions:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
   let(:fixed_charge) { create(:fixed_charge, plan:) }
-
   let(:subscription) do
     create(
       :subscription,
@@ -19,7 +15,6 @@ RSpec.describe Mutations::Subscriptions::Update, :premium do
       subscription_at: Time.current + 3.days
     )
   end
-
   let(:query) do
     <<~GQL
       mutation($input: UpdateSubscriptionInput!) {
@@ -57,6 +52,12 @@ RSpec.describe Mutations::Subscriptions::Update, :premium do
       }
     }
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:add_on) { create_default(:add_on) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
 
   before do
     plan

--- a/spec/graphql/mutations/superset/create_guest_token_spec.rb
+++ b/spec/graphql/mutations/superset/create_guest_token_spec.rb
@@ -4,11 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::Superset::CreateGuestToken do
   let(:required_permission) { "analytics:view" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:dashboard_id) { "42" }
   let(:guest_token) { "fresh-guest-token" }
-
   let(:mutation) do
     <<~GQL
       mutation($input: CreateSupersetGuestTokenInput!) {
@@ -18,10 +15,12 @@ RSpec.describe Mutations::Superset::CreateGuestToken do
       }
     GQL
   end
-
   let(:result) do
     Auth::Superset::GuestTokenService::Result.new.tap { |r| r.guest_token = guest_token }
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     allow(Auth::Superset::GuestTokenService).to receive(:call).and_return(result)

--- a/spec/graphql/mutations/wallet_transactions/create_spec.rb
+++ b/spec/graphql/mutations/wallet_transactions/create_spec.rb
@@ -6,12 +6,8 @@ RSpec.describe Mutations::WalletTransactions::Create do
   subject(:result) { execute_query(query:, input:) }
 
   let(:required_permission) { "wallets:top_up" }
-  let(:organization) { create(:organization) }
-  let(:membership) { create(:membership, organization:) }
-  let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:) }
   let(:wallet) { create(:wallet, customer:, balance: 10.0, credits_balance: 10.0) }
-
   let(:query) do
     <<-GQL
     mutation ($input: CreateCustomerWalletTransactionInput!) {
@@ -37,7 +33,6 @@ RSpec.describe Mutations::WalletTransactions::Create do
     }
     GQL
   end
-
   let(:input) do
     {
       walletId: wallet.id,
@@ -59,6 +54,11 @@ RSpec.describe Mutations::WalletTransactions::Create do
       ]
     }
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:membership) { create_default(:membership, organization:) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     subscription

--- a/spec/graphql/mutations/wallets/alerts/create_spec.rb
+++ b/spec/graphql/mutations/wallets/alerts/create_spec.rb
@@ -16,6 +16,19 @@ RSpec.describe Mutations::Wallets::Alerts::Create do
   end
 
   let(:required_permission) { "wallets:update" }
+  let(:wallet) { create(:wallet, customer:) }
+  let(:input) do
+    {
+      walletId: wallet.id,
+      code: "wallet_balance_alert",
+      alertType: "wallet_balance_amount",
+      thresholds: [
+        {code: "warn", value: "5000"},
+        {code: "alert", value: "2500"},
+        {value: "1000", recurring: true}
+      ]
+    }
+  end
   let(:mutation) do
     <<-GQL
     mutation ($input: CreateCustomerWalletAlertInput!) {
@@ -32,22 +45,10 @@ RSpec.describe Mutations::Wallets::Alerts::Create do
     }
     GQL
   end
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer, organization: membership.organization) }
-  let(:wallet) { create(:wallet, customer:) }
 
-  let(:input) do
-    {
-      walletId: wallet.id,
-      code: "wallet_balance_alert",
-      alertType: "wallet_balance_amount",
-      thresholds: [
-        {code: "warn", value: "5000"},
-        {code: "alert", value: "2500"},
-        {value: "1000", recurring: true}
-      ]
-    }
-  end
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization: membership.organization) }
 
   before do
     wallet

--- a/spec/graphql/mutations/wallets/alerts/destroy_spec.rb
+++ b/spec/graphql/mutations/wallets/alerts/destroy_spec.rb
@@ -4,11 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::Wallets::Alerts::Destroy do
   let(:required_permission) { "wallets:update" }
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer, organization: membership.organization) }
   let(:wallet) { create(:wallet, customer:) }
   let(:alert) { create(:wallet_balance_amount_alert, wallet:, organization: membership.organization, recurring_threshold: 10, thresholds: [75, 50, 25]) }
-
   let(:mutation) do
     <<-GQL
     mutation ($input: DestroyCustomerWalletAlertInput!) {
@@ -25,6 +22,10 @@ RSpec.describe Mutations::Wallets::Alerts::Destroy do
     }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization: membership.organization) }
 
   before do
     alert

--- a/spec/graphql/mutations/wallets/alerts/update_spec.rb
+++ b/spec/graphql/mutations/wallets/alerts/update_spec.rb
@@ -4,11 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::Wallets::Alerts::Update do
   let(:required_permission) { "wallets:update" }
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer, organization: membership.organization) }
   let(:wallet) { create(:wallet, customer:, organization: membership.organization) }
   let(:alert) { create(:wallet_balance_amount_alert, wallet:, organization: membership.organization, recurring_threshold: 10, thresholds: [75, 50, 25]) }
-
   let(:mutation) do
     <<-GQL
     mutation ($input: UpdateCustomerWalletAlertInput!) {
@@ -21,6 +18,10 @@ RSpec.describe Mutations::Wallets::Alerts::Update do
     }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization: membership.organization) }
 
   before do
     wallet

--- a/spec/graphql/mutations/wallets/create_spec.rb
+++ b/spec/graphql/mutations/wallets/create_spec.rb
@@ -4,11 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::Wallets::Create, :premium do
   let(:required_permission) { "wallets:create" }
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer, organization: membership.organization, currency: "EUR") }
   let(:billable_metric) { create(:billable_metric, organization: membership.organization) }
   let(:expiration_at) { Time.zone.now + 1.year }
-
   let(:mutation) do
     <<-GQL
       mutation($input: CreateCustomerWalletInput!) {
@@ -59,6 +56,10 @@ RSpec.describe Mutations::Wallets::Create, :premium do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization: membership.organization, currency: "EUR") }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/wallets/terminate_spec.rb
+++ b/spec/graphql/mutations/wallets/terminate_spec.rb
@@ -4,12 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::Wallets::Terminate do
   let(:required_permission) { "wallets:terminate" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:) }
   let(:wallet) { create(:wallet, customer:) }
-
   let(:mutation) do
     <<-GQL
       mutation($input: TerminateCustomerWalletInput!) {
@@ -19,6 +15,11 @@ RSpec.describe Mutations::Wallets::Terminate do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before { subscription }
 

--- a/spec/graphql/mutations/wallets/update_spec.rb
+++ b/spec/graphql/mutations/wallets/update_spec.rb
@@ -4,9 +4,6 @@ require "rails_helper"
 
 RSpec.describe Mutations::Wallets::Update, :premium do
   let(:required_permission) { "wallets:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:billable_metric) { create(:billable_metric, organization: membership.organization) }
   let(:subscription) { create(:subscription, customer:) }
   let(:wallet) { create(:wallet, customer:, purchase_order_number: wallet_purchase_order_number) }
@@ -16,7 +13,6 @@ RSpec.describe Mutations::Wallets::Update, :premium do
     create(:recurring_transaction_rule, wallet:, purchase_order_number: recurring_transaction_rule_purchase_order_number)
   end
   let(:recurring_transaction_rule_purchase_order_number) { nil }
-
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateCustomerWalletInput!) {
@@ -65,6 +61,11 @@ RSpec.describe Mutations::Wallets::Update, :premium do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     subscription

--- a/spec/graphql/mutations/webhook_endpoints/create_spec.rb
+++ b/spec/graphql/mutations/webhook_endpoints/create_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Mutations::WebhookEndpoints::Create do
   include_context "with mocked security logger"
 
   let(:required_permission) { "developers:manage" }
-  let(:membership) { create(:membership) }
   let(:webhook_url) { Faker::Internet.url }
   let(:input) do
     {
@@ -29,6 +28,9 @@ RSpec.describe Mutations::WebhookEndpoints::Create do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/webhook_endpoints/destroy_spec.rb
+++ b/spec/graphql/mutations/webhook_endpoints/destroy_spec.rb
@@ -22,10 +22,12 @@ RSpec.describe Mutations::WebhookEndpoints::Destroy do
       }
     GQL
   end
-  let(:required_permission) { "developers:manage" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let!(:webhook_endpoint) { create(:webhook_endpoint, organization:) }
+  let(:required_permission) { "developers:manage" }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/mutations/webhook_endpoints/update_spec.rb
+++ b/spec/graphql/mutations/webhook_endpoints/update_spec.rb
@@ -6,10 +6,8 @@ RSpec.describe Mutations::WebhookEndpoints::Update do
   include_context "with mocked security logger"
 
   let(:required_permission) { "developers:manage" }
-  let(:membership) { create(:membership) }
   let(:webhook_url) { Faker::Internet.url }
   let(:webhook_endpoint) { create(:webhook_endpoint, organization: membership.organization) }
-
   let(:input) do
     {
       id: webhook_endpoint.id,
@@ -19,7 +17,6 @@ RSpec.describe Mutations::WebhookEndpoints::Update do
       eventTypes: ["customer_updated"]
     }
   end
-
   let(:mutation) do
     <<-GQL
       mutation($input: WebhookEndpointUpdateInput!) {
@@ -33,6 +30,9 @@ RSpec.describe Mutations::WebhookEndpoints::Update do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before { webhook_endpoint }
 

--- a/spec/graphql/mutations/webhooks/retry_spec.rb
+++ b/spec/graphql/mutations/webhooks/retry_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Mutations::Webhooks::Retry do
   let(:webhook_endpoint) { create(:webhook_endpoint) }
   let(:organization) { webhook_endpoint.organization.reload }
   let(:membership) { create(:membership, organization:) }
-
   let(:mutation) do
     <<-GQL
       mutation($input: RetryWebhookInput!) {
@@ -18,6 +17,9 @@ RSpec.describe Mutations::Webhooks::Retry do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   before { webhook }
 

--- a/spec/graphql/resolvers/activity_log_resolver_spec.rb
+++ b/spec/graphql/resolvers/activity_log_resolver_spec.rb
@@ -3,7 +3,14 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::ActivityLogResolver, clickhouse: true do
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "audit_logs:view" }
+  let(:organization) { membership.organization }
+  let(:clickhouse_activity_log) { create(:clickhouse_activity_log, membership:) }
   let(:query) do
     <<~GQL
       query($activityLogId: ID!) {
@@ -15,9 +22,7 @@ RSpec.describe Resolvers::ActivityLogResolver, clickhouse: true do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:clickhouse_activity_log) { create(:clickhouse_activity_log, membership:) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/add_on_resolver_spec.rb
+++ b/spec/graphql/resolvers/add_on_resolver_spec.rb
@@ -3,7 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::AddOnResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "addons:view" }
+  let(:organization) { membership.organization }
+  let(:applied_add_on_list) { create_list(:applied_add_on, 3, add_on:, customer:) }
+  let(:applied_add_on) { create(:applied_add_on, add_on:, customer: customer2) }
   let(:query) do
     <<~GQL
       query($addOnId: ID!) {
@@ -14,13 +19,10 @@ RSpec.describe Resolvers::AddOnResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:add_on) { create(:add_on, organization:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:customer2) { create(:customer, organization:) }
-  let(:applied_add_on_list) { create_list(:applied_add_on, 3, add_on:, customer:) }
-  let(:applied_add_on) { create(:applied_add_on, add_on:, customer: customer2) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:add_on) { create_default(:add_on, organization:) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:customer2) { create_default(:customer, organization:) }
 
   before do
     customer

--- a/spec/graphql/resolvers/add_ons_resolver_spec.rb
+++ b/spec/graphql/resolvers/add_ons_resolver_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::AddOnsResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "addons:view" }
+  let(:organization) { membership.organization }
   let(:query) do
     <<~GQL
       query {
@@ -15,9 +18,9 @@ RSpec.describe Resolvers::AddOnsResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:add_on) { create(:add_on, organization:) }
+  let_it_be(:membership) { create_default(:membership) }
+
+  let_it_be(:add_on) { create_default(:add_on, organization:) }
 
   before { add_on }
 

--- a/spec/graphql/resolvers/ai_conversation_resolver_spec.rb
+++ b/spec/graphql/resolvers/ai_conversation_resolver_spec.rb
@@ -3,27 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::AiConversationResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "ai_conversations:view" }
-  let(:query) do
-    <<~GQL
-      query($id: ID!) {
-        aiConversation(id: $id) {
-          id
-          name
-          mistralConversationId
-          messages {
-            content
-            createdAt
-            type
-          }
-          createdAt
-          updatedAt
-        }
-      }
-    GQL
-  end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:ai_conversation) { create(:ai_conversation, organization:, mistral_conversation_id: "conv_123") }
   let(:fetch_messages_service) { instance_double(AiConversations::FetchMessagesService) }
@@ -43,6 +25,26 @@ RSpec.describe Resolvers::AiConversationResolver do
     ]
     result
   end
+  let(:query) do
+    <<~GQL
+      query($id: ID!) {
+        aiConversation(id: $id) {
+          id
+          name
+          mistralConversationId
+          messages {
+            content
+            createdAt
+            type
+          }
+          createdAt
+          updatedAt
+        }
+      }
+    GQL
+  end
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     ai_conversation

--- a/spec/graphql/resolvers/ai_conversations_resolver_spec.rb
+++ b/spec/graphql/resolvers/ai_conversations_resolver_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 RSpec.describe Resolvers::AiConversationsResolver do
   let(:required_permission) { "ai_conversations:view" }
+  let(:organization) { membership.organization }
+  let!(:ai_conversation) { create(:ai_conversation, organization:, membership:, mistral_conversation_id: "conv_123") }
   let(:query) do
     <<~GQL
       query($limit: Int) {
@@ -20,9 +22,8 @@ RSpec.describe Resolvers::AiConversationsResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let!(:ai_conversation) { create(:ai_conversation, organization:, membership:, mistral_conversation_id: "conv_123") }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/analytics/gross_revenues_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/gross_revenues_resolver_spec.rb
@@ -3,7 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::Analytics::GrossRevenuesResolver do
+  let_it_be(:organization) { create_default(:organization) }
   let(:required_permission) { "analytics:view" }
+  let(:organization) { membership.organization }
   let(:query) do
     <<~GQL
       query($currency: CurrencyEnum, $externalCustomerId: String, $expireCache: Boolean, $billingEntityCode: String, $billingEntityId: ID) {
@@ -19,8 +21,7 @@ RSpec.describe Resolvers::Analytics::GrossRevenuesResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/analytics/invoice_collections_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/invoice_collections_resolver_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::Analytics::InvoiceCollectionsResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "analytics:view" }
+  let(:organization) { membership.organization }
   let(:query) do
     <<~GQL
       query($currency: CurrencyEnum, $billingEntityCode: String) {
@@ -19,8 +22,7 @@ RSpec.describe Resolvers::Analytics::InvoiceCollectionsResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/analytics/invoiced_usages_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/invoiced_usages_resolver_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::Analytics::InvoicedUsagesResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "analytics:view" }
+  let(:organization) { membership.organization }
   let(:query) do
     <<~GQL
       query($currency: CurrencyEnum, $billingEntityCode: String) {
@@ -18,8 +21,7 @@ RSpec.describe Resolvers::Analytics::InvoicedUsagesResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/analytics/mrrs_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/mrrs_resolver_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::Analytics::MrrsResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "analytics:view" }
+  let(:organization) { membership.organization }
   let(:query) do
     <<~GQL
       query($currency: CurrencyEnum, $billingEntityCode: String) {
@@ -18,8 +21,7 @@ RSpec.describe Resolvers::Analytics::MrrsResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/api_key_resolver_spec.rb
+++ b/spec/graphql/resolvers/api_key_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::ApiKeyResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   subject(:result) do
     execute_graphql(
       current_user: membership.user,
@@ -22,10 +24,10 @@ RSpec.describe Resolvers::ApiKeyResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:required_permission) { "developers:keys:manage" }
   let(:api_key) { membership.organization.api_keys.first }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before { create(:api_key) }
 

--- a/spec/graphql/resolvers/api_keys_resolver_spec.rb
+++ b/spec/graphql/resolvers/api_keys_resolver_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe Resolvers::ApiKeysResolver do
       }
     GQL
   end
-
-  let(:organization) { create(:api_key).organization }
-  let(:membership) { create(:membership, organization:) }
   let(:required_permission) { "developers:keys:manage" }
   let(:api_key) { membership.organization.api_keys.first }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/api_log_resolver_spec.rb
+++ b/spec/graphql/resolvers/api_log_resolver_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::ApiLogResolver, clickhouse: true do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "audit_logs:view" }
+  let(:organization) { membership.organization }
+  let(:clickhouse_api_log) { create(:clickhouse_api_log, membership:) }
   let(:query) do
     <<~GQL
       query($requestId: ID!) {
@@ -14,9 +18,7 @@ RSpec.describe Resolvers::ApiLogResolver, clickhouse: true do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:clickhouse_api_log) { create(:clickhouse_api_log, membership:) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/applied_coupons_resolver_spec.rb
+++ b/spec/graphql/resolvers/applied_coupons_resolver_spec.rb
@@ -3,7 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::AppliedCouponsResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "coupons:view" }
+  let(:organization) { membership.organization }
+  let(:coupon) { create(:coupon, organization:) }
+  let(:applied_coupon) { create(:applied_coupon, customer:, coupon:, organization:) }
   let(:query) do
     <<~GQL
       query {
@@ -15,11 +20,8 @@ RSpec.describe Resolvers::AppliedCouponsResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:coupon) { create(:coupon, organization:) }
-  let(:applied_coupon) { create(:applied_coupon, customer:, coupon:, organization:) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     applied_coupon

--- a/spec/graphql/resolvers/billable_metric_resolver_spec.rb
+++ b/spec/graphql/resolvers/billable_metric_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::BillableMetricResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   subject(:graphql_request) do
     execute_graphql(
       current_user: membership.user,
@@ -14,6 +16,8 @@ RSpec.describe Resolvers::BillableMetricResolver do
   end
 
   let(:required_permission) { "billable_metrics:view" }
+  let(:organization) { membership.organization }
+  let(:billable_metric) { create(:billable_metric, organization:) }
   let(:query) do
     <<~GQL
       query($billableMetricId: ID!) {
@@ -29,9 +33,7 @@ RSpec.describe Resolvers::BillableMetricResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/billing_entities_resolver_spec.rb
+++ b/spec/graphql/resolvers/billing_entities_resolver_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::BillingEntitiesResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "billing_entities:view" }
+  let(:organization) { membership.organization }
+  let(:billing_entity1) { organization.default_billing_entity }
   let(:query) do
     <<~GQL
       query {
@@ -17,10 +21,9 @@ RSpec.describe Resolvers::BillingEntitiesResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:billing_entity1) { organization.default_billing_entity }
-  let(:billing_entity2) { create(:billing_entity, organization:) }
+  let_it_be(:membership) { create_default(:membership) }
+
+  let_it_be(:billing_entity2) { create_default(:billing_entity, organization:) }
 
   before do
     billing_entity1

--- a/spec/graphql/resolvers/billing_entity_resolver_spec.rb
+++ b/spec/graphql/resolvers/billing_entity_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::BillingEntityResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   subject(:graphql_request) do
     execute_graphql(
       current_user: membership.user,
@@ -14,6 +16,7 @@ RSpec.describe Resolvers::BillingEntityResolver do
   end
 
   let(:required_permission) { "billing_entities:view" }
+  let(:organization) { membership.organization }
   let(:query) do
     <<~GQL
       query($billingEntityCode: String!) {
@@ -35,9 +38,9 @@ RSpec.describe Resolvers::BillingEntityResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:billing_entity) { create(:billing_entity, organization:) }
+  let_it_be(:membership) { create_default(:membership) }
+
+  let_it_be(:billing_entity) { create_default(:billing_entity, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/billing_entity_taxes_resolver_spec.rb
+++ b/spec/graphql/resolvers/billing_entity_taxes_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::BillingEntityTaxesResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query($billing_entity_id: ID!) {
@@ -18,12 +20,12 @@ RSpec.describe Resolvers::BillingEntityTaxesResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:billing_entity) { organization.default_billing_entity }
   let(:tax1) { create(:tax, organization: organization) }
   let(:tax2) { create(:tax, organization: organization) }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     create(:billing_entity_applied_tax, billing_entity:, tax: tax1, organization:)

--- a/spec/graphql/resolvers/coupon_resolver_spec.rb
+++ b/spec/graphql/resolvers/coupon_resolver_spec.rb
@@ -3,7 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::CouponResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "coupons:view" }
+  let(:organization) { membership.organization }
+  let(:coupon) { create(:coupon, organization:) }
+  let(:applied_coupon) { create(:applied_coupon, coupon:) }
   let(:query) do
     <<~GQL
       query($couponId: ID!) {
@@ -14,11 +19,8 @@ RSpec.describe Resolvers::CouponResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:coupon) { create(:coupon, organization:) }
-  let(:applied_coupon) { create(:applied_coupon, coupon:) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     customer

--- a/spec/graphql/resolvers/coupons_resolver_spec.rb
+++ b/spec/graphql/resolvers/coupons_resolver_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::CouponsResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "coupons:view" }
+  let(:organization) { membership.organization }
+  let(:coupon) { create(:coupon, organization:) }
   let(:query) do
     <<~GQL
       query {
@@ -15,9 +19,7 @@ RSpec.describe Resolvers::CouponsResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:coupon) { create(:coupon, organization:) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     coupon

--- a/spec/graphql/resolvers/credit_notes/estimate_resolver_spec.rb
+++ b/spec/graphql/resolvers/credit_notes/estimate_resolver_spec.rb
@@ -3,6 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::CreditNotes::EstimateResolver, :premium do
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query($invoiceId: ID!, $items: [CreditNoteItemInput!]!) {
@@ -20,12 +23,8 @@ RSpec.describe Resolvers::CreditNotes::EstimateResolver, :premium do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, organization:, customer:) }
-
   let(:fees) do
     create_list(
       :fee,
@@ -35,7 +34,6 @@ RSpec.describe Resolvers::CreditNotes::EstimateResolver, :premium do
       precise_coupons_amount_cents: 50
     )
   end
-
   let(:coupon) do
     create(
       :coupon,
@@ -46,10 +44,11 @@ RSpec.describe Resolvers::CreditNotes::EstimateResolver, :premium do
       frequency: :forever
     )
   end
-
   let(:applied_coupon) { create(:applied_coupon, coupon:, customer:) }
-
   let(:credit) { create(:credit, invoice:, applied_coupon:, amount_cents: 100) }
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before { credit }
 

--- a/spec/graphql/resolvers/credit_notes_resolver_spec.rb
+++ b/spec/graphql/resolvers/credit_notes_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::CreditNotesResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   subject(:result) do
     execute_graphql(
       current_user: membership.user,
@@ -13,6 +15,9 @@ RSpec.describe Resolvers::CreditNotesResolver do
   end
 
   let(:required_permission) { "credit_notes:view" }
+  let(:organization) { membership.organization }
+  let(:arguments) { "" }
+  let(:response_collection) { result["data"]["creditNotes"]["collection"] }
   let(:query) do
     <<~GQL
       query {
@@ -24,12 +29,8 @@ RSpec.describe Resolvers::CreditNotesResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:arguments) { "" }
-
-  let(:response_collection) { result["data"]["creditNotes"]["collection"] }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before { create(:credit_note, :draft, customer:) }
 

--- a/spec/graphql/resolvers/customer_portal/customer_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/customer_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::CustomerPortal::CustomerResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query {
@@ -17,12 +19,12 @@ RSpec.describe Resolvers::CustomerPortal::CustomerResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) do
     create(:customer, organization:, currency: "EUR")
   end
+
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires a customer portal user"
 

--- a/spec/graphql/resolvers/customer_portal/customers/projected_usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/customers/projected_usage_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::CustomerPortal::Customers::ProjectedUsageResolver do
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:query) do
     <<~GQL
       query($subscriptionId: ID!) {
@@ -43,12 +45,8 @@ RSpec.describe Resolvers::CustomerPortal::Customers::ProjectedUsageResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:tax) { create(:tax, organization:, rate: 20) }
-
-  let(:customer) { create(:customer, organization:) }
   let(:subscription) do
     create(
       :subscription,
@@ -57,9 +55,6 @@ RSpec.describe Resolvers::CustomerPortal::Customers::ProjectedUsageResolver do
       started_at: Time.zone.now - 2.years
     )
   end
-  let(:plan) { create(:plan, interval: "monthly") }
-
-  let(:metric) { create(:billable_metric, aggregation_type: "count_agg") }
   let(:sum_metric) { create(:sum_billable_metric, organization:) }
   let(:charge) do
     create(
@@ -90,15 +85,20 @@ RSpec.describe Resolvers::CustomerPortal::Customers::ProjectedUsageResolver do
       }
     )
   end
-
   let(:billable_metric_filter) do
     create(:billable_metric_filter, billable_metric: sum_metric, key: "cloud", values: %w[aws gcp])
   end
-
   let(:charge_filter) { create(:charge_filter, charge: standard_charge, invoice_display_name: nil) }
   let(:charge_filter_value) do
     create(:charge_filter_value, charge_filter:, billable_metric_filter:, values: ["aws"])
   end
+
+  let_it_be(:membership) { create_default(:membership) }
+
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create_default(:plan, interval: "monthly") }
+
+  let_it_be(:metric) { create_default(:billable_metric, aggregation_type: "count_agg") }
 
   before do
     subscription

--- a/spec/graphql/resolvers/customer_portal/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/customers/usage_resolver_spec.rb
@@ -3,7 +3,56 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::CustomerPortal::Customers::UsageResolver do
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:now) { Time.zone.parse("2025-06-15").in_time_zone }
+  let(:organization) { membership.organization }
+  let(:tax) { create(:tax, organization:, rate: 20) }
+  let(:subscription) do
+    create(
+      :subscription,
+      plan:,
+      customer:,
+      started_at: now - 2.years
+    )
+  end
+  let(:sum_metric) { create(:sum_billable_metric, organization:) }
+  let(:charge) do
+    create(
+      :graduated_charge,
+      plan: subscription.plan,
+      charge_model: "graduated",
+      billable_metric: metric,
+      properties: {
+        graduated_ranges: [
+          {
+            from_value: 0,
+            to_value: nil,
+            per_unit_amount: "0.01",
+            flat_amount: "0.01"
+          }
+        ]
+      }
+    )
+  end
+  let(:standard_charge) do
+    create(
+      :standard_charge,
+      plan: subscription.plan,
+      billable_metric: sum_metric,
+      properties: {
+        amount: 1.to_s,
+        grouped_by: ["agent_name"]
+      }
+    )
+  end
+  let(:billable_metric_filter) do
+    create(:billable_metric_filter, billable_metric: sum_metric, key: "cloud", values: %w[aws gcp])
+  end
+  let(:charge_filter) { create(:charge_filter, charge: standard_charge, invoice_display_name: nil) }
+  let(:charge_filter_value) do
+    create(:charge_filter_value, charge_filter:, billable_metric_filter:, values: ["aws"])
+  end
   let(:timestamp) { now }
   let(:query) do
     <<~GQL
@@ -37,61 +86,12 @@ RSpec.describe Resolvers::CustomerPortal::Customers::UsageResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:tax) { create(:tax, organization:, rate: 20) }
+  let_it_be(:membership) { create_default(:membership) }
 
-  let(:customer) { create(:customer, organization:) }
-  let(:subscription) do
-    create(
-      :subscription,
-      plan:,
-      customer:,
-      started_at: now - 2.years
-    )
-  end
-  let(:plan) { create(:plan, interval: "monthly") }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create_default(:plan, interval: "monthly") }
 
-  let(:metric) { create(:billable_metric, aggregation_type: "count_agg") }
-  let(:sum_metric) { create(:sum_billable_metric, organization:) }
-  let(:charge) do
-    create(
-      :graduated_charge,
-      plan: subscription.plan,
-      charge_model: "graduated",
-      billable_metric: metric,
-      properties: {
-        graduated_ranges: [
-          {
-            from_value: 0,
-            to_value: nil,
-            per_unit_amount: "0.01",
-            flat_amount: "0.01"
-          }
-        ]
-      }
-    )
-  end
-  let(:standard_charge) do
-    create(
-      :standard_charge,
-      plan: subscription.plan,
-      billable_metric: sum_metric,
-      properties: {
-        amount: 1.to_s,
-        grouped_by: ["agent_name"]
-      }
-    )
-  end
-
-  let(:billable_metric_filter) do
-    create(:billable_metric_filter, billable_metric: sum_metric, key: "cloud", values: %w[aws gcp])
-  end
-
-  let(:charge_filter) { create(:charge_filter, charge: standard_charge, invoice_display_name: nil) }
-  let(:charge_filter_value) do
-    create(:charge_filter_value, charge_filter:, billable_metric_filter:, values: ["aws"])
-  end
+  let_it_be(:metric) { create_default(:billable_metric, aggregation_type: "count_agg") }
 
   before do
     subscription

--- a/spec/graphql/resolvers/customer_portal/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/invoices_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::CustomerPortal::InvoicesResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query {
@@ -13,12 +15,12 @@ RSpec.describe Resolvers::CustomerPortal::InvoicesResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:draft_invoice) { create(:invoice, :draft, customer:, organization:) }
   let(:finalized_invoice) { create(:invoice, customer:, organization:) }
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     draft_invoice

--- a/spec/graphql/resolvers/customer_portal/subscription_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/subscription_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::CustomerPortal::SubscriptionResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query($subscriptionId: ID!) {
@@ -19,11 +21,11 @@ RSpec.describe Resolvers::CustomerPortal::SubscriptionResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:) }
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     customer

--- a/spec/graphql/resolvers/customer_portal/subscriptions_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/subscriptions_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::CustomerPortal::SubscriptionsResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query {
@@ -13,13 +15,13 @@ RSpec.describe Resolvers::CustomerPortal::SubscriptionsResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
   let(:active_subscription) { create(:subscription, customer:, plan:) }
   let(:terminated_subscription) { create(:subscription, :terminated, customer:, plan:) }
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
 
   before do
     active_subscription

--- a/spec/graphql/resolvers/customer_portal/wallet_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/wallet_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::CustomerPortal::WalletResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query($walletId: ID!) {
@@ -16,11 +18,11 @@ RSpec.describe Resolvers::CustomerPortal::WalletResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:wallet) { create(:wallet, organization:, customer:) }
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     customer

--- a/spec/graphql/resolvers/customer_portal/wallets_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/wallets_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::CustomerPortal::WalletsResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query {
@@ -19,11 +21,11 @@ RSpec.describe Resolvers::CustomerPortal::WalletsResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:wallet) { create(:wallet, organization:, customer:, paid_top_up_min_amount_cents: 10_00) }
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     wallet

--- a/spec/graphql/resolvers/customer_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_resolver_spec.rb
@@ -4,6 +4,13 @@ require "rails_helper"
 
 RSpec.describe Resolvers::CustomerResolver do
   let(:required_permission) { "customers:view" }
+  let(:organization) { membership.organization }
+  let(:subscription) { create(:subscription, customer:) }
+  let(:applied_add_on) { create(:applied_add_on, customer:) }
+  let(:applied_tax) { create(:customer_applied_tax, customer:) }
+  let(:credit_note) { create(:credit_note, customer:) }
+  let(:credit_note_item) { create(:credit_note_item, credit_note:) }
+  let(:invoice_custom_sections) { create_list(:invoice_custom_section, 3, organization:) }
   let(:query) do
     <<~GQL
       query($customerId: ID, $externalId: ID) {
@@ -56,18 +63,14 @@ RSpec.describe Resolvers::CustomerResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:billing_entity) { create(:billing_entity, organization:, timezone: "America/New_York") }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billing_entity) { create_default(:billing_entity, organization:, timezone: "America/New_York") }
+  let_it_be(:add_on) { create_default(:add_on) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:membership) { create_default(:membership) }
   let(:customer) do
     create(:customer, billing_entity:, organization:, currency: "EUR", skip_invoice_custom_sections: false)
   end
-  let(:subscription) { create(:subscription, customer:) }
-  let(:applied_add_on) { create(:applied_add_on, customer:) }
-  let(:applied_tax) { create(:customer_applied_tax, customer:) }
-  let(:credit_note) { create(:credit_note, customer:) }
-  let(:credit_note_item) { create(:credit_note_item, credit_note:) }
-  let(:invoice_custom_sections) { create_list(:invoice_custom_section, 3, organization:) }
 
   before do
     create_list(:invoice, 2, customer:)

--- a/spec/graphql/resolvers/customer_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_resolver_spec.rb
@@ -4,6 +4,9 @@ require "rails_helper"
 
 RSpec.describe Resolvers::CustomerResolver do
   let(:required_permission) { "customers:view" }
+  let(:customer) do
+    create(:customer, billing_entity:, organization:, currency: "EUR", skip_invoice_custom_sections: false)
+  end
   let(:organization) { membership.organization }
   let(:subscription) { create(:subscription, customer:) }
   let(:applied_add_on) { create(:applied_add_on, customer:) }
@@ -68,9 +71,6 @@ RSpec.describe Resolvers::CustomerResolver do
   let_it_be(:add_on) { create_default(:add_on) }
   let_it_be(:plan) { create_default(:plan) }
   let_it_be(:membership) { create_default(:membership) }
-  let(:customer) do
-    create(:customer, billing_entity:, organization:, currency: "EUR", skip_invoice_custom_sections: false)
-  end
 
   before do
     create_list(:invoice, 2, customer:)

--- a/spec/graphql/resolvers/customers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/invoices_resolver_spec.rb
@@ -3,7 +3,14 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::Customers::InvoicesResolver do
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "invoices:view" }
+  let(:organization) { membership.organization }
+  let(:subscription) { create(:subscription, customer:, organization:) }
+  let(:draft_invoice) { create(:invoice, :draft, customer:, organization:) }
+  let(:finalized_invoice) { create(:invoice, customer:, organization:) }
   let(:query) do
     <<~GQL
       query($customerId: ID!) {
@@ -15,12 +22,8 @@ RSpec.describe Resolvers::Customers::InvoicesResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:subscription) { create(:subscription, customer:, organization:) }
-  let(:draft_invoice) { create(:invoice, :draft, customer:, organization:) }
-  let(:finalized_invoice) { create(:invoice, customer:, organization:) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     subscription

--- a/spec/graphql/resolvers/customers/projected_usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/projected_usage_resolver_spec.rb
@@ -3,7 +3,56 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::Customers::ProjectedUsageResolver do
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:required_permission) { "customers:view" }
+  let(:organization) { membership.organization }
+  let(:tax) { create(:tax, organization:, rate: 20) }
+  let(:subscription) do
+    create(
+      :subscription,
+      plan:,
+      customer:,
+      started_at: Time.zone.now - 2.years
+    )
+  end
+  let(:sum_metric) { create(:sum_billable_metric, name: "sum_metric", organization:) }
+  let(:charge) do
+    create(
+      :graduated_charge,
+      plan: subscription.plan,
+      charge_model: "graduated",
+      billable_metric: metric,
+      properties: {
+        graduated_ranges: [
+          {
+            from_value: 0,
+            to_value: nil,
+            per_unit_amount: "0.01",
+            flat_amount: "0.01"
+          }
+        ]
+      }
+    )
+  end
+  let(:standard_charge) do
+    create(
+      :standard_charge,
+      plan: subscription.plan,
+      billable_metric: sum_metric,
+      properties: {
+        amount: 1.to_s,
+        pricing_group_keys: ["agent_name"]
+      }
+    )
+  end
+  let(:billable_metric_filter) do
+    create(:billable_metric_filter, billable_metric: sum_metric, key: "cloud", values: %w[aws gcp])
+  end
+  let(:charge_filter) { create(:charge_filter, charge: standard_charge, invoice_display_name: nil) }
+  let(:charge_filter_value) do
+    create(:charge_filter_value, charge_filter:, billable_metric_filter:, values: ["aws"])
+  end
   let(:query) do
     <<~GQL
       query($customerId: ID!, $subscriptionId: ID!) {
@@ -43,61 +92,12 @@ RSpec.describe Resolvers::Customers::ProjectedUsageResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:tax) { create(:tax, organization:, rate: 20) }
+  let_it_be(:membership) { create_default(:membership) }
 
-  let(:customer) { create(:customer, organization:) }
-  let(:subscription) do
-    create(
-      :subscription,
-      plan:,
-      customer:,
-      started_at: Time.zone.now - 2.years
-    )
-  end
-  let(:plan) { create(:plan, interval: "monthly") }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create_default(:plan, interval: "monthly") }
 
-  let(:metric) { create(:billable_metric, name: "count_metric", aggregation_type: "count_agg") }
-  let(:sum_metric) { create(:sum_billable_metric, name: "sum_metric", organization:) }
-  let(:charge) do
-    create(
-      :graduated_charge,
-      plan: subscription.plan,
-      charge_model: "graduated",
-      billable_metric: metric,
-      properties: {
-        graduated_ranges: [
-          {
-            from_value: 0,
-            to_value: nil,
-            per_unit_amount: "0.01",
-            flat_amount: "0.01"
-          }
-        ]
-      }
-    )
-  end
-  let(:standard_charge) do
-    create(
-      :standard_charge,
-      plan: subscription.plan,
-      billable_metric: sum_metric,
-      properties: {
-        amount: 1.to_s,
-        pricing_group_keys: ["agent_name"]
-      }
-    )
-  end
-
-  let(:billable_metric_filter) do
-    create(:billable_metric_filter, billable_metric: sum_metric, key: "cloud", values: %w[aws gcp])
-  end
-
-  let(:charge_filter) { create(:charge_filter, charge: standard_charge, invoice_display_name: nil) }
-  let(:charge_filter_value) do
-    create(:charge_filter_value, charge_filter:, billable_metric_filter:, values: ["aws"])
-  end
+  let_it_be(:metric) { create_default(:billable_metric, name: "count_metric", aggregation_type: "count_agg") }
 
   before do
     subscription

--- a/spec/graphql/resolvers/customers/subscriptions_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/subscriptions_resolver_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::Customers::SubscriptionsResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "customers:view" }
+  let(:organization) { membership.organization }
+  let(:status_filter) { nil }
   let(:query) do
     <<~GQL
       query($customerId: ID!) {
@@ -21,11 +25,9 @@ RSpec.describe Resolvers::Customers::SubscriptionsResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:status_filter) { nil }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
 
   before do
     customer

--- a/spec/graphql/resolvers/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/usage_resolver_spec.rb
@@ -3,7 +3,56 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::Customers::UsageResolver do
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:required_permission) { "customers:view" }
+  let(:organization) { membership.organization }
+  let(:tax) { create(:tax, organization:, rate: 20) }
+  let(:subscription) do
+    create(
+      :subscription,
+      plan:,
+      customer:,
+      started_at: Time.zone.now - 2.years
+    )
+  end
+  let(:sum_metric) { create(:sum_billable_metric, name: "sum_metric", organization:) }
+  let(:charge) do
+    create(
+      :graduated_charge,
+      plan: subscription.plan,
+      charge_model: "graduated",
+      billable_metric: metric,
+      properties: {
+        graduated_ranges: [
+          {
+            from_value: 0,
+            to_value: nil,
+            per_unit_amount: "0.01",
+            flat_amount: "0.01"
+          }
+        ]
+      }
+    )
+  end
+  let(:standard_charge) do
+    create(
+      :standard_charge,
+      plan: subscription.plan,
+      billable_metric: sum_metric,
+      properties: {
+        amount: 1.to_s,
+        pricing_group_keys: ["agent_name"]
+      }
+    )
+  end
+  let(:billable_metric_filter) do
+    create(:billable_metric_filter, billable_metric: sum_metric, key: "cloud", values: %w[aws gcp])
+  end
+  let(:charge_filter) { create(:charge_filter, charge: standard_charge, invoice_display_name: nil) }
+  let(:charge_filter_value) do
+    create(:charge_filter_value, charge_filter:, billable_metric_filter:, values: ["aws"])
+  end
   let(:query) do
     <<~GQL
       query($customerId: ID!, $subscriptionId: ID!) {
@@ -37,61 +86,12 @@ RSpec.describe Resolvers::Customers::UsageResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:tax) { create(:tax, organization:, rate: 20) }
+  let_it_be(:membership) { create_default(:membership) }
 
-  let(:customer) { create(:customer, organization:) }
-  let(:subscription) do
-    create(
-      :subscription,
-      plan:,
-      customer:,
-      started_at: Time.zone.now - 2.years
-    )
-  end
-  let(:plan) { create(:plan, interval: "monthly") }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create_default(:plan, interval: "monthly") }
 
-  let(:metric) { create(:billable_metric, name: "count_metric", aggregation_type: "count_agg") }
-  let(:sum_metric) { create(:sum_billable_metric, name: "sum_metric", organization:) }
-  let(:charge) do
-    create(
-      :graduated_charge,
-      plan: subscription.plan,
-      charge_model: "graduated",
-      billable_metric: metric,
-      properties: {
-        graduated_ranges: [
-          {
-            from_value: 0,
-            to_value: nil,
-            per_unit_amount: "0.01",
-            flat_amount: "0.01"
-          }
-        ]
-      }
-    )
-  end
-  let(:standard_charge) do
-    create(
-      :standard_charge,
-      plan: subscription.plan,
-      billable_metric: sum_metric,
-      properties: {
-        amount: 1.to_s,
-        pricing_group_keys: ["agent_name"]
-      }
-    )
-  end
-
-  let(:billable_metric_filter) do
-    create(:billable_metric_filter, billable_metric: sum_metric, key: "cloud", values: %w[aws gcp])
-  end
-
-  let(:charge_filter) { create(:charge_filter, charge: standard_charge, invoice_display_name: nil) }
-  let(:charge_filter_value) do
-    create(:charge_filter_value, charge_filter:, billable_metric_filter:, values: ["aws"])
-  end
+  let_it_be(:metric) { create_default(:billable_metric, name: "count_metric", aggregation_type: "count_agg") }
 
   before do
     subscription

--- a/spec/graphql/resolvers/customers_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers_resolver_spec.rb
@@ -4,10 +4,8 @@ require "rails_helper"
 
 RSpec.describe Resolvers::CustomersResolver do
   let(:required_permission) { "customers:view" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:billing_entity1) { organization.default_billing_entity }
-  let(:billing_entity2) { create(:billing_entity, organization:) }
   let(:query) do
     <<~GQL
       query(
@@ -54,6 +52,10 @@ RSpec.describe Resolvers::CustomersResolver do
       }
     GQL
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:billing_entity2) { create_default(:billing_entity, organization:) }
 
   def test_customers_resolver(expected_customers, variables: {})
     variables = {page: 1, limit: 5}.merge(variables)
@@ -244,7 +246,7 @@ RSpec.describe Resolvers::CustomersResolver do
   end
 
   context "when filtering by search_term" do
-    let!(:john_doe) { create(:customer, organization:, name: "John, Doe", email: "john@doe.com", legal_name: "John-Doe", firstname: "Johnnas", lastname: "Doefe", external_id: "1234567890") }
+    let(:john_doe) { create(:customer, organization:, name: "John, Doe", email: "john@doe.com", legal_name: "John-Doe", firstname: "Johnnas", lastname: "Doefe", external_id: "1234567890") }
 
     before do
       create(:customer, organization:, name: "Jane Doe", email: "jane@doe.com", legal_name: "Jane-Doe", firstname: "Janenas", lastname: "Doefae", external_id: "1234567891")

--- a/spec/graphql/resolvers/data_api/mrrs/plans_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/mrrs/plans_resolver_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::DataApi::Mrrs::PlansResolver, :premium do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "data_api:view" }
+  let(:organization) { membership.organization }
+  let(:body_response) { File.read("spec/fixtures/lago_data_api/mrrs_plans.json") }
   let(:query) do
     <<~GQL
       query($currency: CurrencyEnum, $limit: Int, $page: Int) {
@@ -33,9 +37,7 @@ RSpec.describe Resolvers::DataApi::Mrrs::PlansResolver, :premium do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:body_response) { File.read("spec/fixtures/lago_data_api/mrrs_plans.json") }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/mrrs/#{organization.id}/plans/")

--- a/spec/graphql/resolvers/data_api/mrrs_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/mrrs_resolver_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::DataApi::MrrsResolver, :premium do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "data_api:view" }
+  let(:organization) { membership.organization }
+  let(:body_response) { File.read("spec/fixtures/lago_data_api/mrrs.json") }
   let(:query) do
     <<~GQL
       query($currency: CurrencyEnum) {
@@ -25,9 +29,7 @@ RSpec.describe Resolvers::DataApi::MrrsResolver, :premium do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:body_response) { File.read("spec/fixtures/lago_data_api/mrrs.json") }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/mrrs/#{organization.id}/")

--- a/spec/graphql/resolvers/data_api/prepaid_credits_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/prepaid_credits_resolver_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::DataApi::PrepaidCreditsResolver, :premium do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "data_api:view" }
+  let(:organization) { membership.organization }
+  let(:body_response) { File.read("spec/fixtures/lago_data_api/prepaid_credits.json") }
   let(:query) do
     <<~GQL
       query($currency: CurrencyEnum, $externalCustomerId: String) {
@@ -26,9 +30,7 @@ RSpec.describe Resolvers::DataApi::PrepaidCreditsResolver, :premium do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:body_response) { File.read("spec/fixtures/lago_data_api/prepaid_credits.json") }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/prepaid_credits/#{organization.id}/")

--- a/spec/graphql/resolvers/data_api/revenue_streams/customers_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/revenue_streams/customers_resolver_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::DataApi::RevenueStreams::CustomersResolver, :premium do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "data_api:view" }
+  let(:organization) { membership.organization }
+  let(:body_response) { File.read("spec/fixtures/lago_data_api/revenue_streams_customers.json") }
   let(:query) do
     <<~GQL
       query($currency: CurrencyEnum, $orderBy: OrderByEnum, $limit: Int, $page: Int) {
@@ -31,9 +35,7 @@ RSpec.describe Resolvers::DataApi::RevenueStreams::CustomersResolver, :premium d
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:body_response) { File.read("spec/fixtures/lago_data_api/revenue_streams_customers.json") }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/revenue_streams/#{organization.id}/customers/")

--- a/spec/graphql/resolvers/data_api/revenue_streams/plans_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/revenue_streams/plans_resolver_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::DataApi::RevenueStreams::PlansResolver, :premium do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "data_api:view" }
+  let(:organization) { membership.organization }
+  let(:body_response) { File.read("spec/fixtures/lago_data_api/revenue_streams_plans.json") }
   let(:query) do
     <<~GQL
       query($currency: CurrencyEnum, $orderBy: OrderByEnum, $limit: Int, $page: Int) {
@@ -34,9 +38,7 @@ RSpec.describe Resolvers::DataApi::RevenueStreams::PlansResolver, :premium do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:body_response) { File.read("spec/fixtures/lago_data_api/revenue_streams_plans.json") }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/revenue_streams/#{organization.id}/plans/")

--- a/spec/graphql/resolvers/data_api/revenue_streams_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/revenue_streams_resolver_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::DataApi::RevenueStreamsResolver, :premium do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "data_api:view" }
+  let(:organization) { membership.organization }
+  let(:body_response) { File.read("spec/fixtures/lago_data_api/revenue_streams.json") }
   let(:query) do
     <<~GQL
       query($currency: CurrencyEnum, $externalCustomerId: String) {
@@ -25,9 +29,7 @@ RSpec.describe Resolvers::DataApi::RevenueStreamsResolver, :premium do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:body_response) { File.read("spec/fixtures/lago_data_api/revenue_streams.json") }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/revenue_streams/#{organization.id}/")

--- a/spec/graphql/resolvers/data_api/usages/aggregated_amounts_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/usages/aggregated_amounts_resolver_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::DataApi::Usages::AggregatedAmountsResolver, :premium do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "data_api:view" }
+  let(:organization) { membership.organization }
+  let(:body_response) { File.read("spec/fixtures/lago_data_api/usages_aggregated_amounts.json") }
   let(:query) do
     <<~GQL
       query($currency: CurrencyEnum) {
@@ -19,9 +23,7 @@ RSpec.describe Resolvers::DataApi::Usages::AggregatedAmountsResolver, :premium d
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:body_response) { File.read("spec/fixtures/lago_data_api/usages_aggregated_amounts.json") }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/usages/#{organization.id}/aggregated_amounts/")

--- a/spec/graphql/resolvers/data_api/usages/forecasted_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/usages/forecasted_resolver_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::DataApi::Usages::ForecastedResolver, :premium do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "data_api:view" }
+  let(:organization) { membership.organization }
+  let(:body_response) { File.read("spec/fixtures/lago_data_api/usages_forecasted.json") }
   let(:query) do
     <<~GQL
       query {
@@ -26,9 +30,7 @@ RSpec.describe Resolvers::DataApi::Usages::ForecastedResolver, :premium do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:body_response) { File.read("spec/fixtures/lago_data_api/usages_forecasted.json") }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/usages/#{organization.id}/forecasted/")

--- a/spec/graphql/resolvers/data_api/usages/invoiced_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/usages/invoiced_resolver_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::DataApi::Usages::InvoicedResolver, :premium do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "data_api:view" }
+  let(:organization) { membership.organization }
+  let(:body_response) { File.read("spec/fixtures/lago_data_api/usages_invoiced.json") }
   let(:query) do
     <<~GQL
       query($currency: CurrencyEnum) {
@@ -20,9 +24,7 @@ RSpec.describe Resolvers::DataApi::Usages::InvoicedResolver, :premium do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:body_response) { File.read("spec/fixtures/lago_data_api/usages_invoiced.json") }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/usages/#{organization.id}/invoiced/")

--- a/spec/graphql/resolvers/data_api/usages_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/usages_resolver_spec.rb
@@ -3,7 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::DataApi::UsagesResolver, :premium do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "data_api:view" }
+  let(:organization) { membership.organization }
+  let(:body_response) { File.read("spec/fixtures/lago_data_api/usages.json") }
+  let(:params) { {time_granularity: "daily", billing_entity_code: "code"} }
   let(:query) do
     <<~GQL
       query($currency: CurrencyEnum, $externalCustomerId: String, $billingEntityCode: String) {
@@ -21,10 +26,7 @@ RSpec.describe Resolvers::DataApi::UsagesResolver, :premium do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:body_response) { File.read("spec/fixtures/lago_data_api/usages.json") }
-  let(:params) { {time_granularity: "daily", billing_entity_code: "code"} }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/usages/#{organization.id}/")

--- a/spec/graphql/resolvers/dunning_campaign_resolver_spec.rb
+++ b/spec/graphql/resolvers/dunning_campaign_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::DunningCampaignResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   subject(:result) do
     execute_graphql(
       current_user: membership.user,
@@ -14,6 +16,9 @@ RSpec.describe Resolvers::DunningCampaignResolver do
   end
 
   let(:required_permission) { "dunning_campaigns:view" }
+  let(:organization) { membership.organization }
+  let(:dunning_campaign) { create(:dunning_campaign, organization:, bcc_emails: %w[earl@example.com]) }
+  let(:dunning_campaign_threshold) { create(:dunning_campaign_threshold, dunning_campaign:) }
   let(:query) do
     <<~GQL
       query($dunningCampaignId: ID!) {
@@ -36,10 +41,7 @@ RSpec.describe Resolvers::DunningCampaignResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:dunning_campaign) { create(:dunning_campaign, organization:, bcc_emails: %w[earl@example.com]) }
-  let(:dunning_campaign_threshold) { create(:dunning_campaign_threshold, dunning_campaign:) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     dunning_campaign

--- a/spec/graphql/resolvers/dunning_campaigns_resolver_spec.rb
+++ b/spec/graphql/resolvers/dunning_campaigns_resolver_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::DunningCampaignsResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "dunning_campaigns:view" }
+  let(:organization) { membership.organization }
+  let(:dunning_campaign) { create(:dunning_campaign, organization:) }
   let(:query) do
     <<~GQL
       query {
@@ -15,9 +19,7 @@ RSpec.describe Resolvers::DunningCampaignsResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:dunning_campaign) { create(:dunning_campaign, organization:) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before { dunning_campaign }
 

--- a/spec/graphql/resolvers/entitlement/feature_resolver_spec.rb
+++ b/spec/graphql/resolvers/entitlement/feature_resolver_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Resolvers::Entitlement::FeatureResolver, :premium do
   subject { execute_query(query:, variables:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:required_permission) { "features:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/entitlement/features_resolver_spec.rb
+++ b/spec/graphql/resolvers/entitlement/features_resolver_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Resolvers::Entitlement::FeaturesResolver, :premium do
   subject { execute_query(query:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:required_permission) { "features:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/entitlement/subscription_entitlement_resolver_spec.rb
+++ b/spec/graphql/resolvers/entitlement/subscription_entitlement_resolver_spec.rb
@@ -5,8 +5,9 @@ require "rails_helper"
 RSpec.describe Resolvers::Entitlement::SubscriptionEntitlementResolver, :premium do
   subject { execute_query(query:, variables:) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
+  let(:customer) { create(:customer) }
   let(:subscription) { create(:subscription, organization:, plan:) }
   let(:required_permission) { "subscriptions:view" }
   let(:query) do

--- a/spec/graphql/resolvers/entitlement/subscription_entitlements_resolver_spec.rb
+++ b/spec/graphql/resolvers/entitlement/subscription_entitlements_resolver_spec.rb
@@ -5,8 +5,10 @@ require "rails_helper"
 RSpec.describe Resolvers::Entitlement::SubscriptionEntitlementsResolver, :premium do
   subject { execute_query(query:, variables:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:plan) { create(:plan, organization:) }
+  let(:customer) { create(:customer) }
   let(:subscription) { create(:subscription, organization:, plan:) }
   let(:required_permission) { "subscriptions:view" }
   let(:query) do

--- a/spec/graphql/resolvers/integration_items_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_items_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::IntegrationItemsResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "organization:integrations:view" }
   let(:query) do
     <<~GQL
@@ -19,7 +21,8 @@ RSpec.describe Resolvers::IntegrationItemsResolver do
   let(:integration_item2) { create(:integration_item, item_type: "tax", integration:) }
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     integration_item

--- a/spec/graphql/resolvers/integration_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_resolver_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::IntegrationResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "organization:integrations:view" }
+  let(:organization) { membership.organization }
+  let(:netsuite_integration) { create(:netsuite_integration, organization:) }
   let(:query) do
     <<~GQL
       query($integrationId: ID!) {
@@ -20,10 +24,8 @@ RSpec.describe Resolvers::IntegrationResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:netsuite_integration) { create(:netsuite_integration, organization:) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     customer

--- a/spec/graphql/resolvers/integrations/subsidiaries_resolver_spec.rb
+++ b/spec/graphql/resolvers/integrations/subsidiaries_resolver_spec.rb
@@ -3,7 +3,24 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::Integrations::SubsidiariesResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "organization:integrations:view" }
+  let(:organization) { membership.organization }
+  let(:integration) { create(:netsuite_integration, organization:) }
+  let(:lago_client) { instance_double(LagoHttpClient::Client) }
+  let(:subsidiaries_endpoint) { "https://api.nango.dev/v1/netsuite/subsidiaries" }
+  let(:headers) do
+    {
+      "Connection-Id" => integration.connection_id,
+      "Authorization" => "Bearer #{ENV["NANGO_SECRET_KEY"]}",
+      "Provider-Config-Key" => "netsuite-tba"
+    }
+  end
+  let(:aggregator_response) do
+    path = Rails.root.join("spec/fixtures/integration_aggregator/subsidiaries_response.json")
+    JSON.parse(File.read(path))
+  end
   let(:query) do
     <<~GQL
       query($integrationId: ID!) {
@@ -14,24 +31,7 @@ RSpec.describe Resolvers::Integrations::SubsidiariesResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:integration) { create(:netsuite_integration, organization:) }
-  let(:lago_client) { instance_double(LagoHttpClient::Client) }
-  let(:subsidiaries_endpoint) { "https://api.nango.dev/v1/netsuite/subsidiaries" }
-
-  let(:headers) do
-    {
-      "Connection-Id" => integration.connection_id,
-      "Authorization" => "Bearer #{ENV["NANGO_SECRET_KEY"]}",
-      "Provider-Config-Key" => "netsuite-tba"
-    }
-  end
-
-  let(:aggregator_response) do
-    path = Rails.root.join("spec/fixtures/integration_aggregator/subsidiaries_response.json")
-    JSON.parse(File.read(path))
-  end
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     allow(LagoHttpClient::Client).to receive(:new)

--- a/spec/graphql/resolvers/integrations_resolver_spec.rb
+++ b/spec/graphql/resolvers/integrations_resolver_spec.rb
@@ -3,7 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::IntegrationsResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "customers:view" }
+  let(:organization) { membership.organization }
+  let(:netsuite_integration) { create(:netsuite_integration, organization:) }
+  let(:xero_integration) { create(:xero_integration, organization:) }
   let(:query) do
     <<~GQL
       query {
@@ -21,10 +26,7 @@ RSpec.describe Resolvers::IntegrationsResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:netsuite_integration) { create(:netsuite_integration, organization:) }
-  let(:xero_integration) { create(:xero_integration, organization:) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     netsuite_integration

--- a/spec/graphql/resolvers/invite_resolver_spec.rb
+++ b/spec/graphql/resolvers/invite_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::InviteResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query($token: String!) {
@@ -18,10 +20,10 @@ RSpec.describe Resolvers::InviteResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:invite) { create(:invite, organization:) }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   it "returns a single invite" do
     result = execute_graphql(

--- a/spec/graphql/resolvers/invites_resolver_spec.rb
+++ b/spec/graphql/resolvers/invites_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::InvitesResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query {
@@ -13,10 +15,10 @@ RSpec.describe Resolvers::InvitesResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:invite) { create(:invite, organization:) }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   it "returns a list of invites" do
     result = execute_graphql(

--- a/spec/graphql/resolvers/invoice_build_regeneration_preview_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_build_regeneration_preview_resolver_spec.rb
@@ -3,7 +3,29 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::InvoiceBuildRegenerationPreviewResolver do
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:add_on) { create_default(:add_on) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "invoices:view" }
+  let(:organization) { membership.organization }
+  let(:invoice_subscription) { create(:invoice_subscription, invoice:) }
+  let(:invoice) { create(:invoice, customer:, organization:, fees_amount_cents: 10, taxes_rate: 15) }
+  let(:subscription) { invoice_subscription.subscription }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:charge) { create(:standard_charge, plan: subscription.plan) }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:fee) do
+    create(:fee, subscription:, invoice:, amount_cents: 50)
+  end
+  let(:charge_fee) do
+    create(:charge_fee, subscription:, invoice:, amount_cents: 250, charge:)
+  end
+  let(:fixed_charge) { create(:fixed_charge, plan: subscription.plan) }
+  let(:fixed_charge_fee) do
+    create(:fixed_charge_fee, subscription:, invoice:, amount_cents: 150, fixed_charge:)
+  end
   let(:query) do
     <<~GQL
       query($id: ID!) {
@@ -254,25 +276,8 @@ RSpec.describe Resolvers::InvoiceBuildRegenerationPreviewResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:invoice_subscription) { create(:invoice_subscription, invoice:) }
-  let(:invoice) { create(:invoice, customer:, organization:, fees_amount_cents: 10, taxes_rate: 15) }
-  let(:subscription) { invoice_subscription.subscription }
-  let(:billable_metric) { create(:billable_metric, organization:) }
-  let(:charge) { create(:standard_charge, plan: subscription.plan) }
-  let(:add_on) { create(:add_on, organization:) }
-  let(:fee) do
-    create(:fee, subscription:, invoice:, amount_cents: 50)
-  end
-  let(:charge_fee) do
-    create(:charge_fee, subscription:, invoice:, amount_cents: 250, charge:)
-  end
-  let(:fixed_charge) { create(:fixed_charge, plan: subscription.plan) }
-  let(:fixed_charge_fee) do
-    create(:fixed_charge_fee, subscription:, invoice:, amount_cents: 150, fixed_charge:)
-  end
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     fee

--- a/spec/graphql/resolvers/invoice_credit_notes_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_credit_notes_resolver_spec.rb
@@ -3,7 +3,14 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::InvoiceCreditNotesResolver do
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "credit_notes:view" }
+  let(:organization) { membership.organization }
+  let(:invoice) { create(:invoice, customer:, organization:) }
+  let(:subscription) { create(:subscription, customer:, organization:) }
+  let(:credit_note) { create(:credit_note, organization:, customer:, invoice:) }
   let(:query) do
     <<~GQL
       query($invoiceId: ID!) {
@@ -15,12 +22,8 @@ RSpec.describe Resolvers::InvoiceCreditNotesResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:invoice) { create(:invoice, customer:, organization:) }
-  let(:subscription) { create(:subscription, customer:, organization:) }
-  let(:credit_note) { create(:credit_note, organization:, customer:, invoice:) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     subscription

--- a/spec/graphql/resolvers/invoice_custom_section_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_custom_section_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::InvoiceCustomSectionResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query($invoiceCustomSectionId: ID!) {
@@ -12,10 +14,10 @@ RSpec.describe Resolvers::InvoiceCustomSectionResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:invoice_custom_section) { create(:invoice_custom_section, organization:) }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before { invoice_custom_section }
 

--- a/spec/graphql/resolvers/invoice_custom_sections_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_custom_sections_resolver_spec.rb
@@ -3,7 +3,16 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::InvoiceCustomSectionsResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "invoice_custom_sections:view" }
+  let(:organization) { membership.organization }
+  let(:billing_entity) { create(:billing_entity, organization:) }
+  let(:customer) { create(:customer, organization:, billing_entity:) }
+  let(:invoice_custom_section_1_manual) { create(:invoice_custom_section, organization:, name: "x") }
+  let(:invoice_custom_section_2_manual) { create(:invoice_custom_section, organization:, name: "a") }
+  let(:invoice_custom_section_3_manual) { create(:invoice_custom_section, organization:, name: "c") }
+  let(:invoice_custom_section_4_system_generated) { create(:invoice_custom_section, :system_generated, organization:, name: "not show") }
   let(:query) do
     <<~GQL
       query() {
@@ -15,14 +24,7 @@ RSpec.describe Resolvers::InvoiceCustomSectionsResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:billing_entity) { create(:billing_entity, organization:) }
-  let(:customer) { create(:customer, organization:, billing_entity:) }
-  let(:invoice_custom_section_1_manual) { create(:invoice_custom_section, organization:, name: "x") }
-  let(:invoice_custom_section_2_manual) { create(:invoice_custom_section, organization:, name: "a") }
-  let(:invoice_custom_section_3_manual) { create(:invoice_custom_section, organization:, name: "c") }
-  let(:invoice_custom_section_4_system_generated) { create(:invoice_custom_section, :system_generated, organization:, name: "not show") }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     invoice_custom_section_1_manual

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -4,6 +4,46 @@ require "rails_helper"
 
 RSpec.describe Resolvers::InvoiceResolver do
   let(:required_permission) { "invoices:view" }
+  let(:customer) { create(:customer, organization:) }
+  let(:invoice_subscription) { create(:invoice_subscription, invoice:) }
+  let(:invoice) { create(:invoice, customer:, organization:, fees_amount_cents: 10) }
+  let(:subscription) { invoice_subscription.subscription }
+  let(:fee) do
+    create(:fee, subscription:, invoice:, amount_cents: 10, properties: {
+      from_datetime: Time.current.beginning_of_month,
+      to_datetime: Time.current.end_of_month,
+      charges_from_datetime: Time.current.beginning_of_month - 1.month,
+      charges_to_datetime: Time.current.end_of_month - 1.month,
+      fixed_charges_from_datetime: Time.current.beginning_of_month + 1.month,
+      fixed_charges_to_datetime: Time.current.end_of_month + 1.month
+    }, presentation_breakdowns: [build(:presentation_breakdown, organization:)])
+  end
+  let(:charge_with_display_keys) do
+    create(:standard_charge, properties: {
+      "amount" => "100",
+      "presentation_group_keys" => [{"value" => "department", "options" => {"display_in_invoice" => true}}]
+    })
+  end
+  let(:charge_fee) do
+    create(:charge_fee, charge: charge_with_display_keys, subscription:, invoice:, amount_cents: 10, properties: {
+      from_datetime: Time.current.beginning_of_month,
+      to_datetime: Time.current.end_of_month,
+      charges_from_datetime: Time.current.beginning_of_month - 1.month,
+      charges_to_datetime: Time.current.end_of_month - 1.month,
+      fixed_charges_from_datetime: Time.current.beginning_of_month + 1.month,
+      fixed_charges_to_datetime: Time.current.end_of_month + 1.month
+    }, presentation_breakdowns: [build(:presentation_breakdown, organization:)])
+  end
+  let(:fixed_charge_fee) do
+    create(:fixed_charge_fee, subscription:, invoice:, amount_cents: 10, properties: {
+      from_datetime: Time.current.beginning_of_month,
+      to_datetime: Time.current.end_of_month,
+      charges_from_datetime: Time.current.beginning_of_month - 1.month,
+      charges_to_datetime: Time.current.end_of_month - 1.month,
+      fixed_charges_from_datetime: Time.current.beginning_of_month + 1.month,
+      fixed_charges_to_datetime: Time.current.end_of_month + 1.month
+    }, presentation_breakdowns: [build(:presentation_breakdown, organization:)])
+  end
   let(:query) do
     <<~GQL
       query($id: ID!) {
@@ -116,46 +156,6 @@ RSpec.describe Resolvers::InvoiceResolver do
   let_it_be(:add_on) { create_default(:add_on) }
   let_it_be(:plan) { create_default(:plan) }
   let_it_be(:membership) { create_default(:membership) }
-  let(:customer) { create(:customer, organization:) }
-  let(:invoice_subscription) { create(:invoice_subscription, invoice:) }
-  let(:invoice) { create(:invoice, customer:, organization:, fees_amount_cents: 10) }
-  let(:subscription) { invoice_subscription.subscription }
-  let(:fee) do
-    create(:fee, subscription:, invoice:, amount_cents: 10, properties: {
-      from_datetime: Time.current.beginning_of_month,
-      to_datetime: Time.current.end_of_month,
-      charges_from_datetime: Time.current.beginning_of_month - 1.month,
-      charges_to_datetime: Time.current.end_of_month - 1.month,
-      fixed_charges_from_datetime: Time.current.beginning_of_month + 1.month,
-      fixed_charges_to_datetime: Time.current.end_of_month + 1.month
-    }, presentation_breakdowns: [build(:presentation_breakdown, organization:)])
-  end
-  let(:charge_with_display_keys) do
-    create(:standard_charge, properties: {
-      "amount" => "100",
-      "presentation_group_keys" => [{"value" => "department", "options" => {"display_in_invoice" => true}}]
-    })
-  end
-  let(:charge_fee) do
-    create(:charge_fee, charge: charge_with_display_keys, subscription:, invoice:, amount_cents: 10, properties: {
-      from_datetime: Time.current.beginning_of_month,
-      to_datetime: Time.current.end_of_month,
-      charges_from_datetime: Time.current.beginning_of_month - 1.month,
-      charges_to_datetime: Time.current.end_of_month - 1.month,
-      fixed_charges_from_datetime: Time.current.beginning_of_month + 1.month,
-      fixed_charges_to_datetime: Time.current.end_of_month + 1.month
-    }, presentation_breakdowns: [build(:presentation_breakdown, organization:)])
-  end
-  let(:fixed_charge_fee) do
-    create(:fixed_charge_fee, subscription:, invoice:, amount_cents: 10, properties: {
-      from_datetime: Time.current.beginning_of_month,
-      to_datetime: Time.current.end_of_month,
-      charges_from_datetime: Time.current.beginning_of_month - 1.month,
-      charges_to_datetime: Time.current.end_of_month - 1.month,
-      fixed_charges_from_datetime: Time.current.beginning_of_month + 1.month,
-      fixed_charges_to_datetime: Time.current.end_of_month + 1.month
-    }, presentation_breakdowns: [build(:presentation_breakdown, organization:)])
-  end
 
   before do
     fee

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -111,8 +111,11 @@ RSpec.describe Resolvers::InvoiceResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:add_on) { create_default(:add_on) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:membership) { create_default(:membership) }
   let(:customer) { create(:customer, organization:) }
   let(:invoice_subscription) { create(:invoice_subscription, invoice:) }
   let(:invoice) { create(:invoice, customer:, organization:, fees_amount_cents: 10) }

--- a/spec/graphql/resolvers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoices_resolver_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 RSpec.describe Resolvers::InvoicesResolver do
   let(:required_permission) { "invoices:view" }
+  let(:customer_first) { create(:customer, organization:) }
+  let(:customer_second) { create(:customer, organization:) }
   let(:organization) { membership.organization }
   let(:invoice_first) do
     create(:invoice, customer: customer_first, payment_status: :pending, status: :finalized, organization:)
@@ -24,8 +26,6 @@ RSpec.describe Resolvers::InvoicesResolver do
 
   let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create_default(:membership) }
-  let(:customer_first) { create(:customer, organization:) }
-  let(:customer_second) { create(:customer, organization:) }
 
   before do
     invoice_first

--- a/spec/graphql/resolvers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoices_resolver_spec.rb
@@ -4,6 +4,13 @@ require "rails_helper"
 
 RSpec.describe Resolvers::InvoicesResolver do
   let(:required_permission) { "invoices:view" }
+  let(:organization) { membership.organization }
+  let(:invoice_first) do
+    create(:invoice, customer: customer_first, payment_status: :pending, status: :finalized, organization:)
+  end
+  let(:invoice_second) do
+    create(:invoice, customer: customer_second, payment_status: :succeeded, status: :finalized, organization:)
+  end
   let(:query) do
     <<~GQL
       query {
@@ -15,16 +22,10 @@ RSpec.describe Resolvers::InvoicesResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
   let(:customer_first) { create(:customer, organization:) }
   let(:customer_second) { create(:customer, organization:) }
-  let(:invoice_first) do
-    create(:invoice, customer: customer_first, payment_status: :pending, status: :finalized, organization:)
-  end
-  let(:invoice_second) do
-    create(:invoice, customer: customer_second, payment_status: :succeeded, status: :finalized, organization:)
-  end
 
   before do
     invoice_first

--- a/spec/graphql/resolvers/memberships_resolver_spec.rb
+++ b/spec/graphql/resolvers/memberships_resolver_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Resolvers::MembershipsResolver do
     GQL
   end
 
-  let(:membership) { create(:membership, roles: %i[admin]) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership, roles: %i[admin]) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"
@@ -54,11 +54,10 @@ RSpec.describe Resolvers::MembershipsResolver do
   end
 
   describe "traversal attack attempt" do
-    let!(:other_org) { create(:organization) }
-
-    let(:other_user) { create(:user) }
-    let(:other_user_membership) { create(:membership, user: other_user, organization:) }
-    let(:other_user_other_membership) { create(:membership, user: other_user, organization: other_org) }
+    let_it_be(:other_org) { create(:organization) }
+    let_it_be(:other_user) { create(:user) }
+    let_it_be(:other_user_membership) { create(:membership, user: other_user, organization:) }
+    let_it_be(:other_user_other_membership) { create(:membership, user: other_user, organization: other_org) }
 
     let(:query) do
       <<~GQL

--- a/spec/graphql/resolvers/order_form_resolver_spec.rb
+++ b/spec/graphql/resolvers/order_form_resolver_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::OrderFormResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "order_forms:view" }
+  let(:organization) { membership.organization }
+  let(:order_form) { create(:order_form, organization:, customer:) }
 
   let(:query) do
     <<~GQL
@@ -25,10 +29,8 @@ RSpec.describe Resolvers::OrderFormResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:order_form) { create(:order_form, organization:, customer:) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before { order_form }
 

--- a/spec/graphql/resolvers/order_forms_resolver_spec.rb
+++ b/spec/graphql/resolvers/order_forms_resolver_spec.rb
@@ -3,13 +3,15 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::OrderFormsResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "order_forms:view" }
+  let(:organization) { membership.organization }
+  let!(:order_form) { create(:order_form, organization:, customer:) }
   let(:query) {}
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let!(:order_form) { create(:order_form, organization:, customer:) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before { create(:order_form, :signed, organization:, customer:) }
 

--- a/spec/graphql/resolvers/order_resolver_spec.rb
+++ b/spec/graphql/resolvers/order_resolver_spec.rb
@@ -3,7 +3,13 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::OrderResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "orders:view" }
+  let(:organization) { membership.organization }
+  let(:quote) { create(:quote, organization:, customer:) }
+  let(:order_form) { create(:order_form, :signed, organization:, customer:, quote:) }
+  let(:order) { create(:order, organization:, customer:, order_form:) }
 
   let(:query) do
     <<~GQL
@@ -21,12 +27,8 @@ RSpec.describe Resolvers::OrderResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:quote) { create(:quote, organization:, customer:) }
-  let(:order_form) { create(:order_form, :signed, organization:, customer:, quote:) }
-  let(:order) { create(:order, organization:, customer:, order_form:) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before { order }
 

--- a/spec/graphql/resolvers/orders_resolver_spec.rb
+++ b/spec/graphql/resolvers/orders_resolver_spec.rb
@@ -3,17 +3,19 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::OrdersResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "orders:view" }
-  let(:query) {}
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:order_form) { create(:order_form, :signed, organization:, customer:, quote:) }
   let(:quote_two) { create(:quote, organization:, customer:) }
   let(:order_form_two) { create(:order_form, :signed, organization:, customer:, quote: quote_two) }
   let!(:order_two) { create(:order, organization:, customer:, order_form: order_form_two) }
+  let(:query) {}
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before { create(:order, organization:, customer:, order_form:) }
 

--- a/spec/graphql/resolvers/organization_resolver_spec.rb
+++ b/spec/graphql/resolvers/organization_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::OrganizationResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query {
@@ -15,9 +17,9 @@ RSpec.describe Resolvers::OrganizationResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   it "returns the current organization" do
     result = execute_graphql(

--- a/spec/graphql/resolvers/payment_methods_resolver_spec.rb
+++ b/spec/graphql/resolvers/payment_methods_resolver_spec.rb
@@ -4,11 +4,12 @@ require "rails_helper"
 
 RSpec.describe Resolvers::PaymentMethodsResolver do
   let(:required_permission) { "payment_methods:view" }
-
   let(:payment_method) { create(:payment_method, customer:, organization:) }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
+
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     payment_method

--- a/spec/graphql/resolvers/payment_provider_customers/payment_methods_resolver_spec.rb
+++ b/spec/graphql/resolvers/payment_provider_customers/payment_methods_resolver_spec.rb
@@ -3,18 +3,16 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::PaymentProviderCustomers::PaymentMethodsResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permissions) { %w[customers:view payment_methods:view] }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:, payment_provider: "stripe") }
   let(:connection) { create(:stripe_customer, customer:, organization:) }
   let(:other_connection) { create(:gocardless_customer, customer:, organization:) }
-
   let(:payment_method) { create(:payment_method, customer:, organization:, payment_provider_customer: connection) }
   let(:other_payment_method) do
     create(:payment_method, customer:, organization:, payment_provider_customer: other_connection, is_default: false)
   end
-
   let(:query) do
     <<~GQL
       query($id: ID!, $withDeleted: Boolean) {
@@ -31,6 +29,9 @@ RSpec.describe Resolvers::PaymentProviderCustomers::PaymentMethodsResolver do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:, payment_provider: "stripe") }
 
   before do
     connection

--- a/spec/graphql/resolvers/payment_provider_resolver_spec.rb
+++ b/spec/graphql/resolvers/payment_provider_resolver_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::PaymentProviderResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "organization:integrations:view" }
+  let(:organization) { membership.organization }
+  let(:stripe_provider) { create(:stripe_provider, organization:) }
   let(:query) do
     <<~GQL
       query($paymentProviderId: ID!) {
@@ -37,10 +41,8 @@ RSpec.describe Resolvers::PaymentProviderResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:stripe_provider) { create(:stripe_provider, organization:) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     customer

--- a/spec/graphql/resolvers/payment_providers_resolver_spec.rb
+++ b/spec/graphql/resolvers/payment_providers_resolver_spec.rb
@@ -3,7 +3,14 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::PaymentProvidersResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "customers:view" }
+  let(:organization) { membership.organization }
+  let(:adyen_provider) { create(:adyen_provider, organization:) }
+  let(:cashfree_provider) { create(:cashfree_provider, organization:) }
+  let(:gocardless_provider) { create(:gocardless_provider, organization:) }
+  let(:stripe_provider) { create(:stripe_provider, organization:) }
   let(:query) do
     <<~GQL
       query {
@@ -36,12 +43,7 @@ RSpec.describe Resolvers::PaymentProvidersResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:adyen_provider) { create(:adyen_provider, organization:) }
-  let(:cashfree_provider) { create(:cashfree_provider, organization:) }
-  let(:gocardless_provider) { create(:gocardless_provider, organization:) }
-  let(:stripe_provider) { create(:stripe_provider, organization:) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     adyen_provider

--- a/spec/graphql/resolvers/payment_requests_resolver_spec.rb
+++ b/spec/graphql/resolvers/payment_requests_resolver_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::PaymentRequestsResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "payments:view" }
+  let(:organization) { membership.organization }
+  let(:payment_request) { create(:payment_request, organization:, customer:) }
   let(:filters) { "limit: 5" }
   let(:query) do
     <<~GQL
@@ -21,10 +25,8 @@ RSpec.describe Resolvers::PaymentRequestsResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:payment_request) { create(:payment_request, organization:, customer:) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     payment_request

--- a/spec/graphql/resolvers/payment_resolver_spec.rb
+++ b/spec/graphql/resolvers/payment_resolver_spec.rb
@@ -3,7 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::PaymentResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "payments:view" }
+  let(:organization) { membership.organization }
+  let(:invoice) { create(:invoice, customer:, organization:, fees_amount_cents: 10) }
+  let(:payment) { create(:payment, payable: invoice) }
 
   let(:query) do
     <<~GQL
@@ -15,11 +20,8 @@ RSpec.describe Resolvers::PaymentResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:invoice) { create(:invoice, customer:, organization:, fees_amount_cents: 10) }
-  let(:payment) { create(:payment, payable: invoice) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before { payment }
 

--- a/spec/graphql/resolvers/payments_resolver_spec.rb
+++ b/spec/graphql/resolvers/payments_resolver_spec.rb
@@ -4,14 +4,16 @@ require "rails_helper"
 
 RSpec.describe Resolvers::PaymentsResolver do
   let(:required_permission) { "payments:view" }
-  let(:query) {}
-
   let!(:payment) { create(:payment, payable: invoice1) }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
   let(:invoice1) { create(:invoice, customer:, organization:) }
   let(:invoice2) { create(:invoice, customer:, organization:) }
+  let(:query) {}
+
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:organization) { create_default(:organization) }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     create(:payment, payable: invoice2)

--- a/spec/graphql/resolvers/plan_applied_rate_cards_resolver_spec.rb
+++ b/spec/graphql/resolvers/plan_applied_rate_cards_resolver_spec.rb
@@ -3,6 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::PlanAppliedRateCardsResolver do
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   subject(:execution) do
     execute_graphql(
       current_user: membership.user,
@@ -14,11 +17,8 @@ RSpec.describe Resolvers::PlanAppliedRateCardsResolver do
   end
 
   let(:required_permission) { "plans:view" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
   let!(:plan_rate_card) { create(:plan_rate_card, organization:, plan:) }
-
   let(:query) do
     <<~GQL
       query($planId: ID) {
@@ -29,6 +29,9 @@ RSpec.describe Resolvers::PlanAppliedRateCardsResolver do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/plan_resolver_spec.rb
+++ b/spec/graphql/resolvers/plan_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::PlanResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   subject(:result) do
     execute_graphql(
       current_user: membership.user,
@@ -14,6 +16,11 @@ RSpec.describe Resolvers::PlanResolver do
   end
 
   let(:required_permission) { "plans:view" }
+  let(:organization) { membership.organization }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:) }
+  let(:usage_threshold) { create(:usage_threshold, plan:, amount_cents: 100) }
   let(:query) do
     <<~GQL
       query($planId: ID!) {
@@ -70,15 +77,9 @@ RSpec.describe Resolvers::PlanResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
-
-  let(:add_on) { create(:add_on, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
-  let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:) }
-  let(:usage_threshold) { create(:usage_threshold, plan:, amount_cents: 100) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
 
   before do
     customer

--- a/spec/graphql/resolvers/plans_resolver_spec.rb
+++ b/spec/graphql/resolvers/plans_resolver_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::PlansResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "plans:view" }
+  let(:plan) { create(:plan, organization:) }
   let(:query) do
     <<~GQL
       query($withDeleted: Boolean) {
@@ -15,10 +18,10 @@ RSpec.describe Resolvers::PlansResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:plan) { create(:plan, organization:) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:membership) { create_default(:membership) }
+
+  let_it_be(:organization) { membership.organization }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     plan

--- a/spec/graphql/resolvers/pricing_unit_resolver_spec.rb
+++ b/spec/graphql/resolvers/pricing_unit_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::PricingUnitResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   subject(:result) do
     execute_graphql(
       current_user: membership.user,
@@ -22,10 +24,10 @@ RSpec.describe Resolvers::PricingUnitResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:required_permission) { "pricing_units:view" }
   let(:pricing_unit) { create(:pricing_unit, organization: membership.organization) }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/pricing_units_resolver_spec.rb
+++ b/spec/graphql/resolvers/pricing_units_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::PricingUnitsResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   subject(:result) do
     execute_graphql(
       current_user: membership.user,
@@ -27,11 +29,11 @@ RSpec.describe Resolvers::PricingUnitsResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:required_permission) { "pricing_units:view" }
   let(:pricing_unit) { create(:pricing_unit, name: "Compute token", organization:) }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     create(:pricing_unit, name: "Cloud token", organization:)

--- a/spec/graphql/resolvers/product_categories_resolver_spec.rb
+++ b/spec/graphql/resolvers/product_categories_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::ProductCategoriesResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   subject(:execution) do
     execute_graphql(
       current_user: membership.user,
@@ -14,10 +16,8 @@ RSpec.describe Resolvers::ProductCategoriesResolver do
   end
 
   let(:required_permission) { "product_categories:view" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:variables) { {} }
-
   let(:query) do
     <<~GQL
       query($searchTerm: String) {
@@ -28,8 +28,9 @@ RSpec.describe Resolvers::ProductCategoriesResolver do
       }
     GQL
   end
-
   let!(:product_category) { create(:product_category, organization:, name: "Cards", code: "cards") }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/product_filter_resolver_spec.rb
+++ b/spec/graphql/resolvers/product_filter_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::ProductFilterResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   subject(:execution) do
     execute_graphql(
       current_user: membership.user,
@@ -14,10 +16,8 @@ RSpec.describe Resolvers::ProductFilterResolver do
   end
 
   let(:required_permission) { "product_filters:view" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:product_filter) { create(:product_filter, :with_values, organization:) }
-
   let(:query) do
     <<~GQL
       query($filterId: ID!) {
@@ -28,6 +28,8 @@ RSpec.describe Resolvers::ProductFilterResolver do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/product_filter_resolver_spec.rb
+++ b/spec/graphql/resolvers/product_filter_resolver_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::ProductFilterResolver do
-  let_it_be(:organization) { create_default(:organization) }
-  let_it_be(:user) { create_default(:user) }
   subject(:execution) do
     execute_graphql(
       current_user: membership.user,
@@ -15,8 +13,9 @@ RSpec.describe Resolvers::ProductFilterResolver do
     )
   end
 
-  let(:required_permission) { "product_filters:view" }
+  let_it_be(:membership) { create_default(:membership) }
   let(:organization) { membership.organization }
+  let(:required_permission) { "product_filters:view" }
   let(:product_filter) { create(:product_filter, :with_values, organization:) }
   let(:query) do
     <<~GQL
@@ -28,8 +27,6 @@ RSpec.describe Resolvers::ProductFilterResolver do
       }
     GQL
   end
-
-  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/products_resolver_spec.rb
+++ b/spec/graphql/resolvers/products_resolver_spec.rb
@@ -3,6 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::ProductsResolver do
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   subject(:execution) do
     execute_graphql(
       current_user: membership.user,
@@ -14,10 +17,8 @@ RSpec.describe Resolvers::ProductsResolver do
   end
 
   let(:required_permission) { "products:view" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:variables) { {} }
-
   let(:query) do
     <<~GQL
       query($searchTerm: String, $productType: ProductTypeEnum, $productCategoryIds: [ID!], $withoutProductCategory: Boolean) {
@@ -28,10 +29,11 @@ RSpec.describe Resolvers::ProductsResolver do
       }
     GQL
   end
-
   let(:product_category) { create(:product_category, organization:) }
   let!(:usage_item) { create(:product, organization:, product_category:, name: "Storage", code: "storage") }
   let!(:fixed_item) { create(:product, :fixed, :standalone, organization:, name: "Seats", code: "seats") }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/quote_resolver_spec.rb
+++ b/spec/graphql/resolvers/quote_resolver_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::QuoteResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "quotes:view" }
+  let(:organization) { membership.organization }
   let(:query) do
     <<-GQL
       query($quoteId: ID!) {
@@ -25,9 +28,9 @@ RSpec.describe Resolvers::QuoteResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:membership) { create_default(:membership) }
+
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/quote_version_resolver_spec.rb
+++ b/spec/graphql/resolvers/quote_version_resolver_spec.rb
@@ -3,7 +3,22 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::QuoteVersionResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "quotes:view" }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:quote) { create(:quote, organization:, customer:) }
+  let(:quote_version) do
+    create(
+      :quote_version,
+      organization:,
+      quote:,
+      content: "Some content",
+      billing_items: {"foo" => "bar"},
+      currency: "EUR"
+    )
+  end
   let(:query) do
     <<-GQL
       query($id: ID!) {
@@ -21,20 +36,7 @@ RSpec.describe Resolvers::QuoteVersionResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:quote) { create(:quote, organization:, customer:) }
-  let(:quote_version) do
-    create(
-      :quote_version,
-      organization:,
-      quote:,
-      content: "Some content",
-      billing_items: {"foo" => "bar"},
-      currency: "EUR"
-    )
-  end
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/quotes_resolver_spec.rb
+++ b/spec/graphql/resolvers/quotes_resolver_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::QuotesResolver do
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "quotes:view" }
   let(:query) do
     <<~GQL
@@ -15,9 +16,9 @@ RSpec.describe Resolvers::QuotesResolver do
     GQL
   end
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:membership) { create(:membership, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:membership) { create_default(:membership, organization:) }
 
   before do
     (1..3).each do |version|

--- a/spec/graphql/resolvers/rate_card_rates_resolver_spec.rb
+++ b/spec/graphql/resolvers/rate_card_rates_resolver_spec.rb
@@ -3,6 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::RateCardRatesResolver do
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   subject(:execution) do
     execute_graphql(
       current_user: membership.user,
@@ -14,11 +17,9 @@ RSpec.describe Resolvers::RateCardRatesResolver do
   end
 
   let(:required_permission) { "rate_cards:view" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:rate_card) { create(:rate_card, organization:) }
   let!(:rate) { create(:rate_card_rate, organization:, rate_card:) }
-
   let(:query) do
     <<~GQL
       query($rateCardId: ID!) {
@@ -29,6 +30,8 @@ RSpec.describe Resolvers::RateCardRatesResolver do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before { create(:rate_card_rate, organization:) }
 

--- a/spec/graphql/resolvers/rate_cards_resolver_spec.rb
+++ b/spec/graphql/resolvers/rate_cards_resolver_spec.rb
@@ -3,6 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::RateCardsResolver do
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   subject(:execution) do
     execute_graphql(
       current_user: membership.user,
@@ -14,10 +17,8 @@ RSpec.describe Resolvers::RateCardsResolver do
   end
 
   let(:required_permission) { "rate_cards:view" }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:variables) { {} }
-
   let(:query) do
     <<~GQL
       query($searchTerm: String, $productId: ID) {
@@ -28,10 +29,11 @@ RSpec.describe Resolvers::RateCardsResolver do
       }
     GQL
   end
-
   let(:product) { create(:product, organization:) }
   let!(:card_one) { create(:rate_card, organization:, product:, name: "Growth USD", code: "growth_usd") }
   let!(:card_two) { create(:rate_card, organization:, name: "Standard EUR", code: "standard_eur") }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/role_resolver_spec.rb
+++ b/spec/graphql/resolvers/role_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::RoleResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query($roleId: ID!) {
@@ -12,12 +14,12 @@ RSpec.describe Resolvers::RoleResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:current_organization) { membership.organization }
   let(:current_user) { membership.user }
   let(:permissions) { "roles:view" }
   let(:role) { create(:role, organization: current_organization) }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/roles_resolver_spec.rb
+++ b/spec/graphql/resolvers/roles_resolver_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe Resolvers::RolesResolver do
     )
   end
 
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:organization) { create_default(:organization) }
+
   let(:query) do
     <<~GQL
       query {
@@ -27,10 +30,10 @@ RSpec.describe Resolvers::RolesResolver do
   end
 
   let(:required_permission) { "roles:view" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:other_user) { create(:user, email: "other@example.com") }
-  let!(:other_membership) { create(:membership, organization:, user: other_user) }
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:other_user) { create(:user, email: "other@example.com") }
+  let_it_be(:other_membership) { create(:membership, organization:, user: other_user) }
 
   before do
     create(:role, :admin)

--- a/spec/graphql/resolvers/security_log_resolver_spec.rb
+++ b/spec/graphql/resolvers/security_log_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::SecurityLogResolver, clickhouse: true do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query($logId: ID!) {
@@ -15,10 +17,11 @@ RSpec.describe Resolvers::SecurityLogResolver, clickhouse: true do
       }
     GQL
   end
-  let(:variables) { {logId: security_log.log_id} }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:security_log) { create(:clickhouse_security_log, membership:) }
+  let(:variables) { {logId: security_log.log_id} }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before { organization.update!(premium_integrations: ["security_logs"]) }
 

--- a/spec/graphql/resolvers/security_logs_resolver_spec.rb
+++ b/spec/graphql/resolvers/security_logs_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::SecurityLogsResolver, clickhouse: true do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query($toDatetime: ISO8601DateTime!) {
@@ -18,9 +20,10 @@ RSpec.describe Resolvers::SecurityLogsResolver, clickhouse: true do
       }
     GQL
   end
-  let(:variables) { {toDatetime: Time.current.iso8601} }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
+  let(:variables) { {toDatetime: Time.current.iso8601} }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before { organization.update!(premium_integrations: ["security_logs"]) }
 

--- a/spec/graphql/resolvers/subscription_resolver_spec.rb
+++ b/spec/graphql/resolvers/subscription_resolver_spec.rb
@@ -3,7 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::SubscriptionResolver do
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "subscriptions:view" }
+  let(:organization) { membership.organization }
+  let(:subscription) { create(:subscription, customer:) }
   let(:query) do
     <<~GQL
       query($subscriptionId: ID, $externalId: ID) {
@@ -35,10 +40,8 @@ RSpec.describe Resolvers::SubscriptionResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:subscription) { create(:subscription, customer:) }
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     customer
@@ -130,8 +133,8 @@ RSpec.describe Resolvers::SubscriptionResolver do
   end
 
   context "when subscription has a pending downgrade" do
-    let(:plan) { create(:plan, organization:, amount_cents: 500_00) }
-    let(:lower_plan) { create(:plan, organization:, amount_cents: 100_00) }
+    let_it_be(:plan) { create_default(:plan, organization:, amount_cents: 500_00) }
+    let_it_be(:lower_plan) { create_default(:plan, organization:, amount_cents: 100_00) }
     let(:subscription) do
       create(:subscription, :anniversary, customer:, plan:, subscription_at: Time.zone.parse("2026-04-22 00:00:00"), started_at: Time.zone.parse("2026-04-22 00:00:00"))
     end
@@ -228,11 +231,11 @@ RSpec.describe Resolvers::SubscriptionResolver do
         }
       GQL
     end
-
-    let(:plan) { create(:plan, organization:) }
-    let(:add_on) { create(:add_on, organization:) }
     let(:subscription) { create(:subscription, customer:, plan:) }
     let(:fixed_charge) { create(:fixed_charge, plan:, organization:, add_on:, units: 10) }
+
+    let_it_be(:plan) { create_default(:plan, organization:) }
+    let_it_be(:add_on) { create_default(:add_on, organization:) }
 
     context "without a per-subscription override" do
       before { fixed_charge }

--- a/spec/graphql/resolvers/subscriptions/alert_resolver_spec.rb
+++ b/spec/graphql/resolvers/subscriptions/alert_resolver_spec.rb
@@ -3,7 +3,13 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::Subscriptions::AlertResolver do
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "subscriptions:view" }
+  let(:organization) { membership.organization }
+  let(:alert) { create(:alert, organization:, recurring_threshold: 33, thresholds: [10, 20]) }
   let(:query) do
     <<~GQL
       query($alertId: ID!) {
@@ -14,9 +20,7 @@ RSpec.describe Resolvers::Subscriptions::AlertResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:alert) { create(:alert, organization:, recurring_threshold: 33, thresholds: [10, 20]) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     alert

--- a/spec/graphql/resolvers/subscriptions/alerts_resolver_spec.rb
+++ b/spec/graphql/resolvers/subscriptions/alerts_resolver_spec.rb
@@ -3,15 +3,17 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::Subscriptions::AlertsResolver do
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
   let(:required_permission) { "subscriptions:view" }
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:subscription) { create(:subscription) }
   let(:alert) { create(:alert, organization:, subscription_external_id: subscription.external_id, recurring_threshold: 33, thresholds: [10, 20]) }
   let(:alert_bm) { create(:billable_metric_current_usage_amount_alert, organization:, subscription_external_id: subscription.external_id, recurring_threshold: 33, thresholds: [10, 20]) }
   let(:another_alert) { create(:alert, organization:) }
-
   let(:query) do
     <<~GQL
       query($subscriptionExternalId: String!) {
@@ -22,6 +24,8 @@ RSpec.describe Resolvers::Subscriptions::AlertsResolver do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     alert

--- a/spec/graphql/resolvers/subscriptions_resolver_spec.rb
+++ b/spec/graphql/resolvers/subscriptions_resolver_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 RSpec.describe Resolvers::SubscriptionsResolver do
   let(:required_permission) { "subscriptions:view" }
+  let(:plan) { create(:plan, organization:) }
+  let(:customer) { create(:customer, organization:) }
   let(:query) do
     <<~GQL
       query {
@@ -17,8 +19,6 @@ RSpec.describe Resolvers::SubscriptionsResolver do
 
   let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create_default(:membership) }
-  let(:plan) { create(:plan, organization:) }
-  let(:customer) { create(:customer, organization:) }
 
   before do
     customer

--- a/spec/graphql/resolvers/subscriptions_resolver_spec.rb
+++ b/spec/graphql/resolvers/subscriptions_resolver_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe Resolvers::SubscriptionsResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
   let(:plan) { create(:plan, organization:) }
-  let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
 
   before do

--- a/spec/graphql/resolvers/superset/dashboards_resolver_spec.rb
+++ b/spec/graphql/resolvers/superset/dashboards_resolver_spec.rb
@@ -3,23 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::Superset::DashboardsResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "analytics:view" }
-  let(:query) do
-    <<~GQL
-      query {
-        supersetDashboards {
-          id
-          dashboardTitle
-          embeddedId
-          guestToken
-        }
-      }
-    GQL
-  end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-
   let(:dashboards) do
     [
       {
@@ -36,12 +23,25 @@ RSpec.describe Resolvers::Superset::DashboardsResolver do
       }
     ]
   end
-
   let(:result) do
     Auth::SupersetService::Result.new.tap do |result|
       result.dashboards = dashboards
     end
   end
+  let(:query) do
+    <<~GQL
+      query {
+        supersetDashboards {
+          id
+          dashboardTitle
+          embeddedId
+          guestToken
+        }
+      }
+    GQL
+  end
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     allow(Auth::SupersetService).to receive(:call).and_return(result)

--- a/spec/graphql/resolvers/tax_resolver_spec.rb
+++ b/spec/graphql/resolvers/tax_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::TaxResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query($taxId: ID!) {
@@ -12,10 +14,10 @@ RSpec.describe Resolvers::TaxResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:tax) { create(:tax, organization:) }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     tax

--- a/spec/graphql/resolvers/taxes_resolver_spec.rb
+++ b/spec/graphql/resolvers/taxes_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::TaxesResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query {
@@ -13,10 +15,10 @@ RSpec.describe Resolvers::TaxesResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:tax) { create(:tax, organization:) }
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before { tax }
 

--- a/spec/graphql/resolvers/wallet_resolver_spec.rb
+++ b/spec/graphql/resolvers/wallet_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::WalletResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query($id: ID!) {
@@ -16,11 +18,11 @@ RSpec.describe Resolvers::WalletResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:wallet) { create(:wallet, :with_recurring_transaction_rules, customer:) }
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before { wallet }
 

--- a/spec/graphql/resolvers/wallet_transaction_consumptions_resolver_spec.rb
+++ b/spec/graphql/resolvers/wallet_transaction_consumptions_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::WalletTransactionConsumptionsResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query($walletTransactionId: ID!, $page: Int, $limit: Int) {
@@ -19,10 +21,7 @@ RSpec.describe Resolvers::WalletTransactionConsumptionsResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:wallet) { create(:wallet, customer:, traceable: true) }
   let(:inbound_transaction) do
     create(:wallet_transaction,
@@ -41,6 +40,9 @@ RSpec.describe Resolvers::WalletTransactionConsumptionsResolver do
       outbound_wallet_transaction: outbound_transaction,
       consumed_amount_cents: 500)
   end
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/wallet_transaction_fundings_resolver_spec.rb
+++ b/spec/graphql/resolvers/wallet_transaction_fundings_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::WalletTransactionFundingsResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query($walletTransactionId: ID!, $page: Int, $limit: Int) {
@@ -19,10 +21,7 @@ RSpec.describe Resolvers::WalletTransactionFundingsResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:wallet) { create(:wallet, customer:, traceable: true) }
   let(:inbound_transaction) do
     create(:wallet_transaction,
@@ -41,6 +40,9 @@ RSpec.describe Resolvers::WalletTransactionFundingsResolver do
       outbound_wallet_transaction: outbound_transaction,
       consumed_amount_cents: 500)
   end
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"

--- a/spec/graphql/resolvers/wallet_transaction_resolver_spec.rb
+++ b/spec/graphql/resolvers/wallet_transaction_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::WalletTransactionResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   subject(:result) do
     execute_graphql(
       current_user: membership.user,
@@ -34,14 +36,15 @@ RSpec.describe Resolvers::WalletTransactionResolver do
       }
     GQL
   end
-
-  let(:wallet_transaction_id) { wallet_transaction.id }
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:wallet) { create(:wallet, customer:) }
   let!(:wallet_transaction) { create(:wallet_transaction, :failed, wallet:, invoice:) }
   let(:invoice) { create(:invoice, customer:) }
+
+  let(:wallet_transaction_id) { wallet_transaction.id }
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   context "with valid authorization" do
     let(:current_organization) { organization }

--- a/spec/graphql/resolvers/wallets/alert_resolver_spec.rb
+++ b/spec/graphql/resolvers/wallets/alert_resolver_spec.rb
@@ -3,7 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::Wallets::AlertResolver do
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "wallets:update" }
+  let(:organization) { membership.organization }
+  let(:alert) { create(:wallet_balance_amount_alert, organization:, recurring_threshold: 10, thresholds: [75, 50, 25]) }
   let(:query) do
     <<~GQL
       query($alertId: ID!) {
@@ -14,9 +19,7 @@ RSpec.describe Resolvers::Wallets::AlertResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:alert) { create(:wallet_balance_amount_alert, organization:, recurring_threshold: 10, thresholds: [75, 50, 25]) }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     alert

--- a/spec/graphql/resolvers/wallets/alerts_resolver_spec.rb
+++ b/spec/graphql/resolvers/wallets/alerts_resolver_spec.rb
@@ -3,15 +3,15 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::Wallets::AlertsResolver do
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "wallets:update" }
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:wallet) { create(:wallet, organization:) }
   let(:balance_alert) { create(:wallet_balance_amount_alert, organization:, wallet:, recurring_threshold: 10, thresholds: [75, 50, 25]) }
   let(:credits_alert) { create(:wallet_credits_balance_alert, organization:, wallet:, recurring_threshold: 10, thresholds: [75, 50, 25]) }
   let(:another_alert) { create(:alert, organization:) }
-
   let(:query) do
     <<~GQL
       query($walletId: String!) {
@@ -22,6 +22,8 @@ RSpec.describe Resolvers::Wallets::AlertsResolver do
       }
     GQL
   end
+
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     balance_alert

--- a/spec/graphql/resolvers/wallets_resolver_spec.rb
+++ b/spec/graphql/resolvers/wallets_resolver_spec.rb
@@ -3,6 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::WalletsResolver do
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query($customerId: ID!) {
@@ -17,12 +20,12 @@ RSpec.describe Resolvers::WalletsResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:, organization:) }
   let(:wallet) { create(:wallet, organization:, customer:) }
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     subscription

--- a/spec/graphql/resolvers/wallets_resolver_transactions_spec.rb
+++ b/spec/graphql/resolvers/wallets_resolver_transactions_spec.rb
@@ -3,6 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::WalletsResolver do
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:query) do
     <<~GQL
       query($walletId: ID!) {
@@ -13,13 +16,13 @@ RSpec.describe Resolvers::WalletsResolver do
       }
     GQL
   end
-
-  let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:, organization:) }
   let(:wallet) { create(:wallet, customer:) }
   let(:wallet_transaction) { create(:wallet_transaction, wallet:) }
+
+  let_it_be(:membership) { create_default(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     subscription

--- a/spec/graphql/resolvers/webhook_endpoint_resolver_spec.rb
+++ b/spec/graphql/resolvers/webhook_endpoint_resolver_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::WebhookEndpointResolver do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:user) { create_default(:user) }
   let(:required_permission) { "developers:manage" }
+  let(:webhook_endpoint) { build(:webhook_endpoint, organization:, event_types: ["customer.created"]) }
+  let(:organization) { membership.organization }
   let(:query) do
     <<-GQL
       query($webhookEndpointId: ID!) {
@@ -21,9 +25,7 @@ RSpec.describe Resolvers::WebhookEndpointResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:webhook_endpoint) { build(:webhook_endpoint, organization:, event_types: ["customer.created"]) }
-  let(:organization) { membership.organization }
+  let_it_be(:membership) { create_default(:membership) }
 
   before do
     organization.webhook_endpoints << webhook_endpoint

--- a/spec/graphql/resolvers/webhook_resolver_spec.rb
+++ b/spec/graphql/resolvers/webhook_resolver_spec.rb
@@ -3,6 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::WebhookResolver do
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:required_permission) { "developers:manage" }
   let(:query) do
     <<~GQL
@@ -17,7 +20,8 @@ RSpec.describe Resolvers::WebhookResolver do
   let(:webhook_endpoint) { create(:webhook_endpoint) }
   let(:webhook) { create(:webhook, :succeeded, webhook_endpoint:) }
   let(:organization) { webhook_endpoint.organization.reload }
-  let(:membership) { create(:membership, organization:) }
+
+  let_it_be(:membership) { create_default(:membership, organization:) }
 
   before { webhook }
 

--- a/spec/graphql/resolvers/webhooks_resolver_spec.rb
+++ b/spec/graphql/resolvers/webhooks_resolver_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::WebhooksResolver do
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:required_permission) { "developers:manage" }
   let(:query) do
     <<~GQL
@@ -17,7 +19,8 @@ RSpec.describe Resolvers::WebhooksResolver do
 
   let(:webhook_endpoint) { create(:webhook_endpoint) }
   let(:organization) { webhook_endpoint.organization.reload }
-  let(:membership) { create(:membership, organization:) }
+
+  let_it_be(:membership) { create_default(:membership, organization:) }
 
   before do
     create_list(:webhook, 5, :succeeded, webhook_endpoint:)

--- a/spec/graphql/sources/attached_to_plan_or_subscription_spec.rb
+++ b/spec/graphql/sources/attached_to_plan_or_subscription_spec.rb
@@ -3,7 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Sources::AttachedToPlanOrSubscription do
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
   let(:product) { create(:product, organization:) }
 
   describe "#fetch" do

--- a/spec/graphql/sources/count_by_foreign_key_spec.rb
+++ b/spec/graphql/sources/count_by_foreign_key_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Sources::CountByForeignKey do
   subject(:source) { described_class.new(ProductFilter, :product_id) }
 
-  let(:organization) { create(:organization) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
   let(:product) { create(:product, organization:, billable_metric:) }
 
   describe "#fetch" do

--- a/spec/graphql/types/billable_metrics/object_spec.rb
+++ b/spec/graphql/types/billable_metrics/object_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe Types::BillableMetrics::Object do
   subject { described_class }
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
+  let_it_be(:membership) { create_default(:membership) }
+
   it do
     expect(subject).to have_field(:id).of_type("ID!")
     expect(subject).to have_field(:organization).of_type("Organization")
@@ -33,9 +37,6 @@ RSpec.describe Types::BillableMetrics::Object do
 
   describe "#has_subscriptions" do
     let(:required_permission) { "billable_metrics:view" }
-    let(:membership) { create(:membership) }
-    let(:organization) { membership.organization }
-    let(:billable_metric) { create(:billable_metric, organization:) }
 
     let(:query) do
       <<~GQL
@@ -76,9 +77,6 @@ RSpec.describe Types::BillableMetrics::Object do
 
   describe "#has_active_subscriptions" do
     let(:required_permission) { "billable_metrics:view" }
-    let(:membership) { create(:membership) }
-    let(:organization) { membership.organization }
-    let(:billable_metric) { create(:billable_metric, organization:) }
 
     let(:query) do
       <<~GQL
@@ -129,9 +127,6 @@ RSpec.describe Types::BillableMetrics::Object do
 
   describe "#has_draft_invoices" do
     let(:required_permission) { "billable_metrics:view" }
-    let(:membership) { create(:membership) }
-    let(:organization) { membership.organization }
-    let(:billable_metric) { create(:billable_metric, organization:) }
 
     let(:query) do
       <<~GQL
@@ -199,9 +194,6 @@ RSpec.describe Types::BillableMetrics::Object do
 
   describe "#has_plans" do
     let(:required_permission) { "billable_metrics:view" }
-    let(:membership) { create(:membership) }
-    let(:organization) { membership.organization }
-    let(:billable_metric) { create(:billable_metric, organization:) }
 
     let(:query) do
       <<~GQL
@@ -245,9 +237,6 @@ RSpec.describe Types::BillableMetrics::Object do
 
   describe "#integration_mappings" do
     let(:required_permission) { "billable_metrics:view" }
-    let(:membership) { create(:membership) }
-    let(:organization) { membership.organization }
-    let(:billable_metric) { create(:billable_metric, organization:) }
     let(:netsuite_integration) { create(:netsuite_integration, organization:) }
     let(:xero_integration) { create(:xero_integration, organization:) }
     let(:netsuite_mapping) { create(:netsuite_mapping, integration: netsuite_integration, mappable: billable_metric, organization:) }

--- a/spec/graphql/types/customers/object_spec.rb
+++ b/spec/graphql/types/customers/object_spec.rb
@@ -5,6 +5,9 @@ require "rails_helper"
 RSpec.describe Types::Customers::Object do
   subject { described_class }
 
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:organization) { create_default(:organization) }
+
   it do
     expect(subject).to have_field(:id).of_type("ID!")
     expect(subject).to have_field(:billing_entity).of_type("BillingEntity!")
@@ -93,12 +96,6 @@ RSpec.describe Types::Customers::Object do
 
   describe "credit_notes_balances grouping" do
     let(:required_permission) { "customers:view" }
-    let(:membership) { create(:membership) }
-    let(:organization) { membership.organization }
-    let(:customer) { create(:customer, organization:) }
-    let(:billing_entity_a) { create(:billing_entity, organization:) }
-    let(:billing_entity_b) { create(:billing_entity, organization:) }
-
     let(:query) do
       <<~GQL
         query($customerId: ID!) {
@@ -113,6 +110,11 @@ RSpec.describe Types::Customers::Object do
         }
       GQL
     end
+
+    let_it_be(:membership) { create_default(:membership) }
+    let_it_be(:customer) { create_default(:customer, organization:) }
+    let_it_be(:billing_entity_a) { create(:billing_entity, organization:) }
+    let_it_be(:billing_entity_b) { create(:billing_entity, organization:) }
 
     def execute
       execute_graphql(

--- a/spec/graphql/types/quote_versions/object_spec.rb
+++ b/spec/graphql/types/quote_versions/object_spec.rb
@@ -5,6 +5,9 @@ require "rails_helper"
 RSpec.describe Types::QuoteVersions::Object do
   subject { described_class }
 
+  let_it_be(:user) { create_default(:user) }
+  let_it_be(:organization) { create_default(:organization) }
+
   it do
     expect(subject).to have_field(:id).of_type("ID!")
     expect(subject).to have_field(:organization).of_type("Organization!")
@@ -26,13 +29,7 @@ RSpec.describe Types::QuoteVersions::Object do
 
   describe "#mention_variables" do
     let(:required_permission) { "quotes:view" }
-    let(:membership) { create(:membership) }
-    let(:organization) { membership.organization }
-    let(:customer) do
-      create(:customer, organization:, name: "Hooli", legal_name: "Hooli Inc", firstname: "Gavin", lastname: "Belson")
-    end
     let(:quote) { create(:quote, organization:, customer:) }
-
     let(:query) do
       <<~GQL
         query($quoteId: ID!) {
@@ -41,6 +38,11 @@ RSpec.describe Types::QuoteVersions::Object do
           }
         }
       GQL
+    end
+
+    let_it_be(:membership) { create_default(:membership) }
+    let_it_be(:customer) do
+      create_default(:customer, organization:, name: "Hooli", legal_name: "Hooli Inc", firstname: "Gavin", lastname: "Belson")
     end
 
     def execute
@@ -74,7 +76,7 @@ RSpec.describe Types::QuoteVersions::Object do
     end
 
     context "when the approved snapshot holds locale-sensitive variables" do
-      let(:customer) { create(:customer, organization:, name: "Hooli", document_locale: "en") }
+      let_it_be(:customer) { create_default(:customer, organization:, name: "Hooli", document_locale: "en") }
 
       before do
         create(

--- a/spec/graphql/types/subscriptions/object_spec.rb
+++ b/spec/graphql/types/subscriptions/object_spec.rb
@@ -5,6 +5,9 @@ require "rails_helper"
 RSpec.describe Types::Subscriptions::Object do
   subject { described_class }
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+
   it do
     expect(subject).to have_field(:billing_entity_id).of_type("ID")
     expect(subject).to have_field(:customer).of_type("Customer!")
@@ -63,7 +66,7 @@ RSpec.describe Types::Subscriptions::Object do
   end
 
   context "when the subscription starts in the future" do
-    let(:plan) { create(:plan, interval: "monthly", pay_in_advance: true) }
+    let_it_be(:plan) { create_default(:plan, interval: "monthly", pay_in_advance: true) }
     let(:future_start) { Time.zone.parse("2026-07-03T00:00:00Z") }
     let(:subscription) do
       create(

--- a/spec/graphql/types/wallet_transactions/object_spec.rb
+++ b/spec/graphql/types/wallet_transactions/object_spec.rb
@@ -5,6 +5,9 @@ require "rails_helper"
 RSpec.describe Types::WalletTransactions::Object do
   subject { described_class }
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+
   it "has the expected fields with correct types" do
     expect(subject).to have_field(:wallet).of_type("Wallet")
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,6 +76,10 @@ Sentry.init do |config|
   config.transport.transport_class = Sentry::DummyTransport
 end
 
+require "test_prof/recipes/rspec/sample"
+require "test_prof/recipes/rspec/let_it_be"
+require "test_prof/recipes/rspec/factory_default"
+
 RSpec.configure do |config|
   config.include ActiveJob::TestHelper
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
## Context

Currently, around **50% of the spec runtime** is spent preparing data and creating factories. A lot of this data is either duplicated or recreates the same objects multiple times, so we can get rid of a good chunk of it and significantly speed up the specs.

To avoid creating unnecessary factories, we can use `let_it_be`, `before_all`, and `create_default` from `test-prof`. More info [here](https://test-prof.evilmartians.io/guide/recipes/let_it_be).

## Description

This PR cleans up the graphql specs and removes unnecessary factory usage.

Here are the numbers before and after the cleanup. The times below are for running the specs in a single process:

| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 14,719 | 8,855 |
| Time spent creating factories | 01:15.629 | 00:35.705 |
| Total time | 02:30.069 | 01:23.418 |

## Overall results

This PR is part of a series of PRs focused on cleaning up factory usage across different specs.

Once all the changes are merged, we expect to:

- Reduce the number of factories by **~50k**
- Cut spec runtime by around **20%**
- Shave off roughly **1:15 min** from the CI runtime


| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 157,949 | 103,761 |
| Total time spent creating factories | 17:59.851  | 11:14.739 |
| Total time | 34:41.482 | 27:03.658 |

Here is [the CI run](https://github.com/getlago/lago-api/actions/runs/33399605547/job/99512391170?pr=6255) with all the changes merged together: