### PR TITLE
perf(specs): Clean up factories usage in spec/specs in directories a-e

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -167,6 +167,8 @@ group :test do
   # HTML testing (invoice rendering)
   gem "rspec-snapshot", "~> 2.0"
   gem "htmlbeautifier", "~> 1.4"
+
+  gem "test-prof", "~> 1.0"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1004,6 +1004,8 @@ GEM
     temple (0.10.4)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
+    test-prof (1.6.3)
+      logger
     thor (1.5.0)
     throttling (0.4.1)
       logger
@@ -1181,6 +1183,7 @@ DEPENDENCIES
   stripe
   strong_migrations
   super_diff (~> 0.19.0)
+  test-prof (~> 1.0)
   throttling
   timecop
   tzinfo-data

--- a/spec/services/add_ons/apply_taxes_service_spec.rb
+++ b/spec/services/add_ons/apply_taxes_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe AddOns::ApplyTaxesService do
   subject(:apply_service) { described_class.new(add_on:, tax_codes:) }
 
-  let(:organization) { create(:organization) }
-  let(:add_on) { create(:add_on, organization:) }
-  let(:tax1) { create(:tax, organization:, code: "tax1") }
-  let(:tax2) { create(:tax, organization:, code: "tax2") }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
+  let_it_be(:tax1) { create(:tax, organization:, code: "tax1") }
+  let_it_be(:tax2) { create(:tax, organization:, code: "tax2") }
   let(:tax_codes) { [tax1.code, tax2.code] }
 
   describe "call" do

--- a/spec/services/add_ons/create_service_spec.rb
+++ b/spec/services/add_ons/create_service_spec.rb
@@ -5,10 +5,11 @@ require "rails_helper"
 RSpec.describe AddOns::CreateService do
   subject(:create_service) { described_class.new(create_args) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
   let(:add_on_code) { "free-beer-for-us" }
-  let(:tax) { create(:tax, organization:) }
+
+  let_it_be(:tax) { create(:tax, organization:) }
 
   describe "create" do
     let(:create_args) do

--- a/spec/services/add_ons/destroy_service_spec.rb
+++ b/spec/services/add_ons/destroy_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe AddOns::DestroyService do
   subject(:destroy_service) { described_class.new(add_on:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
   let(:add_on) { create(:add_on, organization:) }
 
   describe "#call" do

--- a/spec/services/add_ons/update_service_spec.rb
+++ b/spec/services/add_ons/update_service_spec.rb
@@ -5,12 +5,12 @@ require "rails_helper"
 RSpec.describe AddOns::UpdateService do
   subject(:add_ons_service) { described_class.new(add_on:, params: update_args) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:add_on) { create(:add_on, organization:) }
-  let(:tax) { create(:tax, organization:) }
-  let(:add_on_applied_tax) { create(:add_on_applied_tax, add_on:, tax:) }
-  let(:tax2) { create(:tax, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
+  let_it_be(:tax) { create(:tax, organization:) }
+  let_it_be(:add_on_applied_tax) { create(:add_on_applied_tax, add_on:, tax:) }
+  let_it_be(:tax2) { create(:tax, organization:) }
 
   before { add_on_applied_tax }
 

--- a/spec/services/adjusted_fees/create_service_spec.rb
+++ b/spec/services/adjusted_fees/create_service_spec.rb
@@ -5,12 +5,12 @@ require "rails_helper"
 RSpec.describe AdjustedFees::CreateService do
   subject(:create_service) { described_class.new(invoice:, params:) }
 
-  let(:customer) { create(:customer) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:customer) { create(:customer) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:subscription) { create(:subscription, plan:, customer:) }
   let(:invoice) { create(:invoice, :subscription, :draft, customer:, subscriptions: [subscription], organization:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:subscription) { create(:subscription, plan:, customer:) }
-  let(:organization) { customer.organization }
-  let(:billable_metric) { create(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, billable_metric:, plan: subscription.plan) }
   let(:charge_filter) { create(:charge_filter, charge:) }
 
@@ -323,7 +323,7 @@ RSpec.describe AdjustedFees::CreateService do
       end
 
       context "when adjusting fixed charge fees" do
-        let(:add_on) { create(:add_on, organization:) }
+        let_it_be(:add_on) { create(:add_on, organization:) }
         let(:fixed_charge) { create(:fixed_charge, plan:, add_on:) }
         let(:fixed_charge_fee) { create(:fixed_charge_fee, invoice:, subscription:, fixed_charge:) }
         let(:params) do

--- a/spec/services/adjusted_fees/destroy_service_spec.rb
+++ b/spec/services/adjusted_fees/destroy_service_spec.rb
@@ -5,11 +5,15 @@ require "rails_helper"
 RSpec.describe AdjustedFees::DestroyService do
   subject(:destroy_service) { described_class.new(fee:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:invoice) { create(:invoice, status: :draft, organization:) }
-  let(:fee) { create(:charge_fee, invoice:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:invoice) { create(:invoice, status: :draft, organization:) }
+  let_it_be(:fee) { create(:charge_fee, invoice:) }
   let(:adjusted_fee) { create(:adjusted_fee, invoice:, fee:) }
+
+  before_all do
+    create_default(:customer)
+  end
 
   describe "#call" do
     before do

--- a/spec/services/adjusted_fees/estimate_service_spec.rb
+++ b/spec/services/adjusted_fees/estimate_service_spec.rb
@@ -5,10 +5,21 @@ require "rails_helper"
 RSpec.describe AdjustedFees::EstimateService do
   subject(:result) { described_class.call(invoice:, params:) }
 
-  let(:customer) { create(:customer) }
-  let(:organization) { customer.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:plan) { create(:plan, organization:, interval: "monthly") }
 
-  let(:invoice) do
+  let_it_be(:started_at) { Time.zone.now - 2.years }
+  let_it_be(:subscription) do
+    create(
+      :subscription,
+      plan:,
+      subscription_at: started_at,
+      started_at:,
+      created_at: started_at
+    )
+  end
+  let_it_be(:invoice) do
     create(
       :invoice,
       :voided,
@@ -20,19 +31,7 @@ RSpec.describe AdjustedFees::EstimateService do
     )
   end
 
-  let(:subscription) do
-    create(
-      :subscription,
-      plan:,
-      subscription_at: started_at,
-      started_at:,
-      created_at: started_at
-    )
-  end
-
   let(:timestamp) { Time.zone.now - 1.year }
-  let(:started_at) { Time.zone.now - 2.years }
-  let(:plan) { create(:plan, organization:, interval: "monthly") }
   let(:fee_subscription) do
     create(
       :fee,
@@ -160,7 +159,7 @@ RSpec.describe AdjustedFees::EstimateService do
   end
 
   context "when adjusting fixed charge fees" do
-    let(:add_on) { create(:add_on, organization:) }
+    let_it_be(:add_on) { create(:add_on, organization:) }
     let(:fixed_charge) do
       create(
         :fixed_charge,
@@ -334,7 +333,7 @@ RSpec.describe AdjustedFees::EstimateService do
   end
 
   context "when adjusting charge fees" do
-    let(:billable_metric) { create(:billable_metric, organization:) }
+    let_it_be(:billable_metric) { create(:billable_metric, organization:) }
     let(:charge) { create(:standard_charge, billable_metric:, plan:) }
     let(:charge_fee) do
       create(

--- a/spec/services/analytics/gross_revenues_service_spec.rb
+++ b/spec/services/analytics/gross_revenues_service_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 RSpec.describe Analytics::GrossRevenuesService do
   let(:service) { described_class.new(organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+
+  let_it_be(:organization) { create(:organization) }
 
   describe "#call" do
     subject(:service_call) { service.call }

--- a/spec/services/analytics/invoice_collections_service_spec.rb
+++ b/spec/services/analytics/invoice_collections_service_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 RSpec.describe Analytics::InvoiceCollectionsService do
   let(:service) { described_class.new(organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+
+  let_it_be(:organization) { create(:organization) }
 
   describe "#call" do
     subject(:service_call) { service.call }

--- a/spec/services/analytics/invoiced_usages_service_spec.rb
+++ b/spec/services/analytics/invoiced_usages_service_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 RSpec.describe Analytics::InvoicedUsagesService do
   let(:service) { described_class.new(organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+
+  let_it_be(:organization) { create(:organization) }
 
   describe "#call" do
     subject(:service_call) { service.call }

--- a/spec/services/analytics/mrrs_service_spec.rb
+++ b/spec/services/analytics/mrrs_service_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 RSpec.describe Analytics::MrrsService do
   let(:service) { described_class.new(organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+
+  let_it_be(:organization) { create(:organization) }
 
   describe "#call" do
     subject(:service_call) { service.call }

--- a/spec/services/analytics/overdue_balances_service_spec.rb
+++ b/spec/services/analytics/overdue_balances_service_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 RSpec.describe Analytics::OverdueBalancesService do
   let(:service) { described_class.new(organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+
+  let_it_be(:organization) { create(:organization) }
 
   describe "#call" do
     subject(:service_call) { service.call }

--- a/spec/services/api_keys/cache_service_spec.rb
+++ b/spec/services/api_keys/cache_service_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe ApiKeys::CacheService, cache: :redis do
   end
 
   describe "#call" do
-    let(:organization) { create(:organization, api_keys: [api_key]) }
-    let(:api_key) { create(:api_key) }
+    let_it_be(:organization) { create_default(:organization) }
+    let_it_be(:api_key) { create(:api_key) }
     let(:auth_token) { api_key.value }
 
     before { organization }

--- a/spec/services/api_keys/create_service_spec.rb
+++ b/spec/services/api_keys/create_service_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe ApiKeys::CreateService do
     subject(:service_result) { described_class.call(params) }
 
     let(:name) { Faker::Lorem.words.join(" ") }
-    let(:organization) { create(:organization) }
+
+    let_it_be(:organization) { create(:organization) }
 
     context "with premium organization", :premium do
       context "when permissions hash is provided" do

--- a/spec/services/applied_coupons/amount_service_spec.rb
+++ b/spec/services/applied_coupons/amount_service_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe AppliedCoupons::AmountService do
     described_class.new(applied_coupon:, base_amount_cents:)
   end
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:base_amount_cents) { 300 }
-  let(:coupon) { create(:coupon, organization:) }
+  let_it_be(:coupon) { create(:coupon, organization:) }
   let(:applied_coupon) { create(:applied_coupon, amount_cents: 12, coupon:, customer:) }
 
   describe "call" do

--- a/spec/services/applied_coupons/amount_service_spec.rb
+++ b/spec/services/applied_coupons/amount_service_spec.rb
@@ -10,8 +10,9 @@ RSpec.describe AppliedCoupons::AmountService do
   let_it_be(:organization) { create(:organization) }
   let_it_be(:customer) { create(:customer, organization:) }
   let(:base_amount_cents) { 300 }
-  let_it_be(:coupon) { create(:coupon, organization:) }
   let(:applied_coupon) { create(:applied_coupon, amount_cents: 12, coupon:, customer:) }
+
+  let_it_be(:coupon) { create(:coupon, organization:) }
 
   describe "call" do
     it "calculates amount" do

--- a/spec/services/applied_coupons/create_service_spec.rb
+++ b/spec/services/applied_coupons/create_service_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe AppliedCoupons::CreateService do
     described_class.new(customer:, coupon:, params:)
   end
 
+  let(:organization) { create_default(:organization) }
   let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-
   let(:customer) { create(:customer, organization:) }
   let(:coupon) { create(:coupon, status: "active", organization:) }
 

--- a/spec/services/applied_coupons/recredit_service_spec.rb
+++ b/spec/services/applied_coupons/recredit_service_spec.rb
@@ -5,11 +5,11 @@ require "rails_helper"
 RSpec.describe AppliedCoupons::RecreditService do
   subject(:recredit_service) { described_class.new(credit:) }
 
-  let(:customer) { create(:customer) }
-  let(:organization) { customer.organization }
-  let(:coupon) { create(:coupon, organization:) }
-  let(:invoice) { create(:invoice, customer:, organization:, status: :finalized) }
-  let(:applied_coupon) { create(:applied_coupon, coupon:, customer:, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create(:customer) }
+  let_it_be(:coupon) { create(:coupon, organization:) }
+  let_it_be(:invoice) { create(:invoice, customer:, organization:, status: :finalized) }
+  let_it_be(:applied_coupon) { create(:applied_coupon, coupon:, customer:, organization:) }
   let(:credit) { create(:credit, invoice:, applied_coupon:, amount_cents: 100) }
 
   describe "#call" do

--- a/spec/services/applied_coupons/terminate_service_spec.rb
+++ b/spec/services/applied_coupons/terminate_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe AppliedCoupons::TerminateService do
   subject(:terminate_service) { described_class.new(applied_coupon:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
   let(:coupon) { create(:coupon, status: "active", organization:) }
   let(:applied_coupon) { create(:applied_coupon, coupon:) }
 

--- a/spec/services/applied_pricing_units/create_service_spec.rb
+++ b/spec/services/applied_pricing_units/create_service_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe AppliedPricingUnits::CreateService do
     end
 
     context "when charge is present" do
-      let(:organization) { create(:organization) }
+      let_it_be(:organization) { create(:organization) }
       let(:charge) { create(:standard_charge, organization:) }
 
       context "when applied pricing unit should not be created" do

--- a/spec/services/auth/entra_id/accept_invite_service_spec.rb
+++ b/spec/services/auth/entra_id/accept_invite_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Auth::EntraId::AcceptInviteService, :premium, cache: :memory do
   subject(:service) { described_class.new(invite_token:, code:, state:) }
 
-  let(:organization) { create(:organization, premium_integrations: ["entra_id"]) }
+  let_it_be(:organization) { create(:organization, premium_integrations: ["entra_id"]) }
   let(:entra_id_integration) { create(:entra_id_integration, domain: "bar.com", organization:) }
   let(:invite) { create(:invite, email: "foo@bar.com", organization:) }
   let(:invite_token) { invite.token }

--- a/spec/services/auth/okta/accept_invite_service_spec.rb
+++ b/spec/services/auth/okta/accept_invite_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Auth::Okta::AcceptInviteService, :premium, cache: :memory do
   subject(:service) { described_class.new(invite_token:, code:, state:) }
 
-  let(:organization) { create(:organization, premium_integrations: ["okta"]) }
+  let_it_be(:organization) { create(:organization, premium_integrations: ["okta"]) }
   let(:okta_integration) { create(:okta_integration, domain: "bar.com", organization_name: "foo", organization:) }
   let(:invite) { create(:invite, email: "foo@bar.com", organization:) }
   let(:invite_token) { invite.token }

--- a/spec/services/auth/superset/guest_token_service_spec.rb
+++ b/spec/services/auth/superset/guest_token_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Auth::Superset::GuestTokenService do
   subject(:service) { described_class.new(organization:, dashboard_id:, user:) }
 
-  let(:organization) { create(:organization, name: "Test Org") }
+  let_it_be(:organization) { create(:organization, name: "Test Org") }
   let(:dashboard_id) { "42" }
   let(:user) { nil }
 

--- a/spec/services/auth/superset_service_spec.rb
+++ b/spec/services/auth/superset_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Auth::SupersetService do
   subject(:service) { described_class.new(organization:, user:) }
 
-  let(:organization) { create(:organization, name: "Test Org") }
+  let_it_be(:organization) { create(:organization, name: "Test Org") }
   let(:user) { nil }
 
   let(:superset_url) { "http://localhost:8089" }

--- a/spec/services/base_service_spec.rb
+++ b/spec/services/base_service_spec.rb
@@ -5,6 +5,12 @@ require "rails_helper"
 RSpec.describe ::BaseService do
   subject(:service) { described_class.new }
 
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+  end
+
   it { is_expected.to be_a(AfterCommitEverywhere) }
   it { is_expected.to respond_to(:call) }
   it { is_expected.to respond_to(:call_async) }
@@ -38,9 +44,9 @@ RSpec.describe ::BaseService do
         attr_reader :subscription
       end
     end
+    let(:activity_loggable_after_commit) { false }
 
     let(:subscription) { create(:subscription, name: "My Subscription") }
-    let(:activity_loggable_after_commit) { false }
 
     def test_service_with_activity_loggable(after_commit:, action_match_updated: false)
       expect(service_class).to use_middleware(Middlewares::ActivityLogMiddleware)

--- a/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
   subject(:service) { described_class.call(billable_metric:, filters_params:) }
 
+  before_all do
+    create_default(:organization)
+  end
+
   let(:billable_metric) { create(:billable_metric) }
 
   context "when filter params is empty" do

--- a/spec/services/billable_metrics/aggregation_factory_spec.rb
+++ b/spec/services/billable_metrics/aggregation_factory_spec.rb
@@ -5,7 +5,21 @@ require "rails_helper"
 RSpec.describe BillableMetrics::AggregationFactory do
   subject(:factory) { described_class }
 
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+  end
+
   let(:billable_metric) { create(billable_aggregation, recurring:) }
+  let(:boundaries) do
+    {
+      charges_from_datetime: subscription.started_at.beginning_of_day,
+      charges_to_datetime: subscription.started_at.end_of_month.end_of_day
+    }
+  end
+  let(:current_usage) { false }
+  let(:result) { factory.new_instance(charge:, current_usage:, subscription:, boundaries:) }
   let(:billable_aggregation) { :billable_metric }
   let(:recurring) { false }
 
@@ -13,17 +27,7 @@ RSpec.describe BillableMetrics::AggregationFactory do
   let(:pay_in_advance) { false }
   let(:prorated) { false }
 
-  let(:subscription) { create(:subscription, started_at: DateTime.parse("2023-03-15")) }
-  let(:boundaries) do
-    {
-      charges_from_datetime: subscription.started_at.beginning_of_day,
-      charges_to_datetime: subscription.started_at.end_of_month.end_of_day
-    }
-  end
-
-  let(:current_usage) { false }
-
-  let(:result) { factory.new_instance(charge:, current_usage:, subscription:, boundaries:) }
+  let_it_be(:subscription) { create(:subscription, started_at: DateTime.parse("2023-03-15")) }
 
   describe "#new_instance" do
     context "with count_agg aggregation" do

--- a/spec/services/billable_metrics/aggregations/base_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/base_service_spec.rb
@@ -3,6 +3,12 @@
 require "rails_helper"
 
 RSpec.describe BillableMetrics::Aggregations::BaseService do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+  end
+
   describe ".null_result" do
     subject(:null_result) { described_class.null_result(result, **args) }
 
@@ -85,10 +91,10 @@ RSpec.describe BillableMetrics::Aggregations::BaseService do
         filters:
       )
     end
-
-    let(:subscription) { create(:subscription) }
     let(:charge) { create(:standard_charge, plan: subscription.plan) }
     let(:filters) { {} }
+
+    let_it_be(:subscription) { create(:subscription) }
 
     context "without grouped_by" do
       it "returns the aggregator's result zeroed out with the aggregator attached" do

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -405,7 +405,6 @@ RSpec.describe BillableMetrics::Aggregations::CountService do
 
   context "with clickhouse event store", :clickhouse do
     let(:event_store_class) { Events::Stores::ClickhouseStore }
-    let_it_be(:organization) { create(:organization, clickhouse_events_store: true) }
     let(:event_list) do
       create_list(
         :clickhouse_events_enriched,
@@ -417,6 +416,8 @@ RSpec.describe BillableMetrics::Aggregations::CountService do
         timestamp: Time.zone.now - 1.day
       )
     end
+
+    let_it_be(:organization) { create(:organization, clickhouse_events_store: true) }
 
     let_it_be(:billable_metric) do
       create(

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -18,39 +18,19 @@ RSpec.describe BillableMetrics::Aggregations::CountService do
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
-  let(:bypass_aggregation) { false }
-  let(:filters) do
-    {event: pay_in_advance_event, grouped_by:, presentation_by:, matching_filters:, ignored_filters:}
-  end
-
-  let(:subscription) { create(:subscription, organization:) }
-  let(:organization) { create(:organization) }
-  let(:customer) { subscription.customer }
   let(:grouped_by) { nil }
   let(:presentation_by) { nil }
   let(:matching_filters) { {} }
   let(:ignored_filters) { [] }
-
-  let(:billable_metric) do
-    create(
-      :billable_metric,
-      organization:,
-      aggregation_type: "count_agg"
-    )
-  end
-
   let(:charge) do
     create(
       :standard_charge,
       billable_metric:
     )
   end
-
   let(:from_datetime) { (Time.current - 1.month).beginning_of_day }
   let(:to_datetime) { Time.current.end_of_day }
-
   let(:pay_in_advance_event) { nil }
-
   let(:event_list) do
     create_list(
       :event,
@@ -62,6 +42,26 @@ RSpec.describe BillableMetrics::Aggregations::CountService do
       timestamp: Time.zone.now - 1.day
     )
   end
+  let(:bypass_aggregation) { false }
+  let(:filters) do
+    {event: pay_in_advance_event, grouped_by:, presentation_by:, matching_filters:, ignored_filters:}
+  end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) do
+    create(
+      :billable_metric,
+      organization:,
+      aggregation_type: "count_agg"
+    )
+  end
+
+  before_all do
+    create_default(:plan)
+  end
+
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:subscription) { create(:subscription, organization:) }
 
   before do
     event_list
@@ -405,8 +405,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService do
 
   context "with clickhouse event store", :clickhouse do
     let(:event_store_class) { Events::Stores::ClickhouseStore }
-    let(:organization) { create(:organization, clickhouse_events_store: true) }
-
+    let_it_be(:organization) { create(:organization, clickhouse_events_store: true) }
     let(:event_list) do
       create_list(
         :clickhouse_events_enriched,
@@ -419,6 +418,15 @@ RSpec.describe BillableMetrics::Aggregations::CountService do
       )
     end
 
+    let_it_be(:billable_metric) do
+      create(
+        :billable_metric,
+        organization:,
+        aggregation_type: "count_agg"
+      )
+    end
+    let_it_be(:subscription) { create(:subscription, organization:) }
+
     it "aggregates the events" do
       result = count_service.aggregate
 
@@ -426,7 +434,15 @@ RSpec.describe BillableMetrics::Aggregations::CountService do
     end
 
     context "with deduplication" do
-      let(:organization) { create(:organization, clickhouse_events_store: true, clickhouse_deduplication_enabled: true) }
+      let_it_be(:organization) { create(:organization, clickhouse_events_store: true, clickhouse_deduplication_enabled: true) }
+      let_it_be(:billable_metric) do
+        create(
+          :billable_metric,
+          organization:,
+          aggregation_type: "count_agg"
+        )
+      end
+      let_it_be(:subscription) { create(:subscription, organization:) }
 
       let(:event_list) do
         create_list(

--- a/spec/services/billable_metrics/aggregations/custom_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/custom_service_spec.rb
@@ -19,17 +19,10 @@ RSpec.describe BillableMetrics::Aggregations::CustomService do
 
   let(:event_store_class) { Events::Stores::PostgresStore }
   let(:bypass_aggregation) { false }
-  let(:filters) { {grouped_by:, matching_filters:, ignored_filters:, event:} }
-
-  let(:subscription) { create(:subscription) }
-  let(:organization) { subscription.organization }
-  let(:customer) { subscription.customer }
-
   let(:grouped_by) { nil }
   let(:matching_filters) { nil }
   let(:ignored_filters) { nil }
   let(:event) { nil }
-
   let(:billable_metric) do
     create(:custom_billable_metric, organization:, custom_aggregator:)
   end
@@ -78,7 +71,6 @@ RSpec.describe BillableMetrics::Aggregations::CustomService do
       end
     RUBY
   end
-
   let(:charge) { create(:standard_charge, billable_metric:, properties: charge_properties) }
   let(:charge_properties) do
     {
@@ -92,10 +84,8 @@ RSpec.describe BillableMetrics::Aggregations::CustomService do
       }
     }
   end
-
   let(:from_datetime) { (Time.current - 1.month).beginning_of_day }
   let(:to_datetime) { Time.current.end_of_day }
-
   let(:event_list) do
     [
       create(
@@ -127,6 +117,16 @@ RSpec.describe BillableMetrics::Aggregations::CustomService do
       )
     ]
   end
+  let(:filters) { {grouped_by:, matching_filters:, ignored_filters:, event:} }
+
+  let_it_be(:organization) { create_default(:organization) }
+
+  before_all do
+    create_default(:plan)
+  end
+
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:subscription) { create(:subscription) }
 
   before do
     event_list

--- a/spec/services/billable_metrics/aggregations/latest_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/latest_service_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe BillableMetrics::Aggregations::LatestService do
   let(:bypass_aggregation) { false }
   let(:filters) { {grouped_by:, presentation_by:, matching_filters:, ignored_filters:} }
 
+  let_it_be(:organization) { create_default(:organization) }
   let(:subscription) { create(:subscription) }
-  let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
   let(:grouped_by) { nil }
   let(:presentation_by) { nil }

--- a/spec/services/billable_metrics/aggregations/latest_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/latest_service_spec.rb
@@ -18,17 +18,12 @@ RSpec.describe BillableMetrics::Aggregations::LatestService do
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
-  let(:bypass_aggregation) { false }
-  let(:filters) { {grouped_by:, presentation_by:, matching_filters:, ignored_filters:} }
-
-  let_it_be(:organization) { create_default(:organization) }
   let(:subscription) { create(:subscription) }
   let(:customer) { subscription.customer }
   let(:grouped_by) { nil }
   let(:presentation_by) { nil }
   let(:matching_filters) { {} }
   let(:ignored_filters) { [] }
-
   let(:billable_metric) do
     create(
       :billable_metric,
@@ -37,17 +32,14 @@ RSpec.describe BillableMetrics::Aggregations::LatestService do
       field_name: "total_count"
     )
   end
-
   let(:charge) do
     create(
       :standard_charge,
       billable_metric:
     )
   end
-
   let(:from_datetime) { (Time.current - 1.month).beginning_of_day }
   let(:to_datetime) { Time.current.end_of_day }
-
   let(:events) do
     [
       create_list(
@@ -76,6 +68,10 @@ RSpec.describe BillableMetrics::Aggregations::LatestService do
       )
     ].flatten
   end
+  let(:bypass_aggregation) { false }
+  let(:filters) { {grouped_by:, presentation_by:, matching_filters:, ignored_filters:} }
+
+  let_it_be(:organization) { create_default(:organization) }
 
   before { events }
 

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -18,17 +18,12 @@ RSpec.describe BillableMetrics::Aggregations::MaxService do
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
-  let(:bypass_aggregation) { false }
-  let(:filters) { {grouped_by:, presentation_by:, matching_filters:, ignored_filters:} }
-
-  let_it_be(:organization) { create_default(:organization) }
   let(:subscription) { create(:subscription) }
   let(:customer) { subscription.customer }
   let(:grouped_by) { nil }
   let(:presentation_by) { nil }
   let(:matching_filters) { {} }
   let(:ignored_filters) { [] }
-
   let(:billable_metric) do
     create(
       :billable_metric,
@@ -37,17 +32,14 @@ RSpec.describe BillableMetrics::Aggregations::MaxService do
       field_name: "total_count"
     )
   end
-
   let(:charge) do
     create(
       :standard_charge,
       billable_metric:
     )
   end
-
   let(:from_datetime) { (Time.current - 1.month).beginning_of_day }
   let(:to_datetime) { Time.current.end_of_day }
-
   let(:events) do
     [
       create_list(
@@ -76,6 +68,10 @@ RSpec.describe BillableMetrics::Aggregations::MaxService do
       )
     ].flatten
   end
+  let(:bypass_aggregation) { false }
+  let(:filters) { {grouped_by:, presentation_by:, matching_filters:, ignored_filters:} }
+
+  let_it_be(:organization) { create_default(:organization) }
 
   before { events }
 

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe BillableMetrics::Aggregations::MaxService do
   let(:bypass_aggregation) { false }
   let(:filters) { {grouped_by:, presentation_by:, matching_filters:, ignored_filters:} }
 
+  let_it_be(:organization) { create_default(:organization) }
   let(:subscription) { create(:subscription) }
-  let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
   let(:grouped_by) { nil }
   let(:presentation_by) { nil }

--- a/spec/services/billable_metrics/create_service_spec.rb
+++ b/spec/services/billable_metrics/create_service_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe BillableMetrics::CreateService do
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
 
   describe "create" do
     let(:create_args) do

--- a/spec/services/billable_metrics/destroy_service_spec.rb
+++ b/spec/services/billable_metrics/destroy_service_spec.rb
@@ -5,9 +5,10 @@ require "rails_helper"
 RSpec.describe BillableMetrics::DestroyService do
   subject(:destroy_service) { described_class.new(metric: billable_metric) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization) }
   let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:membership) { create(:membership) }
+
   let(:subscription) { create(:subscription) }
   let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric:) }
 

--- a/spec/services/billable_metrics/update_service_spec.rb
+++ b/spec/services/billable_metrics/update_service_spec.rb
@@ -3,10 +3,9 @@
 require "rails_helper"
 
 RSpec.describe BillableMetrics::UpdateService do
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-
+  let_it_be(:organization) { create_default(:organization) }
   let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:membership) { create(:membership) }
   let(:params) do
     {
       name: "New Metric",

--- a/spec/services/billing_entities/change_eu_tax_management_service_spec.rb
+++ b/spec/services/billing_entities/change_eu_tax_management_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe BillingEntities::ChangeEuTaxManagementService do
   subject(:service) { described_class.new(billing_entity:, eu_tax_management:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:billing_entity) { organization.default_billing_entity }
   let(:eu_tax_management) { true }
 

--- a/spec/services/billing_entities/change_invoice_numbering_service_spec.rb
+++ b/spec/services/billing_entities/change_invoice_numbering_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe BillingEntities::ChangeInvoiceNumberingService do
   subject(:result) { described_class.call(billing_entity:, document_numbering:) }
 
-  let(:billing_entity) { create(:billing_entity, document_numbering: "per_customer") }
-  let(:organization) { billing_entity.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billing_entity) { create(:billing_entity, document_numbering: "per_customer") }
   let(:document_numbering) { "per_billing_entity" }
 
   describe "#call" do
@@ -25,17 +25,14 @@ RSpec.describe BillingEntities::ChangeInvoiceNumberingService do
     end
 
     context "when changing from per_customer to per_billing_entity" do
-      let(:customer) { create(:customer, billing_entity:) }
-      let(:invoice1) { create(:invoice, customer:, organization:, billing_entity:, status: "finalized", self_billed: false) }
-      let(:invoice2) { create(:invoice, customer:, organization:, billing_entity:, status: "finalized", self_billed: false) }
-      let(:invoice3) { create(:invoice, customer:, organization:, billing_entity:, status: "draft", self_billed: false) }
+      let_it_be(:customer) { create(:customer, billing_entity:) }
+      let_it_be(:invoice1) { create(:invoice, customer:, organization:, billing_entity:, status: "finalized", self_billed: false) }
+      let_it_be(:invoice2) { create(:invoice, customer:, organization:, billing_entity:, status: "finalized", self_billed: false) }
+      let_it_be(:invoice3) { create(:invoice, customer:, organization:, billing_entity:, status: "draft", self_billed: false) }
       let(:voided_invoice) { create(:invoice, customer:, organization:, billing_entity:, status: "voided", self_billed: false) }
       let(:self_billed_invoice) { create(:invoice, customer:, organization:, billing_entity:, status: "finalized", self_billed: true) }
 
       before do
-        invoice1
-        invoice2
-        invoice3
         self_billed_invoice
         voided_invoice
       end

--- a/spec/services/billing_entities/create_service_spec.rb
+++ b/spec/services/billing_entities/create_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BillingEntities::CreateService do
 
   include_context "with mocked security logger"
 
-  let(:organization) { create :organization }
+  let(:organization) { create_default(:organization) }
   let(:params) do
     {
       name: "Billing Entity",

--- a/spec/services/billing_entities/resolve_service_spec.rb
+++ b/spec/services/billing_entities/resolve_service_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe BillingEntities::ResolveService do
   subject(:result) { described_class.call(organization:, billing_entity_code:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
 
   context "when organization has no active billing entity" do
     let(:billing_entity_code) { organization.all_billing_entities.first.code }
@@ -23,7 +23,7 @@ RSpec.describe BillingEntities::ResolveService do
   context "when billing_entity_code is not provided" do
     let(:billing_entity_code) { nil }
 
-    let(:billing_entities) { create_list(:billing_entity, 3, organization:) }
+    let_it_be(:billing_entities) { create_list(:billing_entity, 3, organization:) }
 
     before do
       billing_entities

--- a/spec/services/billing_entities/taxes/apply_taxes_service_spec.rb
+++ b/spec/services/billing_entities/taxes/apply_taxes_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe BillingEntities::Taxes::ApplyTaxesService do
   subject(:service) { described_class.new(billing_entity:, tax_codes:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:billing_entity) { organization.default_billing_entity }
   let(:tax_codes) { ["TAX_CODE_1", "TAX_CODE_2"] }
 

--- a/spec/services/billing_entities/taxes/manage_taxes_service_spec.rb
+++ b/spec/services/billing_entities/taxes/manage_taxes_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe BillingEntities::Taxes::ManageTaxesService do
   subject(:service) { described_class.new(billing_entity:, tax_codes:) }
 
-  let(:organization) { create(:organization) }
+  let(:organization) { create_default(:organization) }
   let(:billing_entity) { organization.default_billing_entity }
   let(:tax1) { create(:tax, organization:, code: "TAX_CODE_1") }
   let(:tax2) { create(:tax, organization:, code: "TAX_CODE_2") }

--- a/spec/services/billing_entities/taxes/remove_taxes_service_spec.rb
+++ b/spec/services/billing_entities/taxes/remove_taxes_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe BillingEntities::Taxes::RemoveTaxesService do
   subject(:service) { described_class.new(billing_entity:, tax_codes:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:billing_entity) { organization.default_billing_entity }
   let(:tax_codes) { ["TAX_CODE_1", "TAX_CODE_2"] }
 

--- a/spec/services/billing_entities/update_applied_dunning_campaign_service_spec.rb
+++ b/spec/services/billing_entities/update_applied_dunning_campaign_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe BillingEntities::UpdateAppliedDunningCampaignService do
 
   include_context "with mocked security logger"
 
-  let(:billing_entity) { create(:billing_entity) }
-  let(:organization) { billing_entity.organization }
-  let(:second_billing_entity) { create(:billing_entity, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billing_entity) { create(:billing_entity) }
+  let_it_be(:second_billing_entity) { create(:billing_entity, organization:) }
   let(:dunning_campaign_1) { create(:dunning_campaign, organization:) }
   let(:dunning_campaign_2) { create(:dunning_campaign, organization:) }
   let(:customer_1) { create(:customer, organization:, billing_entity:, last_dunning_campaign_attempt: 2, last_dunning_campaign_attempt_at: 1.day.ago) }

--- a/spec/services/billing_entities/update_invoice_issuing_date_settings_service_spec.rb
+++ b/spec/services/billing_entities/update_invoice_issuing_date_settings_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe BillingEntities::UpdateInvoiceIssuingDateSettingsService do
 
   subject(:update_service) { described_class.new(billing_entity:, params:) }
 
+  let_it_be(:organization) { create_default(:organization) }
   let(:billing_entity) { create(:billing_entity, invoice_grace_period: 9) }
-  let(:organization) { billing_entity.organization }
   let(:customer) { create(:customer, organization:, net_payment_term: 5) }
   let(:params) do
     {
@@ -19,7 +19,7 @@ RSpec.describe BillingEntities::UpdateInvoiceIssuingDateSettingsService do
   end
 
   describe "#call" do
-    let!(:invoice_draft) do
+    let(:invoice_draft) do
       create(
         :invoice,
         customer:,

--- a/spec/services/billing_entities/update_invoice_payment_due_date_service_spec.rb
+++ b/spec/services/billing_entities/update_invoice_payment_due_date_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe BillingEntities::UpdateInvoicePaymentDueDateService do
   subject(:update_service) { described_class.new(billing_entity:, net_payment_term:) }
 
+  let_it_be(:organization) { create_default(:organization) }
   let(:billing_entity) { create(:billing_entity) }
-  let(:organization) { billing_entity.organization }
   let(:customer) { create(:customer, organization:, net_payment_term: customer_net_payment_term) }
   let(:customer_net_payment_term) { nil }
   let(:net_payment_term) { 30 }

--- a/spec/services/billing_entities/update_service_spec.rb
+++ b/spec/services/billing_entities/update_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe BillingEntities::UpdateService do
 
   include_context "with mocked security logger"
 
+  let_it_be(:organization) { create_default(:organization) }
   let(:billing_entity) { create(:billing_entity) }
-  let(:organization) { billing_entity.organization }
 
   let(:timezone) { nil }
   let(:email_settings) { [] }

--- a/spec/services/charge_filters/cascade_dispatcher_spec.rb
+++ b/spec/services/charge_filters/cascade_dispatcher_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe ChargeFilters::CascadeDispatcher do
-  let(:organization) { create(:organization) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:charge) { create(:standard_charge, plan:, billable_metric:) }
 
   let(:us_values) { {"region" => ["us"]} }

--- a/spec/services/charge_filters/cascade_service_spec.rb
+++ b/spec/services/charge_filters/cascade_service_spec.rb
@@ -3,23 +3,21 @@
 require "rails_helper"
 
 RSpec.describe ChargeFilters::CascadeService do
-  let(:organization) { create(:organization) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
   let(:bm_filter) { create(:billable_metric_filter, billable_metric:, key: "region", values: %w[us eu]) }
-  let(:parent_plan) { create(:plan, organization:) }
   let(:parent_charge) { create(:standard_charge, plan: parent_plan, billable_metric:, properties: {amount: "0"}) }
-
-  let(:child_plan) { create(:plan, organization:, parent: parent_plan) }
   let(:child_charge) { create(:standard_charge, plan: child_plan, billable_metric:, parent: parent_charge, properties: {amount: "0"}) }
-
   # The override deep-copies the plan's filters, code included, so both sides hold the same one
   let(:us_code) { "region_us_1a2b3c4d" }
-
   let(:child_filter) do
     filter = create(:charge_filter, charge: child_charge, invoice_display_name: "US region", properties: {amount: "10"}, code: us_code)
     create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: ["us"])
     filter
   end
+
+  let_it_be(:parent_plan) { create(:plan, organization:) }
+  let_it_be(:child_plan) { create(:plan, organization:, parent: parent_plan) }
 
   before do
     create(:subscription, plan: child_plan, status: :active)

--- a/spec/services/charge_filters/event_matching_service_spec.rb
+++ b/spec/services/charge_filters/event_matching_service_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 RSpec.describe ChargeFilters::EventMatchingService do
   subject(:service_result) { described_class.call(charge:, event:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
 
   let(:event_properties) do
     {
@@ -16,7 +17,6 @@ RSpec.describe ChargeFilters::EventMatchingService do
       card_number: 2
     }
   end
-
   let(:event) do
     create(
       :event,
@@ -25,11 +25,7 @@ RSpec.describe ChargeFilters::EventMatchingService do
       properties: event_properties
     )
   end
-
-  let(:billable_metric) { create(:billable_metric, organization:) }
-
   let(:charge) { create(:standard_charge, billable_metric:) }
-
   let(:payment_method) do
     create(:billable_metric_filter, billable_metric:, key: "payment_method", values: %i[card virtual_card transfer])
   end
@@ -37,7 +33,6 @@ RSpec.describe ChargeFilters::EventMatchingService do
   let(:scheme) { create(:billable_metric_filter, billable_metric:, key: "scheme", values: %i[visa mastercard]) }
   let(:card_type) { create(:billable_metric_filter, billable_metric:, key: "card_type", values: %i[credit debit]) }
   let(:card_number) { create(:billable_metric_filter, billable_metric:, key: "card_number", values: %i[1 2 3]) }
-
   let(:filter1) { create(:charge_filter, charge:) }
   let(:filter1_values) do
     [
@@ -51,7 +46,6 @@ RSpec.describe ChargeFilters::EventMatchingService do
       )
     ]
   end
-
   let(:filter2) { create(:charge_filter, charge:) }
   let(:filter2_values) do
     [

--- a/spec/services/charge_filters/matching_and_ignored_service_spec.rb
+++ b/spec/services/charge_filters/matching_and_ignored_service_spec.rb
@@ -5,7 +5,11 @@ require "rails_helper"
 RSpec.describe ChargeFilters::MatchingAndIgnoredService do
   subject(:service_result) { described_class.call(charge:, filter: current_filter) }
 
-  let(:billable_metric) { create(:billable_metric) }
+  before_all do
+    create_default(:organization)
+  end
+
+  let_it_be(:billable_metric) { create(:billable_metric) }
   let(:charge) { create(:standard_charge, billable_metric:) }
 
   let(:filter_steps) { create(:billable_metric_filter, billable_metric:, key: "steps", values: %w[25 50 75 100]) }

--- a/spec/services/charge_models/percentage_service_spec.rb
+++ b/spec/services/charge_models/percentage_service_spec.rb
@@ -18,6 +18,21 @@ RSpec.describe ChargeModels::PercentageService do
   end
 
   let(:running_total) { [50, 150, 400] }
+  let(:charge) do
+    create(
+      :percentage_charge,
+      organization:,
+      plan:,
+      properties: {
+        rate:,
+        fixed_amount:,
+        free_units_per_events:,
+        free_units_per_total_aggregation:,
+        per_transaction_max_amount:,
+        per_transaction_min_amount:
+      }
+    )
+  end
   let(:aggregation_result) { BillableMetrics::Aggregations::BaseService::Result.new }
   let(:fixed_amount) { "2.0" }
   let(:aggregation) { 800 }
@@ -33,22 +48,6 @@ RSpec.describe ChargeModels::PercentageService do
 
   before_all do
     create_default(:customer)
-  end
-
-  let(:charge) do
-    create(
-      :percentage_charge,
-      organization:,
-      plan:,
-      properties: {
-        rate:,
-        fixed_amount:,
-        free_units_per_events:,
-        free_units_per_total_aggregation:,
-        per_transaction_max_amount:,
-        per_transaction_min_amount:
-      }
-    )
   end
 
   context "when aggregation value is 0" do
@@ -253,10 +252,6 @@ RSpec.describe ChargeModels::PercentageService do
 
   context "when applying min / max amount per transaction" do
     let(:per_transaction_max_amount) { "12" }
-    let(:per_transaction_min_amount) { "1.75" }
-
-    let_it_be(:subscription) { create(:subscription, organization:, plan:) }
-
     let(:aggregator) do
       BillableMetrics::Aggregations::SumService.new(
         event_store_class:,
@@ -265,18 +260,17 @@ RSpec.describe ChargeModels::PercentageService do
         boundaries: nil
       )
     end
-
     let(:event_store_class) { Events::Stores::PostgresStore }
-
     let(:aggregation) { 10_090 }
-
     let(:fixed_amount) { "0" }
     let(:free_units_per_events) { nil }
     let(:free_units_per_total_aggregation) { "0" }
     let(:rate) { "2.99" }
-
     let(:per_event_aggregation) { BillableMetrics::Aggregations::BaseService::PerEventAggregationResult.new.tap { |r| r.event_aggregation = [10, 80, 10_000] } }
     let(:running_total) { [] }
+    let(:per_transaction_min_amount) { "1.75" }
+
+    let_it_be(:subscription) { create(:subscription, organization:, plan:) }
 
     before do
       aggregation_result.aggregator = aggregator

--- a/spec/services/charge_models/percentage_service_spec.rb
+++ b/spec/services/charge_models/percentage_service_spec.rb
@@ -28,8 +28,12 @@ RSpec.describe ChargeModels::PercentageService do
 
   let(:rate) { "1.3" }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
+
+  before_all do
+    create_default(:customer)
+  end
 
   let(:charge) do
     create(
@@ -251,7 +255,7 @@ RSpec.describe ChargeModels::PercentageService do
     let(:per_transaction_max_amount) { "12" }
     let(:per_transaction_min_amount) { "1.75" }
 
-    let(:subscription) { create(:subscription, organization:, plan:) }
+    let_it_be(:subscription) { create(:subscription, organization:, plan:) }
 
     let(:aggregator) do
       BillableMetrics::Aggregations::SumService.new(

--- a/spec/services/charge_models/prorated_graduated_service_spec.rb
+++ b/spec/services/charge_models/prorated_graduated_service_spec.rb
@@ -11,9 +11,14 @@ RSpec.describe ChargeModels::ProratedGraduatedService do
     )
   end
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
-  let(:subscription) { create(:subscription, organization:, plan:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
+
+  before_all do
+    create_default(:customer)
+  end
+
+  let_it_be(:subscription) { create(:subscription, organization:, plan:) }
 
   let(:aggregation_result) { BillableMetrics::Aggregations::BaseService::Result.new }
   let(:billable_metric) { create(:sum_billable_metric, recurring: true) }

--- a/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
+++ b/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
@@ -3,13 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Charges::ApplyPayInAdvanceChargeModelService do
+  before_all do
+    create_default(:customer)
+  end
+
   let(:charge_service) { described_class.new(charge:, aggregation_result:, properties:) }
-
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
   let(:charge) { create(:standard_charge, :pay_in_advance, plan:) }
-  let(:subscription) { create(:subscription, plan:) }
-
   let(:aggregation_result) do
     BillableMetrics::Aggregations::BaseService::Result.new.tap do |result|
       result.aggregation = 10
@@ -21,7 +20,6 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService do
     end
   end
   let(:properties) { {} }
-
   let(:aggregator) do
     BillableMetrics::Aggregations::CountService.new(
       event_store_class: Events::Stores::PostgresStore,
@@ -30,7 +28,6 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService do
       boundaries: nil
     )
   end
-
   let(:pay_in_advance_event) do
     source = create(
       :event,
@@ -41,6 +38,10 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService do
     )
     Events::CommonFactory.new_instance(source:)
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:subscription) { create(:subscription, plan:) }
 
   describe "#call" do
     context "when charge is not pay_in_advance" do
@@ -215,7 +216,7 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService do
     describe "when dynamic charge model" do
       let(:charge) { create(:dynamic_charge, :pay_in_advance, plan:) }
       let(:charge_model_class) { ChargeModels::DynamicService }
-      let(:subscription) { create(:subscription, organization:, plan:) }
+      let_it_be(:subscription) { create(:subscription, organization:, plan:) }
 
       let(:aggregator) do
         BillableMetrics::Aggregations::SumService.new(

--- a/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
+++ b/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
@@ -215,9 +215,6 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService do
 
     describe "when dynamic charge model" do
       let(:charge) { create(:dynamic_charge, :pay_in_advance, plan:) }
-      let(:charge_model_class) { ChargeModels::DynamicService }
-      let_it_be(:subscription) { create(:subscription, organization:, plan:) }
-
       let(:aggregator) do
         BillableMetrics::Aggregations::SumService.new(
           event_store_class: Events::Stores::PostgresStore,
@@ -226,6 +223,9 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService do
           boundaries: nil
         )
       end
+      let(:charge_model_class) { ChargeModels::DynamicService }
+
+      let_it_be(:subscription) { create(:subscription, organization:, plan:) }
 
       it_behaves_like "a charge model"
     end

--- a/spec/services/charges/apply_taxes_service_spec.rb
+++ b/spec/services/charges/apply_taxes_service_spec.rb
@@ -5,7 +5,11 @@ require "rails_helper"
 RSpec.describe Charges::ApplyTaxesService do
   subject(:apply_service) { described_class.new(charge:, tax_codes:) }
 
-  let(:plan) { create(:plan) }
+  before_all do
+    create_default(:organization)
+  end
+
+  let_it_be(:plan) { create(:plan) }
   let(:charge) { create(:standard_charge, plan:) }
   let(:tax1) { create(:tax, organization: plan.organization, code: "tax1") }
   let(:tax2) { create(:tax, organization: plan.organization, code: "tax2") }

--- a/spec/services/charges/bulk_forecasted_usage_amount_service_spec.rb
+++ b/spec/services/charges/bulk_forecasted_usage_amount_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Charges::BulkForecastedUsageAmountService do
   subject(:service) { described_class.new(charges_data: charges_data) }
 
-  let(:organization) { create(:organization) }
-  let(:billable_metric) { create(:billable_metric, organization: organization) }
-  let(:plan) { create(:plan, organization: organization, amount_cents: 1000) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization: organization) }
+  let_it_be(:plan) { create(:plan, organization: organization, amount_cents: 1000) }
   let(:charge1) do
     create(
       :standard_charge,

--- a/spec/services/charges/calculate_price_service_spec.rb
+++ b/spec/services/charges/calculate_price_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Charges::CalculatePriceService do
   subject(:calculate_price_service) { described_class.new(units:, charge:) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:, amount_cents: 1000) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:plan) { create(:plan, organization:, amount_cents: 1000) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
   let(:units) { 5 }
 
   describe "#call" do

--- a/spec/services/charges/create_children_service_spec.rb
+++ b/spec/services/charges/create_children_service_spec.rb
@@ -9,14 +9,13 @@ RSpec.describe Charges::CreateChildrenService do
   let_it_be(:plan) { create(:plan, organization:) }
   let_it_be(:billable_metric) { create(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, organization:, plan:, billable_metric:) }
-
-  let_it_be(:parent_id) { plan.id }
-  let_it_be(:child_plan) { create(:plan, organization:, parent_id:) }
   let(:child_ids) { child_plan.id }
-
   let(:payload) { {} }
   let(:billable_metric_filters) { create_list(:billable_metric_filter, 2, billable_metric:) }
   let(:billable_metric_filter) { billable_metric_filters.first }
+
+  let_it_be(:parent_id) { plan.id }
+  let_it_be(:child_plan) { create(:plan, organization:, parent_id:) }
 
   before do
     charge

--- a/spec/services/charges/create_children_service_spec.rb
+++ b/spec/services/charges/create_children_service_spec.rb
@@ -5,17 +5,16 @@ require "rails_helper"
 RSpec.describe Charges::CreateChildrenService do
   subject(:create_service) { described_class.new(child_ids:, charge:, payload:) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, organization:, plan:, billable_metric:) }
 
-  let(:child_plan) { create(:plan, organization:, parent_id:) }
-  let(:parent_id) { plan.id }
+  let_it_be(:parent_id) { plan.id }
+  let_it_be(:child_plan) { create(:plan, organization:, parent_id:) }
   let(:child_ids) { child_plan.id }
 
   let(:payload) { {} }
-
   let(:billable_metric_filters) { create_list(:billable_metric_filter, 2, billable_metric:) }
   let(:billable_metric_filter) { billable_metric_filters.first }
 

--- a/spec/services/charges/create_service_spec.rb
+++ b/spec/services/charges/create_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Charges::CreateService do
   let(:create_service) { described_class.new(plan:, params:) }
 
-  let(:plan) { create(:plan) }
-  let(:organization) { plan.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create(:plan) }
 
   describe "#call" do
     subject(:result) { create_service.call }
@@ -189,6 +189,8 @@ RSpec.describe Charges::CreateService do
 
           context "with accepts_target_wallet" do
             context "when events_targeting_wallets is enabled" do
+              let(:plan) { create(:plan) }
+
               before do
                 organization.update!(premium_integrations: ["events_targeting_wallets"])
               end

--- a/spec/services/charges/destroy_children_service_spec.rb
+++ b/spec/services/charges/destroy_children_service_spec.rb
@@ -5,15 +5,16 @@ require "rails_helper"
 RSpec.describe Charges::DestroyChildrenService do
   subject(:destroy_service) { described_class.new(charge) }
 
-  let(:billable_metric) { create(:billable_metric) }
-  let(:organization) { billable_metric.organization }
-  let(:plan) { create(:plan, organization:) }
-  let(:charge) { create(:standard_charge, :deleted, plan:, billable_metric:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create(:billable_metric) }
+  let_it_be(:plan) { create(:plan, organization:) }
 
-  let(:child_plan) { create(:plan, organization:, parent_id:) }
-  let(:parent_id) { plan.id }
+  before_all do
+    create_default(:customer)
+  end
+
+  let(:charge) { create(:standard_charge, :deleted, plan:, billable_metric:) }
   let(:charge_parent_id) { charge.id }
-  let(:subscription) { create(:subscription, plan: child_plan) }
   let(:child_charge) do
     create(
       :standard_charge,
@@ -23,6 +24,10 @@ RSpec.describe Charges::DestroyChildrenService do
       properties: {amount: "300"}
     )
   end
+
+  let_it_be(:parent_id) { plan.id }
+  let_it_be(:child_plan) { create(:plan, organization:, parent_id:) }
+  let_it_be(:subscription) { create(:subscription, plan: child_plan) }
 
   before do
     child_charge

--- a/spec/services/charges/destroy_service_spec.rb
+++ b/spec/services/charges/destroy_service_spec.rb
@@ -5,10 +5,16 @@ require "rails_helper"
 RSpec.describe Charges::DestroyService do
   subject(:destroy_service) { described_class.new(charge:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:billable_metric) { create(:billable_metric, organization:) }
-  let(:subscription) { create(:subscription) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
+
+  before_all do
+    create_default(:customer)
+    create_default(:plan)
+  end
+
+  let_it_be(:subscription) { create(:subscription) }
   let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric:) }
 
   let(:filters) { create_list(:billable_metric_filter, 2, billable_metric:) }
@@ -54,7 +60,7 @@ RSpec.describe Charges::DestroyService do
     context "with cascade_updates" do
       subject(:destroy_service) { described_class.new(charge:, cascade_updates: true) }
 
-      let(:child_plan) { create(:plan, organization:, parent: subscription.plan) }
+      let_it_be(:child_plan) { create(:plan, organization:, parent: subscription.plan) }
       let(:child_charge) { create(:standard_charge, plan: child_plan, billable_metric:, parent: charge) }
 
       before do

--- a/spec/services/charges/generate_code_service_spec.rb
+++ b/spec/services/charges/generate_code_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Charges::GenerateCodeService do
   subject(:result) { described_class.call(plan:, billable_metric:) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
 
   describe "#call" do
     context "when no charges exist for the plan" do

--- a/spec/services/charges/override_service_spec.rb
+++ b/spec/services/charges/override_service_spec.rb
@@ -5,10 +5,11 @@ require "rails_helper"
 RSpec.describe Charges::OverrideService do
   subject(:override_service) { described_class.new(charge:, params:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
 
   describe "#call" do
-    let(:billable_metric) { create(:billable_metric, organization:) }
+    let_it_be(:billable_metric) { create(:billable_metric, organization:) }
+    let_it_be(:plan) { create(:plan, organization:) }
     let(:tax) { create(:tax, organization:) }
 
     let(:charge) do
@@ -19,7 +20,7 @@ RSpec.describe Charges::OverrideService do
         properties: {amount: "300"}
       )
     end
-    let(:plan) { create(:plan, organization:) }
+
     let(:params) do
       {
         id: charge.id,

--- a/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
@@ -16,15 +16,6 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
   end
 
   let(:charge) { create(:standard_charge, billable_metric:, pay_in_advance: true) }
-  let(:charge_filter) { nil }
-  let(:event) { create(:event, organization:, external_subscription_id: subscription.external_id, timestamp: subscription.started_at + 3.days + 1.hour) }
-  let(:properties) { {} }
-
-  let_it_be(:customer) { create(:customer, organization:) }
-  let_it_be(:subscription) do
-    create(:subscription, customer:, started_at: DateTime.parse("2023-03-15"))
-  end
-
   let(:boundaries) do
     BillingPeriodBoundaries.new(
       from_datetime: subscription.started_at.beginning_of_day,
@@ -36,6 +27,14 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
     )
   end
   let(:agg_result) { BaseService::Result.new }
+  let(:charge_filter) { nil }
+  let(:event) { create(:event, organization:, external_subscription_id: subscription.external_id, timestamp: subscription.started_at + 3.days + 1.hour) }
+  let(:properties) { {} }
+
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:subscription) do
+    create(:subscription, customer:, started_at: DateTime.parse("2023-03-15"))
+  end
 
   describe "#call" do
     describe "when count aggregation" do

--- a/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
@@ -7,17 +7,21 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
     described_class.new(charge:, boundaries:, properties:, event:, charge_filter:)
   end
 
-  let(:organization) { create(:organization) }
-  let(:billable_metric) { create(:billable_metric, organization:, aggregation_type:, field_name: "item_id") }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:aggregation_type) { "count_agg" }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:, aggregation_type:, field_name: "item_id") }
+
+  before_all do
+    create_default(:plan)
+  end
+
   let(:charge) { create(:standard_charge, billable_metric:, pay_in_advance: true) }
   let(:charge_filter) { nil }
-  let(:aggregation_type) { "count_agg" }
   let(:event) { create(:event, organization:, external_subscription_id: subscription.external_id, timestamp: subscription.started_at + 3.days + 1.hour) }
   let(:properties) { {} }
 
-  let(:customer) { create(:customer, organization:) }
-
-  let(:subscription) do
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:subscription) do
     create(:subscription, customer:, started_at: DateTime.parse("2023-03-15"))
   end
 
@@ -31,7 +35,6 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
       timestamp: subscription.started_at.end_of_month.to_i
     )
   end
-
   let(:agg_result) { BaseService::Result.new }
 
   describe "#call" do
@@ -355,6 +358,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
     end
 
     describe "when sum aggregation" do
+      let(:billable_metric) { create(:billable_metric, organization:, aggregation_type:, field_name: "item_id") }
       let(:aggregation_type) { "sum_agg" }
       let(:sum_service) { instance_double(BillableMetrics::Aggregations::SumService, aggregate: agg_result) }
       let(:properties) do
@@ -390,6 +394,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
     end
 
     describe "when unique_count aggregation" do
+      let(:billable_metric) { create(:billable_metric, organization:, aggregation_type:, field_name: "item_id") }
       let(:aggregation_type) { "unique_count_agg" }
       let(:unique_count_service) do
         instance_double(BillableMetrics::Aggregations::UniqueCountService, aggregate: agg_result)

--- a/spec/services/charges/update_children_service_spec.rb
+++ b/spec/services/charges/update_children_service_spec.rb
@@ -13,25 +13,12 @@ RSpec.describe Charges::UpdateChildrenService do
     )
   end
 
-  let(:billable_metric) { create(:billable_metric) }
-  let(:organization) { billable_metric.organization }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create(:billable_metric) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:parent_id) { plan.id }
+  let_it_be(:child_plan) { create(:plan, organization:, parent_id:) }
   let(:old_parent_attrs) { charge&.attributes }
-  let(:old_parent_applied_pricing_unit_attrs) { charge&.applied_pricing_unit&.attributes }
-  let(:charge) do
-    create(
-      :standard_charge,
-      plan:,
-      billable_metric:,
-      amount_currency: "USD",
-      properties: {
-        amount: "300"
-      }
-    )
-  end
-
-  let(:child_plan) { create(:plan, organization:, parent_id:) }
-  let(:parent_id) { plan.id }
   let(:charge_parent_id) { charge.id }
   let(:child_ids) { [child_charge&.id] }
   let(:child_charge) do
@@ -59,6 +46,18 @@ RSpec.describe Charges::UpdateChildrenService do
       # via per-filter ChargeFilters::CascadeJob (see
       # Charges::CascadeUpdatable / Plans::UpdateService).
     }
+  end
+  let(:old_parent_applied_pricing_unit_attrs) { charge&.applied_pricing_unit&.attributes }
+  let(:charge) do
+    create(
+      :standard_charge,
+      plan:,
+      billable_metric:,
+      amount_currency: "USD",
+      properties: {
+        amount: "300"
+      }
+    )
   end
 
   before do

--- a/spec/services/commitments/apply_taxes_service_spec.rb
+++ b/spec/services/commitments/apply_taxes_service_spec.rb
@@ -5,11 +5,11 @@ require "rails_helper"
 RSpec.describe Commitments::ApplyTaxesService do
   subject(:apply_service) { described_class.new(commitment:, tax_codes:) }
 
-  let(:commitment) { create(:commitment, plan:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:organization) { create(:organization) }
-  let(:tax1) { create(:tax, organization:, code: "tax1") }
-  let(:tax2) { create(:tax, organization:, code: "tax2") }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:commitment) { create(:commitment, plan:) }
+  let_it_be(:tax1) { create(:tax, organization:, code: "tax1") }
+  let_it_be(:tax2) { create(:tax, organization:, code: "tax2") }
   let(:tax_codes) { [tax1.code, tax2.code] }
 
   describe "call" do

--- a/spec/services/commitments/calculate_amount_service_spec.rb
+++ b/spec/services/commitments/calculate_amount_service_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Commitments::CalculateAmountService do
   let(:invoice_subscription) do
     create(:invoice_subscription, subscription:, from_datetime:, to_datetime:, timestamp:)
   end
-
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:, billing_time:, subscription_at:) }
   let(:plan) { create(:plan, organization:, interval:) }
   let(:billing_time) { :calendar }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   describe "call" do
     context "when plan has weekly interval" do

--- a/spec/services/commitments/calculate_amount_service_spec.rb
+++ b/spec/services/commitments/calculate_amount_service_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Commitments::CalculateAmountService do
     create(:invoice_subscription, subscription:, from_datetime:, to_datetime:, timestamp:)
   end
 
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:, billing_time:, subscription_at:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
   let(:plan) { create(:plan, organization:, interval:) }
   let(:billing_time) { :calendar }
 

--- a/spec/services/commitments/calculate_prorated_coefficient_service_spec.rb
+++ b/spec/services/commitments/calculate_prorated_coefficient_service_spec.rb
@@ -4,15 +4,6 @@ require "rails_helper"
 
 RSpec.describe Commitments::CalculateProratedCoefficientService do
   let(:service) { described_class.new(commitment:, invoice_subscription:) }
-  let(:commitment) { create(:commitment, plan:) }
-
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:plan) { create(:plan, organization:) }
-  let_it_be(:customer) { create(:customer, organization:) }
-
-  let_it_be(:started_at) { DateTime.parse("2024-01-01T00:00:00") }
-  let_it_be(:subscription) { create(:subscription, customer:, plan:, started_at:) }
-
   let(:invoice_subscription) do
     create(
       :invoice_subscription,
@@ -29,6 +20,14 @@ RSpec.describe Commitments::CalculateProratedCoefficientService do
   let(:charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
   let(:charges_to_datetime) { DateTime.parse("2024-01-31T23:59:59") }
   let(:timestamp) { DateTime.parse("2024-02-01T10:00:00") }
+  let(:commitment) { create(:commitment, plan:) }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:customer) { create(:customer, organization:) }
+
+  let_it_be(:started_at) { DateTime.parse("2024-01-01T00:00:00") }
+  let_it_be(:subscription) { create(:subscription, customer:, plan:, started_at:) }
 
   describe "#proration_coefficient" do
     subject(:apply_service) { service.proration_coefficient }

--- a/spec/services/commitments/calculate_prorated_coefficient_service_spec.rb
+++ b/spec/services/commitments/calculate_prorated_coefficient_service_spec.rb
@@ -5,10 +5,13 @@ require "rails_helper"
 RSpec.describe Commitments::CalculateProratedCoefficientService do
   let(:service) { described_class.new(commitment:, invoice_subscription:) }
   let(:commitment) { create(:commitment, plan:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:organization) { create(:organization) }
-  let(:subscription) { create(:subscription, customer:, plan:, started_at:) }
-  let(:customer) { create(:customer, organization:) }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:customer) { create(:customer, organization:) }
+
+  let_it_be(:started_at) { DateTime.parse("2024-01-01T00:00:00") }
+  let_it_be(:subscription) { create(:subscription, customer:, plan:, started_at:) }
 
   let(:invoice_subscription) do
     create(
@@ -21,9 +24,7 @@ RSpec.describe Commitments::CalculateProratedCoefficientService do
       timestamp:
     )
   end
-
   let(:from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
-  let(:started_at) { DateTime.parse("2024-01-01T00:00:00") }
   let(:to_datetime) { DateTime.parse("2024-01-31T23:59:59") }
   let(:charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
   let(:charges_to_datetime) { DateTime.parse("2024-01-31T23:59:59") }
@@ -48,9 +49,11 @@ RSpec.describe Commitments::CalculateProratedCoefficientService do
 
     context "when subscription is terminated" do
       let(:from_datetime) { DateTime.current.beginning_of_day }
-      let(:started_at) { DateTime.current }
       let(:to_datetime) { nil }
       let(:days_in_month) { Date.current.end_of_month.day }
+
+      let_it_be(:started_at) { DateTime.current }
+      let_it_be(:subscription) { create(:subscription, customer:, plan:, started_at:) }
 
       before do
         Subscriptions::TerminateService.call(subscription:, async: false)
@@ -65,7 +68,8 @@ RSpec.describe Commitments::CalculateProratedCoefficientService do
     end
 
     context "when subscription is downgraded right after the period ended" do
-      let(:started_at) { DateTime.parse("2024-01-01T00:00:00") }
+      let_it_be(:started_at) { DateTime.parse("2024-01-01T00:00:00") }
+      let_it_be(:subscription) { create(:subscription, customer:, plan:, started_at:) }
       let(:from_datetime) { DateTime.parse("2024-07-01T00:00:00") }
       let(:to_datetime) { DateTime.parse("2024-07-31T23:59:59") }
       let(:charges_from_datetime) { from_datetime }

--- a/spec/services/commitments/dates_service_spec.rb
+++ b/spec/services/commitments/dates_service_spec.rb
@@ -4,12 +4,12 @@ require "rails_helper"
 
 RSpec.describe Commitments::DatesService do
   let(:commitment) { create(:commitment) }
+  let(:plan) { create(:plan, organization:, pay_in_advance:) }
   let(:invoice_subscription) { create(:invoice_subscription, subscription:) }
   let(:subscription) { create(:subscription, customer:, plan:) }
 
   let_it_be(:organization) { create(:organization) }
   let_it_be(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:, pay_in_advance:) }
 
   describe ".new_instance" do
     subject(:new_instance_call) { described_class.new_instance(commitment:, invoice_subscription:) }

--- a/spec/services/commitments/dates_service_spec.rb
+++ b/spec/services/commitments/dates_service_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe Commitments::DatesService do
   let(:commitment) { create(:commitment) }
   let(:invoice_subscription) { create(:invoice_subscription, subscription:) }
   let(:subscription) { create(:subscription, customer:, plan:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:, pay_in_advance:) }
 
   describe ".new_instance" do
@@ -33,7 +34,8 @@ RSpec.describe Commitments::DatesService do
   describe "#call" do
     subject(:service) { described_class.new_instance(commitment:, invoice_subscription:) }
 
-    let(:pay_in_advance) { [false, true].sample }
+    let_it_be(:pay_in_advance) { [false, true].sample }
+    let_it_be(:plan) { create(:plan, organization:, pay_in_advance:) }
     let(:terminated_service) { instance_double("Subscriptions::TerminatedDatesService") }
 
     before do

--- a/spec/services/commitments/minimum/calculate_true_up_fee_service_spec.rb
+++ b/spec/services/commitments/minimum/calculate_true_up_fee_service_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
   let(:fixed_charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
   let(:fixed_charges_to_datetime) { DateTime.parse("2024-12-31T23:59:59.999") }
   let(:timestamp) { DateTime.parse("2025-01-01T10:00:00") }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:, billing_time:, subscription_at:) }
-  let(:customer) { create(:customer, organization:) }
   let(:subscription_at) { DateTime.parse("2024-01-01T00:00:00") }
-  let(:organization) { create(:organization) }
   let(:plan) { create(:plan, organization:, pay_in_advance:, interval:, bill_charges_monthly:, bill_fixed_charges_monthly:) }
   let(:billing_time) { :calendar }
   let(:bill_charges_monthly) { false }

--- a/spec/services/commitments/minimum/calculate_true_up_fee_service_spec.rb
+++ b/spec/services/commitments/minimum/calculate_true_up_fee_service_spec.rb
@@ -18,16 +18,6 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
       timestamp:
     )
   end
-
-  let(:from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
-  let(:to_datetime) { DateTime.parse("2024-12-31T23:59:59.999") }
-  let(:charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
-  let(:charges_to_datetime) { DateTime.parse("2024-12-31T23:59:59.999") }
-  let(:fixed_charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
-  let(:fixed_charges_to_datetime) { DateTime.parse("2024-12-31T23:59:59.999") }
-  let(:timestamp) { DateTime.parse("2025-01-01T10:00:00") }
-  let_it_be(:organization) { create_default(:organization) }
-  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:, billing_time:, subscription_at:) }
   let(:subscription_at) { DateTime.parse("2024-01-01T00:00:00") }
   let(:plan) { create(:plan, organization:, pay_in_advance:, interval:, bill_charges_monthly:, bill_fixed_charges_monthly:) }
@@ -38,6 +28,17 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
   let(:interval) { :yearly }
   let(:fixed_charge) { create(:fixed_charge, plan:, pay_in_advance: false) }
   let(:fixed_charge_pay_in_advance) { create(:fixed_charge, :pay_in_advance, plan:) }
+
+  let(:from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
+  let(:to_datetime) { DateTime.parse("2024-12-31T23:59:59.999") }
+  let(:charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
+  let(:charges_to_datetime) { DateTime.parse("2024-12-31T23:59:59.999") }
+  let(:fixed_charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
+  let(:fixed_charges_to_datetime) { DateTime.parse("2024-12-31T23:59:59.999") }
+  let(:timestamp) { DateTime.parse("2025-01-01T10:00:00") }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   describe "#call" do
     subject(:service_call) { service.call }

--- a/spec/services/commitments/override_service_spec.rb
+++ b/spec/services/commitments/override_service_spec.rb
@@ -5,11 +5,11 @@ require "rails_helper"
 RSpec.describe Commitments::OverrideService do
   subject(:override_service) { described_class.new(commitment:, params:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
 
   describe "#call" do
-    let(:plan) { create(:plan, organization:) }
+    let_it_be(:plan) { create(:plan, organization:) }
     let(:params) do
       {
         plan_id: plan.id,

--- a/spec/services/coupons/create_service_spec.rb
+++ b/spec/services/coupons/create_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Coupons::CreateService do
   subject(:create_service) { described_class.new(create_args) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
   let(:coupon_code) { "free-beer" }
 
   describe "create" do
@@ -143,7 +143,7 @@ RSpec.describe Coupons::CreateService do
     end
 
     context "with plan limitations in graphql context" do
-      let(:plan) { create(:plan, organization:) }
+      let_it_be(:plan) { create(:plan, organization:) }
       let(:create_args) do
         {
           name: "Super Coupon",
@@ -176,7 +176,7 @@ RSpec.describe Coupons::CreateService do
     end
 
     context "with plan limitations in api context" do
-      let(:plan) { create(:plan, organization:) }
+      let_it_be(:plan) { create(:plan, organization:) }
       let(:create_args) do
         {
           name: "Super Coupon",
@@ -208,7 +208,7 @@ RSpec.describe Coupons::CreateService do
       end
 
       context "when a parent plan has childs" do
-        let(:child_plan) { create(:plan, organization:, parent: plan, code: plan.code) }
+        let_it_be(:child_plan) { create(:plan, organization:, parent: plan, code: plan.code) }
 
         before { child_plan }
 
@@ -225,7 +225,7 @@ RSpec.describe Coupons::CreateService do
     end
 
     context "with billable metric limitations in graphql context" do
-      let(:billable_metric) { create(:billable_metric, organization:) }
+      let_it_be(:billable_metric) { create(:billable_metric, organization:) }
       let(:create_args) do
         {
           name: "Super Coupon",
@@ -316,7 +316,7 @@ RSpec.describe Coupons::CreateService do
     end
 
     context "with billable metric limitations in api context" do
-      let(:billable_metric) { create(:billable_metric, organization:) }
+      let_it_be(:billable_metric) { create(:billable_metric, organization:) }
       let(:create_args) do
         {
           name: "Super Coupon",

--- a/spec/services/coupons/destroy_service_spec.rb
+++ b/spec/services/coupons/destroy_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Coupons::DestroyService do
   subject(:destroy_service) { described_class.new(coupon:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
   let(:coupon) { create(:coupon, organization:) }
   let(:coupon_plan) { create(:coupon_plan, coupon:) }
 

--- a/spec/services/coupons/preview_service_spec.rb
+++ b/spec/services/coupons/preview_service_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe Coupons::PreviewService do
   subject(:preview_service) { described_class.new(invoice:, applied_coupons:) }
 
+  before_all do
+    create_default(:organization)
+  end
+
   let(:invoice) do
     build(
       :invoice,
@@ -56,7 +60,7 @@ RSpec.describe Coupons::PreviewService do
       ]
     end
 
-    let(:plan) { create(:plan, interval: "monthly") }
+    let_it_be(:plan) { create(:plan, interval: "monthly") }
 
     before do
       invoice.subscriptions = [subscription]

--- a/spec/services/coupons/terminate_service_spec.rb
+++ b/spec/services/coupons/terminate_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Coupons::TerminateService do
   subject(:terminate_service) { described_class.new(coupon) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
 
   let(:coupon) { create(:coupon, organization:) }
 

--- a/spec/services/coupons/update_service_spec.rb
+++ b/spec/services/coupons/update_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Coupons::UpdateService do
   subject(:update_service) { described_class.new(coupon:, params:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
 
   let(:coupon) { create(:coupon, organization:) }
 
@@ -83,8 +83,8 @@ RSpec.describe Coupons::UpdateService do
     end
 
     context "with new plan limitations" do
-      let(:plan) { create(:plan, organization:) }
-      let(:plan_second) { create(:plan, organization:) }
+      let_it_be(:plan) { create(:plan, organization:) }
+      let_it_be(:plan_second) { create(:plan, organization:) }
       let(:coupon_plan) { create(:coupon_plan, coupon:, plan:) }
       let(:applies_to) { {plan_ids: [plan.id, plan_second.id]} }
 
@@ -127,8 +127,8 @@ RSpec.describe Coupons::UpdateService do
     end
 
     context "with new billable metric limitations" do
-      let(:billable_metric) { create(:billable_metric, organization:) }
-      let(:billable_metric_second) { create(:billable_metric, organization:) }
+      let_it_be(:billable_metric) { create(:billable_metric, organization:) }
+      let_it_be(:billable_metric_second) { create(:billable_metric, organization:) }
       let(:coupon_billable_metric) { create(:coupon_billable_metric, coupon:, billable_metric:) }
       let(:applies_to) { {billable_metric_ids: [billable_metric.id, billable_metric_second.id]} }
 

--- a/spec/services/coupons/validate_service_spec.rb
+++ b/spec/services/coupons/validate_service_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe Coupons::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { BaseService::Result.new }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:expiration_at) { Time.current + 10.days }
   let(:args) do
     {
@@ -21,6 +19,9 @@ RSpec.describe Coupons::ValidateService do
       expiration_at:
     }
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
 
   describe "#valid?" do
     it "returns true" do

--- a/spec/services/credit_notes/adjust_amounts_with_rounding_service_spec.rb
+++ b/spec/services/credit_notes/adjust_amounts_with_rounding_service_spec.rb
@@ -5,8 +5,13 @@ require "rails_helper"
 RSpec.describe CreditNotes::AdjustAmountsWithRoundingService do
   subject(:adjust_service) { described_class.new(credit_note:) }
 
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
+
   describe "#call" do
-    let(:invoice) do
+    let_it_be(:invoice) do
       create(
         :invoice,
         total_amount_cents: 25000,

--- a/spec/services/credit_notes/apply_taxes_service_spec.rb
+++ b/spec/services/credit_notes/apply_taxes_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe CreditNotes::ApplyTaxesService do
   subject(:apply_service) { described_class.new(invoice:, items:) }
 
-  let(:customer) { create(:customer) }
-  let(:organization) { customer.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create(:customer) }
 
-  let(:invoice) do
+  let_it_be(:invoice) do
     create(
       :invoice,
       customer:,

--- a/spec/services/credit_notes/create_from_progressive_billing_invoice_spec.rb
+++ b/spec/services/credit_notes/create_from_progressive_billing_invoice_spec.rb
@@ -6,13 +6,35 @@ RSpec.describe CreditNotes::CreateFromProgressiveBillingInvoice do
   subject(:credit_service) { described_class.new(progressive_billing_invoice:, amount:, reason:) }
 
   let(:reason) { :other }
-  let(:amount) { 0 }
-  let(:invoice_type) { :progressive_billing }
-  let(:customer) { create(:customer) }
-  let(:organization) { customer.organization }
   let(:tax) { create(:tax, organization:, rate: 20) }
+  let(:fee1) do
+    create(
+      :fee,
+      invoice: progressive_billing_invoice,
+      amount_cents: 80,
+      taxes_amount_cents: 16,
+      taxes_rate: 20
+    )
+  end
+  let(:fee2) do
+    create(
+      :fee,
+      invoice: progressive_billing_invoice,
+      amount_cents: 40,
+      taxes_amount_cents: 8,
+      taxes_rate: 20
+    )
+  end
+  let(:fee1_applied_tax) { create(:fee_applied_tax, tax:, fee: fee1) }
+  let(:fee2_applied_tax) { create(:fee_applied_tax, tax:, fee: fee2) }
+  let(:invoice_applied_tax) { create(:invoice_applied_tax, invoice: progressive_billing_invoice, tax:) }
+  let(:amount) { 0 }
 
-  let(:progressive_billing_invoice) do
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:invoice_type) { :progressive_billing }
+  let_it_be(:customer) { create(:customer) }
+
+  let_it_be(:progressive_billing_invoice) do
     create(
       :invoice,
       customer:,
@@ -23,30 +45,6 @@ RSpec.describe CreditNotes::CreateFromProgressiveBillingInvoice do
       invoice_type:
     )
   end
-
-  let(:fee1) do
-    create(
-      :fee,
-      invoice: progressive_billing_invoice,
-      amount_cents: 80,
-      taxes_amount_cents: 16,
-      taxes_rate: 20
-    )
-  end
-
-  let(:fee2) do
-    create(
-      :fee,
-      invoice: progressive_billing_invoice,
-      amount_cents: 40,
-      taxes_amount_cents: 8,
-      taxes_rate: 20
-    )
-  end
-
-  let(:fee1_applied_tax) { create(:fee_applied_tax, tax:, fee: fee1) }
-  let(:fee2_applied_tax) { create(:fee_applied_tax, tax:, fee: fee2) }
-  let(:invoice_applied_tax) { create(:invoice_applied_tax, invoice: progressive_billing_invoice, tax:) }
 
   before do
     progressive_billing_invoice
@@ -66,6 +64,17 @@ RSpec.describe CreditNotes::CreateFromProgressiveBillingInvoice do
       let(:amount) { 100 }
 
       context "when called with a subscription invoice" do
+        let(:progressive_billing_invoice) do
+          create(
+            :invoice,
+            customer:,
+            organization:,
+            currency: "EUR",
+            fees_amount_cents: 120,
+            total_amount_cents: 120,
+            invoice_type:
+          )
+        end
         let(:invoice_type) { :subscription }
 
         it "fails when the passed in invoice is not a progressive billing invoice" do

--- a/spec/services/credit_notes/create_from_termination_spec.rb
+++ b/spec/services/credit_notes/create_from_termination_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe CreditNotes::CreateFromTermination do
   let(:subscription_at) { Time.zone.parse("2022-09-01 10:00") }
   let(:terminated_at) { Time.zone.parse("2022-10-15 10:00") }
 
+  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, **(customer_timezone ? {timezone: customer_timezone} : {})) }
   let(:customer_timezone) { nil }
-  let(:organization) { customer.organization }
   let(:context) { nil }
 
   let(:subscription) do

--- a/spec/services/credit_notes/create_from_termination_spec.rb
+++ b/spec/services/credit_notes/create_from_termination_spec.rb
@@ -6,16 +6,9 @@ RSpec.describe CreditNotes::CreateFromTermination do
   subject(:create_service) { described_class.new(subscription:, context:, **kwargs) }
 
   let(:kwargs) { {} }
-
-  let(:started_at) { Time.zone.parse("2022-09-01 10:00") }
-  let(:subscription_at) { Time.zone.parse("2022-09-01 10:00") }
-  let(:terminated_at) { Time.zone.parse("2022-10-15 10:00") }
-
-  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, **(customer_timezone ? {timezone: customer_timezone} : {})) }
   let(:customer_timezone) { nil }
   let(:context) { nil }
-
   let(:subscription) do
     create(
       :subscription,
@@ -43,12 +36,17 @@ RSpec.describe CreditNotes::CreateFromTermination do
   let(:tax_rate) { 20 }
   let(:coupon_amount) { 0 }
   let(:invoice_purchase_order_number) { nil }
-
   let(:fee_and_invoice) { generate_invoice_and_fee(plan_amount_cents) }
   let(:invoice) { fee_and_invoice[:invoice] }
   let(:subscription_fee) { fee_and_invoice[:subscription_fee] }
   let(:invoice_applied_tax) { fee_and_invoice[:invoice_applied_tax] }
   let(:paid_amount) { 0 }
+
+  let(:started_at) { Time.zone.parse("2022-09-01 10:00") }
+  let(:subscription_at) { Time.zone.parse("2022-09-01 10:00") }
+  let(:terminated_at) { Time.zone.parse("2022-10-15 10:00") }
+
+  let_it_be(:organization) { create_default(:organization) }
 
   before { fee_and_invoice }
 

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe CreditNotes::CreateService do
     )
   end
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:args) { {} }
 
   let(:invoice) do

--- a/spec/services/credit_notes/delete_service_spec.rb
+++ b/spec/services/credit_notes/delete_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe CreditNotes::DeleteService do
   subject(:delete_service) { described_class.new(credit_note:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:invoice) { create(:invoice, :draft, organization:, customer:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:invoice) { create(:invoice, :draft, organization:, customer:) }
   let(:credit_note) { create(:credit_note, :draft, invoice:, customer:) }
 
   describe "#call" do

--- a/spec/services/credit_notes/estimate_service_spec.rb
+++ b/spec/services/credit_notes/estimate_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe CreditNotes::EstimateService, :premium do
   subject(:estimate_service) { described_class.new(invoice: invoice&.reload, items:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
-  let(:invoice) do
+  let_it_be(:invoice) do
     create(
       :invoice,
       organization:,
@@ -233,7 +233,7 @@ RSpec.describe CreditNotes::EstimateService, :premium do
   end
 
   context "when invoice is a prepaid credit invoice" do
-    let(:invoice) do
+    let_it_be(:invoice) do
       create(
         :invoice,
         invoice_type: :credit,

--- a/spec/services/credit_notes/generate_pdf_service_spec.rb
+++ b/spec/services/credit_notes/generate_pdf_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe CreditNotes::GeneratePdfService do
   subject(:credit_note_generate_service) { described_class.new(credit_note:, context:) }
 
-  let(:organization) { create(:organization, name: "LAGO") }
-  let(:customer) { create(:customer, organization:) }
-  let(:invoice) { create(:invoice, customer:, organization:) }
+  let_it_be(:organization) { create(:organization, name: "LAGO") }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:invoice) { create(:invoice, customer:, organization:) }
   let(:credit_note) { create(:credit_note, invoice:, customer:) }
   let(:fee) { create(:fee, invoice:) }
   let(:credit_note_item) { create(:credit_note_item, credit_note:, fee:) }

--- a/spec/services/credit_notes/generate_xml_service_spec.rb
+++ b/spec/services/credit_notes/generate_xml_service_spec.rb
@@ -4,18 +4,16 @@ require "rails_helper"
 
 RSpec.describe CreditNotes::GenerateXmlService, type: :service do
   let(:context) { "graphql" }
-
-  let(:organization) { create(:organization, name: "LAGO") }
-  let(:billing_entity) { create(:billing_entity, organization:, country: "FR", einvoicing:) }
-  let(:einvoicing) { true }
-
   let(:credit_note) { create(:credit_note, status:, billing_entity:) }
   let(:status) { :finalized }
-
   let(:xml_service) { EInvoices::CreditNotes::Ubl::CreateService }
   let(:fake_xml) { "<xml>content</xml>" }
   let(:create_xml_result) { EInvoices::CreditNotes::Ubl::CreateService::Result.new.tap { |result| result.xml = fake_xml } }
   let(:blank_xml_path) { Rails.root.join("spec/fixtures/blank.xml") }
+
+  let_it_be(:organization) { create(:organization, name: "LAGO") }
+  let_it_be(:einvoicing) { true }
+  let_it_be(:billing_entity) { create(:billing_entity, organization:, country: "FR", einvoicing:) }
 
   before do
     credit_note
@@ -117,6 +115,7 @@ RSpec.describe CreditNotes::GenerateXmlService, type: :service do
       end
 
       context "when einvoicing is disabled" do
+        let(:billing_entity) { create(:billing_entity, organization:, country: "FR", einvoicing:) }
         let(:einvoicing) { false }
 
         it_behaves_like "dont generate"

--- a/spec/services/credit_notes/provider_taxes/report_service_spec.rb
+++ b/spec/services/credit_notes/provider_taxes/report_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe CreditNotes::ProviderTaxes::ReportService do
   subject(:report_service) { described_class.new(credit_note:) }
 
   describe "#call" do
-    let(:organization) { create(:organization) }
-    let(:customer) { create(:customer, organization:) }
+    let_it_be(:organization) { create_default(:organization) }
+    let(:customer) { create_default(:customer, organization:) }
 
     let(:invoice) do
       create(

--- a/spec/services/credit_notes/refresh_draft_service_spec.rb
+++ b/spec/services/credit_notes/refresh_draft_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe CreditNotes::RefreshDraftService do
   subject(:refresh_service) { described_class.new(credit_note:, fee:, old_fee_values:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:invoice) { create(:invoice, organization:, customer:, fees_amount_cents: 100, coupons_amount_cents: 20) }
   let(:tax) { create(:tax, organization:, rate: 20) }
-  let(:invoice) { create(:invoice, organization:, customer:, fees_amount_cents: 100, coupons_amount_cents: 20) }
   let(:old_fee_values) do
     [
       {

--- a/spec/services/credit_notes/refunds/adyen_service_spec.rb
+++ b/spec/services/credit_notes/refunds/adyen_service_spec.rb
@@ -5,16 +5,11 @@ require "rails_helper"
 RSpec.describe CreditNotes::Refunds::AdyenService do
   subject(:adyen_service) { described_class.new(credit_note) }
 
-  let(:customer) { create(:customer, payment_provider_code: code) }
-  let(:organization) { customer.organization }
-  let(:invoice) { create(:invoice, customer:, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:code) { "adyen_1" }
+  let_it_be(:customer) { create(:customer, payment_provider_code: code) }
+  let_it_be(:invoice) { create(:invoice, customer:, organization:) }
   let(:adyen_payment_provider) { create(:adyen_provider, organization:, code:) }
-  let(:adyen_customer) { create(:adyen_customer, customer:) }
-  let(:adyen_client) { instance_double(Adyen::Client) }
-  let(:modifications_api) { Adyen::ModificationsApi.new(adyen_client, 70) }
-  let(:checkout) { Adyen::Checkout.new(adyen_client, 70) }
-  let(:refunds_response) { generate(:adyen_refunds_response) }
-  let(:code) { "adyen_1" }
   let(:payment) do
     create(
       :payment,
@@ -25,7 +20,6 @@ RSpec.describe CreditNotes::Refunds::AdyenService do
       payable: credit_note.invoice
     )
   end
-
   let(:credit_note) do
     create(
       :credit_note,
@@ -36,6 +30,11 @@ RSpec.describe CreditNotes::Refunds::AdyenService do
       refund_status: :pending
     )
   end
+  let(:adyen_customer) { create(:adyen_customer, customer:) }
+  let(:adyen_client) { instance_double(Adyen::Client) }
+  let(:modifications_api) { Adyen::ModificationsApi.new(adyen_client, 70) }
+  let(:checkout) { Adyen::Checkout.new(adyen_client, 70) }
+  let(:refunds_response) { generate(:adyen_refunds_response) }
 
   describe "#create" do
     before do

--- a/spec/services/credit_notes/refunds/gocardless_service_spec.rb
+++ b/spec/services/credit_notes/refunds/gocardless_service_spec.rb
@@ -5,14 +5,11 @@ require "rails_helper"
 RSpec.describe CreditNotes::Refunds::GocardlessService do
   subject(:gocardless_service) { described_class.new(credit_note) }
 
-  let(:customer) { create(:customer, payment_provider_code: code) }
-  let(:invoice) { create(:invoice, organization:, customer:) }
-  let(:organization) { customer.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:code) { "gocardless_1" }
+  let_it_be(:customer) { create(:customer, payment_provider_code: code) }
+  let_it_be(:invoice) { create(:invoice, organization:, customer:) }
   let(:gocardless_payment_provider) { create(:gocardless_provider, organization:, code:) }
-  let(:gocardless_customer) { create(:gocardless_customer, customer:) }
-  let(:gocardless_client) { instance_double(GoCardlessPro::Client) }
-  let(:gocardless_refunds_service) { instance_double(GoCardlessPro::Services::RefundsService) }
-  let(:code) { "gocardless_1" }
   let(:payment) do
     create(
       :payment,
@@ -23,7 +20,6 @@ RSpec.describe CreditNotes::Refunds::GocardlessService do
       payable: credit_note.invoice
     )
   end
-
   let(:credit_note) do
     create(
       :credit_note,
@@ -34,6 +30,9 @@ RSpec.describe CreditNotes::Refunds::GocardlessService do
       refund_status: :pending
     )
   end
+  let(:gocardless_customer) { create(:gocardless_customer, customer:) }
+  let(:gocardless_client) { instance_double(GoCardlessPro::Client) }
+  let(:gocardless_refunds_service) { instance_double(GoCardlessPro::Services::RefundsService) }
 
   describe "#create" do
     before do

--- a/spec/services/credit_notes/refunds/stripe_service_spec.rb
+++ b/spec/services/credit_notes/refunds/stripe_service_spec.rb
@@ -5,12 +5,11 @@ require "rails_helper"
 RSpec.describe CreditNotes::Refunds::StripeService do
   subject(:stripe_service) { described_class.new(credit_note) }
 
-  let(:customer) { create(:customer, payment_provider_code: code) }
-  let(:organization) { customer.organization }
-  let(:invoice) { create(:invoice, customer:, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:code) { "stripe_1" }
+  let_it_be(:customer) { create(:customer, payment_provider_code: code) }
+  let_it_be(:invoice) { create(:invoice, customer:, organization:) }
   let(:stripe_payment_provider) { create(:stripe_provider, organization:, code:) }
-  let(:stripe_customer) { create(:stripe_customer, customer:) }
-  let(:code) { "stripe_1" }
   let(:payment) do
     create(
       :payment,
@@ -22,7 +21,6 @@ RSpec.describe CreditNotes::Refunds::StripeService do
       payable: credit_note.invoice
     )
   end
-
   let(:credit_note) do
     create(
       :credit_note,
@@ -33,6 +31,7 @@ RSpec.describe CreditNotes::Refunds::StripeService do
       refund_status: :pending
     )
   end
+  let(:stripe_customer) { create(:stripe_customer, customer:) }
 
   describe "#create" do
     before do

--- a/spec/services/credit_notes/validate_item_service_spec.rb
+++ b/spec/services/credit_notes/validate_item_service_spec.rb
@@ -5,7 +5,15 @@ require "rails_helper"
 RSpec.describe CreditNotes::ValidateItemService do
   subject(:validator) { described_class.new(result, item:) }
 
+  before_all do
+    create_default(:organization)
+  end
+
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:invoice) { create(:invoice, total_amount_cents: 120) }
+
   let(:result) { BaseService::Result.new }
+  let(:fee) { create(:fee, invoice:, amount_cents: 100, taxes_rate: 20) }
   let(:amount_cents) { 10 }
   let(:credit_amount_cents) { 10 }
   let(:refund_amount_cents) { 0 }
@@ -26,11 +34,6 @@ RSpec.describe CreditNotes::ValidateItemService do
       fee:
     )
   end
-
-  let(:invoice) { create(:invoice, total_amount_cents: 120) }
-  let(:customer) { invoice.customer }
-
-  let(:fee) { create(:fee, invoice:, amount_cents: 100, taxes_rate: 20) }
 
   describe ".call" do
     it "validates the item" do

--- a/spec/services/credit_notes/validate_service_spec.rb
+++ b/spec/services/credit_notes/validate_service_spec.rb
@@ -5,7 +5,19 @@ require "rails_helper"
 RSpec.describe CreditNotes::ValidateService do
   subject(:validator) { described_class.new(result, item: credit_note) }
 
+  before_all do
+    create_default(:organization)
+  end
+
   let(:result) { BaseService::Result.new }
+  let(:fee) do
+    create(
+      :fee,
+      invoice:,
+      amount_cents: 100,
+      taxes_rate: 20
+    )
+  end
   let(:amount_cents) { 10 }
   let(:credit_amount_cents) { 12 }
   let(:refund_amount_cents) { 0 }
@@ -36,18 +48,9 @@ RSpec.describe CreditNotes::ValidateService do
     )
   end
 
-  let(:invoice) { create(:invoice, total_amount_cents: 120, total_paid_amount_cents:) }
-  let(:customer) { invoice.customer }
-  let(:total_paid_amount_cents) { 0 }
-
-  let(:fee) do
-    create(
-      :fee,
-      invoice:,
-      amount_cents: 100,
-      taxes_rate: 20
-    )
-  end
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:total_paid_amount_cents) { 0 }
+  let_it_be(:invoice) { create(:invoice, total_amount_cents: 120, total_paid_amount_cents:) }
 
   before do
     item
@@ -64,7 +67,9 @@ RSpec.describe CreditNotes::ValidateService do
 
       context "when paid amount equals the total amount" do
         let(:refund_amount_cents) { 2 }
-        let(:total_paid_amount_cents) { 120 }
+
+        let_it_be(:total_paid_amount_cents) { 120 }
+        let_it_be(:invoice) { create(:invoice, total_amount_cents: 120, total_paid_amount_cents:) }
 
         it "fails the validation" do
           expect(validator).not_to be_valid
@@ -134,7 +139,9 @@ RSpec.describe CreditNotes::ValidateService do
 
     context "when refund amount is higher than invoice amount" do
       let(:refund_amount_cents) { 200 }
-      let(:total_paid_amount_cents) { 20 }
+
+      let_it_be(:total_paid_amount_cents) { 20 }
+      let_it_be(:invoice) { create(:invoice, total_amount_cents: 120, total_paid_amount_cents:) }
 
       before do
         invoice.payment_succeeded!
@@ -170,7 +177,9 @@ RSpec.describe CreditNotes::ValidateService do
 
       let(:credit_amount_cents) { 0 }
       let(:refund_amount_cents) { 10 }
-      let(:total_paid_amount_cents) { 5 }
+
+      let_it_be(:total_paid_amount_cents) { 5 }
+      let_it_be(:invoice) { create(:invoice, total_amount_cents: 120, total_paid_amount_cents:) }
 
       it "fails the validation" do
         expect(validator).not_to be_valid
@@ -200,7 +209,7 @@ RSpec.describe CreditNotes::ValidateService do
     end
 
     context "when invoice is v3 with coupons" do
-      let(:invoice) do
+      let_it_be(:invoice) do
         create(
           :invoice,
           currency: "EUR",
@@ -337,11 +346,13 @@ RSpec.describe CreditNotes::ValidateService do
 
     context "with combined credit, refund, and offset amounts" do
       let(:amount_cents) { 50 }
+      let(:precise_taxes_amount_cents) { 0 }
       let(:offset_amount_cents) { 20 }
       let(:credit_amount_cents) { 10 }
       let(:refund_amount_cents) { 20 }
-      let(:total_paid_amount_cents) { 50 }
-      let(:precise_taxes_amount_cents) { 0 }
+
+      let_it_be(:total_paid_amount_cents) { 50 }
+      let_it_be(:invoice) { create(:invoice, total_amount_cents: 120, total_paid_amount_cents:) }
 
       before do
         invoice.payment_succeeded!
@@ -368,7 +379,7 @@ RSpec.describe CreditNotes::ValidateService do
     end
 
     context "when invoice is type credit and payment status is succeeded" do
-      let(:invoice) {
+      let_it_be(:invoice) {
         create(:invoice,
           :credit,
           total_amount_cents: 12,
@@ -413,7 +424,7 @@ RSpec.describe CreditNotes::ValidateService do
     end
 
     context "when invoice is type credit but not paid" do
-      let(:invoice) {
+      let_it_be(:invoice) {
         create(:invoice,
           :credit,
           total_amount_cents: 12,

--- a/spec/services/credits/allocate_prepaid_credits_by_wallets_service_spec.rb
+++ b/spec/services/credits/allocate_prepaid_credits_by_wallets_service_spec.rb
@@ -3,6 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Credits::AllocatePrepaidCreditsByWalletsService do
+  before_all do
+    create_default(:organization)
+    create_default(:plan)
+  end
+
   let(:invoice) do
     create(
       :invoice,
@@ -52,7 +57,7 @@ RSpec.describe Credits::AllocatePrepaidCreditsByWalletsService do
       priority_limited_subscription_wallet
     ]
   end
-  let(:customer) { create(:customer) }
+  let_it_be(:customer) { create_default(:customer) }
   let(:subscription) { create(:subscription, customer:) }
 
   before do

--- a/spec/services/credits/allocate_prepaid_credits_by_wallets_service_spec.rb
+++ b/spec/services/credits/allocate_prepaid_credits_by_wallets_service_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Credits::AllocatePrepaidCreditsByWalletsService do
       total_amount_cents: amount_cents
     )
   end
+  let(:subscription) { create(:subscription, customer:) }
   let(:fee) {
     create(:charge_fee, invoice:, subscription:,
       amount_cents: fee_amount_cents, precise_amount_cents: fee_amount_cents,
@@ -57,8 +58,8 @@ RSpec.describe Credits::AllocatePrepaidCreditsByWalletsService do
       priority_limited_subscription_wallet
     ]
   end
+
   let_it_be(:customer) { create_default(:customer) }
-  let(:subscription) { create(:subscription, customer:) }
 
   before do
     wallets

--- a/spec/services/credits/applied_coupon_service_spec.rb
+++ b/spec/services/credits/applied_coupon_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Credits::AppliedCouponService do
     described_class.new(invoice:, applied_coupon:)
   end
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   let(:invoice) do
     create(

--- a/spec/services/credits/applied_coupons_service_spec.rb
+++ b/spec/services/credits/applied_coupons_service_spec.rb
@@ -5,6 +5,11 @@ require "rails_helper"
 RSpec.describe Credits::AppliedCouponsService do
   subject(:credit_service) { described_class.new(invoice:) }
 
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
+
   let(:invoice) do
     create(
       :invoice,

--- a/spec/services/credits/progressive_billing_service_spec.rb
+++ b/spec/services/credits/progressive_billing_service_spec.rb
@@ -5,9 +5,14 @@ require "rails_helper"
 Rspec.describe Credits::ProgressiveBillingService do
   subject(:credit_service) { described_class.new(invoice:) }
 
-  let(:subscription) { create(:subscription, customer_id: customer.id) }
-  let(:organization) { subscription.organization }
-  let(:customer) { create(:customer) }
+  let_it_be(:organization) { create_default(:organization) }
+
+  before_all do
+    create_default(:plan)
+  end
+
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:subscription) { create_default(:subscription, customer_id: customer.id) }
   let(:subscriptions) { [subscription] }
 
   let(:invoice) do

--- a/spec/services/customer_portal/customer_update_service_spec.rb
+++ b/spec/services/customer_portal/customer_update_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe CustomerPortal::CustomerUpdateService do
   subject(:result) { described_class.call(customer:, args: update_args) }
 
-  let(:customer) { create :customer }
+  let_it_be(:customer) { create :customer }
 
   let(:update_args) do
     {
@@ -109,7 +109,8 @@ RSpec.describe CustomerPortal::CustomerUpdateService do
   end
 
   context "when organization has eu tax management" do
-    let(:organization) { customer.organization }
+    let_it_be(:organization) { create_default(:organization) }
+    let_it_be(:customer) { create :customer }
     let(:tax_code) { "lago_eu_fr_standard" }
     let(:eu_tax_result) { Customers::EuAutoTaxesService::Result.new }
 

--- a/spec/services/customers/apply_taxes_service_spec.rb
+++ b/spec/services/customers/apply_taxes_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Customers::ApplyTaxesService do
   subject(:apply_service) { described_class.new(customer:, tax_codes:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:tax1) { create(:tax, organization:, code: "tax1") }
   let(:tax2) { create(:tax, organization:, code: "tax2") }
   let(:tax_codes) { [tax1.code, tax2.code] }

--- a/spec/services/customers/destroy_service_spec.rb
+++ b/spec/services/customers/destroy_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Customers::DestroyService do
   subject(:destroy_service) { described_class.new(customer:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
   let(:customer) { create(:customer, organization:) }
 
   before do

--- a/spec/services/customers/eu_auto_taxes_service_spec.rb
+++ b/spec/services/customers/eu_auto_taxes_service_spec.rb
@@ -5,17 +5,18 @@ require "rails_helper"
 RSpec.describe Customers::EuAutoTaxesService do
   subject(:eu_tax_service) { described_class.new(customer:, new_record:, tax_attributes_changed:) }
 
-  let(:organization) { create(:organization, country: "IT", eu_tax_management: true) }
-  let(:billing_entity) { create(:billing_entity, organization:, country: "FR", eu_tax_management: true) }
-  let(:customer) { create(:customer, organization:, billing_entity:, tax_identification_number:, zipcode: nil) }
+  let_it_be(:organization) { create(:organization, country: "IT", eu_tax_management: true) }
+  let_it_be(:billing_entity) { create(:billing_entity, organization:, country: "FR", eu_tax_management: true) }
+  let_it_be(:tax_identification_number) { nil }
+  let_it_be(:customer) { create(:customer, organization:, billing_entity:, tax_identification_number:, zipcode: nil) }
   let(:new_record) { true }
   let(:tax_attributes_changed) { true }
-  let(:tax_identification_number) { nil }
 
   describe ".call" do
     context "when eu_tax_management is false" do
       let(:organization) { create(:organization, country: "IT", eu_tax_management: false) }
       let(:billing_entity) { create(:billing_entity, organization:, country: "FR", eu_tax_management: false) }
+      let(:customer) { create(:customer, organization:, billing_entity:, tax_identification_number:, zipcode: nil) }
 
       it "returns error" do
         result = eu_tax_service.call
@@ -60,7 +61,8 @@ RSpec.describe Customers::EuAutoTaxesService do
     end
 
     context "when tax_identification_number is blank" do
-      let(:tax_identification_number) { nil }
+      let_it_be(:tax_identification_number) { nil }
+      let_it_be(:customer) { create(:customer, organization:, billing_entity:, tax_identification_number:, zipcode: nil) }
 
       before { customer.update!(country: "DE") }
 
@@ -78,7 +80,8 @@ RSpec.describe Customers::EuAutoTaxesService do
     end
 
     context "when tax_identification_number is present" do
-      let(:tax_identification_number) { "IT12345678901" }
+      let_it_be(:tax_identification_number) { "IT12345678901" }
+      let_it_be(:customer) { create(:customer, organization:, billing_entity:, tax_identification_number:, zipcode: nil) }
 
       it "creates a PendingViesCheck" do
         expect { eu_tax_service.call }.to change(PendingViesCheck, :count).by(1)
@@ -118,7 +121,8 @@ RSpec.describe Customers::EuAutoTaxesService do
     end
 
     context "with non B2B (no TIN)" do
-      let(:tax_identification_number) { nil }
+      let_it_be(:tax_identification_number) { nil }
+      let_it_be(:customer) { create(:customer, organization:, billing_entity:, tax_identification_number:, zipcode: nil) }
 
       context "when the customer has no country" do
         before { customer.update(country: nil) }
@@ -162,7 +166,8 @@ RSpec.describe Customers::EuAutoTaxesService do
       end
 
       context "when B2B customer (non-France territories apply exception regardless)" do
-        let(:tax_identification_number) { "IT12345678901" }
+        let_it_be(:tax_identification_number) { "IT12345678901" }
+        let_it_be(:customer) { create(:customer, organization:, billing_entity:, tax_identification_number:, zipcode: nil) }
 
         it_behaves_like "a special territory tax assignment",
           country: "ES", zipcode: "35001", expected_tax_code: "lago_eu_es_exception_canary_islands"
@@ -197,7 +202,8 @@ RSpec.describe Customers::EuAutoTaxesService do
       end
 
       context "when B2C customer (non-France territories apply exception regardless)" do
-        let(:tax_identification_number) { nil }
+        let_it_be(:tax_identification_number) { nil }
+        let_it_be(:customer) { create(:customer, organization:, billing_entity:, tax_identification_number:, zipcode: nil) }
 
         it_behaves_like "a special territory tax assignment",
           country: "ES", zipcode: "35001", expected_tax_code: "lago_eu_es_exception_canary_islands"
@@ -214,7 +220,8 @@ RSpec.describe Customers::EuAutoTaxesService do
       end
 
       context "when B2B customer in France DOM-TOM (exception rate applies)" do
-        let(:tax_identification_number) { "IT12345678901" }
+        let_it_be(:tax_identification_number) { "IT12345678901" }
+        let_it_be(:customer) { create(:customer, organization:, billing_entity:, tax_identification_number:, zipcode: nil) }
 
         it_behaves_like "a special territory tax assignment",
           country: "FR", zipcode: "97200", expected_tax_code: "lago_eu_fr_exception_martinique"
@@ -229,7 +236,8 @@ RSpec.describe Customers::EuAutoTaxesService do
       end
 
       context "when B2C customer in France DOM-TOM (standard rate applies)" do
-        let(:tax_identification_number) { nil }
+        let_it_be(:tax_identification_number) { nil }
+        let_it_be(:customer) { create(:customer, organization:, billing_entity:, tax_identification_number:, zipcode: nil) }
 
         it_behaves_like "a special territory tax assignment",
           country: "FR", zipcode: "97200", expected_tax_code: "lago_eu_fr_standard"
@@ -244,7 +252,8 @@ RSpec.describe Customers::EuAutoTaxesService do
       end
 
       context "when territory is detected" do
-        let(:tax_identification_number) { "IT12345678901" }
+        let_it_be(:tax_identification_number) { "IT12345678901" }
+        let_it_be(:customer) { create(:customer, organization:, billing_entity:, tax_identification_number:, zipcode: nil) }
 
         before { customer.update(country: "ES", zipcode: "35001") }
 
@@ -268,7 +277,8 @@ RSpec.describe Customers::EuAutoTaxesService do
       end
 
       context "when zipcode contains spaces" do
-        let(:tax_identification_number) { nil }
+        let_it_be(:tax_identification_number) { nil }
+        let_it_be(:customer) { create(:customer, organization:, billing_entity:, tax_identification_number:, zipcode: nil) }
 
         it "normalizes the zipcode before matching" do
           customer.update(country: "ES", zipcode: " 35 001 ")
@@ -279,10 +289,12 @@ RSpec.describe Customers::EuAutoTaxesService do
 
       context "when customer relocates from mainland to special territory" do
         let(:new_record) { false }
-        let(:tax_attributes_changed) { true }
-        let(:tax_identification_number) { nil }
         let(:applied_tax) { create(:customer_applied_tax, tax:, customer:) }
         let(:tax) { create(:tax, organization:, code: "lago_eu_es_standard") }
+        let(:tax_attributes_changed) { true }
+
+        let_it_be(:tax_identification_number) { nil }
+        let_it_be(:customer) { create(:customer, organization:, billing_entity:, tax_identification_number:, zipcode: nil) }
 
         before do
           applied_tax
@@ -296,7 +308,8 @@ RSpec.describe Customers::EuAutoTaxesService do
       end
 
       context "when customer has an invalid VAT number in a special territory" do
-        let(:tax_identification_number) { "INVALID123" }
+        let_it_be(:tax_identification_number) { "INVALID123" }
+        let_it_be(:customer) { create(:customer, organization:, billing_entity:, tax_identification_number:, zipcode: nil) }
 
         before { customer.update(country: "FR", zipcode: "97100") }
 
@@ -310,7 +323,8 @@ RSpec.describe Customers::EuAutoTaxesService do
       end
 
       context "when territory is not detected" do
-        let(:tax_identification_number) { nil }
+        let_it_be(:tax_identification_number) { nil }
+        let_it_be(:customer) { create(:customer, organization:, billing_entity:, tax_identification_number:, zipcode: nil) }
 
         it "falls through when zipcode does not match any exception" do
           customer.update(country: "ES", zipcode: "28001")

--- a/spec/services/customers/generate_checkout_url_service_spec.rb
+++ b/spec/services/customers/generate_checkout_url_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Customers::GenerateCheckoutUrlService do
   subject(:generate_checkout_url_service) { described_class.new(customer:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
 
   describe ".call" do

--- a/spec/services/customers/manage_invoice_custom_sections_service_spec.rb
+++ b/spec/services/customers/manage_invoice_custom_sections_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Customers::ManageInvoiceCustomSectionsService do
   subject(:result) { described_class.call(customer:, section_ids:, skip_invoice_custom_sections:, section_codes:) }
 
+  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer) }
-  let(:organization) { customer.organization }
   let(:billing_entity) { customer.billing_entity }
   let(:invoice_custom_section_1) { create(:invoice_custom_section, organization:) }
   let(:invoice_custom_section_2) { create(:invoice_custom_section, organization:) }

--- a/spec/services/customers/metadata/update_service_spec.rb
+++ b/spec/services/customers/metadata/update_service_spec.rb
@@ -5,7 +5,11 @@ require "rails_helper"
 RSpec.describe Customers::Metadata::UpdateService do
   subject(:update_service) { described_class.new(customer:, params:) }
 
-  let(:customer) { create(:customer) }
+  before_all do
+    create_default(:organization)
+  end
+
+  let_it_be(:customer) { create(:customer) }
   let(:customer_metadata) { create(:customer_metadata, customer:) }
   let(:another_customer_metadata) { create(:customer_metadata, customer:, key: "test", value: "1") }
   let(:params) do

--- a/spec/services/customers/refresh_invoices_search_terms_service_spec.rb
+++ b/spec/services/customers/refresh_invoices_search_terms_service_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe Customers::RefreshInvoicesSearchTermsService do
     end
 
     context "with a customer" do
-      let(:organization) { create(:organization) }
-      let(:customer) { create(:customer, organization:, name: "Acme Inc") }
-      let(:other_customer) { create(:customer, organization:, name: "Globex") }
+      let_it_be(:organization) { create(:organization) }
+      let_it_be(:customer) { create(:customer, organization:, name: "Acme Inc") }
+      let_it_be(:other_customer) { create(:customer, organization:, name: "Globex") }
 
-      let!(:invoice) { create(:invoice, organization:, customer:, number: "INV-001") }
-      let!(:other_invoice) { create(:invoice, organization:, customer: other_customer, number: "INV-002") }
+      let_it_be(:invoice) { create(:invoice, organization:, customer:, number: "INV-001") }
+      let_it_be(:other_invoice) { create(:invoice, organization:, customer: other_customer, number: "INV-002") }
 
       before do
         Invoice.where(id: [invoice.id, other_invoice.id]).update_all(search_terms: nil) # rubocop:disable Rails/SkipsModelValidations

--- a/spec/services/customers/refresh_wallets_service_spec.rb
+++ b/spec/services/customers/refresh_wallets_service_spec.rb
@@ -5,17 +5,17 @@ RSpec.describe Customers::RefreshWalletsService do
     subject(:result) { described_class.call(customer:, include_generating_invoices:) }
 
     let(:include_generating_invoices) { false }
-    let(:customer) { create(:customer, awaiting_wallet_refresh: true) }
-    let_it_be(:organization) { create_default(:organization) }
-    let_it_be(:billable_metric) { create_default(:billable_metric, aggregation_type: "count_agg") }
-    let_it_be(:pay_in_advance_billable_metric) { create_default(:billable_metric, aggregation_type: "count_agg") }
-
     let(:subscriptions) do
       [
         create(:subscription, organization:, customer:, started_at: Time.zone.now - 2.years),
         create(:subscription, organization:, customer:, started_at: Time.zone.now - 1.year)
       ]
     end
+    let(:customer) { create(:customer, awaiting_wallet_refresh: true) }
+
+    let_it_be(:organization) { create_default(:organization) }
+    let_it_be(:billable_metric) { create_default(:billable_metric, aggregation_type: "count_agg") }
+    let_it_be(:pay_in_advance_billable_metric) { create_default(:billable_metric, aggregation_type: "count_agg") }
 
     before do
       create(

--- a/spec/services/customers/refresh_wallets_service_spec.rb
+++ b/spec/services/customers/refresh_wallets_service_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Customers::RefreshWalletsService do
 
     let(:include_generating_invoices) { false }
     let(:customer) { create(:customer, awaiting_wallet_refresh: true) }
-    let(:organization) { customer.organization }
-    let(:billable_metric) { create(:billable_metric, aggregation_type: "count_agg") }
-    let(:pay_in_advance_billable_metric) { create(:billable_metric, aggregation_type: "count_agg") }
+    let_it_be(:organization) { create_default(:organization) }
+    let_it_be(:billable_metric) { create_default(:billable_metric, aggregation_type: "count_agg") }
+    let_it_be(:pay_in_advance_billable_metric) { create_default(:billable_metric, aggregation_type: "count_agg") }
 
     let(:subscriptions) do
       [

--- a/spec/services/customers/terminate_relations_service_spec.rb
+++ b/spec/services/customers/terminate_relations_service_spec.rb
@@ -5,7 +5,11 @@ require "rails_helper"
 RSpec.describe Customers::TerminateRelationsService do
   subject(:terminate_service) { described_class.new(customer:) }
 
-  let(:customer) { create(:customer, :deleted) }
+  before_all do
+    create_default(:organization)
+  end
+
+  let_it_be(:customer) { create(:customer, :deleted) }
 
   context "with an active subscription" do
     let(:subscription) { create(:subscription, customer:) }
@@ -37,7 +41,8 @@ RSpec.describe Customers::TerminateRelationsService do
 
   context "with draft invoices" do
     let(:subscription) { create(:subscription, customer:) }
-    let(:invoices) { create_list(:invoice, 2, :draft, customer:) }
+
+    let_it_be(:invoices) { create_list(:invoice, 2, :draft, customer:) }
 
     before do
       create(:invoice_subscription, invoice: invoices.first, subscription:, invoicing_reason: :subscription_starting)

--- a/spec/services/customers/update_currency_service_spec.rb
+++ b/spec/services/customers/update_currency_service_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe Customers::UpdateCurrencyService do
   subject(:currency_service) { described_class.new(customer:, currency:, customer_update:) }
 
+  before_all do
+    create_default(:organization)
+  end
+
   let(:customer) { create(:customer, currency: nil) }
   let(:currency) { "USD" }
   let(:customer_update) { false }
@@ -81,6 +85,7 @@ RSpec.describe Customers::UpdateCurrencyService do
 
       context "when customer_update is true (direct API update)" do
         let(:customer_update) { true }
+
         let(:customer) { create(:customer, currency: "EUR") }
 
         it "allows the currency update" do

--- a/spec/services/customers/update_invoice_issuing_date_settings_service_spec.rb
+++ b/spec/services/customers/update_invoice_issuing_date_settings_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Customers::UpdateInvoiceIssuingDateSettingsService do
   subject(:update_service) { described_class.new(customer:, params:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
   let(:customer) { create(:customer, organization:) }
   let(:params) do
     {

--- a/spec/services/customers/update_invoice_payment_due_date_service_spec.rb
+++ b/spec/services/customers/update_invoice_payment_due_date_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Customers::UpdateInvoicePaymentDueDateService do
   subject(:update_service) { described_class.new(customer:, net_payment_term:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
   let(:billing_entity) { create(:billing_entity, organization:, net_payment_term: 15) }
   let(:customer) { create(:customer, organization:, billing_entity:, net_payment_term: customer_net_payment_term) }
   let(:net_payment_term) { 30 }

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Customers::UpdateService do
   subject(:customers_service) { described_class.new(customer:, args: update_args) }
 
-  let(:billing_entity) { create(:billing_entity) }
-  let(:organization) { billing_entity.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billing_entity) { create_default(:billing_entity) }
   let(:payment_provider_code) { "stripe_1" }
 
   describe "call" do

--- a/spec/services/customers/upsert_from_api_service_spec.rb
+++ b/spec/services/customers/upsert_from_api_service_spec.rb
@@ -7,9 +7,7 @@ RSpec.describe Customers::UpsertFromApiService do
 
   let_it_be(:organization) { create_default(:organization) }
   let(:billing_entity) { organization.default_billing_entity }
-  let_it_be(:membership) { create_default(:membership, organization:) }
   let(:external_id) { SecureRandom.uuid }
-
   let(:create_args) do
     {
       external_id:,
@@ -33,6 +31,8 @@ RSpec.describe Customers::UpsertFromApiService do
       }
     }
   end
+
+  let_it_be(:membership) { create_default(:membership, organization:) }
 
   before do
     allow(CurrentContext).to receive(:source).and_return("api")

--- a/spec/services/customers/upsert_from_api_service_spec.rb
+++ b/spec/services/customers/upsert_from_api_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Customers::UpsertFromApiService do
   subject(:result) { described_class.call(organization:, params: create_args) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:billing_entity) { organization.default_billing_entity }
-  let(:membership) { create(:membership, organization:) }
+  let_it_be(:membership) { create_default(:membership, organization:) }
   let(:external_id) { SecureRandom.uuid }
 
   let(:create_args) do

--- a/spec/services/customers/vies_check_service_spec.rb
+++ b/spec/services/customers/vies_check_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Customers::ViesCheckService do
   subject(:vies_check_service) { described_class.new(customer:) }
 
-  let(:organization) { create(:organization, country: "IT", eu_tax_management: true) }
-  let(:billing_entity) { create(:billing_entity, organization:, country: "FR", eu_tax_management: true) }
+  let_it_be(:organization) { create_default(:organization, country: "IT", eu_tax_management: true) }
+  let_it_be(:billing_entity) { create_default(:billing_entity, organization:, country: "FR", eu_tax_management: true) }
   let(:customer) { create(:customer, organization:, billing_entity:, tax_identification_number:, zipcode: nil, country: "DE") }
   let(:tax_identification_number) { "IT12345678901" }
 

--- a/spec/services/daily_usages/compute_all_service_spec.rb
+++ b/spec/services/daily_usages/compute_all_service_spec.rb
@@ -7,14 +7,16 @@ RSpec.describe DailyUsages::ComputeAllService do
 
   let(:timestamp) { Time.zone.parse("2024-10-22 00:05:00") }
 
-  let(:organization) { create(:organization, premium_integrations:) }
-  let(:billing_entity) { create(:billing_entity, organization:) }
+  let_it_be(:premium_integrations) { ["revenue_analytics"] }
+  let_it_be(:organization) { create_default(:organization, premium_integrations:) }
+  let_it_be(:billing_entity) { create_default(:billing_entity, organization:) }
+
+  before_all do
+    create_default(:plan)
+  end
+
   let(:customer) { create(:customer, organization:, billing_entity:) }
   let(:subscriptions) { create_list(:subscription, 5, customer:, last_received_event_on: timestamp.to_date - 1.day) }
-
-  let(:premium_integrations) do
-    ["revenue_analytics"]
-  end
 
   before { subscriptions }
 
@@ -95,6 +97,7 @@ RSpec.describe DailyUsages::ComputeAllService do
 
     context "when the organization has a timezone" do
       let(:organization) { create(:organization, timezone: "America/Sao_Paulo", premium_integrations:) }
+      let(:billing_entity) { create_default(:billing_entity, organization:) }
 
       before do
         billing_entity.update(timezone: "America/Sao_Paulo")
@@ -285,7 +288,7 @@ RSpec.describe DailyUsages::ComputeAllService do
     end
 
     context "when revenue_analytics premium integration flag is not present" do
-      let(:premium_integrations) { [] }
+      let(:organization) { create_default(:organization, premium_integrations: []) }
 
       it "does not enqueue any job" do
         expect(compute_service.call).to be_success

--- a/spec/services/daily_usages/compute_all_service_spec.rb
+++ b/spec/services/daily_usages/compute_all_service_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe DailyUsages::ComputeAllService do
   subject(:compute_service) { described_class.new(timestamp:) }
 
   let(:timestamp) { Time.zone.parse("2024-10-22 00:05:00") }
+  let(:customer) { create(:customer, organization:, billing_entity:) }
+  let(:subscriptions) { create_list(:subscription, 5, customer:, last_received_event_on: timestamp.to_date - 1.day) }
 
   let_it_be(:premium_integrations) { ["revenue_analytics"] }
   let_it_be(:organization) { create_default(:organization, premium_integrations:) }
@@ -14,9 +16,6 @@ RSpec.describe DailyUsages::ComputeAllService do
   before_all do
     create_default(:plan)
   end
-
-  let(:customer) { create(:customer, organization:, billing_entity:) }
-  let(:subscriptions) { create_list(:subscription, 5, customer:, last_received_event_on: timestamp.to_date - 1.day) }
 
   before { subscriptions }
 

--- a/spec/services/daily_usages/compute_diff_service_spec.rb
+++ b/spec/services/daily_usages/compute_diff_service_spec.rb
@@ -5,6 +5,12 @@ require "rails_helper"
 RSpec.describe DailyUsages::ComputeDiffService do
   subject(:diff_service) { described_class.new(daily_usage:, previous_daily_usage:) }
 
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+  end
+
   let(:daily_usage) { create(:daily_usage, usage:) }
   let(:previous_daily_usage) { create(:daily_usage, usage: previous_usage) }
 

--- a/spec/services/daily_usages/compute_service_spec.rb
+++ b/spec/services/daily_usages/compute_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe DailyUsages::ComputeService do
   subject(:compute_service) { described_class.new(subscription:, timestamp:) }
 
-  let(:organization) { create(:organization) }
-  let(:billing_entity) { create(:billing_entity, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billing_entity) { create_default(:billing_entity, organization:) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
   let(:customer) { create(:customer, organization:, billing_entity:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, plan:, billable_metric:, properties: properties) }
   let(:plan) { create(:plan, organization:) }
   let(:subscription) do

--- a/spec/services/daily_usages/fill_from_invoice_service_spec.rb
+++ b/spec/services/daily_usages/fill_from_invoice_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe DailyUsages::FillFromInvoiceService do
   subject(:fill_service) { described_class.new(invoice:, subscriptions:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:, timezone: "America/New_York") }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:, timezone: "America/New_York") }
   let(:subscription) { create(:subscription, customer:) }
   let(:subscriptions) { [subscription] }
 

--- a/spec/services/daily_usages/fill_history_service_spec.rb
+++ b/spec/services/daily_usages/fill_history_service_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe DailyUsages::FillHistoryService do
   describe "#call" do
     subject(:call_service) { service.call }
 
-    let(:organization) { create(:organization) }
-    let(:billing_entity) { create(:billing_entity, organization:) }
-    let(:customer) { create(:customer, organization:, billing_entity:) }
-    let(:plan) { create(:plan, organization:) }
+    let_it_be(:organization) { create_default(:organization) }
+    let_it_be(:billing_entity) { create_default(:billing_entity, organization:) }
+    let_it_be(:customer) { create_default(:customer, organization:, billing_entity:) }
+    let_it_be(:plan) { create_default(:plan, organization:) }
     let(:billable_metric) { create(:billable_metric, organization:) }
     let(:subscription_started_at) { Time.zone.parse("2024-10-01 00:00:00") }
     let(:subscription) do
@@ -281,6 +281,12 @@ RSpec.describe DailyUsages::FillHistoryService do
   end
 
   describe "#to" do
+    before_all do
+      create_default(:organization)
+      create_default(:customer)
+      create_default(:plan)
+    end
+
     subject(:to) { service.to }
 
     let(:subscription) { create(:subscription, started_at: Time.current - 1.month) }

--- a/spec/services/data_api/mrrs/plans_service_spec.rb
+++ b/spec/services/data_api/mrrs/plans_service_spec.rb
@@ -4,10 +4,11 @@ require "rails_helper"
 
 RSpec.describe DataApi::Mrrs::PlansService do
   let(:service) { described_class.new(organization, **params) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
   let(:body_response) { File.read("spec/fixtures/lago_data_api/mrrs_plans.json") }
   let(:params) { {} }
+  let(:customer) { create(:customer, organization:) }
+
+  let_it_be(:organization) { create(:organization) }
 
   before do
     stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/mrrs/#{organization.id}/plans/")

--- a/spec/services/data_api/mrrs_service_spec.rb
+++ b/spec/services/data_api/mrrs_service_spec.rb
@@ -4,10 +4,11 @@ require "rails_helper"
 
 RSpec.describe DataApi::MrrsService do
   let(:service) { described_class.new(organization, **params) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
   let(:body_response) { File.read("spec/fixtures/lago_data_api/mrrs.json") }
   let(:params) { {} }
+  let(:customer) { create(:customer, organization:) }
+
+  let_it_be(:organization) { create(:organization) }
 
   before do
     stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/mrrs/#{organization.id}/")

--- a/spec/services/data_api/prepaid_credits_service_spec.rb
+++ b/spec/services/data_api/prepaid_credits_service_spec.rb
@@ -4,10 +4,11 @@ require "rails_helper"
 
 RSpec.describe DataApi::PrepaidCreditsService do
   let(:service) { described_class.new(organization, **params) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
   let(:body_response) { File.read("spec/fixtures/lago_data_api/prepaid_credits.json") }
   let(:params) { {} }
+  let(:customer) { create(:customer, organization:) }
+
+  let_it_be(:organization) { create(:organization) }
 
   before do
     stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/prepaid_credits/#{organization.id}/")

--- a/spec/services/data_api/revenue_streams/customers_service_spec.rb
+++ b/spec/services/data_api/revenue_streams/customers_service_spec.rb
@@ -4,10 +4,11 @@ require "rails_helper"
 
 RSpec.describe DataApi::RevenueStreams::CustomersService do
   let(:service) { described_class.new(organization, **params) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
   let(:body_response) { File.read("spec/fixtures/lago_data_api/revenue_streams_customers.json") }
   let(:params) { {} }
+  let(:customer) { create(:customer, organization:) }
+
+  let_it_be(:organization) { create(:organization) }
 
   before do
     stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/revenue_streams/#{organization.id}/customers/")

--- a/spec/services/data_api/revenue_streams/plans_service_spec.rb
+++ b/spec/services/data_api/revenue_streams/plans_service_spec.rb
@@ -4,10 +4,11 @@ require "rails_helper"
 
 RSpec.describe DataApi::RevenueStreams::PlansService do
   let(:service) { described_class.new(organization, **params) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
   let(:body_response) { File.read("spec/fixtures/lago_data_api/revenue_streams_plans.json") }
   let(:params) { {} }
+  let(:customer) { create(:customer, organization:) }
+
+  let_it_be(:organization) { create(:organization) }
 
   before do
     stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/revenue_streams/#{organization.id}/plans/")

--- a/spec/services/data_api/revenue_streams_service_spec.rb
+++ b/spec/services/data_api/revenue_streams_service_spec.rb
@@ -4,10 +4,11 @@ require "rails_helper"
 
 RSpec.describe DataApi::RevenueStreamsService do
   let(:service) { described_class.new(organization, **params) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
   let(:body_response) { File.read("spec/fixtures/lago_data_api/revenue_streams.json") }
   let(:params) { {} }
+  let(:customer) { create(:customer, organization:) }
+
+  let_it_be(:organization) { create(:organization) }
 
   before do
     stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/revenue_streams/#{organization.id}/")

--- a/spec/services/data_api/usages/aggregated_amounts_service_spec.rb
+++ b/spec/services/data_api/usages/aggregated_amounts_service_spec.rb
@@ -4,10 +4,11 @@ require "rails_helper"
 
 RSpec.describe DataApi::Usages::AggregatedAmountsService do
   let(:service) { described_class.new(organization, **params) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
   let(:body_response) { File.read("spec/fixtures/lago_data_api/usages_aggregated_amounts.json") }
   let(:params) { {} }
+  let(:customer) { create(:customer, organization:) }
+
+  let_it_be(:organization) { create(:organization) }
 
   before do
     stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/usages/#{organization.id}/aggregated_amounts/")

--- a/spec/services/data_api/usages/forecasted_service_spec.rb
+++ b/spec/services/data_api/usages/forecasted_service_spec.rb
@@ -4,10 +4,11 @@ require "rails_helper"
 
 RSpec.describe DataApi::Usages::ForecastedService do
   let(:service) { described_class.new(organization, **params) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
   let(:body_response) { File.read("spec/fixtures/lago_data_api/usages_forecasted.json") }
   let(:params) { {} }
+  let(:customer) { create(:customer, organization:) }
+
+  let_it_be(:organization) { create(:organization) }
 
   before do
     stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/usages/#{organization.id}/forecasted/")

--- a/spec/services/data_api/usages/invoiced_service_spec.rb
+++ b/spec/services/data_api/usages/invoiced_service_spec.rb
@@ -4,10 +4,11 @@ require "rails_helper"
 
 RSpec.describe DataApi::Usages::InvoicedService do
   let(:service) { described_class.new(organization, **params) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
   let(:body_response) { File.read("spec/fixtures/lago_data_api/usages_invoiced.json") }
   let(:params) { {} }
+  let(:customer) { create(:customer, organization:) }
+
+  let_it_be(:organization) { create(:organization) }
 
   before do
     stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/usages/#{organization.id}/invoiced/")

--- a/spec/services/data_api/usages_service_spec.rb
+++ b/spec/services/data_api/usages_service_spec.rb
@@ -4,11 +4,8 @@ require "rails_helper"
 
 RSpec.describe DataApi::UsagesService do
   let(:service) { described_class.new(organization, **params) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
   let(:body_response) { File.read("spec/fixtures/lago_data_api/usages.json") }
   let(:from_date) { Date.current - 60.days }
-
   let(:usage_json) do
     {
       "start_of_period_dt" => "2024-01-01",
@@ -20,6 +17,9 @@ RSpec.describe DataApi::UsagesService do
       "units" => 266
     }
   end
+  let(:customer) { create(:customer, organization:) }
+
+  let_it_be(:organization) { create(:organization) }
 
   describe "#call" do
     subject(:service_call) { service.call }

--- a/spec/services/data_exports/create_service_spec.rb
+++ b/spec/services/data_exports/create_service_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe DataExports::CreateService do
 
   include_context "with mocked security logger"
 
-  let(:organization) { create(:organization) }
-  let(:user) { create(:user) }
-  let(:membership) { create(:membership, user:, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:user) { create(:user) }
+  let_it_be(:membership) { create(:membership, user:, organization:) }
 
   let(:format) { "csv" }
   let(:resource_type) { "invoices" }

--- a/spec/services/data_exports/csv/credit_notes_spec.rb
+++ b/spec/services/data_exports/csv/credit_notes_spec.rb
@@ -7,14 +7,10 @@ RSpec.describe DataExports::Csv::CreditNotes do
     subject(:result) { described_class.new(data_export_part:).call }
 
     let(:data_export) { create(:data_export, resource_type: "credit_notes", organization:) }
-    let(:billing_entity) { create(:billing_entity) }
-    let(:organization) { billing_entity.organization }
     let(:credit_notes) { create_pair(:credit_note, billing_entity:) }
-
     let(:data_export_part) do
       create(:data_export_part, data_export:, object_ids: credit_notes.pluck(:id))
     end
-
     let(:expected_rows) do
       credit_notes.map do |credit_note|
         [
@@ -48,6 +44,9 @@ RSpec.describe DataExports::Csv::CreditNotes do
         ].map(&:to_s)
       end
     end
+
+    let(:organization) { create_default(:organization) }
+    let(:billing_entity) { create(:billing_entity) }
 
     before { create(:credit_note) }
 

--- a/spec/services/data_exports/csv/invoice_fees_spec.rb
+++ b/spec/services/data_exports/csv/invoice_fees_spec.rb
@@ -5,7 +5,6 @@ require "rails_helper"
 RSpec.describe DataExports::Csv::InvoiceFees do
   let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, timezone:) }
-  let_it_be(:plan) { create_default(:plan, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:, organization: customer.organization) }
   let(:invoice) { create(:invoice, customer:, organization: customer.organization) }
   let(:to_utc) { "2024-06-06 12:48:59 UTC" }
@@ -50,6 +49,8 @@ RSpec.describe DataExports::Csv::InvoiceFees do
   let(:invoice_serializer) { instance_double("V1::InvoiceSerializer", serialize: serialized_invoice) }
   let(:fee_serializer_klass) { class_double("V1::FeeSerializer") }
   let(:invoice_serializer_klass) { class_double("V1::InvoiceSerializer") }
+
+  let_it_be(:plan) { create_default(:plan, organization:) }
 
   describe ".base_headers" do
     it "uses timezone-agnostic column names" do

--- a/spec/services/data_exports/csv/invoice_fees_spec.rb
+++ b/spec/services/data_exports/csv/invoice_fees_spec.rb
@@ -3,8 +3,9 @@
 require "rails_helper"
 
 RSpec.describe DataExports::Csv::InvoiceFees do
+  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, timezone:) }
-  let(:plan) { create(:plan, organization: customer.organization) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:, organization: customer.organization) }
   let(:invoice) { create(:invoice, customer:, organization: customer.organization) }
   let(:to_utc) { "2024-06-06 12:48:59 UTC" }

--- a/spec/services/data_exports/csv/invoices_spec.rb
+++ b/spec/services/data_exports/csv/invoices_spec.rb
@@ -4,45 +4,6 @@ require "rails_helper"
 
 RSpec.describe DataExports::Csv::Invoices, :premium do
   let(:data_export) { create :data_export, :processing, resource_query:, organization: }
-
-  let(:data_export_part) { data_export.data_export_parts.create(object_ids: [invoice.id], index: 1, organization:) }
-
-  let(:resource_query) do
-    {
-      currency:,
-      customer_external_id:,
-      customer_id:,
-      invoice_type:,
-      issuing_date_from:,
-      issuing_date_to:,
-      payment_dispute_lost:,
-      payment_overdue:,
-      payment_status:,
-      search_term:,
-      self_billed:,
-      status:
-    }
-  end
-
-  let(:currency) { "EUR" }
-  let(:customer_id) { "customer-lago-id-123" }
-  let(:customer_external_id) { "custext123" }
-  let(:invoice_type) { "credit" }
-  let(:issuing_date_from) { "2023-12-25" }
-  let(:issuing_date_to) { "2024-07-01" }
-  let(:payment_dispute_lost) { false }
-  let(:payment_overdue) { true }
-  let(:payment_status) { "pending" }
-  let(:search_term) { "service ABC" }
-  let(:self_billed) { false }
-  let(:status) { "finalized" }
-
-  let(:serializer_klass) { class_double("V1::InvoiceSerializer") }
-  let(:invoice_serializer) do
-    instance_double("V1::InvoiceSerializer", serialize: serialized_invoice)
-  end
-  let(:organization) { create(:organization, premium_integrations: ["progressive_billing"]) }
-  let(:invoice) { create :invoice, organization: }
   let(:serialized_invoice) do
     {
       lago_id: "invoice-lago-id-123",
@@ -80,6 +41,51 @@ RSpec.describe DataExports::Csv::Invoices, :premium do
       billing_entity_code: "the-test-bil-ent"
     }
   end
+
+  let(:data_export_part) { data_export.data_export_parts.create(object_ids: [invoice.id], index: 1, organization:) }
+
+  let(:resource_query) do
+    {
+      currency:,
+      customer_external_id:,
+      customer_id:,
+      invoice_type:,
+      issuing_date_from:,
+      issuing_date_to:,
+      payment_dispute_lost:,
+      payment_overdue:,
+      payment_status:,
+      search_term:,
+      self_billed:,
+      status:
+    }
+  end
+
+  let(:currency) { "EUR" }
+  let(:customer_id) { "customer-lago-id-123" }
+  let(:customer_external_id) { "custext123" }
+  let(:invoice_type) { "credit" }
+  let(:issuing_date_from) { "2023-12-25" }
+  let(:issuing_date_to) { "2024-07-01" }
+  let(:payment_dispute_lost) { false }
+  let(:payment_overdue) { true }
+  let(:payment_status) { "pending" }
+  let(:search_term) { "service ABC" }
+  let(:self_billed) { false }
+  let(:status) { "finalized" }
+
+  let(:serializer_klass) { class_double("V1::InvoiceSerializer") }
+  let(:invoice_serializer) do
+    instance_double("V1::InvoiceSerializer", serialize: serialized_invoice)
+  end
+
+  let_it_be(:organization) { create_default(:organization, premium_integrations: ["progressive_billing"]) }
+
+  before_all do
+    create_default(:customer)
+  end
+
+  let_it_be(:invoice) { create :invoice, organization: }
 
   before do
     invoice

--- a/spec/services/data_exports/export_resources_service_spec.rb
+++ b/spec/services/data_exports/export_resources_service_spec.rb
@@ -5,13 +5,17 @@ require "rails_helper"
 RSpec.describe DataExports::ExportResourcesService do
   subject(:result) { described_class.call(data_export:, batch_size:) }
 
-  let(:organization) { data_export.organization }
-  let(:batch_size) { 100 }
   let(:data_export) { create :data_export, resource_type: "invoices", format: "csv" }
 
-  let(:issuing_date) { Date.new(2023, 12, 1) }
+  let_it_be(:organization) { create_default(:organization) }
+  let(:batch_size) { 100 }
 
-  let(:invoice) { create(:invoice, organization:, issuing_date:) }
+  before_all do
+    create_default(:customer)
+  end
+
+  let_it_be(:issuing_date) { Date.new(2023, 12, 1) }
+  let_it_be(:invoice) { create(:invoice, organization:, issuing_date:) }
 
   before do
     invoice

--- a/spec/services/data_exports/export_resources_service_spec.rb
+++ b/spec/services/data_exports/export_resources_service_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe DataExports::ExportResourcesService do
   subject(:result) { described_class.call(data_export:, batch_size:) }
 
   let(:data_export) { create :data_export, resource_type: "invoices", format: "csv" }
+  let(:batch_size) { 100 }
 
   let_it_be(:organization) { create_default(:organization) }
-  let(:batch_size) { 100 }
 
   before_all do
     create_default(:customer)

--- a/spec/services/data_exports/process_part_service_spec.rb
+++ b/spec/services/data_exports/process_part_service_spec.rb
@@ -3,11 +3,14 @@
 require "rails_helper"
 
 RSpec.describe DataExports::ProcessPartService do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
+
   subject(:result) { described_class.call(data_export_part:) }
 
   let(:data_export) { create :data_export, resource_type: "invoices", format: "csv" }
-  let(:data_export_part) { create :data_export_part, data_export:, object_ids: [invoice.id] }
-  let(:invoice) { create :invoice }
   let(:serialized_invoice) do
     {
       lago_id: "invoice-lago-id-123",
@@ -46,6 +49,9 @@ RSpec.describe DataExports::ProcessPartService do
   let(:invoice_serializer) do
     instance_double("V1::InvoiceSerializer", serialize: serialized_invoice)
   end
+  let(:data_export_part) { create :data_export_part, data_export:, object_ids: [invoice.id] }
+
+  let_it_be(:invoice) { create :invoice }
 
   before do
     create(:credit_note, offset_amount_cents: 334, invoice:)

--- a/spec/services/database_migrations/enqueue_charge_filter_code_backfill_service_spec.rb
+++ b/spec/services/database_migrations/enqueue_charge_filter_code_backfill_service_spec.rb
@@ -5,12 +5,12 @@ require "rails_helper"
 RSpec.describe DatabaseMigrations::EnqueueChargeFilterCodeBackfillService do
   subject(:service) { described_class.call(poll_interval: 0) }
 
-  let(:organization) { create(:organization) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
   let(:bm_filter) { create(:billable_metric_filter, billable_metric:, key: "region", values: %w[us eu]) }
-
-  let(:plan) { create(:plan, organization:) }
   let(:charge) { create(:standard_charge, plan:, billable_metric:) }
+
+  let_it_be(:plan) { create(:plan, organization:) }
 
   def build_filter(on, values, **attrs)
     filter = create(:charge_filter, charge: on, **attrs)

--- a/spec/services/dunning_campaigns/bulk_process_service_spec.rb
+++ b/spec/services/dunning_campaigns/bulk_process_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe DunningCampaigns::BulkProcessService do
   let(:currency) { "EUR" }
 
   context "when premium features are enabled", :premium do
-    let(:organization) { create :organization, premium_integrations: %w[auto_dunning] }
+    let_it_be(:organization) { create_default(:organization, premium_integrations: %w[auto_dunning]) }
     let(:billing_entity) { organization.default_billing_entity }
     let(:customer) { create :customer, organization:, billing_entity:, currency: }
 

--- a/spec/services/dunning_campaigns/create_service_spec.rb
+++ b/spec/services/dunning_campaigns/create_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe DunningCampaigns::CreateService do
   subject(:create_service) { described_class.new(organization:, params:) }
 
-  let(:organization) { create :organization }
+  let_it_be(:organization) { create_default(:organization) }
   let(:billing_entity) { organization.default_billing_entity }
   let(:params) do
     {

--- a/spec/services/dunning_campaigns/destroy_service_spec.rb
+++ b/spec/services/dunning_campaigns/destroy_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe DunningCampaigns::DestroyService do
   subject(:destroy_service) { described_class.new(dunning_campaign:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:membership) { create(:membership, organization:) }
 
   let(:dunning_campaign) { create(:dunning_campaign, organization:) }
@@ -52,7 +52,7 @@ RSpec.describe DunningCampaigns::DestroyService do
       end
 
       context "when auto_dunning premium integration" do
-        let(:organization) do
+        let_it_be(:organization) do
           create(:organization, premium_integrations: ["auto_dunning"])
         end
 

--- a/spec/services/dunning_campaigns/process_attempt_service_spec.rb
+++ b/spec/services/dunning_campaigns/process_attempt_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe DunningCampaigns::ProcessAttemptService do
   subject(:result) { described_class.call(customer:, dunning_campaign_threshold:, billing_entity:) }
 
-  let(:customer) { create :customer, organization:, currency:, billing_entity: }
-  let(:organization) { create :organization }
+  let_it_be(:organization) { create_default(:organization) }
   let(:billing_entity) { organization.default_billing_entity }
+  let(:customer) { create :customer, organization:, currency:, billing_entity: }
   let(:currency) { "EUR" }
   let(:dunning_campaign) { create :dunning_campaign, organization: }
   let(:dunning_campaign_threshold) do

--- a/spec/services/dunning_campaigns/update_service_spec.rb
+++ b/spec/services/dunning_campaigns/update_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe DunningCampaigns::UpdateService do
   subject(:update_service) { described_class.new(organization:, dunning_campaign:, params:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:billing_entity) { organization.default_billing_entity }
   let(:billing_entity_2) { create(:billing_entity, organization:) }
   let(:membership) { create(:membership, organization:) }

--- a/spec/services/e_invoices/payments/cii/create_service_spec.rb
+++ b/spec/services/e_invoices/payments/cii/create_service_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe EInvoices::Payments::Cii::CreateService, :premium do
-  let(:organization) { create(:organization, premium_integrations: %w[issue_receipts]) }
+  let_it_be(:organization) { create(:organization, premium_integrations: %w[issue_receipts]) }
   let(:payment) { create(:payment, organization:) }
   let(:xml_builder_double) { instance_double(Nokogiri::XML::Builder, to_xml: xml_content) }
   let(:xml_content) { "<xml>content</xml>" }

--- a/spec/services/e_invoices/payments/ubl/create_service_spec.rb
+++ b/spec/services/e_invoices/payments/ubl/create_service_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe EInvoices::Payments::Ubl::CreateService, :premium do
-  let(:organization) { create(:organization, premium_integrations: %w[issue_receipts]) }
+  let_it_be(:organization) { create(:organization, premium_integrations: %w[issue_receipts]) }
   let(:payment) { create(:payment, organization:) }
   let(:xml_builder_double) { instance_double(Nokogiri::XML::Builder, to_xml: xml_content) }
   let(:xml_content) { "<xml>content</xml>" }

--- a/spec/services/emails/resend_service_spec.rb
+++ b/spec/services/emails/resend_service_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe Emails::ResendService do
   subject(:service) { described_class.new(resource:, to:, cc:, bcc:) }
 
   let(:to) { nil }
-  let(:cc) { nil }
-  let(:bcc) { nil }
-  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, organization:, email: "customer@example.com") }
   let(:billing_entity) { customer.billing_entity }
+  let(:cc) { nil }
+  let(:bcc) { nil }
+
+  let_it_be(:organization) { create_default(:organization) }
 
   before do
     billing_entity.update!(email: "billing@example.com")

--- a/spec/services/emails/resend_service_spec.rb
+++ b/spec/services/emails/resend_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Emails::ResendService do
   let(:to) { nil }
   let(:cc) { nil }
   let(:bcc) { nil }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, organization:, email: "customer@example.com") }
   let(:billing_entity) { customer.billing_entity }
 

--- a/spec/services/entitlement/feature_create_service_spec.rb
+++ b/spec/services/entitlement/feature_create_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Entitlement::FeatureCreateService do
   subject { described_class.call(organization:, params:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:params) do
     {
       code: "seats",

--- a/spec/services/entitlement/feature_destroy_service_spec.rb
+++ b/spec/services/entitlement/feature_destroy_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Entitlement::FeatureDestroyService do
   subject { described_class.call(feature:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:feature) { create(:feature, organization:) }
   let(:privilege1) { create(:privilege, feature:, code: "max_admins", value_type: "integer") }
   let(:privilege2) { create(:privilege, feature:, code: "has_root", value_type: "boolean") }

--- a/spec/services/entitlement/feature_update_service_spec.rb
+++ b/spec/services/entitlement/feature_update_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Entitlement::FeatureUpdateService do
   subject { described_class.call(feature:, params:, partial:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:feature) { create(:feature, organization:) }
   let(:privilege1) { create(:privilege, feature:, code: "max", name: "Maximum") }
   let(:privilege2) { create(:privilege, feature:, code: "min", name: "Minimum") }

--- a/spec/services/entitlement/plan_entitlement_destroy_service_spec.rb
+++ b/spec/services/entitlement/plan_entitlement_destroy_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Entitlement::PlanEntitlementDestroyService do
   subject(:result) { described_class.call(entitlement:) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:feature) { create(:feature, organization:) }
   let(:privilege) { create(:privilege, organization:, feature:) }
   let(:entitlement) { create(:entitlement, organization:, plan:, feature:) }

--- a/spec/services/entitlement/plan_entitlement_privilege_destroy_service_spec.rb
+++ b/spec/services/entitlement/plan_entitlement_privilege_destroy_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Entitlement::PlanEntitlementPrivilegeDestroyService do
   subject(:result) { described_class.call(entitlement:, privilege_code:) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:feature) { create(:feature, organization:) }
   let(:privilege) { create(:privilege, organization:, feature:, code: "max") }
   let(:privilege2) { create(:privilege, organization:, feature:, code: "max_admins") }

--- a/spec/services/entitlement/plan_entitlements_update_service-full_spec.rb
+++ b/spec/services/entitlement/plan_entitlements_update_service-full_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Entitlement::PlanEntitlementsUpdateService do
   subject(:result) { described_class.call(organization:, plan:, entitlements_params:, partial: false) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:feature) { create(:feature, organization:, code: "seats") }
   let(:privilege) { create(:privilege, organization:, feature:, code: "max", value_type: "integer") }
   let(:entitlements_params) do

--- a/spec/services/entitlement/plan_entitlements_update_service-partial_spec.rb
+++ b/spec/services/entitlement/plan_entitlements_update_service-partial_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Entitlement::PlanEntitlementsUpdateService do
   subject(:result) { described_class.call(organization:, plan:, entitlements_params:, partial: true) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:feature) { create(:feature, organization:) }
   let(:privilege) { create(:privilege, feature:, code: "max", value_type: "integer") }
   let(:privilege2) { create(:privilege, feature:, code: "max_admins", value_type: "integer") }

--- a/spec/services/entitlement/privilege_destroy_service_spec.rb
+++ b/spec/services/entitlement/privilege_destroy_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Entitlement::PrivilegeDestroyService do
   subject { described_class.call(privilege:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:feature) { create(:feature, organization:) }
   let(:privilege) { create(:privilege, feature:, code: "max_admins", value_type: "integer") }
 

--- a/spec/services/entitlement/subscription_entitlement_core_update_service_spec.rb
+++ b/spec/services/entitlement/subscription_entitlement_core_update_service_spec.rb
@@ -3,11 +3,15 @@
 require "rails_helper"
 
 RSpec.describe Entitlement::SubscriptionEntitlementCoreUpdateService do
+  before_all do
+    create_default(:customer)
+  end
+
   subject(:result) { described_class.call(subscription:, plan:, feature: seats, plan_entitlement:, sub_entitlement:, privilege_params:, partial:) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
-  let(:subscription) { create(:subscription, organization:, plan:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:subscription) { create(:subscription, organization:, plan:) }
 
   let(:plan_entitlement) { plan.entitlements.includes(values: :privilege).find_by(feature: seats) }
   let(:sub_entitlement) { subscription.entitlements.includes(values: :privilege).find_by(feature: seats) }
@@ -17,7 +21,7 @@ RSpec.describe Entitlement::SubscriptionEntitlementCoreUpdateService do
   let(:seats_reset) { create(:privilege, feature: seats, code: "reset", name: "Password Reset", value_type: "boolean") }
   let(:seats_signin) { create(:privilege, feature: seats, code: "signin", name: "Sign In", value_type: "select", config: {select_options: ["password", "okta"]}) }
 
-  let(:same_code_feature) { create(:feature, organization: create(:organization), code: "seats", name: "Nb users") }
+  let_it_be(:same_code_feature) { create(:feature, organization: create(:organization), code: "seats", name: "Nb users") }
 
   before do
     seats_reset

--- a/spec/services/entitlement/subscription_entitlement_update_service_spec.rb
+++ b/spec/services/entitlement/subscription_entitlement_update_service_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe Entitlement::SubscriptionEntitlementUpdateService do
     )
   end
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:subscription) { create(:subscription, organization:, customer:, plan:) }
 
   let(:feature) { create(:feature, organization:, code: "seats") }
   let(:privilege) { create(:privilege, organization:, feature:, code: "max", value_type: "integer") }

--- a/spec/services/entitlement/subscription_entitlements_update_service-full_spec.rb
+++ b/spec/services/entitlement/subscription_entitlements_update_service-full_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe Entitlement::SubscriptionEntitlementsUpdateService do
   subject(:result) { described_class.call(subscription:, entitlements_params:, partial: false) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:subscription) { create(:subscription, organization:, customer:, plan:) }
   let(:feature) { create(:feature, organization:, code: "seats") }
   let(:privilege) { create(:privilege, organization:, feature:, code: "max", value_type: "integer") }
   let(:entitlements_params) do

--- a/spec/services/entitlement/subscription_entitlements_update_service-partial_spec.rb
+++ b/spec/services/entitlement/subscription_entitlements_update_service-partial_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe Entitlement::SubscriptionEntitlementsUpdateService do
   subject(:result) { described_class.call(subscription:, entitlements_params:, partial: true) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:subscription) { create(:subscription, organization:, customer:, plan:) }
   let(:feature) { create(:feature, organization:, code: "seats") }
   let(:privilege) { create(:privilege, organization:, feature:, code: "max", value_type: "integer") }
   let(:entitlements_params) do

--- a/spec/services/entitlement/subscription_feature_privilege_remove_service_spec.rb
+++ b/spec/services/entitlement/subscription_feature_privilege_remove_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe Entitlement::SubscriptionFeaturePrivilegeRemoveService do
   subject(:result) { described_class.call(subscription:, feature_code:, privilege_code:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:subscription) { create(:subscription, organization:, customer:, plan:) }
   let(:feature) { create(:feature, organization:, code: "test_feature") }
   let(:privilege) { create(:privilege, feature:, code: "max") }
   let(:feature_code) { feature.code }

--- a/spec/services/entitlement/subscription_feature_remove_service_spec.rb
+++ b/spec/services/entitlement/subscription_feature_remove_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe Entitlement::SubscriptionFeatureRemoveService do
   subject(:result) { described_class.call(subscription:, feature_code:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:subscription) { create(:subscription, organization:, customer:, plan:) }
   let(:feature) { create(:feature, organization:, code: "test_feature") }
   let(:feature_code) { feature.code }
 

--- a/spec/services/error_details/create_service_spec.rb
+++ b/spec/services/error_details/create_service_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 RSpec.describe ErrorDetails::CreateService do
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:owner) { create(:invoice, organization:, customer:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:owner) { create(:invoice, organization:, customer:) }
 
   describe "#call" do
     subject(:service_call) { described_class.call(params:, owner:, organization:) }

--- a/spec/services/events/billing_period_filter_service_spec.rb
+++ b/spec/services/events/billing_period_filter_service_spec.rb
@@ -366,8 +366,8 @@ RSpec.describe Events::BillingPeriodFilterService do
     end
   end
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   let(:subscription) do
     create(

--- a/spec/services/events/calculate_expression_service_spec.rb
+++ b/spec/services/events/calculate_expression_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Events::CalculateExpressionService do
   describe "#call" do
     subject(:service_call) { described_class.new(organization: organization, event: event).call }
 
-    let(:organization) { create(:organization) }
+    let_it_be(:organization) { create(:organization) }
     let(:event) { create(:event, organization: organization, timestamp: Time.current, code: code, properties: properties) }
     let(:code) { "test_code" }
     let(:properties) { {"left" => "1", "right" => "2"} }

--- a/spec/services/events/create_batch_service_spec.rb
+++ b/spec/services/events/create_batch_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Events::CreateBatchService do
     )
   end
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:timestamp) { Time.parse("2024-01-01T01:02:03.123456Z").to_f }
   let(:code) { "sum_agg" }
   let(:metadata) { {} }
@@ -359,7 +359,7 @@ RSpec.describe Events::CreateBatchService do
     end
 
     context "when clickhouse is enabled on the organization" do
-      let(:organization) { create(:organization, clickhouse_events_store: true) }
+      let_it_be(:organization) { create(:organization, clickhouse_events_store: true) }
 
       it "does not store the event in postgres" do
         result = nil

--- a/spec/services/events/create_service_spec.rb
+++ b/spec/services/events/create_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Events::CreateService do
     )
   end
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
 
   let(:code) { "sum_agg" }
   let(:external_subscription_id) { SecureRandom.uuid }

--- a/spec/services/events/enrich_service_spec.rb
+++ b/spec/services/events/enrich_service_spec.rb
@@ -7,9 +7,14 @@ RSpec.describe Events::EnrichService do
     described_class.new(event:, subscription:, billable_metric:, charges_and_filters:, persist:)
   end
 
-  let(:organization) { create(:organization) }
-  let(:subscription) { create(:subscription, organization:) }
-  let(:plan) { subscription.plan }
+  let_it_be(:organization) { create_default(:organization) }
+
+  before_all do
+    create_default(:customer)
+  end
+
+  let_it_be(:plan) { create_default(:plan) }
+  let_it_be(:subscription) { create(:subscription, organization:) }
   let(:billable_metric) { create(:sum_billable_metric, organization:) }
   let(:charge) { create(:standard_charge, plan:, billable_metric:) }
   let(:charges_and_filters) { {charge => charge_filter} }
@@ -319,7 +324,7 @@ RSpec.describe Events::EnrichService do
     end
 
     context "when the charge has the accepts_target_wallet flag set to true", :premium do
-      let(:organization) { create(:organization, premium_integrations: ["events_targeting_wallets"]) }
+      let_it_be(:organization) { create(:organization, premium_integrations: ["events_targeting_wallets"]) }
       let(:charge) { create(:standard_charge, plan:, billable_metric:, accepts_target_wallet: true) }
 
       let(:event) do

--- a/spec/services/events/kafka_producer_service_spec.rb
+++ b/spec/services/events/kafka_producer_service_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Events::KafkaProducerService, :capture_kafka_messages do
   subject(:producer_service) { described_class.new(events:, organization:) }
 
   let(:events) { create_list(:event, 2, organization:) }
-  let(:organization) { create(:organization) }
+
+  let_it_be(:organization) { create(:organization) }
 
   describe "#call" do
     context "with Kafka config" do

--- a/spec/services/events/pay_in_advance_service_spec.rb
+++ b/spec/services/events/pay_in_advance_service_spec.rb
@@ -4,18 +4,11 @@ require "rails_helper"
 
 RSpec.describe Events::PayInAdvanceService do
   let(:in_advance_service) { described_class.new(event:) }
-
-  let(:organization) { create(:organization) }
   let(:billable_metric) { create(:billable_metric, organization:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:subscription) { create(:subscription, customer:, plan:, started_at:) }
   let(:event_properties) { {} }
   let(:timestamp) { Time.current - 1.second }
   let(:code) { billable_metric&.code }
   let(:external_subscription_id) { subscription.external_id }
-  let(:started_at) { Time.current - 3.days }
-
   let(:event) do
     build(
       :common_event,
@@ -27,13 +20,19 @@ RSpec.describe Events::PayInAdvanceService do
     )
   end
 
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:started_at) { Time.current - 3.days }
+  let_it_be(:subscription) { create(:subscription, customer:, plan:, started_at:) }
+
   describe "#call" do
     let(:charge) { create(:standard_charge, :pay_in_advance, plan:, billable_metric:, invoiceable: false) }
-    let(:billable_metric) do
+    let(:event_properties) { {billable_metric.field_name => "12"} }
+
+    let_it_be(:billable_metric) do
       create(:billable_metric, organization:, aggregation_type: "sum_agg", field_name: "item_id")
     end
-
-    let(:event_properties) { {billable_metric.field_name => "12"} }
 
     before { charge }
 
@@ -59,11 +58,11 @@ RSpec.describe Events::PayInAdvanceService do
 
     context "when event matches a pay_in_advance charge that is invoiceable" do
       let(:charge) { create(:standard_charge, :pay_in_advance, plan:, billable_metric:, invoiceable: true) }
-      let(:billable_metric) do
+      let(:event_properties) { {billable_metric.field_name => "12"} }
+
+      let_it_be(:billable_metric) do
         create(:billable_metric, organization:, aggregation_type: "sum_agg", field_name: "item_id")
       end
-
-      let(:event_properties) { {billable_metric.field_name => "12"} }
 
       before { charge }
 

--- a/spec/services/events/post_process_service_spec.rb
+++ b/spec/services/events/post_process_service_spec.rb
@@ -5,11 +5,11 @@ require "rails_helper"
 RSpec.describe Events::PostProcessService do
   subject(:process_service) { described_class.new(event:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
   let(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, organization:, customer:, plan:, started_at:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, :pay_in_advance, plan:, billable_metric:) }
 
   let(:started_at) { Time.current - 3.days }
@@ -210,6 +210,7 @@ RSpec.describe Events::PostProcessService do
         end
 
         context "when active wallet with target code does not exist" do
+          let(:organization) { create(:organization) }
           let(:wallet) { create(:wallet, customer:, code: target_wallet_code, status: :terminated) }
 
           before { wallet }

--- a/spec/services/events/re_enrich_all_service_spec.rb
+++ b/spec/services/events/re_enrich_all_service_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Events::ReEnrichAllService do
   end
 
   let(:re_enrich_service) { described_class.new(subscription:) }
+  let(:subscription) { create(:subscription, organization:) }
   let(:billable_metric) { create(:sum_billable_metric, organization:) }
   let(:charge) { create(:standard_charge, plan:, billable_metric:) }
   let(:event) do
@@ -25,7 +26,6 @@ RSpec.describe Events::ReEnrichAllService do
 
   let_it_be(:organization) { create_default(:organization) }
   let_it_be(:plan) { create_default(:plan) }
-  let(:subscription) { create(:subscription, organization:) }
 
   before do
     event

--- a/spec/services/events/re_enrich_all_service_spec.rb
+++ b/spec/services/events/re_enrich_all_service_spec.rb
@@ -3,14 +3,13 @@
 require "rails_helper"
 
 RSpec.describe Events::ReEnrichAllService do
-  let(:re_enrich_service) { described_class.new(subscription:) }
+  before_all do
+    create_default(:customer)
+  end
 
-  let(:organization) { create(:organization) }
-  let(:subscription) { create(:subscription, organization:) }
-  let(:plan) { subscription.plan }
+  let(:re_enrich_service) { described_class.new(subscription:) }
   let(:billable_metric) { create(:sum_billable_metric, organization:) }
   let(:charge) { create(:standard_charge, plan:, billable_metric:) }
-
   let(:event) do
     create(
       :event,
@@ -23,6 +22,10 @@ RSpec.describe Events::ReEnrichAllService do
       timestamp: Time.current
     )
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create_default(:plan) }
+  let(:subscription) { create(:subscription, organization:) }
 
   before do
     event

--- a/spec/services/events/stores/clickhouse/clean_duplicated_enriched_expanded_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/clean_duplicated_enriched_expanded_service_spec.rb
@@ -5,11 +5,11 @@ require "spec_helper"
 RSpec.describe Events::Stores::Clickhouse::CleanDuplicatedEnrichedExpandedService, :clickhouse do
   subject(:service) { described_class.new(subscription:, codes:, timeout:) }
 
-  let(:organization) { create(:organization, clickhouse_events_store: true) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create(:organization, clickhouse_events_store: true) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, organization:, customer:, plan:, started_at: 1.month.ago) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, billable_metric:, plan:) }
   let(:charge_filter) { nil }
   let(:codes) { [] }

--- a/spec/services/events/stores/clickhouse/clean_duplicated_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/clean_duplicated_service_spec.rb
@@ -3,10 +3,15 @@
 require "spec_helper"
 
 RSpec.describe Events::Stores::Clickhouse::CleanDuplicatedService, :clickhouse do
+  before_all do
+    create_default(:customer)
+    create_default(:plan)
+  end
+
   subject(:clean_service) { described_class.new(subscription:, timestamp:) }
 
-  let(:organization) { create(:organization, clickhouse_events_store: true) }
-  let(:subscription) { create(:subscription, organization:) }
+  let_it_be(:organization) { create_default(:organization, clickhouse_events_store: true) }
+  let_it_be(:subscription) { create(:subscription, organization:) }
   let(:timestamp) { Time.current }
 
   # ReplacingMergeTree dedupes rows sharing the ORDER BY tuple at merge time, which prevents

--- a/spec/services/events/stores/clickhouse/enriched_store_migration/comparison_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/enriched_store_migration/comparison_service_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::ComparisonSer
     }
   end
 
-
   describe "#call" do
     let(:legacy_fee) do
       Fee.new(

--- a/spec/services/events/stores/clickhouse/enriched_store_migration/comparison_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/enriched_store_migration/comparison_service_spec.rb
@@ -5,15 +5,13 @@ require "rails_helper"
 RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::ComparisonService do
   subject(:service) { described_class.new(subscription:, deduplicate:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:, code: "api_calls", aggregation_type: "count_agg") }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:subscription) { create(:subscription, organization:, customer:, plan:) }
   let(:deduplicate) { false }
-
-  let(:billable_metric) { create(:billable_metric, organization:, code: "api_calls", aggregation_type: "count_agg") }
   let(:charge) { create(:standard_charge, plan:, billable_metric:, organization:) }
-
   let(:fee_attributes) do
     {
       charge:,
@@ -22,6 +20,7 @@ RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::ComparisonSer
       properties: {"charges_from_datetime" => "2026-04-01T00:00:00Z", "charges_to_datetime" => "2026-04-30T23:59:59Z"}
     }
   end
+
 
   describe "#call" do
     let(:legacy_fee) do

--- a/spec/services/events/stores/clickhouse/enriched_store_migration/subscription_orchestrator_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/enriched_store_migration/subscription_orchestrator_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::SubscriptionOrchestratorService do
   subject(:service) { described_class.new(subscription_migration:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:subscription) { create(:subscription, organization:, customer:, plan:) }
   let(:migration) { create(:enriched_store_migration, :processing, organization:) }
 
   let(:comparison_service) { Events::Stores::Clickhouse::EnrichedStoreMigration::ComparisonService }

--- a/spec/services/events/stores/clickhouse/enriched_store_migration/wait_for_enrichment_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/enriched_store_migration/wait_for_enrichment_service_spec.rb
@@ -3,14 +3,18 @@
 require "rails_helper"
 
 RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::WaitForEnrichmentService, clickhouse: {clean_before: true} do
+  before_all do
+    create_default(:customer)
+  end
+
   subject(:service) { described_class.new(subscription_migration:, attempt:, max_attempts:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:, code: "code1") }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:subscription) { create(:subscription, organization:, plan:) }
   let(:migration) { create(:enriched_store_migration, :processing, organization:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:, code: "code1") }
   let(:charge) { create(:standard_charge, plan:, billable_metric:) }
-  let(:subscription) { create(:subscription, organization:, plan:) }
   let(:subscription_migration) do
     create(:enriched_store_subscription_migration, :waiting_for_enrichment,
       enriched_store_migration: migration,
@@ -19,7 +23,6 @@ RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::WaitForEnrich
       events_reprocessed_count:,
       billable_metric_codes: ["code1"])
   end
-
   let(:attempt) { 1 }
   let(:max_attempts) { 10 }
   let(:events_reprocessed_count) { 3 }

--- a/spec/services/events/stores/clickhouse/pre_enrichment_check_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/pre_enrichment_check_service_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Events::Stores::Clickhouse::PreEnrichmentCheckService do
     described_class.new(organization:, reprocess:, batch_size: 1000, sleep_seconds: 0)
   end
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:reprocess) { false }
 
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
   let(:started_at) { Time.zone.parse("2024-12-01") }
   let(:subscription) do
     create(:subscription, organization:, customer:, plan:, started_at:)

--- a/spec/services/events/stores/clickhouse/pre_enrichment_check_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/pre_enrichment_check_service_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe Events::Stores::Clickhouse::PreEnrichmentCheckService do
   let_it_be(:organization) { create_default(:organization) }
   let_it_be(:customer) { create_default(:customer, organization:) }
   let(:reprocess) { false }
-
-  let_it_be(:plan) { create_default(:plan, organization:) }
   let(:started_at) { Time.zone.parse("2024-12-01") }
   let(:subscription) do
     create(:subscription, organization:, customer:, plan:, started_at:)
   end
+
+  let_it_be(:plan) { create_default(:plan, organization:) }
 
   before { subscription }
 

--- a/spec/services/events/stores/clickhouse/re_enrich_subscription_events_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/re_enrich_subscription_events_service_spec.rb
@@ -17,15 +17,14 @@ RSpec.describe Events::Stores::Clickhouse::ReEnrichSubscriptionEventsService, :c
   let_it_be(:customer) { create_default(:customer, organization:) }
   let_it_be(:plan) { create_default(:plan, organization:) }
   let(:subscription) { create(:subscription, status:, organization:, customer:, plan:, started_at: 1.month.ago, terminated_at:) }
-  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
   let(:codes) { [] }
   let(:reprocess) { true }
   let(:batch_size) { 1000 }
-
   let(:kafka_producer) { instance_double(WaterDrop::Producer) }
-
   let(:status) { :active }
   let(:terminated_at) { nil }
+
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
 
   before do
     allow(Karafka).to receive(:producer).and_return(kafka_producer)

--- a/spec/services/events/stores/clickhouse/re_enrich_subscription_events_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/re_enrich_subscription_events_service_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe Events::Stores::Clickhouse::ReEnrichSubscriptionEventsService, :c
     )
   end
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
   let(:subscription) { create(:subscription, status:, organization:, customer:, plan:, started_at: 1.month.ago, terminated_at:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:billable_metric) { create_default(:billable_metric, organization:) }
   let(:codes) { [] }
   let(:reprocess) { true }
   let(:batch_size) { 1000 }

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -18,12 +18,12 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
     )
   end
 
-  let(:billable_metric) { create(:sum_billable_metric, field_name: "value", code: "bm:code") }
-  let(:organization) { billable_metric.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create_default(:sum_billable_metric, field_name: "value", code: "bm:code") }
   let(:charge) { create(:standard_charge, organization:, billable_metric:) }
   let(:charge_filter) { nil }
 
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:, started_at:) }
 
   let(:started_at) { DateTime.parse("2023-03-15") }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,6 +76,10 @@ Sentry.init do |config|
   config.transport.transport_class = Sentry::DummyTransport
 end
 
+require "test_prof/recipes/rspec/sample"
+require "test_prof/recipes/rspec/let_it_be"
+require "test_prof/recipes/rspec/factory_default"
+
 RSpec.configure do |config|
   config.include ActiveJob::TestHelper
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
## Context

Currently, around **50% of the spec runtime** is spent preparing data and creating factories. A lot of this data is either duplicated or recreates the same objects multiple times, so we can get rid of a good chunk of it and significantly speed up the specs.

To avoid creating unnecessary factories, we can use `let_it_be`, `before_all`, and `create_default` from `test-prof`. More info [here](https://test-prof.evilmartians.io/guide/recipes/let_it_be).

## Description

This PR cleans up the services specs in folders `a-e` and removes unnecessary factory usage.

Here are the numbers before and after the cleanup. The times below are for running the specs in a single process:

| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 97,841 | 63,994 |
| Time spent creating factories |  11:51.790 | 07:40.512 |
| Total time | 18:00.870 | 14:22.880 |

## Overall results

This PR is part of a series of PRs focused on cleaning up factory usage across different specs.

Once all the changes are merged, we expect to:

- Reduce the number of factories by **~50k**
- Cut spec runtime by around **20%**
- Shave off roughly **1:15 min** from the CI runtime


| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 157,949 | 103,761 |
| Total time spent creating factories | 17:59.851  | 11:14.739 |
| Total time | 34:41.482 | 27:03.658 |

Here is [the CI run](https://github.com/getlago/lago-api/actions/runs/33399605547/job/99512391170?pr=6255) with all the changes merged together: