### PR TITLE
perf(specs): Clean up factories usage in spec/requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -167,6 +167,8 @@ group :test do
   # HTML testing (invoice rendering)
   gem "rspec-snapshot", "~> 2.0"
   gem "htmlbeautifier", "~> 1.4"
+
+  gem "test-prof", "~> 1.0"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1004,6 +1004,8 @@ GEM
     temple (0.10.4)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
+    test-prof (1.6.3)
+      logger
     thor (1.5.0)
     throttling (0.4.1)
       logger
@@ -1181,6 +1183,7 @@ DEPENDENCIES
   stripe
   strong_migrations
   super_diff (~> 0.19.0)
+  test-prof (~> 1.0)
   throttling
   timecop
   tzinfo-data

--- a/spec/requests/api/base_controller_spec.rb
+++ b/spec/requests/api/base_controller_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Api::BaseController, type: :controller do
+  let_it_be(:organization) { create_default(:organization) }
   controller do
     def index
       render nothing: true

--- a/spec/requests/api/v1/add_ons_controller_spec.rb
+++ b/spec/requests/api/v1/add_ons_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::AddOnsController do
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:tax) { create(:tax, organization:) }
 
   describe "POST /api/v1/add_ons" do
@@ -42,7 +42,7 @@ RSpec.describe Api::V1::AddOnsController do
       put_with_token(organization, "/api/v1/add_ons/#{add_on_code}", {add_on: update_params})
     end
 
-    let(:add_on) { create(:add_on, organization:) }
+    let_it_be(:add_on) { create_default(:add_on, organization:) }
     let(:add_on_code) { add_on.code }
     let(:add_on_applied_tax) { create(:add_on_applied_tax, add_on:, tax:) }
     let(:code) { "add_on_code" }
@@ -124,7 +124,7 @@ RSpec.describe Api::V1::AddOnsController do
   describe "DELETE /api/v1/add_ons/:code" do
     subject { delete_with_token(organization, "/api/v1/add_ons/#{add_on_code}") }
 
-    let!(:add_on) { create(:add_on, organization:) }
+    let_it_be(:add_on) { create_default(:add_on, organization:) }
     let(:add_on_code) { add_on.code }
 
     include_examples "requires API permission", "add_on", "write"
@@ -154,7 +154,7 @@ RSpec.describe Api::V1::AddOnsController do
   describe "GET /api/v1/add_ons" do
     subject { get_with_token(organization, "/api/v1/add_ons", params) }
 
-    let(:add_on) { create(:add_on, organization:) }
+    let_it_be(:add_on) { create_default(:add_on, organization:) }
     let(:params) { {} }
 
     before { create(:add_on_applied_tax, add_on:, tax:) }

--- a/spec/requests/api/v1/analytics/invoice_collections_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/invoice_collections_controller_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe Api::V1::Analytics::InvoiceCollectionsController do # rubocop:dis
     subject { get_with_token(organization, "/api/v1/analytics/invoice_collection", params) }
 
     let(:customer) { create(:customer, organization:) }
-    let(:organization) { create(:organization) }
     let(:billing_entity) { create(:billing_entity, organization: organization) }
     let(:params) { {} }
+
+    let_it_be(:organization) { create_default(:organization) }
 
     before do
       allow(Analytics::InvoiceCollectionsService).to receive(:call).and_call_original

--- a/spec/requests/api/v1/analytics/invoiced_usages_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/invoiced_usages_controller_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe Api::V1::Analytics::InvoicedUsagesController do # rubocop:disable
     subject { get_with_token(organization, "/api/v1/analytics/invoiced_usage", params) }
 
     let(:customer) { create(:customer, organization:) }
-    let(:organization) { create(:organization) }
     let(:billing_entity) { create(:billing_entity, organization: organization) }
     let(:params) { {} }
+
+    let_it_be(:organization) { create_default(:organization) }
 
     before do
       allow(Analytics::InvoicedUsagesService).to receive(:call).and_call_original

--- a/spec/requests/api/v1/analytics/mrrs_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/mrrs_controller_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe Api::V1::Analytics::MrrsController do # rubocop:disable Rails/Fil
     subject { get_with_token(organization, "/api/v1/analytics/mrr", params) }
 
     let(:customer) { create(:customer, organization:) }
-    let(:organization) { create(:organization) }
     let(:billing_entity) { create(:billing_entity, organization: organization) }
     let(:params) { {} }
+
+    let_it_be(:organization) { create_default(:organization) }
 
     before do
       allow(Analytics::MrrsService).to receive(:call).and_call_original

--- a/spec/requests/api/v1/analytics/overdue_balances_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/overdue_balances_controller_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe Api::V1::Analytics::OverdueBalancesController do
     subject { get_with_token(organization, "/api/v1/analytics/overdue_balance", params) }
 
     let(:customer) { create(:customer, organization:) }
-    let(:organization) { create(:organization, created_at: DateTime.new(2023, 11, 1)) }
     let(:billing_entity) { create(:billing_entity, organization: organization) }
     let(:params) { {} }
+
+    let_it_be(:organization) { create_default(:organization, created_at: DateTime.new(2023, 11, 1)) }
 
     before do
       allow(Analytics::OverdueBalancesService).to receive(:call).and_call_original

--- a/spec/requests/api/v1/applied_coupons_controller_spec.rb
+++ b/spec/requests/api/v1/applied_coupons_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::AppliedCouponsController, :bullet do
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, organization:) }
 
   describe "POST /api/v1/applied_coupons" do
@@ -58,7 +58,6 @@ RSpec.describe Api::V1::AppliedCouponsController, :bullet do
 
       context "with external_customer_id filter" do
         let(:params) { {external_customer_id: customer.external_id} }
-
         let(:other_customer) { create(:customer, organization:) }
         let(:other_customer_applied_coupon) do
           create(:applied_coupon, customer: other_customer, coupon: coupon_1)

--- a/spec/requests/api/v1/coupons_controller_spec.rb
+++ b/spec/requests/api/v1/coupons_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::CouponsController do
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
 
   describe "POST /api/v1/coupons" do
     subject { post_with_token(organization, "/api/v1/coupons", {coupon: create_params}) }

--- a/spec/requests/api/v1/credit_notes/metadata_controller_spec.rb
+++ b/spec/requests/api/v1/credit_notes/metadata_controller_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::CreditNotes::MetadataController do
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:credit_note) { create(:credit_note, customer:) }
 
   describe "POST /api/v1/credit_notes/:id/metadata" do

--- a/spec/requests/api/v1/customers/wallets/alerts_controller_spec.rb
+++ b/spec/requests/api/v1/customers/wallets/alerts_controller_spec.rb
@@ -3,14 +3,15 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::Customers::Wallets::AlertsController do
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:customer_external_id) { customer.external_id }
-  let(:wallet_code) { wallet.code }
-  let(:customer) { create(:customer, organization:) }
   let(:wallet) { create(:wallet, customer:, organization:) }
   let(:code) { "my-wallet-alert" }
   let(:alert) { create(:wallet_balance_amount_alert, :processed, code:, wallet:, organization:) }
   let(:deleted_alert) { create(:wallet_balance_amount_alert, :processed, deleted_at: Time.current, wallet:, organization:, thresholds: []) }
+  let(:wallet_code) { wallet.code }
+
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     alert

--- a/spec/requests/api/v1/data_api/usages_controller_spec.rb
+++ b/spec/requests/api/v1/data_api/usages_controller_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe Api::V1::DataApi::UsagesController do # rubocop:disable Rails/Fil
     subject { get_with_token(organization, "/api/v1/analytics/usage", params) }
 
     let(:customer) { create(:customer, organization:) }
-    let(:organization) { create(:organization) }
     let(:params) { {currency: "EUR"} }
-
     let(:result) do
       DataApi::UsagesService::Result.new.tap do |result|
         result.usages = [{amount_currency: nil, amount_cents: nil}]
       end
     end
+
+    let_it_be(:organization) { create_default(:organization) }
 
     before do
       allow(DataApi::UsagesService).to receive(:call).and_return(result)

--- a/spec/requests/api/v1/features/privileges_controller_spec.rb
+++ b/spec/requests/api/v1/features/privileges_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Api::V1::Features::PrivilegesController do
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:feature1) { create(:feature, organization:, code: "seats", name: "Number of seats", description: "Number of users of the account") }
   let(:privilege1) { create(:privilege, feature: feature1, code: "max_admins", name: "", value_type: "integer") }
   let(:privilege2) { create(:privilege, feature: feature1, code: "max", name: "Maximum", value_type: "integer") }

--- a/spec/requests/api/v1/features_controller_spec.rb
+++ b/spec/requests/api/v1/features_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::FeaturesController do
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:feature1) { create(:feature, organization:, code: "seats", name: "Number of seats", description: "Number of users of the account") }
   let(:feature2) { create(:feature, organization:, code: "storage", name: "Storage", description: "Storage space") }
   let(:privilege1) { create(:privilege, feature: feature1, code: "max_admins", name: "", value_type: "integer") }

--- a/spec/requests/api/v1/legacy_billing_gate_spec.rb
+++ b/spec/requests/api/v1/legacy_billing_gate_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "v1 pricing endpoints on a product-catalog organization", type: :request do
-  let(:organization) { create(:organization, feature_flags: ["product_catalog"]) }
-  let(:plan) { create(:plan, organization:, pricing_type: "product_catalog") }
+  let_it_be(:organization) { create_default(:organization, feature_flags: ["product_catalog"]) }
+  let_it_be(:plan) { create_default(:plan, organization:, pricing_type: "product_catalog") }
 
   it "rejects legacy pricing fields on plan creation" do
     post_with_token(organization, "/api/v1/plans", {plan: {name: "Legacy", code: "legacy", interval: "monthly", amount_cents: 100, amount_currency: "USD", pay_in_advance: false}})

--- a/spec/requests/api/v1/order_forms_controller_spec.rb
+++ b/spec/requests/api/v1/order_forms_controller_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::OrderFormsController do
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:quote_version) { create(:quote_version, quote:, organization:) }
   let(:order_form) { create(:order_form, organization:, customer:, quote_version:) }

--- a/spec/requests/api/v1/orders_controller_spec.rb
+++ b/spec/requests/api/v1/orders_controller_spec.rb
@@ -3,8 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::OrdersController do
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:add_on) { create_default(:add_on) }
+  let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:order_form) { create(:order_form, :signed, organization:, customer:, quote:) }
   let(:order) { create(:order, organization:, customer:, order_form:) }
@@ -106,7 +107,6 @@ RSpec.describe Api::V1::OrdersController do
     subject { post_with_token(organization, "/api/v1/orders/#{order.id}/execute", params) }
 
     let(:params) { {} }
-    let(:customer) { create(:customer, organization:, currency: "EUR") }
     let(:quote) { create(:quote, organization:, customer:, order_type: :one_off) }
     let(:quote_version) do
       create(:quote_version, :approved, :with_one_off_billing_items, quote:, organization:)
@@ -114,6 +114,8 @@ RSpec.describe Api::V1::OrdersController do
     let(:order_form) { create(:order_form, :signed, organization:, customer:, quote_version:) }
     let(:order) { create(:order, organization:, customer:, order_form:, execution_mode:) }
     let(:execution_mode) { :order_only }
+
+    let_it_be(:customer) { create_default(:customer, organization:, currency: "EUR") }
 
     before { order }
 

--- a/spec/requests/api/v1/organizations_controller_spec.rb
+++ b/spec/requests/api/v1/organizations_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::OrganizationsController do
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:webhook_url) { Faker::Internet.url }
 
   describe "PUT /api/v1/organizations" do

--- a/spec/requests/api/v1/payments_controller_spec.rb
+++ b/spec/requests/api/v1/payments_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::PaymentsController do
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
 
   describe "POST /api/v1/payments" do
     subject do
@@ -14,7 +14,7 @@ RSpec.describe Api::V1::PaymentsController do
       )
     end
 
-    let(:customer) { create(:customer, organization:) }
+    let_it_be(:customer) { create_default(:customer, organization:) }
     let(:invoice) { create(:invoice, organization:, customer:) }
     let(:params) do
       {
@@ -120,7 +120,7 @@ RSpec.describe Api::V1::PaymentsController do
   describe "GET /api/v1/payments/:id" do
     subject { get_with_token(organization, "/api/v1/payments/#{id}") }
 
-    let(:customer) { create(:customer, organization:) }
+    let_it_be(:customer) { create_default(:customer, organization:) }
     let(:invoice) { create(:invoice, customer:, organization:) }
     let(:payment) { create(:payment, payable: invoice) }
 

--- a/spec/requests/api/v1/plans/charges/filters_controller_spec.rb
+++ b/spec/requests/api/v1/plans/charges/filters_controller_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::Plans::Charges::FiltersController do
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
   let(:billable_metric_filter) { create(:billable_metric_filter, billable_metric:, key: "region", values: %w[us eu]) }
 

--- a/spec/requests/api/v1/plans/entitlements/privileges_controller_spec.rb
+++ b/spec/requests/api/v1/plans/entitlements/privileges_controller_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::Plans::Entitlements::PrivilegesController do
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
   let(:feature) { create(:feature, organization:) }
   let(:privilege) { create(:privilege, organization:, feature:, code: "max_users") }
   let(:privilege2) { create(:privilege, organization:, feature:, code: "max_admins") }

--- a/spec/requests/api/v1/plans/entitlements_controller_spec.rb
+++ b/spec/requests/api/v1/plans/entitlements_controller_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::Plans::EntitlementsController do
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
   let(:feature) { create(:feature, organization:, code: "seats") }
   let(:privilege) { create(:privilege, organization:, feature:, code: "max", value_type: "integer") }
 

--- a/spec/requests/api/v1/plans/fixed_charges_controller_spec.rb
+++ b/spec/requests/api/v1/plans/fixed_charges_controller_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::Plans::FixedChargesController do
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
-  let(:add_on) { create(:add_on, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
+  let_it_be(:add_on) { create_default(:add_on, organization:) }
 
   describe "GET /api/v1/plans/:plan_code/fixed_charges" do
     subject { get_with_token(organization, "/api/v1/plans/#{plan.code}/fixed_charges") }

--- a/spec/requests/api/v1/plans/metadata_controller_spec.rb
+++ b/spec/requests/api/v1/plans/metadata_controller_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::Plans::MetadataController do
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
 
   describe "POST /api/v1/plans/:code/metadata" do
     subject { post_with_token(organization, "/api/v1/plans/#{plan_code}/metadata", {metadata: params}) }

--- a/spec/requests/api/v1/plans_controller_spec.rb
+++ b/spec/requests/api/v1/plans_controller_spec.rb
@@ -4,10 +4,12 @@ require "rails_helper"
 
 RSpec.describe Api::V1::PlansController do
   let(:tax) { create(:tax, organization:) }
-  let(:organization) { create(:organization) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
-  let(:add_on) { create(:add_on, organization:) }
   let(:plan) { create(:plan, code: "plan_code") }
+
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
+  let_it_be(:add_on) { create_default(:add_on, organization:) }
 
   describe "POST /api/v1/plans" do
     subject { post_with_token(organization, "/api/v1/plans", {plan: create_params}) }
@@ -400,11 +402,9 @@ RSpec.describe Api::V1::PlansController do
     end
 
     let(:minimum_commitment) { create(:commitment, plan:) }
-    let(:plan) { create(:plan, organization:) }
     let(:plan_code) { plan.code }
     let(:code) { "plan_code" }
     let(:tax_codes) { [tax.code] }
-
     let(:update_params) do
       {
         name: "P1",
@@ -420,7 +420,6 @@ RSpec.describe Api::V1::PlansController do
         usage_thresholds: usage_thresholds_params
       }
     end
-
     let(:usage_thresholds_params) do
       [
         {
@@ -429,7 +428,6 @@ RSpec.describe Api::V1::PlansController do
         }
       ]
     end
-
     let(:charges_params) do
       [
         {
@@ -443,7 +441,6 @@ RSpec.describe Api::V1::PlansController do
         }
       ]
     end
-
     let(:fixed_charges_params) do
       [
         {
@@ -458,7 +455,6 @@ RSpec.describe Api::V1::PlansController do
         }
       ]
     end
-
     let(:minimum_commitment_params) do
       {
         minimum_commitment: {
@@ -467,6 +463,8 @@ RSpec.describe Api::V1::PlansController do
         }
       }
     end
+
+    let_it_be(:plan) { create_default(:plan, organization:) }
 
     include_examples "requires API permission", "plan", "write"
 
@@ -762,7 +760,7 @@ RSpec.describe Api::V1::PlansController do
     end
 
     context "when adding a fixed charge" do
-      let(:plan) { create(:plan, organization:, interval: :weekly) }
+      let_it_be(:plan) { create_default(:plan, organization:, interval: :weekly) }
       let(:subscription) { create(:subscription, :active, :anniversary, plan:, started_at:, subscription_at: started_at) }
       let(:started_at) { 3.days.ago }
 
@@ -848,7 +846,7 @@ RSpec.describe Api::V1::PlansController do
     end
 
     context "when editing a fixed charge" do
-      let(:plan) { create(:plan, organization:, interval: :weekly) }
+      let_it_be(:plan) { create_default(:plan, organization:, interval: :weekly) }
       let(:subscription) { create(:subscription, :active, :anniversary, plan:, started_at:, subscription_at: started_at) }
       let(:fixed_charge) { create(:fixed_charge, plan:, add_on:, units: 1) }
       let(:started_at) { 3.days.ago }
@@ -947,7 +945,7 @@ RSpec.describe Api::V1::PlansController do
   describe "GET /api/v1/plans/:code" do
     subject { get_with_token(organization, "/api/v1/plans/#{plan_code}") }
 
-    let(:plan) { create(:plan, organization:) }
+    let_it_be(:plan) { create_default(:plan, organization:) }
     let(:plan_code) { plan.code }
 
     include_examples "requires API permission", "plan", "read"
@@ -1033,7 +1031,7 @@ RSpec.describe Api::V1::PlansController do
   describe "DELETE /api/v1/plans/:code" do
     subject { delete_with_token(organization, "/api/v1/plans/#{plan_code}") }
 
-    let(:plan) { create(:plan, organization:) }
+    let_it_be(:plan) { create_default(:plan, organization:) }
     let(:plan_code) { plan.code }
 
     include_examples "requires API permission", "plan", "write"
@@ -1074,7 +1072,7 @@ RSpec.describe Api::V1::PlansController do
   describe "GET /api/v1/plans" do
     subject { get_with_token(organization, "/api/v1/plans?page=1&per_page=1") }
 
-    let(:plan) { create(:plan, organization:) }
+    let_it_be(:plan) { create_default(:plan, organization:) }
 
     before { create(:usage_threshold, plan:) }
 

--- a/spec/requests/api/v1/quote_versions_controller_spec.rb
+++ b/spec/requests/api/v1/quote_versions_controller_spec.rb
@@ -3,10 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::QuoteVersionsController do
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-  let(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:quote_version) { create(:quote_version, quote:, organization:) }
+
+  let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   describe "GET /api/v1/quote_versions/:id" do
     subject { get_with_token(organization, "/api/v1/quote_versions/#{quote_version_id}") }
@@ -41,6 +43,9 @@ RSpec.describe Api::V1::QuoteVersionsController do
 
     context "when the quote version belongs to another organization" do
       let(:quote_version) { create(:quote_version) }
+
+      let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+      let(:customer) { create(:customer, organization:) }
 
       it "returns not found" do
         subject

--- a/spec/requests/api/v1/quotes/versions_controller_spec.rb
+++ b/spec/requests/api/v1/quotes/versions_controller_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::Quotes::VersionsController do
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   describe "GET /api/v1/quotes/:quote_id/versions" do
     subject { get_with_token(organization, "/api/v1/quotes/#{quote_id}/versions", params) }

--- a/spec/requests/api/v1/quotes_controller_spec.rb
+++ b/spec/requests/api/v1/quotes_controller_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::QuotesController do
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   describe "GET /api/v1/quotes" do
     subject { get_with_token(organization, "/api/v1/quotes", params) }
@@ -238,6 +238,8 @@ RSpec.describe Api::V1::QuotesController do
 
     context "when the quote belongs to another organization" do
       let(:quote) { create(:quote) }
+      let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+      let(:customer) { create(:customer, organization:) }
 
       it "returns not found" do
         subject

--- a/spec/requests/api/v1/subscriptions/charges/filters_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/charges/filters_controller_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::Subscriptions::Charges::FiltersController do
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
   let(:billable_metric_filter) { create(:billable_metric_filter, billable_metric:, key: "region", values: %w[us eu]) }
   let(:external_id) { "sub_123" }
   let(:external_id_query_param) { external_id }
@@ -212,7 +212,7 @@ RSpec.describe Api::V1::Subscriptions::Charges::FiltersController do
       end
 
       context "when subscription already has plan override with charge override" do
-        let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+        let_it_be(:overridden_plan) { create_default(:plan, organization:, parent: plan) }
         let(:subscription) { create(:subscription, customer:, plan: overridden_plan, external_id:) }
         let(:overridden_charge) { create(:standard_charge, plan: overridden_plan, organization:, billable_metric:, parent: charge, code: charge.code) }
 
@@ -311,7 +311,7 @@ RSpec.describe Api::V1::Subscriptions::Charges::FiltersController do
       end
 
       context "when subscription already has plan override with charge and filter override" do
-        let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+        let_it_be(:overridden_plan) { create_default(:plan, organization:, parent: plan) }
         let(:subscription) { create(:subscription, customer:, plan: overridden_plan, external_id:) }
         let(:overridden_charge) { create(:standard_charge, plan: overridden_plan, organization:, billable_metric:, parent: charge, code: charge.code) }
         let(:charge_filter) { create(:charge_filter, charge: overridden_charge, organization:, invoice_display_name: "Original Name", properties: {"amount" => "10"}) }
@@ -408,7 +408,7 @@ RSpec.describe Api::V1::Subscriptions::Charges::FiltersController do
       end
 
       context "when subscription already has plan override with charge and filter override" do
-        let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+        let_it_be(:overridden_plan) { create_default(:plan, organization:, parent: plan) }
         let(:subscription) { create(:subscription, customer:, plan: overridden_plan, external_id:) }
         let(:overridden_charge) { create(:standard_charge, plan: overridden_plan, organization:, billable_metric:, parent: charge, code: charge.code) }
         let(:charge_filter) { create(:charge_filter, charge: overridden_charge, organization:) }

--- a/spec/requests/api/v1/subscriptions/charges_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/charges_controller_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::Subscriptions::ChargesController do
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
   let(:external_id) { "sub_123" }
   let(:external_id_query_param) { external_id }
   let(:subscription) { create(:subscription, customer:, plan:, external_id:) }
@@ -208,7 +208,7 @@ RSpec.describe Api::V1::Subscriptions::ChargesController do
       end
 
       context "when subscription already has plan override" do
-        let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+        let_it_be(:overridden_plan) { create_default(:plan, organization:, parent: plan) }
         let(:subscription) { create(:subscription, customer:, plan: overridden_plan, external_id:) }
         let(:overridden_charge) { create(:standard_charge, plan: overridden_plan, organization:, billable_metric:, parent: charge, code: charge.code) }
 

--- a/spec/requests/api/v1/subscriptions/entitlements/privileges_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/entitlements/privileges_controller_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::Subscriptions::Entitlements::PrivilegesController do
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
   let(:subscription) { create(:subscription, organization:, customer:, plan:) }
   let(:feature) { create(:feature, organization:, code: "seats") }
   let(:privilege) { create(:privilege, organization:, feature:, code: "max", value_type: "integer") }

--- a/spec/requests/api/v1/subscriptions/entitlements_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/entitlements_controller_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::Subscriptions::EntitlementsController do
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
   let(:subscription) { create(:subscription, organization:, customer:, plan:) }
   let(:feature) { create(:feature, organization:, code: "seats") }
   let(:privilege1) { create(:privilege, organization:, feature:, code: "max", value_type: "integer") }

--- a/spec/requests/api/v1/subscriptions/fixed_charges_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/fixed_charges_controller_spec.rb
@@ -4,14 +4,15 @@ require "rails_helper"
 
 RSpec.describe Api::V1::Subscriptions::FixedChargesController do
   let(:external_id) { "sub+1" }
-  let(:external_id_query_param) { external_id }
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:add_on) { create(:add_on, organization:) }
   let(:subscription) { create(:subscription, external_id:, customer:, plan:) }
   let(:fixed_charge) { create(:fixed_charge, plan:, organization:, add_on:) }
   let(:deleted_fixed_charge) { create(:fixed_charge, :deleted, plan:, organization:) }
+  let(:external_id_query_param) { external_id }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
+  let_it_be(:add_on) { create_default(:add_on, organization:) }
 
   before do
     subscription
@@ -237,7 +238,7 @@ RSpec.describe Api::V1::Subscriptions::FixedChargesController do
       end
 
       context "when subscription already has plan override" do
-        let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+        let_it_be(:overridden_plan) { create_default(:plan, organization:, parent: plan) }
         let(:subscription) { create(:subscription, customer:, plan: overridden_plan, external_id:) }
         let(:overridden_fixed_charge) { create(:fixed_charge, plan: overridden_plan, organization:, add_on:, parent: fixed_charge, code: fixed_charge.code) }
 

--- a/spec/requests/api/v1/subscriptions/lifetime_usages_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/lifetime_usages_controller_spec.rb
@@ -4,11 +4,13 @@ require "rails_helper"
 
 RSpec.describe Api::V1::Subscriptions::LifetimeUsagesController do
   let!(:lifetime_usage) { create(:lifetime_usage, organization:, subscription:) }
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, plan:, organization:, subscription_at:, customer:) }
   let(:subscription_at) { Date.new(2022, 8, 22) }
-  let(:plan) { create(:plan) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+
+  let_it_be(:plan) { create_default(:plan) }
 
   before { create(:usage_threshold, plan:, amount_cents: 100) }
 

--- a/spec/requests/api/v1/taxes_controller_spec.rb
+++ b/spec/requests/api/v1/taxes_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::TaxesController do
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
 
   describe "POST /api/v1/taxes" do
     subject { post_with_token(organization, "/api/v1/taxes", {tax: create_params}) }

--- a/spec/requests/api/v1/wallet_transactions_controller_spec.rb
+++ b/spec/requests/api/v1/wallet_transactions_controller_spec.rb
@@ -3,8 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::WalletTransactionsController do
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:) }
   let(:wallet) { create(:wallet, customer:, credits_balance: 10, balance_cents: 1000) }
   let(:wallet_id) { wallet.id }

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -3,8 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::WalletsController do
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:, currency: "EUR") }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:, currency: "EUR") }
+  let(:plan) { create_default(:plan) }
   let(:subscription) { create(:subscription, customer:) }
   let(:expiration_at) { (Time.current + 1.year).iso8601 }
   let(:section_1) { create(:invoice_custom_section, organization:, code: "section_code_1") }
@@ -60,6 +61,9 @@ RSpec.describe Api::V1::WalletsController do
 
   describe "DELETE /api/v1/wallets/:id" do
     it_behaves_like "a wallet terminate endpoint" do
+      let(:organization) { create(:organization) }
+      let(:customer) { create(:customer, organization:, currency: "EUR") }
+
       subject { delete_with_token(organization, "/api/v1/wallets/#{id}") }
 
       let(:id) { wallet.id }
@@ -68,6 +72,9 @@ RSpec.describe Api::V1::WalletsController do
 
   describe "GET /api/v1/wallets" do
     it_behaves_like "a wallet index endpoint" do
+      let(:organization) { create(:organization) }
+      let(:customer) { create(:customer, organization:, currency: "EUR") }
+
       subject do
         get_with_token(organization, "/api/v1/wallets?external_customer_id=#{external_id}", params)
       end

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -61,10 +61,10 @@ RSpec.describe Api::V1::WalletsController do
 
   describe "DELETE /api/v1/wallets/:id" do
     it_behaves_like "a wallet terminate endpoint" do
+      subject { delete_with_token(organization, "/api/v1/wallets/#{id}") }
+
       let(:organization) { create(:organization) }
       let(:customer) { create(:customer, organization:, currency: "EUR") }
-
-      subject { delete_with_token(organization, "/api/v1/wallets/#{id}") }
 
       let(:id) { wallet.id }
     end
@@ -72,12 +72,12 @@ RSpec.describe Api::V1::WalletsController do
 
   describe "GET /api/v1/wallets" do
     it_behaves_like "a wallet index endpoint" do
-      let(:organization) { create(:organization) }
-      let(:customer) { create(:customer, organization:, currency: "EUR") }
-
       subject do
         get_with_token(organization, "/api/v1/wallets?external_customer_id=#{external_id}", params)
       end
+
+      let(:organization) { create(:organization) }
+      let(:customer) { create(:customer, organization:, currency: "EUR") }
 
       context "when external_customer_id does not belong to the current organization" do
         let(:other_org_customer) { create(:customer) }

--- a/spec/requests/api/v1/webhook_endpoints_controller_spec.rb
+++ b/spec/requests/api/v1/webhook_endpoints_controller_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::WebhookEndpointsController do
+  let_it_be(:organization) { create_default(:organization) }
   describe "POST /api/v1/webhook_endpoints" do
     subject do
       post_with_token(
@@ -12,7 +13,7 @@ RSpec.describe Api::V1::WebhookEndpointsController do
       )
     end
 
-    let(:organization) { create(:organization) }
+    let_it_be(:organization) { create_default(:organization) }
     let(:create_params) do
       {
         webhook_url: Faker::Internet.url,

--- a/spec/requests/api/v1/webhooks_controller_spec.rb
+++ b/spec/requests/api/v1/webhooks_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::WebhooksController do
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
 
   describe "GET /api/v1/webhooks/public_key" do
     subject { get_with_token(organization, "/api/v1/webhooks/public_key") }

--- a/spec/requests/api/v2/plans_controller_spec.rb
+++ b/spec/requests/api/v2/plans_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V2::PlansController do
-  let(:organization) { create(:organization, feature_flags: ["product_catalog"]) }
+  let_it_be(:organization) { create_default(:organization, feature_flags: ["product_catalog"]) }
 
   describe "POST /api/v2/plans" do
     subject { post_with_token(organization, "/api/v2/plans", {plan: create_params}) }
@@ -84,6 +84,7 @@ RSpec.describe Api::V2::PlansController do
     subject { get_with_token(organization, "/api/v2/plans", params) }
 
     let(:params) { {} }
+    let(:organization) { create(:organization, feature_flags: ["product_catalog"]) }
     let!(:plan) { create(:plan, organization:, pricing_type: "product_catalog") }
 
     include_examples "requires API permission", "plan", "read"

--- a/spec/requests/data_api/v1/charges_controller_spec.rb
+++ b/spec/requests/data_api/v1/charges_controller_spec.rb
@@ -22,21 +22,6 @@ RSpec.describe DataApi::V1::ChargesController do # rubocop:disable Rails/FilePat
         properties: {amount: "10"}
       )
     end
-
-    let(:charge2) do
-      create(
-        :standard_charge,
-        plan:,
-        billable_metric:,
-        properties: {amount: "20"}
-      )
-    end
-
-    let(:charge_filter) { create(:charge_filter, charge: charge1) }
-    let(:plan) { create(:plan, organization:, amount_cents: 1000) }
-    let(:billable_metric) { create(:billable_metric, organization:) }
-    let(:organization) { create(:organization) }
-
     let(:params) do
       {
         charges: [
@@ -58,7 +43,6 @@ RSpec.describe DataApi::V1::ChargesController do # rubocop:disable Rails/FilePat
         ]
       }
     end
-
     let(:result) do
       Charges::CalculatePriceService::Result.new.tap do |result|
         result.charge_amount_cents = 10
@@ -66,6 +50,21 @@ RSpec.describe DataApi::V1::ChargesController do # rubocop:disable Rails/FilePat
         result.total_amount_cents = 20
       end
     end
+
+    let(:charge2) do
+      create(
+        :standard_charge,
+        plan:,
+        billable_metric:,
+        properties: {amount: "20"}
+      )
+    end
+
+    let(:charge_filter) { create(:charge_filter, charge: charge1) }
+    let(:plan) { create(:plan, organization:, amount_cents: 1000) }
+
+    let_it_be(:organization) { create_default(:organization) }
+    let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
 
     before do
       allow(Charges::CalculatePriceService).to receive(:call).and_return(result)

--- a/spec/requests/webhooks_controller_spec.rb
+++ b/spec/requests/webhooks_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe WebhooksController do
   end
 
   describe "POST /gocardless" do
-    let(:organization) { create(:organization) }
+    let_it_be(:organization) { create_default(:organization) }
 
     let(:gocardless_provider) do
       create(
@@ -138,7 +138,7 @@ RSpec.describe WebhooksController do
   end
 
   describe "POST /adyen" do
-    let(:organization) { create(:organization) }
+    let_it_be(:organization) { create_default(:organization) }
 
     let(:adyen_provider) do
       create(:adyen_provider, organization:)
@@ -199,7 +199,7 @@ RSpec.describe WebhooksController do
   end
 
   describe "POST /cashfree" do
-    let(:organization) { create(:organization) }
+    let_it_be(:organization) { create_default(:organization) }
 
     let(:cashfree_provider) do
       create(:cashfree_provider, organization:)
@@ -329,7 +329,7 @@ RSpec.describe WebhooksController do
   end
 
   describe "POST /flutterwave" do
-    let(:organization) { create(:organization) }
+    let_it_be(:organization) { create_default(:organization) }
 
     let(:flutterwave_provider) do
       create(:flutterwave_provider, organization:)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,6 +76,10 @@ Sentry.init do |config|
   config.transport.transport_class = Sentry::DummyTransport
 end
 
+require "test_prof/recipes/rspec/sample"
+require "test_prof/recipes/rspec/let_it_be"
+require "test_prof/recipes/rspec/factory_default"
+
 RSpec.configure do |config|
   config.include ActiveJob::TestHelper
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
## Context

Currently, around **50% of the spec runtime** is spent preparing data and creating factories. A lot of this data is either duplicated or recreates the same objects multiple times, so we can get rid of a good chunk of it and significantly speed up the specs.

To avoid creating unnecessary factories, we can use `let_it_be`, `before_all`, and `create_default` from `test-prof`. More info [here](https://test-prof.evilmartians.io/guide/recipes/let_it_be).

## Description

This PR cleans up the requests specs and removes unnecessary factory usage.

Here are the numbers before and after the cleanup. The times below are for running the specs in a single process:

| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 17,286 | 14,450 |
| Time spent creating factories |  01:33.563 | 01:12.321 |
| Total time | 02:27.380 | 02:09.595 |

## Overall results

This PR is part of a series of PRs focused on cleaning up factory usage across different specs.

Once all the changes are merged, we expect to:

- Reduce the number of factories by **~50k**
- Cut spec runtime by around **20%**
- Shave off roughly **1:15 min** from the CI runtime


| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 157,949 | 103,761 |
| Total time spent creating factories | 17:59.851  | 11:14.739 |
| Total time | 34:41.482 | 27:03.658 |

Here is [the CI run](https://github.com/getlago/lago-api/actions/runs/33399605547/job/99512391170?pr=6255) with all the changes merged together: