### PR TITLE
perf(specs): Clean up factories usage in spec/serializers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -167,6 +167,8 @@ group :test do
   # HTML testing (invoice rendering)
   gem "rspec-snapshot", "~> 2.0"
   gem "htmlbeautifier", "~> 1.4"
+
+  gem "test-prof", "~> 1.0"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1004,6 +1004,8 @@ GEM
     temple (0.10.4)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
+    test-prof (1.6.3)
+      logger
     thor (1.5.0)
     throttling (0.4.1)
       logger
@@ -1181,6 +1183,7 @@ DEPENDENCIES
   stripe
   strong_migrations
   super_diff (~> 0.19.0)
+  test-prof (~> 1.0)
   throttling
   timecop
   tzinfo-data

--- a/spec/serializers/e_invoices/cii/header_spec.rb
+++ b/spec/serializers/e_invoices/cii/header_spec.rb
@@ -9,13 +9,15 @@ RSpec.describe EInvoices::Cii::Header do
     end
   end
 
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:invoice) { create(:invoice, issuing_date: issuing_date.to_date) }
+  let(:root) { "//rsm:ExchangedDocument" }
   let(:resource) { invoice }
   let(:type_code) { described_class::COMMERCIAL_INVOICE }
   let(:notes) { ["Invoice ID: #{invoice.id}", "Allow multiple notes"] }
-  let(:issuing_date) { "20250316" }
 
-  let(:root) { "//rsm:ExchangedDocument" }
+  let(:issuing_date) { "20250316" }
 
   before { invoice }
 
@@ -56,9 +58,10 @@ RSpec.describe EInvoices::Cii::Header do
 
     context "when credit note" do
       let(:credit_note) { create(:credit_note, invoice:, issuing_date: issuing_date.to_date) }
-      let(:issuing_date) { "20250317" }
       let(:resource) { credit_note }
       let(:type_code) { described_class::CREDIT_NOTE }
+
+      let_it_be(:issuing_date) { "20250317" }
 
       it "expects to have the credit note number" do
         expect(subject).to contains_xml_node("#{root}/ram:ID").with_value(credit_note.number)

--- a/spec/serializers/e_invoices/cii/line_item_spec.rb
+++ b/spec/serializers/e_invoices/cii/line_item_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe EInvoices::Cii::LineItem do
     end
   end
 
-  let(:resource) { create(:invoice) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:resource) { create_default(:invoice) }
   let(:data) do
     described_class::Data.new(
       line_id:,

--- a/spec/serializers/e_invoices/cii/monetary_summation_spec.rb
+++ b/spec/serializers/e_invoices/cii/monetary_summation_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe EInvoices::Cii::MonetarySummation do
     end
   end
 
-  let(:resource) { create(:invoice, currency: "USD") }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:resource) { create_default(:invoice, currency: "USD") }
   let(:amounts) do
     described_class::Amounts.new(
       line_total_amount: Money.new(100000),

--- a/spec/serializers/e_invoices/cii/trade_agreement_spec.rb
+++ b/spec/serializers/e_invoices/cii/trade_agreement_spec.rb
@@ -10,11 +10,12 @@ RSpec.describe EInvoices::Cii::TradeAgreement do
   end
 
   let(:options) { described_class::Options.new }
-  let(:root) { "//ram:ApplicableHeaderTradeAgreement" }
-  let(:membership) { create(:membership) }
-  let_it_be(:organization) { create_default(:organization) }
   let(:resource) { create(:invoice, customer:, organization:, billing_entity:, invoice_type:) }
   let(:invoice_type) { :subscription }
+  let(:root) { "//ram:ApplicableHeaderTradeAgreement" }
+  let(:membership) { create(:membership) }
+
+  let_it_be(:organization) { create_default(:organization) }
 
   let_it_be(:customer) do
     create_default(:customer,

--- a/spec/serializers/e_invoices/cii/trade_agreement_spec.rb
+++ b/spec/serializers/e_invoices/cii/trade_agreement_spec.rb
@@ -10,18 +10,20 @@ RSpec.describe EInvoices::Cii::TradeAgreement do
   end
 
   let(:options) { described_class::Options.new }
+  let(:root) { "//ram:ApplicableHeaderTradeAgreement" }
   let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization) }
   let(:resource) { create(:invoice, customer:, organization:, billing_entity:, invoice_type:) }
   let(:invoice_type) { :subscription }
-  let(:customer) do
-    create(:customer,
+
+  let_it_be(:customer) do
+    create_default(:customer,
       organization:,
       name: "Its Mii",
       legal_name: nil)
   end
-  let(:billing_entity) do
-    create(:billing_entity,
+  let_it_be(:billing_entity) do
+    create_default(:billing_entity,
       organization:,
       code: "BE_CODE",
       legal_name: "BE Legal Name",
@@ -32,8 +34,6 @@ RSpec.describe EInvoices::Cii::TradeAgreement do
       country: "BR",
       tax_identification_number: "BR987654321")
   end
-
-  let(:root) { "//ram:ApplicableHeaderTradeAgreement" }
 
   describe ".serialize" do
     it { is_expected.not_to be_nil }

--- a/spec/serializers/e_invoices/cii/trade_allowance_charge_spec.rb
+++ b/spec/serializers/e_invoices/cii/trade_allowance_charge_spec.rb
@@ -11,11 +11,13 @@ RSpec.describe EInvoices::Cii::TradeAllowanceCharge do
   end
 
   let(:indicator) { described_class::INVOICE_DISCOUNT }
-  let(:resource) { create(:invoice) }
   let(:tax_rate) { 19.00 }
   let(:amount) { Money.new(1000) }
-
   let(:root) { "//ram:SpecifiedTradeAllowanceCharge" }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:resource) { create_default(:invoice) }
 
   describe ".serialize" do
     it { is_expected.not_to be_nil }

--- a/spec/serializers/e_invoices/cii/trade_settlement_payment_spec.rb
+++ b/spec/serializers/e_invoices/cii/trade_settlement_payment_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe EInvoices::Cii::TradeSettlementPayment do
     end
   end
 
-  let(:resource) { create(:invoice, currency: "USD") }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:resource) { create_default(:invoice, currency: "USD") }
   let(:type) { described_class::STANDARD_PAYMENT }
   let(:amount) { Money.new(1000) }
 

--- a/spec/serializers/e_invoices/cii/trade_settlement_spec.rb
+++ b/spec/serializers/e_invoices/cii/trade_settlement_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe EInvoices::Cii::TradeSettlement do
     end
   end
 
-  let(:resource) { create(:invoice, currency: "EUR") }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:resource) { create_default(:invoice, currency: "EUR") }
 
   let(:root) { "//ram:ApplicableHeaderTradeSettlement" }
 

--- a/spec/serializers/e_invoices/credit_notes/cii/builder_spec.rb
+++ b/spec/serializers/e_invoices/credit_notes/cii/builder_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe EInvoices::CreditNotes::Cii::Builder do
     end
   end
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:invoice) { create_default(:invoice) }
   let(:credit_note) { create(:credit_note, total_amount_currency: "EUR", credit_amount: 1) }
   let(:credit_note_item1) { create(:credit_note_item, credit_note:, fee:, precise_amount_cents: 1000) }
   let(:credit_note_item2) { create(:credit_note_item, credit_note:, fee: fee2, precise_amount_cents: 2500) }
@@ -168,8 +172,6 @@ RSpec.describe EInvoices::CreditNotes::Cii::Builder do
 
     context "when ApplicableTradeTax tag" do
       let(:root) { "//ram:ApplicableHeaderTradeSettlement//ram:ApplicableTradeTax" }
-
-      let(:invoice) { create(:invoice) }
       let(:credit_note) { create(:credit_note, invoice:) }
       let(:credit_note_item0) { create(:credit_note_item, credit_note:, fee: fee0, precise_amount_cents: 500) }
       let(:credit_note_item1) { create(:credit_note_item, credit_note:, fee: fee1, precise_amount_cents: 500) }
@@ -183,6 +185,8 @@ RSpec.describe EInvoices::CreditNotes::Cii::Builder do
       let(:fee4) { create(:fee, invoice:, taxes_rate: 10.0, precise_amount_cents: 600, taxes_precise_amount_cents: 60) }
       let(:credit_note_applied_tax1) { create(:credit_note_applied_tax, credit_note:, tax_rate: 5.0, amount_cents: 20, base_amount_cents: 400) }
       let(:credit_note_applied_tax2) { create(:credit_note_applied_tax, credit_note:, tax_rate: 10.0, amount_cents: 60, base_amount_cents: 600) }
+
+      let_it_be(:invoice) { create_default(:invoice) }
 
       before do
         credit_note_item0
@@ -224,8 +228,6 @@ RSpec.describe EInvoices::CreditNotes::Cii::Builder do
 
     context "when SpecifiedTradeAllowanceCharge tag" do
       let(:root) { "//ram:ApplicableHeaderTradeSettlement//ram:SpecifiedTradeAllowanceCharge" }
-
-      let(:invoice) { create(:invoice, coupons_amount_cents: 100) }
       let(:credit_note) { create(:credit_note, invoice:, precise_coupons_adjustment_amount_cents: 100) }
       let(:invoice_fee1) { create(:fee, invoice:, taxes_rate: 0.0, precise_coupons_amount_cents: 100, precise_amount_cents: 2000, taxes_precise_amount_cents: 0) }
       let(:invoice_fee2) { create(:fee, invoice:, taxes_rate: 5.0, precise_coupons_amount_cents: 10, precise_amount_cents: 100, taxes_precise_amount_cents: 4.75) }
@@ -235,6 +237,8 @@ RSpec.describe EInvoices::CreditNotes::Cii::Builder do
       let(:credit_note_item2) { create(:credit_note_item, credit_note:, fee: invoice_fee2, precise_amount_cents: 100) }
       let(:credit_note_item3) { create(:credit_note_item, credit_note:, fee: invoice_fee3, precise_amount_cents: 300) }
       let(:credit_note_item4) { create(:credit_note_item, credit_note:, fee: invoice_fee4, precise_amount_cents: 600) }
+
+      let_it_be(:invoice) { create_default(:invoice, coupons_amount_cents: 100) }
 
       before do
         credit_note_item1
@@ -294,9 +298,9 @@ RSpec.describe EInvoices::CreditNotes::Cii::Builder do
 
     context "when SpecifiedTradeSettlementHeaderMonetarySummation tag" do
       let(:root) { "//ram:ApplicableHeaderTradeSettlement//ram:SpecifiedTradeSettlementHeaderMonetarySummation" }
-
-      let(:invoice) { create(:invoice, coupons_amount_cents: 100) }
       let(:credit_note) { create(:credit_note, invoice:, precise_coupons_adjustment_amount_cents: 100, taxes_amount: 10, total_amount: 20, credit_amount: 10) }
+
+      let_it_be(:invoice) { create_default(:invoice, coupons_amount_cents: 100) }
 
       it "contains the tag" do
         expect(subject).to contains_xml_node(root)

--- a/spec/serializers/e_invoices/credit_notes/ubl/builder_spec.rb
+++ b/spec/serializers/e_invoices/credit_notes/ubl/builder_spec.rb
@@ -10,7 +10,11 @@ RSpec.describe EInvoices::CreditNotes::Ubl::Builder do
   end
 
   let(:credit_note) { create(:credit_note, invoice:, total_amount_currency: "EUR", credit_amount: 1) }
-  let(:invoice) { create(:invoice, number: "LAGO-TEST-123") }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:invoice) { create_default(:invoice, number: "LAGO-TEST-123") }
 
   before do
     credit_note.reload
@@ -165,6 +169,7 @@ RSpec.describe EInvoices::CreditNotes::Ubl::Builder do
 
     context "when AllowanceCharge tags" do
       let(:root) { "//cac:AllowanceCharge" }
+      let(:credit_note) { create(:credit_note, invoice:, precise_coupons_adjustment_amount_cents: 100) }
 
       let(:invoice_fee1) { create(:fee, invoice:, taxes_rate: 0.0, precise_coupons_amount_cents: 100, precise_amount_cents: 2000, taxes_precise_amount_cents: 0) }
       let(:invoice_fee2) { create(:fee, invoice:, taxes_rate: 5.0, precise_coupons_amount_cents: 10, precise_amount_cents: 100, taxes_precise_amount_cents: 4.75) }
@@ -174,8 +179,8 @@ RSpec.describe EInvoices::CreditNotes::Ubl::Builder do
       let(:credit_note_item2) { create(:credit_note_item, credit_note:, fee: invoice_fee2, precise_amount_cents: 100) }
       let(:credit_note_item3) { create(:credit_note_item, credit_note:, fee: invoice_fee3, precise_amount_cents: 300) }
       let(:credit_note_item4) { create(:credit_note_item, credit_note:, fee: invoice_fee4, precise_amount_cents: 600) }
-      let(:invoice) { create(:invoice, coupons_amount_cents: 100) }
-      let(:credit_note) { create(:credit_note, invoice:, precise_coupons_adjustment_amount_cents: 100) }
+
+      let_it_be(:invoice) { create_default(:invoice, coupons_amount_cents: 100) }
 
       before do
         credit_note_item1
@@ -236,7 +241,7 @@ RSpec.describe EInvoices::CreditNotes::Ubl::Builder do
       let(:root) { "//cac:TaxTotal/cac:TaxSubtotal" }
 
       context "with multiple taxes" do
-        let(:invoice) { create(:invoice) }
+        let_it_be(:invoice) { create_default(:invoice) }
         let(:credit_note) { create(:credit_note, invoice:) }
         let(:credit_note_item0) { create(:credit_note_item, credit_note:, fee: fee0, precise_amount_cents: 500) }
         let(:credit_note_item1) { create(:credit_note_item, credit_note:, fee: fee1, precise_amount_cents: 500) }
@@ -290,7 +295,7 @@ RSpec.describe EInvoices::CreditNotes::Ubl::Builder do
       end
 
       context "when credit invoice" do
-        let(:invoice) { create(:invoice, invoice_type: :credit) }
+        let_it_be(:invoice) { create_default(:invoice, invoice_type: :credit) }
         let(:credit_note) { create(:credit_note, invoice:) }
         let(:fee0) { create(:fee, invoice:, fee_type: :credit, taxes_rate: 0.0, precise_amount_cents: 500, taxes_precise_amount_cents: 0) }
         let(:credit_note_item0) { create(:credit_note_item, credit_note:, fee: fee0, precise_amount_cents: 500) }

--- a/spec/serializers/e_invoices/invoices/cii/builder_spec.rb
+++ b/spec/serializers/e_invoices/invoices/cii/builder_spec.rb
@@ -9,10 +9,14 @@ RSpec.describe EInvoices::Invoices::Cii::Builder do
     end
   end
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
   let(:invoice) { create(:invoice, invoice_type:, currency: "USD", total_amount_cents: 3000, payment_due_date: "20250316".to_date) }
-  let(:invoice_type) { :one_off }
   let(:invoice_fee1) { create(:fee, invoice:, units: 5, amount: 10, precise_unit_amount: 2) }
   let(:invoice_fee2) { create(:fee, invoice:, units: 1, amount: 25, precise_unit_amount: 25) }
+
+  let(:invoice_type) { :one_off }
 
   before do
     invoice_fee1
@@ -246,12 +250,12 @@ RSpec.describe EInvoices::Invoices::Cii::Builder do
 
     context "when ApplicableTradeTax tag" do
       let(:root) { "//ram:ApplicableHeaderTradeSettlement//ram:ApplicableTradeTax" }
-
-      let(:invoice) { create(:invoice, coupons_amount_cents: 100, invoice_type:) }
       let(:invoice_fee1) { create(:fee, invoice:, taxes_rate: 0.0, precise_amount_cents: 1000, taxes_precise_amount_cents: 0) }
       let(:invoice_fee2) { create(:fee, invoice:, taxes_rate: 5.0, precise_amount_cents: 100, taxes_precise_amount_cents: 4.75) }
       let(:invoice_fee3) { create(:fee, invoice:, taxes_rate: 5.0, precise_amount_cents: 300, taxes_precise_amount_cents: 14.25) }
       let(:invoice_fee4) { create(:fee, invoice:, taxes_rate: 10.0, precise_amount_cents: 600, taxes_precise_amount_cents: 57) }
+
+      let(:invoice) { create(:invoice, coupons_amount_cents: 100, invoice_type:) }
 
       before do
         invoice_fee1
@@ -286,12 +290,12 @@ RSpec.describe EInvoices::Invoices::Cii::Builder do
 
     context "when SpecifiedTradeAllowanceCharge tag" do
       let(:root) { "//ram:ApplicableHeaderTradeSettlement//ram:SpecifiedTradeAllowanceCharge" }
-
-      let(:invoice) { create(:invoice, coupons_amount_cents: 100, invoice_type:) }
       let(:invoice_fee1) { create(:fee, invoice:, taxes_rate: 0.0, precise_amount_cents: 1000, taxes_precise_amount_cents: 0) }
       let(:invoice_fee2) { create(:fee, invoice:, taxes_rate: 5.0, precise_amount_cents: 100, taxes_precise_amount_cents: 4.75) }
       let(:invoice_fee3) { create(:fee, invoice:, taxes_rate: 5.0, precise_amount_cents: 300, taxes_precise_amount_cents: 14.25) }
       let(:invoice_fee4) { create(:fee, invoice:, taxes_rate: 10.0, precise_amount_cents: 600, taxes_precise_amount_cents: 57) }
+
+      let(:invoice) { create(:invoice, coupons_amount_cents: 100, invoice_type:) }
 
       before do
         invoice_fee1

--- a/spec/serializers/e_invoices/invoices/ubl/builder_spec.rb
+++ b/spec/serializers/e_invoices/invoices/ubl/builder_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe EInvoices::Invoices::Ubl::Builder do
     end
   end
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
   let(:invoice) { create(:invoice, invoice_type:, currency: "USD", total_amount_cents: 3000, payment_due_date: "20250316".to_date, taxes_amount_cents: 2500) }
   let(:invoice_type) { :one_off }
   let(:invoice_fee1) { create(:fee, invoice:, units: 5, amount: 10, precise_unit_amount: 2, amount_currency: "EUR") }
@@ -238,12 +241,12 @@ RSpec.describe EInvoices::Invoices::Ubl::Builder do
 
     context "when AllowanceCharge tag" do
       let(:root) { "//cac:AllowanceCharge" }
-
-      let(:invoice) { create(:invoice, coupons_amount_cents: 100, invoice_type:) }
       let(:invoice_fee1) { create(:fee, invoice:, taxes_rate: 0.0, precise_amount_cents: 1000, taxes_precise_amount_cents: 0) }
       let(:invoice_fee2) { create(:fee, invoice:, taxes_rate: 5.0, precise_amount_cents: 100, taxes_precise_amount_cents: 4.75) }
       let(:invoice_fee3) { create(:fee, invoice:, taxes_rate: 5.0, precise_amount_cents: 300, taxes_precise_amount_cents: 14.25) }
       let(:invoice_fee4) { create(:fee, invoice:, taxes_rate: 10.0, precise_amount_cents: 600, taxes_precise_amount_cents: 57) }
+
+      let(:invoice) { create(:invoice, coupons_amount_cents: 100, invoice_type:) }
 
       before do
         invoice_fee1
@@ -316,12 +319,12 @@ RSpec.describe EInvoices::Invoices::Ubl::Builder do
 
     context "when TaxSubtotal tag" do
       let(:root) { "//cac:TaxTotal/cac:TaxSubtotal" }
-
-      let(:invoice) { create(:invoice, coupons_amount_cents: 100, invoice_type:) }
       let(:invoice_fee1) { create(:fee, invoice:, taxes_rate: 0.0, precise_amount_cents: 1000, taxes_precise_amount_cents: 0) }
       let(:invoice_fee2) { create(:fee, invoice:, taxes_rate: 5.0, precise_amount_cents: 100, taxes_precise_amount_cents: 4.75) }
       let(:invoice_fee3) { create(:fee, invoice:, taxes_rate: 5.0, precise_amount_cents: 300, taxes_precise_amount_cents: 14.25) }
       let(:invoice_fee4) { create(:fee, invoice:, taxes_rate: 10.0, precise_amount_cents: 600, taxes_precise_amount_cents: 57) }
+
+      let(:invoice) { create(:invoice, coupons_amount_cents: 100, invoice_type:) }
 
       before do
         invoice_fee1

--- a/spec/serializers/e_invoices/payments/cii/builder_spec.rb
+++ b/spec/serializers/e_invoices/payments/cii/builder_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe EInvoices::Payments::Cii::Builder do
     end
   end
 
-  let(:organization) { create(:organization, premium_integrations: %w[issue_receipts]) }
+  let_it_be(:organization) { create_default(:organization, premium_integrations: %w[issue_receipts]) }
   let(:billing_entity) { create(:billing_entity, tax_identification_number: "MAR1234BR") }
   let(:customer) { create(:customer, billing_entity:) }
   let(:invoice) { create(:invoice, total_amount_cents: 1000, number: "INV-24680-OIC-E") }

--- a/spec/serializers/e_invoices/payments/ubl/builder_spec.rb
+++ b/spec/serializers/e_invoices/payments/ubl/builder_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe EInvoices::Payments::Ubl::Builder do
     end
   end
 
-  let(:organization) { create(:organization, premium_integrations: %w[issue_receipts]) }
-  let(:billing_entity) { create(:billing_entity, tax_identification_number: "MAR1234BR") }
-  let(:customer) { create(:customer, billing_entity:) }
-  let(:invoice) { create(:invoice, total_amount_cents: 1000, number: "INV-24680-OIC-E") }
+  let_it_be(:organization) { create_default(:organization, premium_integrations: %w[issue_receipts]) }
+  let_it_be(:billing_entity) { create_default(:billing_entity, tax_identification_number: "MAR1234BR") }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:invoice) { create_default(:invoice, total_amount_cents: 1000, number: "INV-24680-OIC-E") }
   let(:payment) do
     create(:payment,
       customer:,

--- a/spec/serializers/e_invoices/ubl/allowance_charge_spec.rb
+++ b/spec/serializers/e_invoices/ubl/allowance_charge_spec.rb
@@ -10,12 +10,14 @@ RSpec.describe EInvoices::Ubl::AllowanceCharge do
   end
 
   let(:indicator) { described_class::INVOICE_DISCOUNT }
-  let(:resource) { invoice }
-  let(:invoice) { create(:invoice, currency: "USD") }
   let(:tax_rate) { 19.00 }
   let(:amount) { Money.new(1000) }
-
   let(:root) { "//cac:AllowanceCharge" }
+  let(:resource) { invoice }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:invoice) { create_default(:invoice, currency: "USD") }
 
   before { invoice }
 

--- a/spec/serializers/e_invoices/ubl/billing_reference_spec.rb
+++ b/spec/serializers/e_invoices/ubl/billing_reference_spec.rb
@@ -9,10 +9,13 @@ RSpec.describe EInvoices::Ubl::BillingReference do
     end
   end
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+
   let(:resource) { invoice }
-  let(:issuing_date) { "2025-03-16".to_date }
-  let(:invoice) { create(:invoice, issuing_date:) }
   let(:root) { "//cac:BillingReference" }
+  let_it_be(:issuing_date) { "2025-03-16".to_date }
+  let_it_be(:invoice) { create_default(:invoice, issuing_date:) }
 
   describe ".serialize" do
     it { is_expected.not_to be_nil }

--- a/spec/serializers/e_invoices/ubl/billing_reference_spec.rb
+++ b/spec/serializers/e_invoices/ubl/billing_reference_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe EInvoices::Ubl::BillingReference do
 
   let(:resource) { invoice }
   let(:root) { "//cac:BillingReference" }
+
   let_it_be(:issuing_date) { "2025-03-16".to_date }
   let_it_be(:invoice) { create_default(:invoice, issuing_date:) }
 

--- a/spec/serializers/e_invoices/ubl/customer_party_spec.rb
+++ b/spec/serializers/e_invoices/ubl/customer_party_spec.rb
@@ -9,10 +9,12 @@ RSpec.describe EInvoices::Ubl::CustomerParty do
     end
   end
 
+  let_it_be(:organization) { create_default(:organization) }
   let(:resource) { invoice }
+  let(:root) { "//cac:AccountingCustomerParty/cac:Party" }
   let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:invoice) { create(:invoice, organization:, customer:) }
+
   let(:customer) do
     create(:customer,
       organization:,
@@ -23,8 +25,6 @@ RSpec.describe EInvoices::Ubl::CustomerParty do
       country: "BR",
       name: "Andre")
   end
-
-  let(:root) { "//cac:AccountingCustomerParty/cac:Party" }
 
   before { invoice }
 

--- a/spec/serializers/e_invoices/ubl/document_response_spec.rb
+++ b/spec/serializers/e_invoices/ubl/document_response_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe EInvoices::Ubl::DocumentResponse do
     end
   end
 
-  let(:invoice) { create(:invoice) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:invoice) { create_default(:invoice) }
   let(:response) do
     described_class::Response.new(
       code: described_class::PAID,

--- a/spec/serializers/e_invoices/ubl/header_spec.rb
+++ b/spec/serializers/e_invoices/ubl/header_spec.rb
@@ -9,10 +9,13 @@ RSpec.describe EInvoices::Ubl::Header do
     end
   end
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
   let(:resource) { create(:invoice, issuing_date: issuing_date.to_date, currency:) }
-  let(:issuing_date) { "2025-03-16" }
-  let(:currency) { "USD" }
   let(:type_code) { described_class::COMMERCIAL_INVOICE }
+  let(:issuing_date) { "2025-03-16" }
+
+  let(:currency) { "USD" }
 
   before { resource }
 

--- a/spec/serializers/e_invoices/ubl/monetary_total_spec.rb
+++ b/spec/serializers/e_invoices/ubl/monetary_total_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe EInvoices::Ubl::MonetaryTotal do
     end
   end
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
   let(:resource) { invoice }
+  let(:root) { "//cac:LegalMonetaryTotal" }
   let(:amounts) do
     described_class::Amounts.new(
       line_extension_amount: 1000,
@@ -22,11 +25,10 @@ RSpec.describe EInvoices::Ubl::MonetaryTotal do
       payable_amount: 1188.84
     )
   end
-  let(:invoice) do
-    create(:invoice, currency: "USD")
-  end
 
-  let(:root) { "//cac:LegalMonetaryTotal" }
+  let_it_be(:invoice) do
+    create_default(:invoice, currency: "USD")
+  end
 
   describe ".serialize" do
     it { is_expected.not_to be_nil }

--- a/spec/serializers/e_invoices/ubl/receiver_party_spec.rb
+++ b/spec/serializers/e_invoices/ubl/receiver_party_spec.rb
@@ -10,7 +10,11 @@ RSpec.describe EInvoices::Ubl::ReceiverParty do
   end
 
   let(:resource) { create(:payment, customer:) }
-  let(:customer) do
+  let(:root) { "//cac:ReceiverParty" }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:invoice) { create_default(:invoice) }
+  let_it_be(:customer) do
     create(
       :customer,
       name: "Customer Jr",
@@ -21,8 +25,6 @@ RSpec.describe EInvoices::Ubl::ReceiverParty do
       country: "BR"
     )
   end
-
-  let(:root) { "//cac:ReceiverParty" }
 
   before { resource }
 

--- a/spec/serializers/e_invoices/ubl/sender_party_spec.rb
+++ b/spec/serializers/e_invoices/ubl/sender_party_spec.rb
@@ -11,7 +11,11 @@ RSpec.describe EInvoices::Ubl::SenderParty do
 
   let(:resource) { create(:payment, customer:) }
   let(:customer) { create(:customer, billing_entity:) }
-  let(:billing_entity) do
+  let(:root) { "//cac:SenderParty" }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:invoice) { create_default(:invoice) }
+  let_it_be(:billing_entity) do
     create(
       :billing_entity,
       code: "test_be",
@@ -25,8 +29,6 @@ RSpec.describe EInvoices::Ubl::SenderParty do
       email: "lago-be@test.com"
     )
   end
-
-  let(:root) { "//cac:SenderParty" }
 
   before { resource }
 

--- a/spec/serializers/e_invoices/ubl/supplier_party_spec.rb
+++ b/spec/serializers/e_invoices/ubl/supplier_party_spec.rb
@@ -10,11 +10,14 @@ RSpec.describe EInvoices::Ubl::SupplierParty do
   end
 
   let(:options) { described_class::Options.new }
+  let(:root) { "//cac:AccountingSupplierParty/cac:Party" }
   let(:resource) { invoice }
   let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
   let(:invoice) { create(:invoice, organization:, billing_entity:, invoice_type:) }
   let(:invoice_type) { :subscription }
+
   let(:billing_entity) do
     create(:billing_entity,
       organization:,
@@ -27,8 +30,6 @@ RSpec.describe EInvoices::Ubl::SupplierParty do
       country: "BR",
       tax_identification_number: "BR987654321")
   end
-
-  let(:root) { "//cac:AccountingSupplierParty/cac:Party" }
 
   before { invoice }
 

--- a/spec/serializers/e_invoices/ubl/supplier_party_spec.rb
+++ b/spec/serializers/e_invoices/ubl/supplier_party_spec.rb
@@ -10,14 +10,8 @@ RSpec.describe EInvoices::Ubl::SupplierParty do
   end
 
   let(:options) { described_class::Options.new }
-  let(:root) { "//cac:AccountingSupplierParty/cac:Party" }
-  let(:resource) { invoice }
-  let(:membership) { create(:membership) }
-  let_it_be(:organization) { create_default(:organization) }
-  let_it_be(:customer) { create_default(:customer) }
   let(:invoice) { create(:invoice, organization:, billing_entity:, invoice_type:) }
   let(:invoice_type) { :subscription }
-
   let(:billing_entity) do
     create(:billing_entity,
       organization:,
@@ -30,6 +24,12 @@ RSpec.describe EInvoices::Ubl::SupplierParty do
       country: "BR",
       tax_identification_number: "BR987654321")
   end
+  let(:root) { "//cac:AccountingSupplierParty/cac:Party" }
+  let(:resource) { invoice }
+  let(:membership) { create(:membership) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   before { invoice }
 

--- a/spec/serializers/e_invoices/ubl/tax_subtotal_spec.rb
+++ b/spec/serializers/e_invoices/ubl/tax_subtotal_spec.rb
@@ -10,13 +10,15 @@ RSpec.describe EInvoices::Ubl::TaxSubtotal do
   end
 
   let(:resource) { invoice }
+  let(:root) { "//cac:TaxSubtotal" }
   let(:tax_category) { described_class::S_CATEGORY }
   let(:tax_rate) { 20.00 }
   let(:basis_amount) { 10 }
   let(:tax_amount) { basis_amount * (tax_rate / 100) }
-  let(:invoice) { create(:invoice) }
 
-  let(:root) { "//cac:TaxSubtotal" }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:invoice) { create_default(:invoice) }
 
   describe ".serialize" do
     it { is_expected.not_to be_nil }

--- a/spec/serializers/v1/billable_metric_serializer_spec.rb
+++ b/spec/serializers/v1/billable_metric_serializer_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe ::V1::BillableMetricSerializer do
   subject(:serializer) { described_class.new(billable_metric, root_name: "billable_metric", includes:) }
 
+  let_it_be(:organization) { create_default(:organization) }
   let(:billable_metric) { create(:weighted_sum_billable_metric) }
   let(:result) { JSON.parse(serializer.to_json) }
 

--- a/spec/serializers/v1/billing_entity_serializer_spec.rb
+++ b/spec/serializers/v1/billing_entity_serializer_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe V1::BillingEntitySerializer do
   subject(:serializer) { described_class.new(billing_entity, root_name: "billing_entity", includes: includes_options) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:billing_entity) { create(:billing_entity, organization:, phone: "+49 30 1234567") }
   let(:result) { JSON.parse(serializer.to_json) }
   let(:includes_options) { nil }

--- a/spec/serializers/v1/charge_filter_serializer_spec.rb
+++ b/spec/serializers/v1/charge_filter_serializer_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe ::V1::ChargeFilterSerializer do
   subject(:serializer) { described_class.new(charge_filter, root_name: "filter") }
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
   let(:charge_filter) { create(:charge_filter, properties:) }
   let(:properties) { {"amount" => "1000"} }
   let(:filter) { create(:billable_metric_filter) }

--- a/spec/serializers/v1/charge_serializer_spec.rb
+++ b/spec/serializers/v1/charge_serializer_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe ::V1::ChargeSerializer do
 
   let(:serializer) { described_class.new(charge, root_name: "charge", includes: %i[taxes]) }
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:plan) { create_default(:plan) }
   let(:charge) { create(:standard_charge, properties:) }
   let(:properties) { {"amount" => "1000"} }
 

--- a/spec/serializers/v1/charge_serializer_spec.rb
+++ b/spec/serializers/v1/charge_serializer_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe ::V1::ChargeSerializer do
   subject(:result) { JSON.parse(serializer.to_json) }
 
   let(:serializer) { described_class.new(charge, root_name: "charge", includes: %i[taxes]) }
+  let(:charge) { create(:standard_charge, properties:) }
+  let(:properties) { {"amount" => "1000"} }
 
   let_it_be(:organization) { create_default(:organization) }
   let_it_be(:billable_metric) { create_default(:billable_metric) }
   let_it_be(:plan) { create_default(:plan) }
-  let(:charge) { create(:standard_charge, properties:) }
-  let(:properties) { {"amount" => "1000"} }
 
   it "serializes the object" do
     expect(result["charge"]["lago_id"]).to eq(charge.id)

--- a/spec/serializers/v1/commitment_serializer_spec.rb
+++ b/spec/serializers/v1/commitment_serializer_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe ::V1::CommitmentSerializer do
     described_class.new(commitment, root_name: "commitment", includes: %i[taxes])
   end
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
   let(:commitment) { create(:commitment) }
   let(:tax) { create(:tax, organization: commitment.plan.organization) }
   let(:commitment_applied_tax) { create(:commitment_applied_tax, commitment:, tax:) }

--- a/spec/serializers/v1/coupon_serializer_spec.rb
+++ b/spec/serializers/v1/coupon_serializer_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe ::V1::CouponSerializer do
   subject(:serializer) { described_class.new(coupon, root_name: "coupon") }
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
   let(:coupon_plan) { create(:coupon_plan) }
   let(:coupon) { coupon_plan.coupon }
 

--- a/spec/serializers/v1/customer_serializer_spec.rb
+++ b/spec/serializers/v1/customer_serializer_spec.rb
@@ -8,15 +8,16 @@ RSpec.describe ::V1::CustomerSerializer do
   end
 
   let(:result) { JSON.parse(serializer.to_json) }
-  let(:organization) { customer.organization }
-  let(:billing_entity) { customer.billing_entity }
-  let(:customer) { create(:customer, :with_salesforce_integration, shipping_city: "Paris", shipping_address_line1: "test1", shipping_zipcode: "002") }
   let(:metadata) { create(:customer_metadata, customer:) }
   let(:tax) { create(:tax, organization: customer.organization) }
   let(:customer_applied_tax) { create(:customer_applied_tax, customer:, tax:) }
   let(:invoice_custom_section) { create(:invoice_custom_section, organization:) }
-
   let(:error_detail) { create(:error_detail, owner: customer) }
+  let(:organization) { customer.organization }
+  let(:billing_entity) { customer.billing_entity }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let(:customer) { create(:customer, :with_salesforce_integration, shipping_city: "Paris", shipping_address_line1: "test1", shipping_zipcode: "002") }
 
   before do
     metadata

--- a/spec/serializers/v1/customer_serializer_spec.rb
+++ b/spec/serializers/v1/customer_serializer_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe ::V1::CustomerSerializer do
   end
 
   let(:result) { JSON.parse(serializer.to_json) }
+  let(:customer) { create(:customer, :with_salesforce_integration, shipping_city: "Paris", shipping_address_line1: "test1", shipping_zipcode: "002") }
   let(:metadata) { create(:customer_metadata, customer:) }
   let(:tax) { create(:tax, organization: customer.organization) }
   let(:customer_applied_tax) { create(:customer_applied_tax, customer:, tax:) }
@@ -17,7 +18,6 @@ RSpec.describe ::V1::CustomerSerializer do
   let(:billing_entity) { customer.billing_entity }
 
   let_it_be(:organization) { create_default(:organization) }
-  let(:customer) { create(:customer, :with_salesforce_integration, shipping_city: "Paris", shipping_address_line1: "test1", shipping_zipcode: "002") }
 
   before do
     metadata

--- a/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe ::V1::Customers::ChargeUsageSerializer do
   subject(:serializer) { described_class.new(usage, root_name: "charges") }
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
   let(:charge) { create(:standard_charge) }
   let(:result) { JSON.parse(serializer.to_json) }
   let(:billable_metric) { charge.billable_metric }

--- a/spec/serializers/v1/customers/projected_charge_usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/projected_charge_usage_serializer_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe ::V1::Customers::ProjectedChargeUsageSerializer do
   subject(:serializer) { described_class.new(usage, root_name: "charges") }
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
   let(:charge) { create(:standard_charge) }
   let(:result) { JSON.parse(serializer.to_json) }
   let(:billable_metric) { charge.billable_metric }

--- a/spec/serializers/v1/dunning_campaign_finished_serializer_spec.rb
+++ b/spec/serializers/v1/dunning_campaign_finished_serializer_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 RSpec.describe ::V1::DunningCampaignFinishedSerializer do
   subject(:serializer) { described_class.new(customer, params) }
 
-  let(:customer) { create(:customer) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
   let(:params) do
     {
       root_name: "dunning_campaign",

--- a/spec/serializers/v1/entitlement/feature_serializer_spec.rb
+++ b/spec/serializers/v1/entitlement/feature_serializer_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe V1::Entitlement::FeatureSerializer do
   subject { described_class.new(feature) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:feature) do
     create(:feature,
       organization:,

--- a/spec/serializers/v1/entitlement/plan_entitlement_serializer_spec.rb
+++ b/spec/serializers/v1/entitlement/plan_entitlement_serializer_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe V1::Entitlement::PlanEntitlementSerializer do
   subject { described_class.new(entitlement) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
   let(:feature) { create(:feature, organization:, code: "seats") }
   let(:privilege) { create(:privilege, :integer_type, feature:, organization:) }
   let(:privilege2) { create(:privilege, :boolean_type, feature:, organization:) }

--- a/spec/serializers/v1/entitlement/subscription_entitlement_serializer_spec.rb
+++ b/spec/serializers/v1/entitlement/subscription_entitlement_serializer_spec.rb
@@ -11,30 +11,28 @@ RSpec.describe V1::Entitlement::SubscriptionEntitlementSerializer do
     )
   end
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:collection) { Entitlement::SubscriptionEntitlement.for_subscription(subscription) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, organization:, customer:, plan:) }
   let(:feature) { create(:feature, organization:, code: "seats") }
   let(:privilege1) { create(:privilege, organization:, feature:, code: "max", value_type: "integer") }
   let(:privilege2) { create(:privilege, organization:, feature:, code: "reset", value_type: "string") }
   let(:privilege3) { create(:privilege, organization:, feature:, code: "root?", value_type: "boolean") }
-
   let(:entitlement) { create(:entitlement, plan:, feature:) }
   let(:entitlement_value1) { create(:entitlement_value, entitlement:, privilege: privilege1, value: 30, created_at: 2.days.ago) }
   let(:entitlement_value2) { create(:entitlement_value, entitlement:, privilege: privilege2, value: :email) }
-
   let(:sub_entitlement) { create(:entitlement, subscription:, plan: nil, feature:) }
   let(:entitlement_value3) { create(:entitlement_value, entitlement: sub_entitlement, privilege: privilege3, value: true, created_at: 3.days.ago) }
   let(:entitlement_value25) { create(:entitlement_value, entitlement: sub_entitlement, privilege: privilege2, value: :slack) }
-
   let(:feature2) { create(:feature, organization:, code: "storage", name: nil, description: nil) }
   let(:privilege4) { create(:privilege, organization:, feature: feature2, code: "limit", name: "L", value_type: "integer") }
   let(:entitlement2) { create(:entitlement, plan:, feature: feature2, created_at: 12.years.ago) }
   let(:entitlement_value4) { create(:entitlement_value, entitlement: entitlement2, privilege: privilege4, value: 100) }
   let(:entitlement25) { create(:entitlement, plan: nil, subscription:, feature: feature2, created_at: 1.year.ago) }
   let(:entitlement_value45) { create(:entitlement_value, entitlement: entitlement25, privilege: privilege4, value: 999) }
+
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
 
   before do
     entitlement_value1

--- a/spec/serializers/v1/fee_serializer_spec.rb
+++ b/spec/serializers/v1/fee_serializer_spec.rb
@@ -5,6 +5,11 @@ require "rails_helper"
 RSpec.describe ::V1::FeeSerializer do
   subject(:serializer) { described_class.new(fee, root_name: "fee", includes: inclusion) }
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:invoice) { create_default(:invoice) }
   let(:charge) do
     create(:standard_charge, properties: {
       "amount" => "100",
@@ -189,9 +194,9 @@ RSpec.describe ::V1::FeeSerializer do
   end
 
   context "when fee is fixed_charge" do
-    let(:organization) { create(:organization) }
-    let(:customer) { create(:customer, organization:) }
-    let(:plan) { create(:plan, organization:) }
+    let_it_be(:organization) { create_default(:organization) }
+    let_it_be(:customer) { create_default(:customer, organization:) }
+    let_it_be(:plan) { create_default(:plan, organization:) }
     let(:subscription) { create(:subscription, customer:, plan:) }
     let(:add_on) { create(:add_on, organization:) }
     let(:fixed_charge) { create(:fixed_charge, plan:, add_on:) }

--- a/spec/serializers/v1/fixed_charge_serializer_spec.rb
+++ b/spec/serializers/v1/fixed_charge_serializer_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe ::V1::FixedChargeSerializer do
   subject(:result) { JSON.parse(serializer.to_json) }
 
   let(:serializer) { described_class.new(fixed_charge, root_name: "fixed_charge", includes: %i[taxes]) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
   let(:fixed_charge) { create(:fixed_charge, properties:) }
   let(:properties) { {"amount" => "1000"} }
 

--- a/spec/serializers/v1/fixed_charge_serializer_spec.rb
+++ b/spec/serializers/v1/fixed_charge_serializer_spec.rb
@@ -6,10 +6,11 @@ RSpec.describe ::V1::FixedChargeSerializer do
   subject(:result) { JSON.parse(serializer.to_json) }
 
   let(:serializer) { described_class.new(fixed_charge, root_name: "fixed_charge", includes: %i[taxes]) }
-  let_it_be(:organization) { create_default(:organization) }
-  let_it_be(:plan) { create_default(:plan) }
   let(:fixed_charge) { create(:fixed_charge, properties:) }
   let(:properties) { {"amount" => "1000"} }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
 
   it "serializes the object" do
     expect(result["fixed_charge"]["lago_id"]).to eq(fixed_charge.id)

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe ::V1::InvoiceSerializer do
   subject(:serializer) { described_class.new(invoice, root_name: "invoice", includes:) }
 
   let(:includes) { %i[metadata error_details] }
-
-  let(:invoice) { create(:invoice) }
-
   let(:metadata) { create(:invoice_metadata, invoice:) }
   let(:error_details1) { create(:error_detail, owner: invoice) }
   let(:error_details2) { create(:error_detail, owner: invoice, deleted_at: Time.current) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:invoice) { create_default(:invoice) }
 
   before do
     metadata
@@ -100,15 +101,12 @@ RSpec.describe ::V1::InvoiceSerializer do
 
   context "when including subscriptions with multiple subscriptions" do
     let(:includes) { %i[subscriptions billing_periods] }
-    let(:organization) { invoice.organization }
-    let(:customer) { invoice.customer }
-
-    let(:plan_zebra) { create(:plan, organization:, name: "Zebra Plan", invoice_display_name: nil) }
-    let(:plan_alpha) { create(:plan, organization:, name: "Alpha Plan", invoice_display_name: nil) }
-
     let(:subscription_zebra) { create(:subscription, customer:, plan: plan_zebra, name: nil) }
     let(:subscription_alpha) { create(:subscription, customer:, plan: plan_alpha, name: nil) }
     let(:subscription_custom) { create(:subscription, customer:, plan: plan_zebra, name: "AAA Custom") }
+
+    let_it_be(:plan_zebra) { create_default(:plan, organization:, name: "Zebra Plan", invoice_display_name: nil) }
+    let_it_be(:plan_alpha) { create_default(:plan, organization:, name: "Alpha Plan", invoice_display_name: nil) }
 
     before do
       create(:invoice_subscription, :boundaries, invoice:, subscription: subscription_zebra)

--- a/spec/serializers/v1/invoices/payment_dispute_lost_serializer_spec.rb
+++ b/spec/serializers/v1/invoices/payment_dispute_lost_serializer_spec.rb
@@ -5,7 +5,9 @@ require "rails_helper"
 RSpec.describe ::V1::Invoices::PaymentDisputeLostSerializer do
   subject(:serializer) { described_class.new(invoice, options) }
 
-  let(:invoice) { create(:invoice, :dispute_lost) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:invoice) { create_default(:invoice, :dispute_lost) }
 
   context "when options are present" do
     let(:options) do

--- a/spec/serializers/v1/order_serializer_spec.rb
+++ b/spec/serializers/v1/order_serializer_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe ::V1::OrderSerializer do
   subject(:serializer) { described_class.new(order, root_name: "order", includes:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:quote_version) { create(:quote_version, organization:, quote:, currency: "EUR") }
   let(:order_form) { create(:order_form, :signed, organization:, customer:, quote_version:) }

--- a/spec/serializers/v1/payment_serializer_spec.rb
+++ b/spec/serializers/v1/payment_serializer_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe ::V1::PaymentSerializer do
     described_class.new(payment, root_name: "payment", includes:)
   end
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+
   context "when payable is an invoice" do
     let(:payment) { create(:payment) }
 

--- a/spec/serializers/v1/plan_serializer_spec.rb
+++ b/spec/serializers/v1/plan_serializer_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe ::V1::PlanSerializer do
     )
   end
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
   let(:plan) { create(:plan) }
   let(:customer) { create(:customer, organization: plan.organization) }
   let(:subscription) { create(:subscription, customer:, plan:) }

--- a/spec/serializers/v1/quote_serializer_spec.rb
+++ b/spec/serializers/v1/quote_serializer_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe ::V1::QuoteSerializer do
   subject(:serializer) { described_class.new(quote, root_name: "quote", includes:) }
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
   let(:quote) { create(:quote) }
   let(:owner) { create(:membership, organization: quote.organization).user }
   let!(:quote_version) { create(:quote_version, quote:, organization: quote.organization) }

--- a/spec/serializers/v1/quote_version_serializer_spec.rb
+++ b/spec/serializers/v1/quote_version_serializer_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe ::V1::QuoteVersionSerializer do
   subject(:serializer) { described_class.new(quote_version, root_name: "quote_version", includes:) }
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
   let(:quote_version) { create(:quote_version, :approved) }
   let(:includes) { [] }
   let(:result) { JSON.parse(serializer.to_json) }

--- a/spec/serializers/v1/quote_with_version_serializer_spec.rb
+++ b/spec/serializers/v1/quote_with_version_serializer_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe ::V1::QuoteWithVersionSerializer do
   subject(:serializer) { described_class.new(quote_version, root_name: "quote") }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:quote_version) do
     create(:quote_version, :voided, organization:, quote:, currency: "EUR", content: "<p>Terms</p>")

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -5,6 +5,9 @@ require "rails_helper"
 RSpec.describe ::V1::SubscriptionSerializer do
   subject(:serializer) { described_class.new(subscription, root_name: "subscription", includes:) }
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:customer) { create_default(:customer) }
   let(:started_at) { Time.zone.parse("2024-04-23 10:02:03") }
   let(:ending_at) { Time.zone.parse("2024-06-30") }
   let(:subscription) do

--- a/spec/serializers/v1/tax_with_billing_entities_serializer_spec.rb
+++ b/spec/serializers/v1/tax_with_billing_entities_serializer_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe ::V1::TaxWithBillingEntitiesSerializer do
   subject(:serializer) { described_class.new(tax, root_name: "tax", default_billing_entity:) }
 
+  let_it_be(:organization) { create_default(:organization) }
   let(:tax) { create(:tax) }
   let(:default_billing_entity) { tax.organization.default_billing_entity }
 

--- a/spec/serializers/v1/usage_monitoring/triggered_alert_serializer_spec.rb
+++ b/spec/serializers/v1/usage_monitoring/triggered_alert_serializer_spec.rb
@@ -6,7 +6,11 @@ RSpec.describe ::V1::UsageMonitoring::TriggeredAlertSerializer do
   subject(:serializer) { described_class.new(triggered_alert, root_name: "triggered_alert") }
 
   let(:triggered_alert) { create(:triggered_alert, alert:, subscription:, triggered_at: DateTime.new(2000, 1, 1, 12, 0, 0)) }
-  let(:subscription) { create(:subscription, external_id: "ext-id", customer: create(:customer, external_id: "cust-ext-id")) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:subscription) { create(:subscription, external_id: "ext-id", customer: create_default(:customer, external_id: "cust-ext-id")) }
 
   before { triggered_alert }
 

--- a/spec/serializers/v1/wallet_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_serializer_spec.rb
@@ -5,6 +5,9 @@ require "rails_helper"
 RSpec.describe ::V1::WalletSerializer do
   subject(:serializer) { described_class.new(wallet, root_name: "wallet", includes: %i[limitations recurring_transaction_rules applied_invoice_custom_sections]) }
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:billable_metric) }
+  let_it_be(:customer) { create_default(:customer) }
   let(:wallet) { create(:wallet, :with_purchase_order_number, :with_top_up_limits, allowed_fee_types: %w[charge]) }
   let(:recurring_transaction_rule) { create(:recurring_transaction_rule, :with_purchase_order_number, wallet:) }
   let(:wallet_target) { create(:wallet_target, wallet:) }

--- a/spec/serializers/v1/wallet_transaction_consumption_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_transaction_consumption_serializer_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe ::V1::WalletTransactionConsumptionSerializer do
     described_class.new(consumption, root_name: "wallet_transaction_consumption", includes:)
   end
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
   let(:consumption) { create(:wallet_transaction_consumption) }
   let(:includes) { [] }
 

--- a/spec/serializers/v1/wallet_transaction_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_transaction_serializer_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe ::V1::WalletTransactionSerializer do
     described_class.new(wallet_transaction, root_name: "wallet_transaction", includes:)
   end
 
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
   let(:wallet_transaction) { create(:wallet_transaction, :with_purchase_order_number) }
   let(:includes) { [] }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,6 +76,10 @@ Sentry.init do |config|
   config.transport.transport_class = Sentry::DummyTransport
 end
 
+require "test_prof/recipes/rspec/sample"
+require "test_prof/recipes/rspec/let_it_be"
+require "test_prof/recipes/rspec/factory_default"
+
 RSpec.configure do |config|
   config.include ActiveJob::TestHelper
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
## Context

Currently, around **50% of the spec runtime** is spent preparing data and creating factories. A lot of this data is either duplicated or recreates the same objects multiple times, so we can get rid of a good chunk of it and significantly speed up the specs.

To avoid creating unnecessary factories, we can use `let_it_be`, `before_all`, and `create_default` from `test-prof`. More info [here](https://test-prof.evilmartians.io/guide/recipes/let_it_be).

## Description

This PR cleans up the serializers specs and removes unnecessary factory usage.

Here are the numbers before and after the cleanup. The times below are for running the specs in a single process:

| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 7,020 | 3,001 |
| Time spent creating factories |  00:43.959 | 00:12.180 |
| Total time | 00:53.400 | 00:21.676 |

## Overall results

This PR is part of a series of PRs focused on cleaning up factory usage across different specs.

Once all the changes are merged, we expect to:

- Reduce the number of factories by **~50k**
- Cut spec runtime by around **20%**
- Shave off roughly **1:15 min** from the CI runtime


| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 157,949 | 103,761 |
| Total time spent creating factories | 17:59.851  | 11:14.739 |
| Total time | 34:41.482 | 27:03.658 |

Here is [the CI run](https://github.com/getlago/lago-api/actions/runs/33399605547/job/99512391170?pr=6255) with all the changes merged together: