### PR TITLE
perf(specs): Clean up factories usage in spec/specs in directories f-j

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -167,6 +167,8 @@ group :test do
   # HTML testing (invoice rendering)
   gem "rspec-snapshot", "~> 2.0"
   gem "htmlbeautifier", "~> 1.4"
+
+  gem "test-prof", "~> 1.0"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1004,6 +1004,8 @@ GEM
     temple (0.10.4)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
+    test-prof (1.6.3)
+      logger
     thor (1.5.0)
     throttling (0.4.1)
       logger
@@ -1181,6 +1183,7 @@ DEPENDENCIES
   stripe
   strong_migrations
   super_diff (~> 0.19.0)
+  test-prof (~> 1.0)
   throttling
   timecop
   tzinfo-data

--- a/spec/services/fees/apply_provider_taxes_to_standalone_fees_service_spec.rb
+++ b/spec/services/fees/apply_provider_taxes_to_standalone_fees_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Fees::ApplyProviderTaxesToStandaloneFeesService do
   subject(:service) { described_class.new(customer:, fees:, currency: "EUR") }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:integration) { create(:anrok_integration, organization:) }
   let(:integration_customer) { create(:anrok_customer, integration:, customer:) }

--- a/spec/services/fees/apply_taxes_service_spec.rb
+++ b/spec/services/fees/apply_taxes_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Fees::ApplyTaxesService do
   subject(:apply_service) { described_class.new(fee:) }
 
-  let(:customer) { create(:customer) }
-  let(:organization) { customer.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let(:customer) { create_default(:customer) }
   let(:billing_entity) { customer.billing_entity }
 
   let(:invoice) { create(:invoice, organization:, customer:) }
@@ -118,7 +118,7 @@ RSpec.describe Fees::ApplyTaxesService do
     end
 
     context "when fee is a charge type with taxes applied to the plan" do
-      let(:plan) { create(:plan, organization:) }
+      let(:plan) { create_default(:plan, organization:) }
       let(:charge) { create(:standard_charge, plan:) }
       let(:subscription) { create(:subscription, organization:, customer:, plan:) }
 
@@ -356,7 +356,7 @@ RSpec.describe Fees::ApplyTaxesService do
 
     context "with explicit customer and plan arguments" do
       let(:other_customer) { create(:customer, organization:) }
-      let(:plan) { create(:plan, organization:) }
+      let(:plan) { create_default(:plan, organization:) }
       let(:passed_plan) { create(:plan, organization:) }
       let(:subscription) { create(:subscription, organization:, customer:, plan:) }
 
@@ -390,7 +390,7 @@ RSpec.describe Fees::ApplyTaxesService do
     end
 
     context "when customer and plan are passed as nil" do
-      let(:plan) { create(:plan, organization:) }
+      let(:plan) { create_default(:plan, organization:) }
       let(:subscription) { create(:subscription, organization:, customer:, plan:) }
 
       context "when the fee has an invoice" do

--- a/spec/services/fees/build_pay_in_advance_fixed_charge_service_spec.rb
+++ b/spec/services/fees/build_pay_in_advance_fixed_charge_service_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe Fees::BuildPayInAdvanceFixedChargeService, :premium do
 
   let_it_be(:organization) { create(:organization) }
   let(:customer) { create_default(:customer, organization:) }
-  let_it_be(:plan) { create(:plan, organization:, interval: "monthly", pay_in_advance: true) }
-  let_it_be(:add_on) { create(:add_on, organization:) }
   let(:subscription) do
     create(
       :subscription,
@@ -21,7 +19,6 @@ RSpec.describe Fees::BuildPayInAdvanceFixedChargeService, :premium do
       started_at: Time.zone.parse("2024-03-01")
     )
   end
-
   let(:fixed_charge) do
     create(
       :fixed_charge,
@@ -33,8 +30,10 @@ RSpec.describe Fees::BuildPayInAdvanceFixedChargeService, :premium do
       pay_in_advance: true
     )
   end
-
   let(:timestamp) { Time.zone.parse("2024-03-15").to_i }
+
+  let_it_be(:plan) { create(:plan, organization:, interval: "monthly", pay_in_advance: true) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
 
   context "when there are no existing fees (fixed charge added)" do
     let(:fixed_charge_event) do

--- a/spec/services/fees/build_pay_in_advance_fixed_charge_service_spec.rb
+++ b/spec/services/fees/build_pay_in_advance_fixed_charge_service_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe Fees::BuildPayInAdvanceFixedChargeService, :premium do
     described_class.call(subscription:, fixed_charge:, fixed_charge_event:, timestamp:)
   end
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:, interval: "monthly", pay_in_advance: true) }
-  let(:add_on) { create(:add_on, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:, interval: "monthly", pay_in_advance: true) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
   let(:subscription) do
     create(
       :subscription,
@@ -680,7 +680,9 @@ RSpec.describe Fees::BuildPayInAdvanceFixedChargeService, :premium do
   end
 
   context "when organization has the fixed_charge_usage_delta_migration feature flag enabled" do
-    let(:organization) { create(:organization, feature_flags: ["fixed_charge_usage_delta_migration"]) }
+    let_it_be(:organization) { create(:organization, feature_flags: ["fixed_charge_usage_delta_migration"]) }
+    let_it_be(:add_on) { create(:add_on, organization:) }
+    let_it_be(:plan) { create(:plan, organization:, interval: "monthly", pay_in_advance: true) }
     let(:billable_metric) { create(:sum_billable_metric, :recurring, organization:) }
     let(:usage_charge) do
       create(

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Fees::ChargeService, :premium do
   end
 
   let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+  let(:organization) { create_default(:organization) }
   let(:context) { :finalize }
   let(:apply_taxes) { false }
   let(:filtered_aggregations) { nil }

--- a/spec/services/fees/commitments/minimum/calculate_preview_fee_service_spec.rb
+++ b/spec/services/fees/commitments/minimum/calculate_preview_fee_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Fees::Commitments::Minimum::CalculatePreviewFeeService do
     )
   end
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:, interval: :yearly, pay_in_advance: false, amount_cents: 100_00) }
   let(:subscription) { create(:subscription, customer:, plan:, started_at: from_datetime) }

--- a/spec/services/fees/commitments/minimum/create_service_spec.rb
+++ b/spec/services/fees/commitments/minimum/create_service_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Fees::Commitments::Minimum::CreateService do
   subject(:service_call) { described_class.call(invoice_subscription:) }
 
   let(:invoice) { create(:invoice, customer:, organization:) }
+  let(:plan) { create(:plan, organization:, interval: :yearly, pay_in_advance: false) }
   let(:invoice_subscription) do
     create(
       :invoice_subscription,
@@ -21,8 +22,8 @@ RSpec.describe Fees::Commitments::Minimum::CreateService do
   let(:to_datetime) { DateTime.parse("2024-12-31T23:59:59") }
   let(:timestamp) { DateTime.parse("2025-01-01T10:00:00") }
   let(:customer) { create(:customer, organization:) }
+
   let_it_be(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:, interval: :yearly, pay_in_advance: false) }
 
   context "when plan has no minimum commitment" do
     it "does not create a commitment fee" do

--- a/spec/services/fees/commitments/minimum/create_service_spec.rb
+++ b/spec/services/fees/commitments/minimum/create_service_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Fees::Commitments::Minimum::CreateService do
   let(:to_datetime) { DateTime.parse("2024-12-31T23:59:59") }
   let(:timestamp) { DateTime.parse("2025-01-01T10:00:00") }
   let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
   let(:plan) { create(:plan, organization:, interval: :yearly, pay_in_advance: false) }
-  let(:organization) { create(:organization) }
 
   context "when plan has no minimum commitment" do
     it "does not create a commitment fee" do

--- a/spec/services/fees/create_true_up_service_spec.rb
+++ b/spec/services/fees/create_true_up_service_spec.rb
@@ -4,12 +4,7 @@ require "rails_helper"
 
 RSpec.describe Fees::CreateTrueUpService do
   let(:create_service) { described_class.new(fee:, used_amount_cents:, used_precise_amount_cents:) }
-
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:customer) { create(:customer, organization:) }
   let(:tax) { create(:tax, organization:, rate: 20) }
-  let_it_be(:plan) { create(:plan, organization:) }
-
   let(:charge) { create(:standard_charge, plan:, min_amount_cents: 1000) }
   let(:invoice) { create(:invoice, customer:, organization:) }
   let(:fee) do
@@ -30,6 +25,10 @@ RSpec.describe Fees::CreateTrueUpService do
   end
   let(:used_amount_cents) { 700 }
   let(:used_precise_amount_cents) { 700.0 }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
 
   before { tax }
 

--- a/spec/services/fees/create_true_up_service_spec.rb
+++ b/spec/services/fees/create_true_up_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe Fees::CreateTrueUpService do
   let(:create_service) { described_class.new(fee:, used_amount_cents:, used_precise_amount_cents:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:tax) { create(:tax, organization:, rate: 20) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
 
   let(:charge) { create(:standard_charge, plan:, min_amount_cents: 1000) }
   let(:invoice) { create(:invoice, customer:, organization:) }

--- a/spec/services/fees/estimate_instant/batch_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/estimate_instant/batch_pay_in_advance_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Fees::EstimateInstant::BatchPayInAdvanceService do
   subject { described_class.new(organization:, external_subscription_id:, events:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:billable_metric) { create(:sum_billable_metric, organization:) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:charge) { create(:percentage_charge, :pay_in_advance, plan:, billable_metric:, properties: {rate: "0.1", fixed_amount: "0"}) }
 
   let(:customer) { create(:customer, organization:) }

--- a/spec/services/fees/estimate_instant/batch_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/estimate_instant/batch_pay_in_advance_service_spec.rb
@@ -7,11 +7,8 @@ RSpec.describe Fees::EstimateInstant::BatchPayInAdvanceService do
 
   let_it_be(:organization) { create(:organization) }
   let(:billable_metric) { create(:sum_billable_metric, organization:) }
-  let_it_be(:plan) { create(:plan, organization:) }
   let(:charge) { create(:percentage_charge, :pay_in_advance, plan:, billable_metric:, properties: {rate: "0.1", fixed_amount: "0"}) }
-
   let(:customer) { create(:customer, organization:) }
-
   let(:subscription) do
     create(
       :subscription,
@@ -20,7 +17,6 @@ RSpec.describe Fees::EstimateInstant::BatchPayInAdvanceService do
       started_at: 1.year.ago
     )
   end
-
   let(:event) do
     {
       organization_id:,
@@ -33,17 +29,16 @@ RSpec.describe Fees::EstimateInstant::BatchPayInAdvanceService do
     }
   end
   let(:events) { [event] }
-
   let(:transaction_id) { SecureRandom.uuid }
-
   let(:properties) { nil }
-
   let(:code) { billable_metric&.code }
   let(:external_customer_id) { customer&.external_id }
   let(:external_subscription_id) { subscription&.external_id }
   let(:organization_id) { organization.id }
   let(:timestamp) { Time.current.to_i.to_s }
   let(:currency) { subscription.plan.amount.currency }
+
+  let_it_be(:plan) { create(:plan, organization:) }
 
   before { charge }
 

--- a/spec/services/fees/estimate_instant/pay_in_advance_service_spec.rb
+++ b/spec/services/fees/estimate_instant/pay_in_advance_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Fees::EstimateInstant::PayInAdvanceService do
   subject { described_class.new(organization:, params:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:billable_metric) { create(:sum_billable_metric, organization:) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:charge) { create(:percentage_charge, :pay_in_advance, plan:, billable_metric:, properties: {rate: "0.1", fixed_amount: "0"}) }
 
   let(:customer) { create(:customer, organization:) }

--- a/spec/services/fees/estimate_instant/pay_in_advance_service_spec.rb
+++ b/spec/services/fees/estimate_instant/pay_in_advance_service_spec.rb
@@ -7,11 +7,8 @@ RSpec.describe Fees::EstimateInstant::PayInAdvanceService do
 
   let_it_be(:organization) { create(:organization) }
   let(:billable_metric) { create(:sum_billable_metric, organization:) }
-  let_it_be(:plan) { create(:plan, organization:) }
   let(:charge) { create(:percentage_charge, :pay_in_advance, plan:, billable_metric:, properties: {rate: "0.1", fixed_amount: "0"}) }
-
   let(:customer) { create(:customer, organization:) }
-
   let(:subscription) do
     create(
       :subscription,
@@ -20,7 +17,6 @@ RSpec.describe Fees::EstimateInstant::PayInAdvanceService do
       started_at: 1.year.ago
     )
   end
-
   let(:params) do
     {
       organization_id:,
@@ -32,17 +28,16 @@ RSpec.describe Fees::EstimateInstant::PayInAdvanceService do
       properties:
     }
   end
-
   let(:transaction_id) { SecureRandom.uuid }
-
   let(:properties) { nil }
-
   let(:code) { billable_metric&.code }
   let(:external_customer_id) { customer&.external_id }
   let(:external_subscription_id) { subscription&.external_id }
   let(:organization_id) { organization.id }
   let(:timestamp) { Time.current.to_i.to_s }
   let(:currency) { subscription.plan.amount.currency }
+
+  let_it_be(:plan) { create(:plan, organization:) }
 
   before { charge }
 

--- a/spec/services/fees/estimate_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/estimate_pay_in_advance_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Fees::EstimatePayInAdvanceService do
   subject(:estimate_service) { described_class.new(organization:, params:) }
 
-  let(:organization) { create(:organization) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:charge) { create(:standard_charge, :pay_in_advance, plan:, billable_metric:, properties: {amount: "100"}) }
 
   let(:customer) { create(:customer, organization:) }

--- a/spec/services/fees/fixed_charge_service_spec.rb
+++ b/spec/services/fees/fixed_charge_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Fees::FixedChargeService, :premium do
     described_class.new(invoice:, fixed_charge:, subscription:, boundaries:, context:, apply_taxes:)
   end
 
-  let(:customer) { create(:customer) }
-  let(:organization) { customer.organization }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
   let(:context) { :finalize }
   let(:apply_taxes) { false }
   let(:started_at) { Time.zone.parse("2022-03-17") }

--- a/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
+++ b/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe Fees::InitFromAdjustedChargeFeeService do
       started_at: DateTime.parse("2022-03-15")
     )
   end
-  let(:organization) { invoice.organization }
+  let_it_be(:organization) { create_default(:organization)}
   let(:billing_entity) { organization.default_billing_entity }
   let(:invoice) { create(:invoice, status: :draft) }
   let(:invoice_subscription) { create(:invoice_subscription, invoice:, subscription:) }
 
-  let(:billable_metric) { create(:billable_metric, aggregation_type: "count_agg") }
+  let_it_be(:billable_metric) { create(:billable_metric, aggregation_type: "count_agg") }
   let(:charge) do
     create(
       :standard_charge,

--- a/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
+++ b/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
@@ -12,12 +12,9 @@ RSpec.describe Fees::InitFromAdjustedChargeFeeService do
       started_at: DateTime.parse("2022-03-15")
     )
   end
-  let_it_be(:organization) { create_default(:organization)}
   let(:billing_entity) { organization.default_billing_entity }
   let(:invoice) { create(:invoice, status: :draft) }
   let(:invoice_subscription) { create(:invoice_subscription, invoice:, subscription:) }
-
-  let_it_be(:billable_metric) { create(:billable_metric, aggregation_type: "count_agg") }
   let(:charge) do
     create(
       :standard_charge,
@@ -30,14 +27,12 @@ RSpec.describe Fees::InitFromAdjustedChargeFeeService do
     )
   end
   let(:properties) { charge.properties }
-
   let(:boundaries) do
     {
       charges_from_datetime: subscription.started_at.beginning_of_day,
       charges_to_datetime: subscription.started_at.end_of_month.end_of_day
     }
   end
-
   let(:adjusted_fee) do
     create(
       :adjusted_fee,
@@ -51,6 +46,10 @@ RSpec.describe Fees::InitFromAdjustedChargeFeeService do
       units: 7
     )
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+
+  let_it_be(:billable_metric) { create(:billable_metric, aggregation_type: "count_agg") }
 
   before do
     invoice_subscription

--- a/spec/services/fees/projection_service_spec.rb
+++ b/spec/services/fees/projection_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Fees::ProjectionService do
   subject(:service) { described_class.new(fees: fees) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
 
   let(:fees) { [fee] }
   let(:fee) do
@@ -18,7 +18,7 @@ RSpec.describe Fees::ProjectionService do
       amount_currency: currency)
   end
 
-  let(:billable_metric) do
+  let_it_be(:billable_metric) do
     create(:billable_metric, recurring: false, organization:)
   end
 
@@ -31,8 +31,8 @@ RSpec.describe Fees::ProjectionService do
 
   let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, plan:, organization:, customer:) }
-  let(:plan) { create(:plan, amount_cents: 100, amount_currency: currency) }
-  let(:currency) { "EUR" }
+  let_it_be(:currency) { "EUR" }
+  let_it_be(:plan) { create(:plan, amount_cents: 100, amount_currency: currency) }
 
   let(:charge_filter) { nil }
   let(:applied_pricing_unit) { nil }
@@ -285,7 +285,7 @@ RSpec.describe Fees::ProjectionService do
     end
 
     context "when billable metric is recurring" do
-      let(:billable_metric) { create(:billable_metric, recurring: true, aggregation_type: "sum_agg", field_name: "amount", organization:) }
+      let_it_be(:billable_metric) { create(:billable_metric, recurring: true, aggregation_type: "sum_agg", field_name: "amount", organization:) }
 
       it "returns projected values without applying period_ratio" do
         result = service.call
@@ -384,6 +384,7 @@ RSpec.describe Fees::ProjectionService do
 
     context "when currency has different exponent" do
       let(:currency) { "KWD" }
+      let(:plan) { create(:plan, amount_cents: 100, amount_currency: currency) }
 
       it "rounds and converts correctly" do
         result = service.call

--- a/spec/services/fees/projection_service_spec.rb
+++ b/spec/services/fees/projection_service_spec.rb
@@ -8,6 +8,43 @@ RSpec.describe Fees::ProjectionService do
   let_it_be(:organization) { create_default(:organization) }
 
   let(:fees) { [fee] }
+  let(:charge) do
+    create(:standard_charge,
+      applied_pricing_unit: applied_pricing_unit,
+      filters: [],
+      billable_metric: billable_metric)
+  end
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, plan:, organization:, customer:) }
+  let(:charge_filter) { nil }
+  let(:applied_pricing_unit) { nil }
+  let(:fee_properties) do
+    {
+      "from_datetime" => from_datetime,
+      "to_datetime" => to_datetime,
+      "charges_duration" => charges_duration
+    }
+  end
+  let(:from_datetime) { Time.current.beginning_of_month }
+  let(:to_datetime) { Time.current.end_of_month }
+  let(:charges_duration) { nil }
+  let(:aggregation_result) do
+    instance_double(
+      "AggregationResult",
+      success?: true,
+      error: nil
+    )
+  end
+  let(:charge_model_result) do
+    instance_double(
+      "ChargeModelResult",
+      success?: true,
+      error: nil,
+      projected_amount: BigDecimal("100.50"),
+      projected_units: BigDecimal(10),
+      unit_amount: BigDecimal("10.05")
+    )
+  end
   let(:fee) do
     build(:fee,
       charge: charge,
@@ -22,51 +59,8 @@ RSpec.describe Fees::ProjectionService do
     create(:billable_metric, recurring: false, organization:)
   end
 
-  let(:charge) do
-    create(:standard_charge,
-      applied_pricing_unit: applied_pricing_unit,
-      filters: [],
-      billable_metric: billable_metric)
-  end
-
-  let(:customer) { create(:customer, organization:) }
-  let(:subscription) { create(:subscription, plan:, organization:, customer:) }
   let_it_be(:currency) { "EUR" }
   let_it_be(:plan) { create(:plan, amount_cents: 100, amount_currency: currency) }
-
-  let(:charge_filter) { nil }
-  let(:applied_pricing_unit) { nil }
-
-  let(:fee_properties) do
-    {
-      "from_datetime" => from_datetime,
-      "to_datetime" => to_datetime,
-      "charges_duration" => charges_duration
-    }
-  end
-
-  let(:from_datetime) { Time.current.beginning_of_month }
-  let(:to_datetime) { Time.current.end_of_month }
-  let(:charges_duration) { nil }
-
-  let(:aggregation_result) do
-    instance_double(
-      "AggregationResult",
-      success?: true,
-      error: nil
-    )
-  end
-
-  let(:charge_model_result) do
-    instance_double(
-      "ChargeModelResult",
-      success?: true,
-      error: nil,
-      projected_amount: BigDecimal("100.50"),
-      projected_units: BigDecimal(10),
-      unit_amount: BigDecimal("10.05")
-    )
-  end
 
   before do
     allow(BillableMetrics::AggregationFactory).to receive(:new_instance).and_return(

--- a/spec/services/finance_assistant/ask_service_spec.rb
+++ b/spec/services/finance_assistant/ask_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe FinanceAssistant::AskService do
   subject(:result) { described_class.call(organization:, question:, session_id:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:question) { "Show MRR for the past 3 months" }
   let(:session_id) { SecureRandom.uuid }
   let(:message_id) { SecureRandom.uuid }

--- a/spec/services/finance_assistant/export_service_spec.rb
+++ b/spec/services/finance_assistant/export_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe FinanceAssistant::ExportService do
   subject(:result) { described_class.call(organization:, message_id:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:message_id) { SecureRandom.uuid }
   let(:finance_assistant_url) { "http://finance-assistant.test" }
 

--- a/spec/services/fixed_charge_events/aggregations/preview_aggregation_service_spec.rb
+++ b/spec/services/fixed_charge_events/aggregations/preview_aggregation_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe FixedChargeEvents::Aggregations::PreviewAggregationService do
   subject(:result) { described_class.call(fixed_charge:, subscription:, boundaries:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:add_on) { create(:add_on, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
   let(:fixed_charge) do
     create(
       :fixed_charge,

--- a/spec/services/fixed_charge_events/aggregations/preview_aggregation_service_spec.rb
+++ b/spec/services/fixed_charge_events/aggregations/preview_aggregation_service_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe FixedChargeEvents::Aggregations::PreviewAggregationService do
 
   let_it_be(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
-  let_it_be(:plan) { create(:plan, organization:) }
-  let_it_be(:add_on) { create(:add_on, organization:) }
   let(:fixed_charge) do
     create(
       :fixed_charge,
@@ -38,6 +36,9 @@ RSpec.describe FixedChargeEvents::Aggregations::PreviewAggregationService do
       "fixed_charges_duration" => 30
     }
   end
+
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
 
   it "returns the fixed_charge units" do
     expect(result).to be_success

--- a/spec/services/fixed_charge_events/aggregations/prorated_aggregation_service_spec.rb
+++ b/spec/services/fixed_charge_events/aggregations/prorated_aggregation_service_spec.rb
@@ -5,6 +5,12 @@ require "rails_helper"
 RSpec.describe FixedChargeEvents::Aggregations::ProratedAggregationService do
   subject { described_class.new(fixed_charge:, subscription:, boundaries:) }
 
+  before_all do
+    create_default(:organization)
+    create_default(:add_on)
+    create_default(:plan)
+  end
+
   let(:fixed_charge) { create(:fixed_charge) }
   let(:subscription) { create(:subscription) }
   let(:fixed_charges_from_datetime) { 9.days.ago } # total duration is 10 days

--- a/spec/services/fixed_charge_events/aggregations/simple_aggregation_service_spec.rb
+++ b/spec/services/fixed_charge_events/aggregations/simple_aggregation_service_spec.rb
@@ -5,6 +5,12 @@ require "rails_helper"
 RSpec.describe FixedChargeEvents::Aggregations::SimpleAggregationService do
   subject { described_class.new(fixed_charge:, subscription:, boundaries:) }
 
+  before_all do
+    create_default(:organization)
+    create_default(:add_on)
+    create_default(:plan)
+  end
+
   let(:fixed_charge) { create(:fixed_charge) }
   let(:subscription) { create(:subscription) }
   let(:fixed_charges_from_datetime) { 9.days.ago }

--- a/spec/services/fixed_charge_events/bulk_create_service_spec.rb
+++ b/spec/services/fixed_charge_events/bulk_create_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe FixedChargeEvents::BulkCreateService do
   subject(:service) { described_class.new(events_attributes:) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
-  let(:add_on) { create(:add_on, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
   let(:fixed_charge) { create(:fixed_charge, plan:, add_on:) }
   let(:subscription) { create(:subscription, :active, plan:) }
   let(:timestamp) { Time.current }

--- a/spec/services/fixed_charges/apply_taxes_service_spec.rb
+++ b/spec/services/fixed_charges/apply_taxes_service_spec.rb
@@ -5,8 +5,12 @@ require "rails_helper"
 RSpec.describe FixedCharges::ApplyTaxesService do
   subject(:apply_service) { described_class.new(fixed_charge:, tax_codes:) }
 
-  let(:plan) { create(:plan) }
-  let(:add_on) { create(:add_on, organization: plan.organization) }
+  before_all do
+    create_default(:organization)
+  end
+
+  let_it_be(:plan) { create(:plan) }
+  let_it_be(:add_on) { create(:add_on, organization: plan.organization) }
   let(:fixed_charge) { create(:fixed_charge, plan:, add_on:) }
   let(:tax1) { create(:tax, organization: plan.organization, code: "tax1") }
   let(:tax2) { create(:tax, organization: plan.organization, code: "tax2") }

--- a/spec/services/fixed_charges/cascade_child_plan_update_service_spec.rb
+++ b/spec/services/fixed_charges/cascade_child_plan_update_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe FixedCharges::CascadeChildPlanUpdateService do
   subject(:result) { described_class.call(plan:, cascade_fixed_charges_payload:, timestamp:) }
 
-  let(:organization) { create(:organization) }
-  let(:parent_plan) { create(:plan, organization:) }
-  let(:plan) { create(:plan, organization:, parent: parent_plan) }
-  let(:add_on) { create(:add_on, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:parent_plan) { create(:plan, organization:) }
+  let_it_be(:plan) { create(:plan, organization:, parent: parent_plan) }
+  let_it_be(:add_on) { create_default(:add_on, organization:) }
   let(:timestamp) { Time.current.to_i }
   let(:subscription) { create(:subscription, :pending, plan:) }
   let(:parent_fixed_charge) { create(:fixed_charge, plan: parent_plan, add_on:, units: new_units) }

--- a/spec/services/fixed_charges/create_children_service_spec.rb
+++ b/spec/services/fixed_charges/create_children_service_spec.rb
@@ -9,11 +9,10 @@ RSpec.describe FixedCharges::CreateChildrenService do
   let_it_be(:plan) { create(:plan, organization:) }
   let_it_be(:add_on) { create(:add_on, organization:) }
   let(:fixed_charge) { create(:fixed_charge, organization:, plan:, add_on:) }
+  let(:child_ids) { child_plan.id }
+  let(:payload) { {} }
 
   let_it_be(:child_plan) { create(:plan, organization:, parent_id: plan.id) }
-  let(:child_ids) { child_plan.id }
-
-  let(:payload) { {} }
 
   before do
     fixed_charge

--- a/spec/services/fixed_charges/create_children_service_spec.rb
+++ b/spec/services/fixed_charges/create_children_service_spec.rb
@@ -5,12 +5,12 @@ require "rails_helper"
 RSpec.describe FixedCharges::CreateChildrenService do
   subject(:create_service) { described_class.new(child_ids:, fixed_charge:, payload:) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
-  let(:add_on) { create(:add_on, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
   let(:fixed_charge) { create(:fixed_charge, organization:, plan:, add_on:) }
 
-  let(:child_plan) { create(:plan, organization:, parent_id: plan.id) }
+  let_it_be(:child_plan) { create(:plan, organization:, parent_id: plan.id) }
   let(:child_ids) { child_plan.id }
 
   let(:payload) { {} }

--- a/spec/services/fixed_charges/create_service_spec.rb
+++ b/spec/services/fixed_charges/create_service_spec.rb
@@ -5,9 +5,13 @@ require "rails_helper"
 RSpec.describe FixedCharges::CreateService do
   subject(:create_service) { described_class.new(plan:, params:) }
 
-  let(:plan) { create(:plan) }
-  let(:organization) { plan.organization }
-  let(:add_on) { create(:add_on, organization:) }
+  before_all do
+    create_default(:organization)
+  end
+
+  let_it_be(:plan) { create(:plan) }
+  let_it_be(:organization) { plan.organization }
+  let_it_be(:add_on) { create(:add_on, organization:) }
 
   describe "#call" do
     subject(:result) { create_service.call }

--- a/spec/services/fixed_charges/destroy_children_service_spec.rb
+++ b/spec/services/fixed_charges/destroy_children_service_spec.rb
@@ -5,12 +5,12 @@ require "rails_helper"
 RSpec.describe FixedCharges::DestroyChildrenService do
   subject(:destroy_service) { described_class.new(fixed_charge) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
-  let(:add_on) { create(:add_on, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
   let(:fixed_charge) { create(:fixed_charge, :deleted, plan:, add_on:) }
 
-  let(:child_plan) { create(:plan, organization:, parent: plan) }
+  let_it_be(:child_plan) { create(:plan, organization:, parent: plan) }
   let(:subscription) { create(:subscription, plan: child_plan) }
   let(:child_fixed_charge) do
     create(

--- a/spec/services/fixed_charges/destroy_children_service_spec.rb
+++ b/spec/services/fixed_charges/destroy_children_service_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe FixedCharges::DestroyChildrenService do
   let_it_be(:plan) { create(:plan, organization:) }
   let_it_be(:add_on) { create(:add_on, organization:) }
   let(:fixed_charge) { create(:fixed_charge, :deleted, plan:, add_on:) }
-
-  let_it_be(:child_plan) { create(:plan, organization:, parent: plan) }
   let(:subscription) { create(:subscription, plan: child_plan) }
   let(:child_fixed_charge) do
     create(
@@ -21,6 +19,8 @@ RSpec.describe FixedCharges::DestroyChildrenService do
       properties: {amount: "100"}
     )
   end
+
+  let_it_be(:child_plan) { create(:plan, organization:, parent: plan) }
 
   before do
     child_fixed_charge

--- a/spec/services/fixed_charges/destroy_service_spec.rb
+++ b/spec/services/fixed_charges/destroy_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe FixedCharges::DestroyService do
   subject(:destroy_service) { described_class.new(fixed_charge:) }
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let_it_be(:plan) { create_default(:plan, organization:) }
   let_it_be(:add_on) { create(:add_on, organization:) }

--- a/spec/services/fixed_charges/destroy_service_spec.rb
+++ b/spec/services/fixed_charges/destroy_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe FixedCharges::DestroyService do
   subject(:destroy_service) { described_class.new(fixed_charge:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
-  let(:add_on) { create(:add_on, organization:) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:plan) { create_default(:plan, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
   let(:fixed_charge) { create(:fixed_charge, plan:, add_on:) }
 
   describe "#call" do
@@ -84,7 +84,7 @@ RSpec.describe FixedCharges::DestroyService do
     context "with cascade_updates" do
       subject(:destroy_service) { described_class.new(fixed_charge:, cascade_updates: true) }
 
-      let(:child_plan) { create(:plan, organization:, parent: plan) }
+      let_it_be(:child_plan) { create(:plan, organization:, parent: plan) }
       let(:child_fixed_charge) { create(:fixed_charge, plan: child_plan, add_on:, parent: fixed_charge) }
 
       before do

--- a/spec/services/fixed_charges/emit_events_service_spec.rb
+++ b/spec/services/fixed_charges/emit_events_service_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe FixedCharges::EmitEventsService do
 
   let(:subscription) { nil }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:, interval: :yearly, bill_fixed_charges_monthly: true) }
-  let(:add_on) { create(:add_on, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create(:plan, organization:, interval: :yearly, bill_fixed_charges_monthly: true) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
   let(:fixed_charge) { create(:fixed_charge, plan:, add_on:) }
 
   let(:customer_1) { create(:customer, organization:) }

--- a/spec/services/fixed_charges/emit_events_service_spec.rb
+++ b/spec/services/fixed_charges/emit_events_service_spec.rb
@@ -8,12 +8,7 @@ RSpec.describe FixedCharges::EmitEventsService do
   end
 
   let(:subscription) { nil }
-
-  let_it_be(:organization) { create_default(:organization) }
-  let_it_be(:plan) { create(:plan, organization:, interval: :yearly, bill_fixed_charges_monthly: true) }
-  let_it_be(:add_on) { create(:add_on, organization:) }
   let(:fixed_charge) { create(:fixed_charge, plan:, add_on:) }
-
   let(:customer_1) { create(:customer, organization:) }
   let(:customer_2) { create(:customer, organization:) }
   let(:active_subscription_1) do
@@ -27,7 +22,6 @@ RSpec.describe FixedCharges::EmitEventsService do
       subscription_at: 2.days.ago
     )
   end
-
   let(:active_subscription_2) {
     create(
       :subscription,
@@ -40,6 +34,10 @@ RSpec.describe FixedCharges::EmitEventsService do
     )
   }
   let(:terminated_subscription) { create(:subscription, :terminated, plan:, customer: customer_1) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create(:plan, organization:, interval: :yearly, bill_fixed_charges_monthly: true) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
 
   describe "#call" do
     subject(:result) { service.call }

--- a/spec/services/fixed_charges/generate_code_service_spec.rb
+++ b/spec/services/fixed_charges/generate_code_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe FixedCharges::GenerateCodeService do
   subject(:result) { described_class.call(plan:, add_on:) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
-  let(:add_on) { create(:add_on, organization:, code: "setup_fee") }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:, code: "setup_fee") }
 
   describe "#call" do
     context "when no fixed charges exist for the plan" do

--- a/spec/services/fixed_charges/override_service_spec.rb
+++ b/spec/services/fixed_charges/override_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe FixedCharges::OverrideService do
   subject(:override_service) { described_class.new(fixed_charge:, params:) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
-  let(:plan2) { create(:plan, organization:) }
-  let(:add_on) { create(:add_on, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:plan2) { create(:plan, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
   let(:tax) { create(:tax, organization:) }
 
   let(:fixed_charge) do

--- a/spec/services/fixed_charges/update_children_service_spec.rb
+++ b/spec/services/fixed_charges/update_children_service_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe FixedCharges::UpdateChildrenService do
     )
   end
 
-  let(:organization) { create(:organization) }
-  let(:add_on) { create(:add_on, organization:) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:old_parent_attrs) { fixed_charge&.attributes }
   let(:fixed_charge) do
     create(

--- a/spec/services/fixed_charges/update_service_spec.rb
+++ b/spec/services/fixed_charges/update_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe FixedCharges::UpdateService do
     described_class.new(fixed_charge:, params:, cascade_options:, timestamp:)
   end
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
-  let(:add_on) { create(:add_on, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
   let(:timestamp) { Time.current.to_i }
 
   let(:fixed_charge) do

--- a/spec/services/idempotency_records/create_service_spec.rb
+++ b/spec/services/idempotency_records/create_service_spec.rb
@@ -5,8 +5,12 @@ require "rails_helper"
 RSpec.describe IdempotencyRecords::CreateService do
   subject(:result) { described_class.call(idempotency_key:, resource:) }
 
+before_all do
+  create_default(:organization)
+end
+
   let(:idempotency_key) { SecureRandom.uuid }
-  let(:resource) { create(:customer) }
+  let_it_be(:resource) { create(:customer) }
 
   it "creates a new idempotency record" do
     expect { result }.to change(IdempotencyRecord, :count).by(1)

--- a/spec/services/idempotency_records/create_service_spec.rb
+++ b/spec/services/idempotency_records/create_service_spec.rb
@@ -5,11 +5,12 @@ require "rails_helper"
 RSpec.describe IdempotencyRecords::CreateService do
   subject(:result) { described_class.call(idempotency_key:, resource:) }
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let(:idempotency_key) { SecureRandom.uuid }
+
   let_it_be(:resource) { create(:customer) }
 
   it "creates a new idempotency record" do

--- a/spec/services/inbound_webhooks/create_service_spec.rb
+++ b/spec/services/inbound_webhooks/create_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe InboundWebhooks::CreateService do
     )
   end
 
-  let(:organization) { create :organization }
+  let_it_be(:organization) { create :organization }
   let(:code) { "stripe_1" }
   let(:webhook_source) { "stripe" }
   let(:signature) { "signature" }

--- a/spec/services/inbound_webhooks/process_service_spec.rb
+++ b/spec/services/inbound_webhooks/process_service_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe InboundWebhooks::ProcessService do
   subject(:result) { described_class.call(inbound_webhook:) }
 
+before_all do
+  create_default(:organization)
+end
+
   let(:inbound_webhook) { create :inbound_webhook, source: webhook_source }
   let(:webhook_source) { "stripe" }
   let(:handle_incoming_webhook_service_result) { PaymentProviders::Stripe::HandleIncomingWebhookService::Result.new }

--- a/spec/services/inbound_webhooks/process_service_spec.rb
+++ b/spec/services/inbound_webhooks/process_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe InboundWebhooks::ProcessService do
   subject(:result) { described_class.call(inbound_webhook:) }
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let(:inbound_webhook) { create :inbound_webhook, source: webhook_source }
   let(:webhook_source) { "stripe" }

--- a/spec/services/inbound_webhooks/validate_payload_service_spec.rb
+++ b/spec/services/inbound_webhooks/validate_payload_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe InboundWebhooks::ValidatePayloadService do
     )
   end
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:code) { "payment_provider_1" }
   let(:payload) { "webhook_payload" }
   let(:signature) { "signature" }

--- a/spec/services/integration_collection_mappings/create_service_spec.rb
+++ b/spec/services/integration_collection_mappings/create_service_spec.rb
@@ -4,9 +4,10 @@ require "rails_helper"
 
 RSpec.describe IntegrationCollectionMappings::CreateService do
   let(:integration) { create(:netsuite_integration, organization:) }
+  let(:add_on) { create(:add_on, organization:) }
+
   let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
-  let(:add_on) { create(:add_on, organization:) }
 
   describe "#call" do
     subject(:service_call) { described_class.call(params: create_args) }

--- a/spec/services/integration_collection_mappings/create_service_spec.rb
+++ b/spec/services/integration_collection_mappings/create_service_spec.rb
@@ -4,8 +4,8 @@ require "rails_helper"
 
 RSpec.describe IntegrationCollectionMappings::CreateService do
   let(:integration) { create(:netsuite_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
   let(:add_on) { create(:add_on, organization:) }
 
   describe "#call" do

--- a/spec/services/integration_collection_mappings/destroy_service_spec.rb
+++ b/spec/services/integration_collection_mappings/destroy_service_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe IntegrationCollectionMappings::DestroyService do
   subject(:destroy_service) { described_class.new(integration_collection_mapping:) }
 
   let(:integration) { create(:netsuite_integration, organization:) }
+
   let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create_default(:membership) }
 

--- a/spec/services/integration_collection_mappings/destroy_service_spec.rb
+++ b/spec/services/integration_collection_mappings/destroy_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe IntegrationCollectionMappings::DestroyService do
   subject(:destroy_service) { described_class.new(integration_collection_mapping:) }
 
   let(:integration) { create(:netsuite_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   describe ".call" do
     before { integration_collection_mapping }

--- a/spec/services/integration_collection_mappings/update_service_spec.rb
+++ b/spec/services/integration_collection_mappings/update_service_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 RSpec.describe IntegrationCollectionMappings::UpdateService do
   let(:integration_collection_mapping) { create(:netsuite_collection_mapping, integration:) }
   let(:integration) { create(:netsuite_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization)}
+
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
 
   describe "#call" do

--- a/spec/services/integration_collection_mappings/update_service_spec.rb
+++ b/spec/services/integration_collection_mappings/update_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe IntegrationCollectionMappings::UpdateService do
   let(:integration_collection_mapping) { create(:netsuite_collection_mapping, integration:) }
   let(:integration) { create(:netsuite_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
 
   describe "#call" do
     subject(:service_call) { described_class.call(integration_collection_mapping:, params: update_args) }

--- a/spec/services/integration_customers/anrok_service_spec.rb
+++ b/spec/services/integration_customers/anrok_service_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 RSpec.describe IntegrationCustomers::AnrokService do
   let(:integration) { create(:netsuite_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   describe "#create" do
     subject(:service_call) { described_class.new(subsidiary_id: nil, integration:, customer:).create }

--- a/spec/services/integration_customers/anrok_service_spec.rb
+++ b/spec/services/integration_customers/anrok_service_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 RSpec.describe IntegrationCustomers::AnrokService do
   let(:integration) { create(:netsuite_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization)}
+
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let_it_be(:customer) { create(:customer, organization:) }
 

--- a/spec/services/integration_customers/avalara_service_spec.rb
+++ b/spec/services/integration_customers/avalara_service_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 RSpec.describe IntegrationCustomers::AvalaraService do
   let(:integration) { create(:avalara_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization)}
+
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let_it_be(:customer) { create(:customer, organization:) }
 

--- a/spec/services/integration_customers/avalara_service_spec.rb
+++ b/spec/services/integration_customers/avalara_service_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 RSpec.describe IntegrationCustomers::AvalaraService do
   let(:integration) { create(:avalara_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   describe "#create" do
     subject(:service_call) { described_class.new(integration:, customer:, subsidiary_id: nil).create }

--- a/spec/services/integration_customers/create_or_update_batch_service_spec.rb
+++ b/spec/services/integration_customers/create_or_update_batch_service_spec.rb
@@ -3,14 +3,11 @@
 require "rails_helper"
 
 RSpec.describe IntegrationCustomers::CreateOrUpdateBatchService do
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let(:integration) { create(:netsuite_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization) }
-  let_it_be(:membership) { create(:membership) }
-  let_it_be(:customer) { create(:customer, organization:) }
   let(:subsidiary_id) { "1" }
   let(:integration_customers) do
     [
@@ -23,6 +20,10 @@ end
       }
     ]
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   describe "#call" do
     subject(:service_call) { described_class.call(integration_customers:, customer:, new_customer:) }

--- a/spec/services/integration_customers/create_or_update_batch_service_spec.rb
+++ b/spec/services/integration_customers/create_or_update_batch_service_spec.rb
@@ -3,10 +3,14 @@
 require "rails_helper"
 
 RSpec.describe IntegrationCustomers::CreateOrUpdateBatchService do
+before_all do
+  create_default(:organization)
+end
+
   let(:integration) { create(:netsuite_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:subsidiary_id) { "1" }
   let(:integration_customers) do
     [

--- a/spec/services/integration_customers/create_service_spec.rb
+++ b/spec/services/integration_customers/create_service_spec.rb
@@ -4,10 +4,11 @@ require "rails_helper"
 
 RSpec.describe IntegrationCustomers::CreateService do
   let(:integration) { create(:netsuite_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization)}
+  let(:integration_type) { "netsuite" }
+
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let_it_be(:customer) { create(:customer, organization:) }
-  let(:integration_type) { "netsuite" }
 
   describe "#call" do
     subject(:service_call) { described_class.call(params:, integration:, customer:) }

--- a/spec/services/integration_customers/create_service_spec.rb
+++ b/spec/services/integration_customers/create_service_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 RSpec.describe IntegrationCustomers::CreateService do
   let(:integration) { create(:netsuite_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:integration_type) { "netsuite" }
 
   describe "#call" do

--- a/spec/services/integration_customers/destroy_service_spec.rb
+++ b/spec/services/integration_customers/destroy_service_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe IntegrationCustomers::DestroyService do
   subject(:destroy_service) { described_class.new(integration_customer:) }
 
   let(:integration) { create(:netsuite_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   describe "#call" do
     before { integration_customer }

--- a/spec/services/integration_customers/destroy_service_spec.rb
+++ b/spec/services/integration_customers/destroy_service_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe IntegrationCustomers::DestroyService do
   subject(:destroy_service) { described_class.new(integration_customer:) }
 
   let(:integration) { create(:netsuite_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization)}
+
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let_it_be(:customer) { create(:customer, organization:) }
 

--- a/spec/services/integration_customers/factory_spec.rb
+++ b/spec/services/integration_customers/factory_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe IntegrationCustomers::Factory do
   describe ".new_instance" do
     subject { described_class.new_instance(integration:, customer:, subsidiary_id:, **params) }
 
-    let(:organization) { membership.organization }
-    let(:membership) { create(:membership) }
-    let(:customer) { create(:customer, organization:) }
+    let_it_be(:organization) { create_default(:organization)}
+    let_it_be(:membership) { create(:membership) }
+    let_it_be(:customer) { create(:customer, organization:) }
     let(:subsidiary_id) {}
     let(:params) { {} }
 

--- a/spec/services/integration_customers/factory_spec.rb
+++ b/spec/services/integration_customers/factory_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe IntegrationCustomers::Factory do
   describe ".new_instance" do
     subject { described_class.new_instance(integration:, customer:, subsidiary_id:, **params) }
 
-    let_it_be(:organization) { create_default(:organization)}
+    let_it_be(:organization) { create_default(:organization) }
     let_it_be(:membership) { create(:membership) }
     let_it_be(:customer) { create(:customer, organization:) }
     let(:subsidiary_id) {}

--- a/spec/services/integration_customers/hubspot_service_spec.rb
+++ b/spec/services/integration_customers/hubspot_service_spec.rb
@@ -4,10 +4,11 @@ require "rails_helper"
 
 RSpec.describe IntegrationCustomers::HubspotService do
   let(:integration) { create(:hubspot_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization)}
+  let(:targeted_object) { "contacts" }
+
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let_it_be(:customer) { create(:customer, organization:, customer_type: "individual") }
-  let(:targeted_object) { "contacts" }
 
   describe "#create" do
     subject(:service_call) { described_class.new(integration:, customer:, subsidiary_id: nil, targeted_object:).create }

--- a/spec/services/integration_customers/hubspot_service_spec.rb
+++ b/spec/services/integration_customers/hubspot_service_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 RSpec.describe IntegrationCustomers::HubspotService do
   let(:integration) { create(:hubspot_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer, organization:, customer_type: "individual") }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create(:customer, organization:, customer_type: "individual") }
   let(:targeted_object) { "contacts" }
 
   describe "#create" do
@@ -42,8 +42,8 @@ RSpec.describe IntegrationCustomers::HubspotService do
     end
 
     context "with targeted_object" do
-      let(:customer) { create(:customer, organization:, customer_type:) }
-      let(:customer_type) { "individual" }
+      let_it_be(:customer_type) { "individual" }
+      let_it_be(:customer) { create(:customer, organization:, customer_type:) }
 
       context 'when params[:targeted_object] is specified as "contacts"' do
         let(:targeted_object) { "contacts" }

--- a/spec/services/integration_customers/netsuite_service_spec.rb
+++ b/spec/services/integration_customers/netsuite_service_spec.rb
@@ -4,10 +4,11 @@ require "rails_helper"
 
 RSpec.describe IntegrationCustomers::NetsuiteService do
   let(:integration) { create(:netsuite_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization)}
+  let(:subsidiary_id) { "1" }
+
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let_it_be(:customer) { create(:customer, organization:) }
-  let(:subsidiary_id) { "1" }
 
   describe "#create" do
     subject(:service_call) { described_class.new(subsidiary_id:, integration:, customer:).create }

--- a/spec/services/integration_customers/netsuite_service_spec.rb
+++ b/spec/services/integration_customers/netsuite_service_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 RSpec.describe IntegrationCustomers::NetsuiteService do
   let(:integration) { create(:netsuite_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:subsidiary_id) { "1" }
 
   describe "#create" do

--- a/spec/services/integration_customers/salesforce_service_spec.rb
+++ b/spec/services/integration_customers/salesforce_service_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 RSpec.describe IntegrationCustomers::SalesforceService do
   let(:integration) { create(:salesforce_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer, organization:, customer_type: "individual") }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create(:customer, organization:, customer_type: "individual") }
 
   describe "#create" do
     subject(:service_call) { described_class.new(integration:, customer:, subsidiary_id: nil).create }

--- a/spec/services/integration_customers/salesforce_service_spec.rb
+++ b/spec/services/integration_customers/salesforce_service_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 RSpec.describe IntegrationCustomers::SalesforceService do
   let(:integration) { create(:salesforce_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization)}
+
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let_it_be(:customer) { create(:customer, organization:, customer_type: "individual") }
 

--- a/spec/services/integration_customers/set_as_default_service_spec.rb
+++ b/spec/services/integration_customers/set_as_default_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe IntegrationCustomers::SetAsDefaultService do
   subject(:set_as_default_service) { described_class.new(integration_customer:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   # accounting category
   let(:netsuite_customer) { create(:netsuite_customer, customer:, organization:, category: "accounting", is_default: true) }

--- a/spec/services/integration_customers/update_connection_service_spec.rb
+++ b/spec/services/integration_customers/update_connection_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe IntegrationCustomers::UpdateConnectionService do
   subject(:update_service) { described_class.new(integration_customer:, params:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:integration_customer) { create(:netsuite_customer, integration:, customer:, code: "old_code") }
   let(:params) { {} }
@@ -136,7 +136,7 @@ RSpec.describe IntegrationCustomers::UpdateConnectionService do
     end
 
     context "when the customer is a partner account" do
-      let(:customer) { create(:customer, organization:, account_type: "partner") }
+      let_it_be(:customer) { create(:customer, organization:, account_type: "partner") }
       let(:params) { {code: "new_code", external_customer_id: "external-123"} }
 
       it "updates the code" do

--- a/spec/services/integration_customers/update_service_spec.rb
+++ b/spec/services/integration_customers/update_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe IntegrationCustomers::UpdateService do
   let(:integration) { create(:netsuite_integration, organization:) }
 
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   describe "#call" do
     subject(:service_call) { described_class.call(params:, integration:, integration_customer:) }

--- a/spec/services/integration_customers/update_service_spec.rb
+++ b/spec/services/integration_customers/update_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe IntegrationCustomers::UpdateService do
   let(:integration) { create(:netsuite_integration, organization:) }
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let_it_be(:customer) { create(:customer, organization:) }
 

--- a/spec/services/integration_customers/xero_service_spec.rb
+++ b/spec/services/integration_customers/xero_service_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 RSpec.describe IntegrationCustomers::XeroService do
   let(:integration) { create(:xero_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization)}
+
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let_it_be(:customer) { create(:customer, organization:) }
 

--- a/spec/services/integration_customers/xero_service_spec.rb
+++ b/spec/services/integration_customers/xero_service_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 RSpec.describe IntegrationCustomers::XeroService do
   let(:integration) { create(:xero_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   describe "#create" do
     subject(:service_call) { described_class.new(integration:, customer:, subsidiary_id: nil).create }

--- a/spec/services/integration_mappings/create_service_spec.rb
+++ b/spec/services/integration_mappings/create_service_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe IntegrationMappings::CreateService do
   let(:service) { described_class.new(membership.user) }
 
   let(:integration) { create(:netsuite_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization)}
+
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let_it_be(:add_on) { create(:add_on, organization:) }
 

--- a/spec/services/integration_mappings/create_service_spec.rb
+++ b/spec/services/integration_mappings/create_service_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe IntegrationMappings::CreateService do
   let(:service) { described_class.new(membership.user) }
 
   let(:integration) { create(:netsuite_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
-  let(:add_on) { create(:add_on, organization:) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
 
   describe "#call" do
     subject(:service_call) { service.call(**create_args) }

--- a/spec/services/integration_mappings/destroy_service_spec.rb
+++ b/spec/services/integration_mappings/destroy_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe IntegrationMappings::DestroyService do
   subject(:destroy_service) { described_class.new(integration_mapping:) }
 
   let(:integration) { create(:netsuite_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
 
   describe ".call" do
     before { integration_mapping }

--- a/spec/services/integration_mappings/destroy_service_spec.rb
+++ b/spec/services/integration_mappings/destroy_service_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe IntegrationMappings::DestroyService do
   subject(:destroy_service) { described_class.new(integration_mapping:) }
 
   let(:integration) { create(:netsuite_integration, organization:) }
+
   let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create_default(:membership) }
 

--- a/spec/services/integration_mappings/update_service_spec.rb
+++ b/spec/services/integration_mappings/update_service_spec.rb
@@ -5,8 +5,12 @@ require "rails_helper"
 RSpec.describe IntegrationMappings::UpdateService do
   let(:integration_mapping) { create(:netsuite_mapping, integration:) }
   let(:integration) { create(:netsuite_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+
+  before_all do
+    create_default(:add_on)
+  end
 
   describe "#call" do
     subject(:service_call) { described_class.call(integration_mapping:, params: update_args) }

--- a/spec/services/integration_mappings/update_service_spec.rb
+++ b/spec/services/integration_mappings/update_service_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 RSpec.describe IntegrationMappings::UpdateService do
   let(:integration_mapping) { create(:netsuite_mapping, integration:) }
   let(:integration) { create(:netsuite_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization)}
+
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
 
   before_all do

--- a/spec/services/integrations/aggregator/account_information_service_spec.rb
+++ b/spec/services/integrations/aggregator/account_information_service_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe Integrations::Aggregator::AccountInformationService do
   subject(:service) { described_class.new(integration:) }
 
+before_all do
+  create_default(:organization)
+end
+
   let(:integration) { create(:hubspot_integration) }
 
   describe ".call" do

--- a/spec/services/integrations/aggregator/account_information_service_spec.rb
+++ b/spec/services/integrations/aggregator/account_information_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Integrations::Aggregator::AccountInformationService do
   subject(:service) { described_class.new(integration:) }
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let(:integration) { create(:hubspot_integration) }
 

--- a/spec/services/integrations/aggregator/accounts_service_spec.rb
+++ b/spec/services/integrations/aggregator/accounts_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Integrations::Aggregator::AccountsService do
   subject(:accounts_service) { described_class.new(integration:) }
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let(:integration) { create(:netsuite_integration) }
 

--- a/spec/services/integrations/aggregator/accounts_service_spec.rb
+++ b/spec/services/integrations/aggregator/accounts_service_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe Integrations::Aggregator::AccountsService do
   subject(:accounts_service) { described_class.new(integration:) }
 
+before_all do
+  create_default(:organization)
+end
+
   let(:integration) { create(:netsuite_integration) }
 
   describe ".call" do

--- a/spec/services/integrations/aggregator/base_service_spec.rb
+++ b/spec/services/integrations/aggregator/base_service_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe Integrations::Aggregator::BaseService do
   subject(:sync_service) { described_class.new(integration:) }
 
+before_all do
+  create_default(:organization)
+end
+
   let(:integration) { create(:netsuite_integration) }
 
   describe "#request_limit_error?" do

--- a/spec/services/integrations/aggregator/base_service_spec.rb
+++ b/spec/services/integrations/aggregator/base_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Integrations::Aggregator::BaseService do
   subject(:sync_service) { described_class.new(integration:) }
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let(:integration) { create(:netsuite_integration) }
 

--- a/spec/services/integrations/aggregator/companies/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/companies/create_service_spec.rb
@@ -6,12 +6,8 @@ RSpec.describe Integrations::Aggregator::Companies::CreateService do
   subject(:service_call) { described_class.call(integration:, customer:, subsidiary_id:) }
 
   let(:service) { described_class.new(integration:, customer:, subsidiary_id:) }
-  let(:subsidiary_id) { "1" }
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:customer) { create(:customer, :with_same_billing_and_shipping_address, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/#{integration_type}/companies" }
-
   let(:headers) do
     {
       "Connection-Id" => integration.connection_id,
@@ -19,12 +15,15 @@ RSpec.describe Integrations::Aggregator::Companies::CreateService do
       "Provider-Config-Key" => integration_type_key
     }
   end
-
   let(:customer_link) do
     url = Rails.application.config.lago_front_url
 
     URI.join(url, "/#{customer.organization.slug}/customer/", customer.id).to_s
   end
+  let(:subsidiary_id) { "1" }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, :with_same_billing_and_shipping_address, organization:) }
 
   before do
     allow(LagoHttpClient::Client).to receive(:new)

--- a/spec/services/integrations/aggregator/companies/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/companies/create_service_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Integrations::Aggregator::Companies::CreateService do
   subject(:service_call) { described_class.call(integration:, customer:, subsidiary_id:) }
 
   let(:service) { described_class.new(integration:, customer:, subsidiary_id:) }
-  let(:customer) { create(:customer, :with_same_billing_and_shipping_address, organization:) }
   let(:subsidiary_id) { "1" }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, :with_same_billing_and_shipping_address, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/#{integration_type}/companies" }
 

--- a/spec/services/integrations/aggregator/companies/payloads/hubspot_spec.rb
+++ b/spec/services/integrations/aggregator/companies/payloads/hubspot_spec.rb
@@ -3,9 +3,13 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Companies::Payloads::Hubspot do
+before_all do
+  create_default(:organization)
+end
+
   let(:integration) { integration_customer.integration }
   let(:integration_customer) { FactoryBot.create(:hubspot_customer, customer:) }
-  let(:customer) { create(:customer, customer_type: "company") }
+  let_it_be(:customer) { create(:customer, customer_type: "company") }
   let(:payload) { described_class.new(integration:, customer:, integration_customer:) }
   let(:customer_link) { payload.__send__(:customer_url) }
   let(:domain) { payload.__send__(:clean_url, customer.url) }

--- a/spec/services/integrations/aggregator/companies/payloads/hubspot_spec.rb
+++ b/spec/services/integrations/aggregator/companies/payloads/hubspot_spec.rb
@@ -3,16 +3,17 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Companies::Payloads::Hubspot do
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let(:integration) { integration_customer.integration }
-  let(:integration_customer) { FactoryBot.create(:hubspot_customer, customer:) }
-  let_it_be(:customer) { create(:customer, customer_type: "company") }
   let(:payload) { described_class.new(integration:, customer:, integration_customer:) }
   let(:customer_link) { payload.__send__(:customer_url) }
   let(:domain) { payload.__send__(:clean_url, customer.url) }
+  let(:integration_customer) { FactoryBot.create(:hubspot_customer, customer:) }
+
+  let_it_be(:customer) { create(:customer, customer_type: "company") }
 
   describe "#create_body" do
     subject(:create_body_call) { payload.create_body }

--- a/spec/services/integrations/aggregator/companies/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/companies/update_service_spec.rb
@@ -6,11 +6,8 @@ RSpec.describe Integrations::Aggregator::Companies::UpdateService do
   subject(:service_call) { described_class.call(integration:, integration_customer:) }
 
   let(:service) { described_class.new(integration:, integration_customer:) }
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:customer) { create(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/#{integration_type}/companies" }
-
   let(:headers) do
     {
       "Connection-Id" => integration.connection_id,
@@ -18,12 +15,14 @@ RSpec.describe Integrations::Aggregator::Companies::UpdateService do
       "Provider-Config-Key" => integration_type_key
     }
   end
-
   let(:customer_link) do
     url = Rails.application.config.lago_front_url
 
     URI.join(url, "/#{customer.organization.slug}/customer/", customer.id).to_s
   end
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   before do
     allow(LagoHttpClient::Client).to receive(:new)

--- a/spec/services/integrations/aggregator/companies/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/companies/update_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Integrations::Aggregator::Companies::UpdateService do
   subject(:service_call) { described_class.call(integration:, integration_customer:) }
 
   let(:service) { described_class.new(integration:, integration_customer:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/#{integration_type}/companies" }
 

--- a/spec/services/integrations/aggregator/contacts/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/create_service_spec.rb
@@ -6,12 +6,8 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
   subject(:service_call) { described_class.call(integration:, customer:, subsidiary_id:) }
 
   let(:service) { described_class.new(integration:, customer:, subsidiary_id:) }
-  let(:subsidiary_id) { "1" }
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:customer) { create(:customer, :with_same_billing_and_shipping_address, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/#{integration_type}/contacts" }
-
   let(:headers) do
     {
       "Connection-Id" => integration.connection_id,
@@ -19,12 +15,15 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
       "Provider-Config-Key" => integration_type_key
     }
   end
-
   let(:customer_link) do
     url = Rails.application.config.lago_front_url
 
     URI.join(url, "/#{customer.organization.slug}/customer/", customer.id).to_s
   end
+  let(:subsidiary_id) { "1" }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, :with_same_billing_and_shipping_address, organization:) }
 
   before do
     allow(LagoHttpClient::Client).to receive(:new)

--- a/spec/services/integrations/aggregator/contacts/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/create_service_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
   subject(:service_call) { described_class.call(integration:, customer:, subsidiary_id:) }
 
   let(:service) { described_class.new(integration:, customer:, subsidiary_id:) }
-  let(:customer) { create(:customer, :with_same_billing_and_shipping_address, organization:) }
   let(:subsidiary_id) { "1" }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, :with_same_billing_and_shipping_address, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/#{integration_type}/contacts" }
 

--- a/spec/services/integrations/aggregator/contacts/payloads/anrok_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/anrok_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Contacts::Payloads::Anrok do
-  let(:integration) { integration_customer.integration }
+  let(:integration) { create_default(:organization) }
   let(:integration_customer) { FactoryBot.create(:anrok_customer, customer:) }
-  let(:customer) { create(:customer) }
+  let_it_be(:customer) { create(:customer) }
   let(:payload) { described_class.new(integration:, customer:, integration_customer:) }
   let(:customer_link) { payload.__send__(:customer_url) }
 

--- a/spec/services/integrations/aggregator/contacts/payloads/anrok_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/anrok_spec.rb
@@ -4,10 +4,11 @@ require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Contacts::Payloads::Anrok do
   let(:integration) { create_default(:organization) }
-  let(:integration_customer) { FactoryBot.create(:anrok_customer, customer:) }
-  let_it_be(:customer) { create(:customer) }
   let(:payload) { described_class.new(integration:, customer:, integration_customer:) }
   let(:customer_link) { payload.__send__(:customer_url) }
+  let(:integration_customer) { FactoryBot.create(:anrok_customer, customer:) }
+
+  let_it_be(:customer) { create(:customer) }
 
   describe "#create_body" do
     subject(:create_body_call) { payload.create_body }

--- a/spec/services/integrations/aggregator/contacts/payloads/avalara_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/avalara_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Contacts::Payloads::Avalara do
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let(:integration) { create(:avalara_integration, company_id: "12345") }
   let(:integration_customer) { create(:avalara_customer, customer:, integration:, external_customer_id: "abc-12345") }

--- a/spec/services/integrations/aggregator/contacts/payloads/avalara_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/avalara_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Contacts::Payloads::Avalara do
+before_all do
+  create_default(:organization)
+end
+
   let(:integration) { create(:avalara_integration, company_id: "12345") }
   let(:integration_customer) { create(:avalara_customer, customer:, integration:, external_customer_id: "abc-12345") }
   let(:payload) { described_class.new(integration:, customer:, integration_customer:) }

--- a/spec/services/integrations/aggregator/contacts/payloads/hubspot_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/hubspot_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Contacts::Payloads::Hubspot do
-  let(:integration) { integration_customer.integration }
+  let_it_be(:integration) { create_default(:organization) }
   let(:integration_customer) { FactoryBot.create(:hubspot_customer, customer:) }
-  let(:customer) { create(:customer, customer_type: "individual") }
+  let_it_be(:customer) { create(:customer, customer_type: "individual") }
   let(:payload) { described_class.new(integration:, customer:, integration_customer:) }
   let(:customer_link) { payload.__send__(:customer_url) }
   let(:website) { payload.__send__(:clean_url, customer.url) }

--- a/spec/services/integrations/aggregator/contacts/payloads/hubspot_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/hubspot_spec.rb
@@ -5,10 +5,11 @@ require "rails_helper"
 RSpec.describe Integrations::Aggregator::Contacts::Payloads::Hubspot do
   let_it_be(:integration) { create_default(:organization) }
   let(:integration_customer) { FactoryBot.create(:hubspot_customer, customer:) }
-  let_it_be(:customer) { create(:customer, customer_type: "individual") }
   let(:payload) { described_class.new(integration:, customer:, integration_customer:) }
   let(:customer_link) { payload.__send__(:customer_url) }
   let(:website) { payload.__send__(:clean_url, customer.url) }
+
+  let_it_be(:customer) { create(:customer, customer_type: "individual") }
 
   describe "#create_body" do
     subject(:create_body_call) { payload.create_body }

--- a/spec/services/integrations/aggregator/contacts/payloads/netsuite_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/netsuite_spec.rb
@@ -3,8 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Contacts::Payloads::Netsuite do
+  before_all do
+    create_default(:organization)
+  end
+
   let(:integration) { integration_customer.integration }
-  let(:integration_customer) { FactoryBot.create(:netsuite_customer, customer:) }
+  let(:integration_customer) { create(:netsuite_customer, customer:) }
   let(:customer) { create(:customer, email:, phone:) }
   let(:subsidiary_id) { Faker::Number.number(digits: 2) }
   let(:payload) { described_class.new(integration:, customer:, integration_customer:, subsidiary_id:) }

--- a/spec/services/integrations/aggregator/contacts/payloads/xero_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/xero_spec.rb
@@ -3,9 +3,13 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Contacts::Payloads::Xero do
+  before_all do
+    create_default(:organization)
+  end
+
   let(:integration) { integration_customer.integration }
-  let(:integration_customer) { FactoryBot.create(:xero_customer, customer:) }
-  let(:customer) { create(:customer, firstname:, lastname:) }
+  let(:customer) { create_default(:customer, firstname:, lastname:) }
+  let(:integration_customer) { create_default(:xero_customer, customer:) }
   let(:payload) { described_class.new(integration:, customer:, integration_customer:) }
   let(:customer_link) { payload.__send__(:customer_url) }
   let(:contact_names) { {"firstname" => firstname, "lastname" => lastname}.compact_blank }

--- a/spec/services/integrations/aggregator/contacts/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/update_service_spec.rb
@@ -6,11 +6,8 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
   subject(:service_call) { described_class.call(integration:, integration_customer:) }
 
   let(:service) { described_class.new(integration:, integration_customer:) }
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:customer) { create(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/#{integration_type}/contacts" }
-
   let(:headers) do
     {
       "Connection-Id" => integration.connection_id,
@@ -18,12 +15,14 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
       "Provider-Config-Key" => integration_type_key
     }
   end
-
   let(:customer_link) do
     url = Rails.application.config.lago_front_url
 
     URI.join(url, "/#{customer.organization.slug}/customer/", customer.id).to_s
   end
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   before do
     allow(LagoHttpClient::Client).to receive(:new)

--- a/spec/services/integrations/aggregator/contacts/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/update_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
   subject(:service_call) { described_class.call(integration:, integration_customer:) }
 
   let(:service) { described_class.new(integration:, integration_customer:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/#{integration_type}/contacts" }
 

--- a/spec/services/integrations/aggregator/credit_notes/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/credit_notes/create_service_spec.rb
@@ -8,12 +8,17 @@ RSpec.describe Integrations::Aggregator::CreditNotes::CreateService do
   let(:service) { described_class.new(credit_note: credit_note.reload) }
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
+
+before_all do
+  create_default(:plan)
+end
+
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/netsuite/creditnotes" }
-  let(:add_on) { create(:add_on, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, billable_metric:) }
 
   let(:integration_collection_mapping1) do

--- a/spec/services/integrations/aggregator/credit_notes/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/credit_notes/create_service_spec.rb
@@ -6,21 +6,9 @@ RSpec.describe Integrations::Aggregator::CreditNotes::CreateService do
   subject(:service_call) { described_class.call(credit_note: credit_note.reload) }
 
   let(:service) { described_class.new(credit_note: credit_note.reload) }
-  let(:integration) { create(:netsuite_integration, organization:) }
-  let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
-  let_it_be(:organization) { create_default(:organization) }
-
-before_all do
-  create_default(:plan)
-end
-
-  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/netsuite/creditnotes" }
-  let_it_be(:add_on) { create(:add_on, organization:) }
-  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, billable_metric:) }
-
   let(:integration_collection_mapping1) do
     create(
       :netsuite_collection_mapping,
@@ -79,7 +67,6 @@ end
       settings: {external_id: "m2", external_account_code: "m22", external_name: ""}
     )
   end
-
   let(:invoice) do
     create(
       :invoice,
@@ -123,9 +110,7 @@ end
       precise_unit_amount: 4.12
     )
   end
-
   let(:credit_note_item3) { create(:credit_note_item, credit_note:, fee: charge_fee, amount_cents: 212) }
-
   let(:headers) do
     {
       "Connection-Id" => integration.connection_id,
@@ -133,7 +118,6 @@ end
       "Provider-Config-Key" => "netsuite-tba"
     }
   end
-
   let(:params) do
     {
       "type" => "creditmemo",
@@ -217,8 +201,19 @@ end
       }
     }
   end
-
   let(:description) { credit_note.invoice.credits.coupon_kind.map(&:item_name).join(",") }
+  let(:integration) { create(:netsuite_integration, organization:) }
+  let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+
+  before_all do
+    create_default(:plan)
+  end
+
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
 
   before do
     allow(LagoHttpClient::Client).to receive(:new)

--- a/spec/services/integrations/aggregator/credit_notes/payloads/factory_spec.rb
+++ b/spec/services/integrations/aggregator/credit_notes/payloads/factory_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::CreditNotes::Payloads::Factory do
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
 
   describe ".new_instance" do
     subject(:new_instance_call) { described_class.new_instance(integration_customer:, credit_note:) }

--- a/spec/services/integrations/aggregator/credit_notes/payloads/factory_spec.rb
+++ b/spec/services/integrations/aggregator/credit_notes/payloads/factory_spec.rb
@@ -3,6 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::CreditNotes::Payloads::Factory do
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
   describe ".new_instance" do
     subject(:new_instance_call) { described_class.new_instance(integration_customer:, credit_note:) }
 

--- a/spec/services/integrations/aggregator/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/create_service_spec.rb
@@ -6,23 +6,10 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
   subject(:service_call) { described_class.call(invoice:) }
 
   let(:service) { described_class.new(invoice:) }
-  let(:integration) { create(:netsuite_integration, organization:) }
-  let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
-  let_it_be(:organization) { create_default(:organization) }
-  let_it_be(:customer) { create_default(:customer, organization:) }
-
-before_all do
-  create_default(:plan)
-create_default(:billing_entity)
-end
-
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/netsuite/invoices" }
-  let_it_be(:add_on) { create(:add_on, organization:) }
-  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, billable_metric:) }
   let(:current_time) { Time.current }
-
   let(:integration_collection_mapping1) do
     create(
       :netsuite_collection_mapping,
@@ -89,7 +76,6 @@ end
       settings: {external_id: "m2", external_account_code: "m22", external_name: ""}
     )
   end
-
   let(:invoice) do
     create(
       :invoice,
@@ -125,7 +111,6 @@ end
       created_at: current_time
     )
   end
-
   let(:headers) do
     {
       "Connection-Id" => integration.connection_id,
@@ -133,16 +118,13 @@ end
       "Provider-Config-Key" => "netsuite-tba"
     }
   end
-
   let(:invoice_url) do
     url = Rails.application.config.lago_front_url
 
     URI.join(url, "/#{invoice.customer.organization.slug}/customer/#{invoice.customer.id}/", "invoice/#{invoice.id}/overview").to_s
   end
-
   let(:due_date) { invoice.payment_due_date.strftime("%-m/%-d/%Y") }
   let(:issuing_date) { invoice.issuing_date.strftime("%-m/%-d/%Y") }
-
   let(:params) do
     {
       "type" => "invoice",
@@ -287,6 +269,19 @@ end
       }
     }
   end
+  let(:integration) { create(:netsuite_integration, organization:) }
+  let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+
+  before_all do
+    create_default(:plan)
+    create_default(:billing_entity)
+  end
+
+  let_it_be(:add_on) { create(:add_on, organization:) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
 
   before do
     allow(LagoHttpClient::Client).to receive(:new)

--- a/spec/services/integrations/aggregator/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/create_service_spec.rb
@@ -8,12 +8,18 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
   let(:service) { described_class.new(invoice:) }
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+
+before_all do
+  create_default(:plan)
+create_default(:billing_entity)
+end
+
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/netsuite/invoices" }
-  let(:add_on) { create(:add_on, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, billable_metric:) }
   let(:current_time) { Time.current }
 

--- a/spec/services/integrations/aggregator/invoices/hubspot/base_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/base_service_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::BaseService do
   let(:invoice) { create(:invoice, customer:, organization:) }
   let(:integration) { create(:hubspot_integration, organization:) }
   let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
+
   let_it_be(:organization) { create(:organization) }
   let_it_be(:customer) { create(:customer, organization:) }
 

--- a/spec/services/integrations/aggregator/invoices/hubspot/base_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/base_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::BaseService do
   let(:invoice) { create(:invoice, customer:, organization:) }
   let(:integration) { create(:hubspot_integration, organization:) }
   let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   describe "#initialize" do
     it "assigns the invoice" do

--- a/spec/services/integrations/aggregator/invoices/hubspot/create_customer_association_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/create_customer_association_service_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateCustomerAssoci
   let(:service) { described_class.new(invoice:) }
   let(:integration) { create(:hubspot_integration, organization:, sync_invoices:) }
   let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/hubspot/association" }
   let(:invoice_file_url) { invoice.file_url }

--- a/spec/services/integrations/aggregator/invoices/hubspot/create_customer_association_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/create_customer_association_service_spec.rb
@@ -6,15 +6,10 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateCustomerAssoci
   subject(:service_call) { service.call }
 
   let(:service) { described_class.new(invoice:) }
-  let(:integration) { create(:hubspot_integration, organization:, sync_invoices:) }
-  let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:customer) { create(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/hubspot/association" }
   let(:invoice_file_url) { invoice.file_url }
   let(:due_date) { invoice.payment_due_date.strftime("%Y-%m-%d") }
-
   let(:invoice) do
     create(
       :invoice,
@@ -27,9 +22,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateCustomerAssoci
       taxes_amount_cents: 8000
     )
   end
-
   let(:integration_invoice) { create(:integration_resource, syncable: invoice, integration:) }
-
   let(:headers) do
     {
       "Connection-Id" => integration.connection_id,
@@ -37,10 +30,14 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateCustomerAssoci
       "Provider-Config-Key" => "hubspot"
     }
   end
-
   let(:params) do
     service.__send__(:payload).customer_association_body
   end
+  let(:integration) { create(:hubspot_integration, organization:, sync_invoices:) }
+  let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   before do
     integration_customer

--- a/spec/services/integrations/aggregator/invoices/hubspot/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/create_service_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateService do
   subject(:service_call) { service.call }
 
   let(:service) { described_class.new(invoice:) }
-  let(:integration) { create(:hubspot_integration, organization:, invoices_properties_version: 2) }
-  let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:customer) { create(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/hubspot/records" }
   let(:invoice_file_url) { invoice.file_url }
@@ -17,7 +13,6 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateService do
   let(:due_date) { invoice.payment_due_date.strftime("%Y-%m-%d") }
   let(:purchase_order_number) { "PO-123" }
   let(:invoice_url_path) { "/#{organization.slug}/customer/#{customer.id}/invoice/#{invoice.id}/overview" }
-
   let(:invoice) do
     create(
       :invoice,
@@ -31,7 +26,6 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateService do
       purchase_order_number:
     )
   end
-
   let(:headers) do
     {
       "Connection-Id" => integration.connection_id,
@@ -39,10 +33,14 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateService do
       "Provider-Config-Key" => "hubspot"
     }
   end
-
   let(:params) do
     service.__send__(:payload).create_body
   end
+  let(:integration) { create(:hubspot_integration, organization:, invoices_properties_version: 2) }
+  let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   before do
     allow(LagoHttpClient::Client).to receive(:new)

--- a/spec/services/integrations/aggregator/invoices/hubspot/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/create_service_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateService do
   let(:service) { described_class.new(invoice:) }
   let(:integration) { create(:hubspot_integration, organization:, invoices_properties_version: 2) }
   let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/hubspot/records" }
   let(:invoice_file_url) { invoice.file_url }

--- a/spec/services/integrations/aggregator/invoices/hubspot/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/update_service_spec.rb
@@ -6,11 +6,6 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::UpdateService do
   subject(:service_call) { service.call }
 
   let(:service) { described_class.new(invoice:) }
-  let(:integration) { create(:hubspot_integration, organization:, invoices_properties_version: 2) }
-  let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
-  let(:integration_invoice) { create(:integration_resource, syncable: invoice, integration:) }
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:customer) { create(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/hubspot/records" }
   let(:invoice_file_url) { invoice.file_url }
@@ -18,7 +13,6 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::UpdateService do
   let(:due_date) { invoice.payment_due_date.strftime("%Y-%m-%d") }
   let(:purchase_order_number) { "PO-123" }
   let(:invoice_url_path) { "/#{organization.slug}/customer/#{customer.id}/invoice/#{invoice.id}/overview" }
-
   let(:invoice) do
     create(
       :invoice,
@@ -31,7 +25,6 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::UpdateService do
       purchase_order_number:
     )
   end
-
   let(:headers) do
     {
       "Connection-Id" => integration.connection_id,
@@ -39,10 +32,15 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::UpdateService do
       "Provider-Config-Key" => "hubspot"
     }
   end
-
   let(:params) do
     service.__send__(:payload).update_body
   end
+  let(:integration) { create(:hubspot_integration, organization:, invoices_properties_version: 2) }
+  let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
+  let(:integration_invoice) { create(:integration_resource, syncable: invoice, integration:) }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   before do
     allow(LagoHttpClient::Client).to receive(:new)

--- a/spec/services/integrations/aggregator/invoices/hubspot/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/update_service_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::UpdateService do
   let(:integration) { create(:hubspot_integration, organization:, invoices_properties_version: 2) }
   let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
   let(:integration_invoice) { create(:integration_resource, syncable: invoice, integration:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/hubspot/records" }
   let(:invoice_file_url) { invoice.file_url }

--- a/spec/services/integrations/aggregator/invoices/payloads/base_payload_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/base_payload_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::BasePayload do
   let(:payload) { described_class.new(integration_customer:, invoice:) }
   let(:integration_customer) { create(:xero_customer, integration:, customer:) }
   let(:integration) { create(:xero_integration, organization:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:) }
 
   describe "#fees" do

--- a/spec/services/integrations/aggregator/invoices/payloads/base_payload_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/base_payload_spec.rb
@@ -4,11 +4,12 @@ require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Invoices::Payloads::BasePayload do
   let(:payload) { described_class.new(integration_customer:, invoice:) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
   let(:integration_customer) { create(:xero_customer, integration:, customer:) }
   let(:integration) { create(:xero_integration, organization:) }
+
   let_it_be(:organization) { create(:organization) }
   let_it_be(:customer) { create(:customer, organization:) }
-  let(:invoice) { create(:invoice, customer:, organization:) }
 
   describe "#fees" do
     subject(:fees_call) { payload.__send__(:fees) }

--- a/spec/services/integrations/aggregator/invoices/payloads/factory_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/factory_spec.rb
@@ -3,6 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Invoices::Payloads::Factory do
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
   describe ".new_instance" do
     subject(:new_instance_call) { described_class.new_instance(integration_customer:, invoice:) }
 

--- a/spec/services/integrations/aggregator/invoices/payloads/factory_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/factory_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Invoices::Payloads::Factory do
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
 
   describe ".new_instance" do
     subject(:new_instance_call) { described_class.new_instance(integration_customer:, invoice:) }

--- a/spec/services/integrations/aggregator/invoices/payloads/hubspot_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/hubspot_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Hubspot do
   let(:payload) { described_class.new(integration_customer:, invoice:) }
   let(:integration_customer) { FactoryBot.create(:hubspot_customer, integration:, customer:) }
   let(:integration) { create(:hubspot_integration, organization:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:file_url) { Faker::Internet.url }
   let(:invoice_url) do
     url = Rails.application.config.lago_front_url

--- a/spec/services/integrations/aggregator/invoices/payloads/hubspot_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/hubspot_spec.rb
@@ -4,17 +4,12 @@ require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Invoices::Payloads::Hubspot do
   let(:payload) { described_class.new(integration_customer:, invoice:) }
-  let(:integration_customer) { FactoryBot.create(:hubspot_customer, integration:, customer:) }
-  let(:integration) { create(:hubspot_integration, organization:) }
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:customer) { create(:customer, organization:) }
   let(:file_url) { Faker::Internet.url }
   let(:invoice_url) do
     url = Rails.application.config.lago_front_url
 
     URI.join(url, "/#{customer.organization.slug}/customer/#{customer.id}/", "invoice/#{invoice.id}/overview").to_s
   end
-
   let(:invoice) do
     create(
       :invoice,
@@ -27,10 +22,14 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Hubspot do
       issuing_date: DateTime.new(2024, 7, 8)
     )
   end
-
   let(:integration_invoice) do
     create(:integration_resource, integration:, resource_type: "invoice", syncable: invoice)
   end
+  let(:integration_customer) { FactoryBot.create(:hubspot_customer, integration:, customer:) }
+  let(:integration) { create(:hubspot_integration, organization:) }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   before do
     integration_invoice

--- a/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
@@ -4,11 +4,6 @@ require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
   let(:payload) { described_class.new(integration_customer:, invoice:) }
-  let(:integration_customer) { create(:xero_customer, integration:, customer:) }
-  let(:integration) { create(:netsuite_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization) }
-  let_it_be(:customer) { create_default(:customer, organization:) }
-
   let(:invoice) do
     create(
       :invoice,
@@ -22,6 +17,11 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
       issuing_date: DateTime.new(2024, 7, 8)
     )
   end
+  let(:integration_customer) { create(:xero_customer, integration:, customer:) }
+  let(:integration) { create(:netsuite_integration, organization:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   describe "#body" do
     subject(:body_call) { payload.body }
@@ -709,7 +709,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
     end
 
     context "when invoice has a fixed_charge fee" do
-      let_it_be(:plan) { create_default(:plan)}
+      let_it_be(:plan) { create_default(:plan) }
       let(:fixed_charge) { create(:fixed_charge, organization:, plan:, add_on:) }
       let(:fixed_charge_fee) do
         create(

--- a/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
   let(:payload) { described_class.new(integration_customer:, invoice:) }
   let(:integration_customer) { create(:xero_customer, integration:, customer:) }
   let(:integration) { create(:netsuite_integration, organization:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   let(:invoice) do
     create(
@@ -26,8 +26,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
   describe "#body" do
     subject(:body_call) { payload.body }
 
-    let(:add_on) { create(:add_on, organization:) }
-    let(:billable_metric) { create(:billable_metric, organization:) }
+    let_it_be(:add_on) { create(:add_on, organization:) }
+    let_it_be(:billable_metric) { create(:billable_metric, organization:) }
     let(:charge) { create(:standard_charge, billable_metric:) }
     let(:current_time) { Time.current }
 
@@ -709,7 +709,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
     end
 
     context "when invoice has a fixed_charge fee" do
-      let(:plan) { create(:plan, organization:) }
+      let_it_be(:plan) { create_default(:plan)}
       let(:fixed_charge) { create(:fixed_charge, organization:, plan:, add_on:) }
       let(:fixed_charge_fee) do
         create(

--- a/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
@@ -119,13 +119,9 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
       let_it_be(:organization) { create(:organization) }
       let_it_be(:billing_entity) { create(:billing_entity, organization:) }
       let(:integration) { create(:xero_integration, organization:) }
-      let_it_be(:customer) { create_default(:customer, organization:, billing_entity:) }
       let(:integration_customer) { create(:xero_customer, customer:, integration:) }
-      let_it_be(:billable_metric) { create(:billable_metric, organization:) }
-      let_it_be(:plan) { create(:plan, organization:) }
       let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
       let(:subscription) { create(:subscription, organization:, plan:) }
-
       let(:invoice) do
         invoice = create(
           :invoice,
@@ -142,7 +138,6 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
         create(:invoice_subscription, invoice:, subscription:)
         invoice
       end
-
       let(:billable_metric_mapping) do
         create(
           :xero_mapping,
@@ -153,6 +148,10 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
           settings: {external_id: "metric_ext_id", external_account_code: "100", external_name: "metric"}
         )
       end
+
+      let_it_be(:customer) { create_default(:customer, organization:, billing_entity:) }
+      let_it_be(:billable_metric) { create(:billable_metric, organization:) }
+      let_it_be(:plan) { create(:plan, organization:) }
 
       before { billable_metric_mapping }
 

--- a/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
@@ -116,13 +116,13 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
     end
 
     context "with a single billable metric charge" do
-      let(:organization) { create(:organization) }
-      let(:billing_entity) { create(:billing_entity, organization:) }
+      let_it_be(:organization) { create(:organization) }
+      let_it_be(:billing_entity) { create(:billing_entity, organization:) }
       let(:integration) { create(:xero_integration, organization:) }
-      let(:customer) { create(:customer, organization:, billing_entity:) }
+      let_it_be(:customer) { create_default(:customer, organization:, billing_entity:) }
       let(:integration_customer) { create(:xero_customer, customer:, integration:) }
-      let(:billable_metric) { create(:billable_metric, organization:) }
-      let(:plan) { create(:plan, organization:) }
+      let_it_be(:billable_metric) { create(:billable_metric, organization:) }
+      let_it_be(:plan) { create(:plan, organization:) }
       let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
       let(:subscription) { create(:subscription, organization:, plan:) }
 

--- a/spec/services/integrations/aggregator/invoices/reconcile_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/reconcile_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Integrations::Aggregator::Invoices::ReconcileService do
   subject(:service_call) { described_class.call(invoice:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
   let(:invoice) { create(:invoice, customer:, organization:, number: "INV-001") }

--- a/spec/services/integrations/aggregator/items_service_spec.rb
+++ b/spec/services/integrations/aggregator/items_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Integrations::Aggregator::ItemsService do
   subject(:items_service) { described_class.new(integration:) }
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let(:integration) { create(:netsuite_integration) }
 

--- a/spec/services/integrations/aggregator/items_service_spec.rb
+++ b/spec/services/integrations/aggregator/items_service_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe Integrations::Aggregator::ItemsService do
   subject(:items_service) { described_class.new(integration:) }
 
+before_all do
+  create_default(:organization)
+end
+
   let(:integration) { create(:netsuite_integration) }
 
   describe ".call" do

--- a/spec/services/integrations/aggregator/payments/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/payments/create_service_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Integrations::Aggregator::Payments::CreateService do
   let(:service) { described_class.new(payment:) }
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/netsuite/payments" }
   let(:payment) { create(:payment, payable: invoice) }

--- a/spec/services/integrations/aggregator/payments/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/payments/create_service_spec.rb
@@ -6,16 +6,11 @@ RSpec.describe Integrations::Aggregator::Payments::CreateService do
   subject(:service_call) { described_class.call(payment:) }
 
   let(:service) { described_class.new(payment:) }
-  let(:integration) { create(:netsuite_integration, organization:) }
-  let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
-  let_it_be(:organization) { create_default(:organization) }
-  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/netsuite/payments" }
   let(:payment) { create(:payment, payable: invoice) }
   let(:invoice) { create(:invoice, customer:, organization:) }
   let(:integration_invoice) { create(:integration_resource, syncable: invoice, integration:) }
-
   let(:headers) do
     {
       "Connection-Id" => integration.connection_id,
@@ -23,7 +18,6 @@ RSpec.describe Integrations::Aggregator::Payments::CreateService do
       "Provider-Config-Key" => "netsuite-tba"
     }
   end
-
   let(:params) do
     {
       "isDynamic" => true,
@@ -49,6 +43,11 @@ RSpec.describe Integrations::Aggregator::Payments::CreateService do
       ]
     }
   end
+  let(:integration) { create(:netsuite_integration, organization:) }
+  let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     allow(LagoHttpClient::Client).to receive(:new)

--- a/spec/services/integrations/aggregator/payments/payloads/factory_spec.rb
+++ b/spec/services/integrations/aggregator/payments/payloads/factory_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Payments::Payloads::Factory do
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
 
   describe ".new_instance" do
     subject(:new_instance_call) { described_class.new_instance(integration:, payment:) }

--- a/spec/services/integrations/aggregator/payments/payloads/factory_spec.rb
+++ b/spec/services/integrations/aggregator/payments/payloads/factory_spec.rb
@@ -3,6 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Payments::Payloads::Factory do
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
   describe ".new_instance" do
     subject(:new_instance_call) { described_class.new_instance(integration:, payment:) }
 

--- a/spec/services/integrations/aggregator/subscriptions/hubspot/base_service_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/hubspot/base_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::BaseService do
   let(:service) { described_class.new(subscription:) }
   let(:subscription) { create(:subscription, customer:, plan:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:integration) { create(:hubspot_integration, organization:) }
   let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
 

--- a/spec/services/integrations/aggregator/subscriptions/hubspot/base_service_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/hubspot/base_service_spec.rb
@@ -4,12 +4,13 @@ require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::BaseService do
   let(:service) { described_class.new(subscription:) }
+  let(:integration) { create(:hubspot_integration, organization:) }
+  let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
   let(:subscription) { create(:subscription, customer:, plan:) }
+
   let_it_be(:organization) { create(:organization) }
   let_it_be(:plan) { create(:plan, organization:) }
   let_it_be(:customer) { create(:customer, organization:) }
-  let(:integration) { create(:hubspot_integration, organization:) }
-  let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
 
   describe "#initialize" do
     it "assigns the subscription" do

--- a/spec/services/integrations/aggregator/subscriptions/hubspot/create_customer_association_service_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/hubspot/create_customer_association_service_spec.rb
@@ -6,19 +6,12 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::CreateCustomerA
   subject(:service_call) { service.call }
 
   let(:service) { described_class.new(subscription:) }
-  let(:integration) { create(:hubspot_integration, organization:, sync_subscriptions:) }
-  let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:customer) { create(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/hubspot/association" }
-  let_it_be(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, customer:, organization:, plan:) }
-
   let(:integration_subscription) do
     create(:integration_resource, resource_type: "subscription", syncable: subscription, integration:)
   end
-
   let(:headers) do
     {
       "Connection-Id" => integration.connection_id,
@@ -26,10 +19,15 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::CreateCustomerA
       "Provider-Config-Key" => "hubspot"
     }
   end
-
   let(:params) do
     service.__send__(:payload).customer_association_body
   end
+  let(:integration) { create(:hubspot_integration, organization:, sync_subscriptions:) }
+  let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
 
   before do
     integration_customer

--- a/spec/services/integrations/aggregator/subscriptions/hubspot/create_customer_association_service_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/hubspot/create_customer_association_service_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::CreateCustomerA
   let(:service) { described_class.new(subscription:) }
   let(:integration) { create(:hubspot_integration, organization:, sync_subscriptions:) }
   let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/hubspot/association" }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, customer:, organization:, plan:) }
 
   let(:integration_subscription) do

--- a/spec/services/integrations/aggregator/subscriptions/hubspot/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/hubspot/create_service_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::CreateService d
 
   let(:service) { described_class.new(subscription:) }
   let(:subscription) { create(:subscription, customer:, plan:) }
-  let(:plan) { create(:plan, organization:) }
   let(:integration) { create(:hubspot_integration, organization:) }
   let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:lago_properties_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/hubspot/records" }

--- a/spec/services/integrations/aggregator/subscriptions/hubspot/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/hubspot/create_service_spec.rb
@@ -6,12 +6,6 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::CreateService d
   subject(:service_call) { service.call }
 
   let(:service) { described_class.new(subscription:) }
-  let(:subscription) { create(:subscription, customer:, plan:) }
-  let(:integration) { create(:hubspot_integration, organization:) }
-  let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:customer) { create(:customer, organization:) }
-  let_it_be(:plan) { create(:plan, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:lago_properties_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/hubspot/records" }
@@ -20,7 +14,6 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::CreateService d
   let(:file_url) { Faker::Internet.url }
   let(:due_date) { subscription.payment_due_date.strftime("%Y-%m-%d") }
   let(:params) { service.__send__(:payload).create_body }
-
   let(:headers) do
     {
       "Connection-Id" => integration.connection_id,
@@ -28,6 +21,13 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::CreateService d
       "Provider-Config-Key" => "hubspot"
     }
   end
+  let(:subscription) { create(:subscription, customer:, plan:) }
+  let(:integration) { create(:hubspot_integration, organization:) }
+  let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
 
   before do
     allow(LagoHttpClient::Client).to receive(:new)

--- a/spec/services/integrations/aggregator/subscriptions/hubspot/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/hubspot/update_service_spec.rb
@@ -6,21 +6,14 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::UpdateService d
   subject(:service_call) { service.call }
 
   let(:service) { described_class.new(subscription:) }
-  let(:integration) { create(:hubspot_integration, organization:) }
-  let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:customer) { create(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:lago_properties_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/hubspot/records" }
   let(:properties_endpoint) { "https://api.nango.dev/v1/hubspot/properties" }
-  let_it_be(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, customer:, organization:, plan:) }
-
   let(:integration_subscription) do
     create(:integration_resource, resource_type: "subscription", syncable: subscription, integration:)
   end
-
   let(:headers) do
     {
       "Connection-Id" => integration.connection_id,
@@ -28,10 +21,15 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::UpdateService d
       "Provider-Config-Key" => "hubspot"
     }
   end
-
   let(:params) do
     service.__send__(:payload).update_body
   end
+  let(:integration) { create(:hubspot_integration, organization:) }
+  let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
 
   before do
     allow(LagoHttpClient::Client).to receive(:new)

--- a/spec/services/integrations/aggregator/subscriptions/hubspot/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/hubspot/update_service_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::UpdateService d
   let(:service) { described_class.new(subscription:) }
   let(:integration) { create(:hubspot_integration, organization:) }
   let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:lago_properties_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/hubspot/records" }
   let(:properties_endpoint) { "https://api.nango.dev/v1/hubspot/properties" }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, customer:, organization:, plan:) }
 
   let(:integration_subscription) do

--- a/spec/services/integrations/aggregator/subscriptions/payloads/factory_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/payloads/factory_spec.rb
@@ -3,11 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Subscriptions::Payloads::Factory do
-before_all do
-  create_default(:organization)
-create_default(:customer)
-create_default(:plan)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+  end
 
   describe ".new_instance" do
     subject(:new_instance_call) { described_class.new_instance(integration_customer:, subscription:) }

--- a/spec/services/integrations/aggregator/subscriptions/payloads/factory_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/payloads/factory_spec.rb
@@ -3,6 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Subscriptions::Payloads::Factory do
+before_all do
+  create_default(:organization)
+create_default(:customer)
+create_default(:plan)
+end
+
   describe ".new_instance" do
     subject(:new_instance_call) { described_class.new_instance(integration_customer:, subscription:) }
 

--- a/spec/services/integrations/aggregator/subscriptions/payloads/hubspot_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/payloads/hubspot_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Payloads::Hubspot do
   let(:payload) { described_class.new(integration_customer:, subscription:) }
   let(:integration_customer) { FactoryBot.create(:hubspot_customer, integration:, customer:) }
   let(:integration) { create(:hubspot_integration, organization:) }
-  let(:customer) { create(:customer, organization:) }
   let(:file_url) { Faker::Internet.url }
   let(:subscription) { create(:subscription, customer:, plan:) }
   let(:plan) { create(:plan, organization:) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   let(:integration_subscription) do
     create(:integration_resource, integration:, resource_type: "subscription", syncable: subscription)

--- a/spec/services/integrations/aggregator/subscriptions/payloads/hubspot_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/payloads/hubspot_spec.rb
@@ -4,22 +4,21 @@ require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Subscriptions::Payloads::Hubspot do
   let(:payload) { described_class.new(integration_customer:, subscription:) }
+  let(:integration_subscription) do
+    create(:integration_resource, integration:, resource_type: "subscription", syncable: subscription)
+  end
+  let(:subscription_url) do
+    url = Rails.application.config.lago_front_url
+    URI.join(url, "/#{customer.organization.slug}/customer/#{customer.id}/subscription/#{subscription.id}/overview").to_s
+  end
   let(:integration_customer) { FactoryBot.create(:hubspot_customer, integration:, customer:) }
   let(:integration) { create(:hubspot_integration, organization:) }
   let(:file_url) { Faker::Internet.url }
   let(:subscription) { create(:subscription, customer:, plan:) }
   let(:plan) { create(:plan, organization:) }
+
   let_it_be(:organization) { create(:organization) }
   let_it_be(:customer) { create(:customer, organization:) }
-
-  let(:integration_subscription) do
-    create(:integration_resource, integration:, resource_type: "subscription", syncable: subscription)
-  end
-
-  let(:subscription_url) do
-    url = Rails.application.config.lago_front_url
-    URI.join(url, "/#{customer.organization.slug}/customer/#{customer.id}/subscription/#{subscription.id}/overview").to_s
-  end
 
   before do
     integration_subscription

--- a/spec/services/integrations/aggregator/taxes/avalara/fetch_company_id_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/avalara/fetch_company_id_service_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Integrations::Aggregator::Taxes::Avalara::FetchCompanyIdService d
   subject(:service_call) { described_class.call(integration:) }
 
   let(:integration) { create(:avalara_integration, organization:) }
-  let_it_be(:organization) { create(:organization) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/avalara/companies" }
   let(:headers) do
@@ -23,6 +22,8 @@ RSpec.describe Integrations::Aggregator::Taxes::Avalara::FetchCompanyIdService d
       }
     ]
   end
+
+  let_it_be(:organization) { create(:organization) }
 
   before do
     integration

--- a/spec/services/integrations/aggregator/taxes/avalara/fetch_company_id_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/avalara/fetch_company_id_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Integrations::Aggregator::Taxes::Avalara::FetchCompanyIdService d
   subject(:service_call) { described_class.call(integration:) }
 
   let(:integration) { create(:avalara_integration, organization:) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/avalara/companies" }
   let(:headers) do

--- a/spec/services/integrations/aggregator/taxes/credit_notes/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/credit_notes/create_service_spec.rb
@@ -6,20 +6,10 @@ RSpec.describe Integrations::Aggregator::Taxes::CreditNotes::CreateService do
   subject(:service_call) { described_class.call(credit_note:) }
 
   let(:integration) { create(:anrok_integration, organization:) }
-  let(:integration_customer) { create(:anrok_customer, integration:, customer:, external_customer_id: nil) }
-  let_it_be(:organization) { create_default(:organization) }
-
-before_all do
-  create_default(:plan)
-end
-
   let(:customer) { create(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/anrok/finalized_invoices" }
-  let_it_be(:add_on) { create(:add_on, organization:) }
-  let_it_be(:add_on_two) { create(:add_on, organization:) }
   let(:current_time) { Time.current }
-
   let(:integration_collection_mapping1) do
     create(
       :netsuite_collection_mapping,
@@ -37,7 +27,6 @@ end
       settings: {external_id: "m1", external_account_code: "m11", external_name: ""}
     )
   end
-
   let(:invoice) do
     create(
       :invoice,
@@ -70,14 +59,12 @@ end
       organization:
     )
   end
-
   let(:credit_note_item1) do
     create(:credit_note_item, credit_note:, fee: fee_add_on, amount_cents: fee_add_on.amount_cents)
   end
   let(:credit_note_item2) do
     create(:credit_note_item, credit_note:, fee: fee_add_on_two, amount_cents: fee_add_on_two.amount_cents)
   end
-
   let(:headers) do
     {
       "Connection-Id" => integration.connection_id,
@@ -85,7 +72,6 @@ end
       "Provider-Config-Key" => "anrok"
     }
   end
-
   let(:params) do
     [
       {
@@ -118,6 +104,16 @@ end
       }
     ]
   end
+  let(:integration_customer) { create(:anrok_customer, integration:, customer:, external_customer_id: nil) }
+
+  let_it_be(:organization) { create_default(:organization) }
+
+  before_all do
+    create_default(:plan)
+  end
+
+  let_it_be(:add_on) { create(:add_on, organization:) }
+  let_it_be(:add_on_two) { create(:add_on, organization:) }
 
   before do
     allow(LagoHttpClient::Client).to receive(:new)

--- a/spec/services/integrations/aggregator/taxes/credit_notes/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/credit_notes/create_service_spec.rb
@@ -7,12 +7,17 @@ RSpec.describe Integrations::Aggregator::Taxes::CreditNotes::CreateService do
 
   let(:integration) { create(:anrok_integration, organization:) }
   let(:integration_customer) { create(:anrok_customer, integration:, customer:, external_customer_id: nil) }
+  let_it_be(:organization) { create_default(:organization) }
+
+before_all do
+  create_default(:plan)
+end
+
   let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/anrok/finalized_invoices" }
-  let(:add_on) { create(:add_on, organization:) }
-  let(:add_on_two) { create(:add_on, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
+  let_it_be(:add_on_two) { create(:add_on, organization:) }
   let(:current_time) { Time.current }
 
   let(:integration_collection_mapping1) do

--- a/spec/services/integrations/aggregator/taxes/credit_notes/payloads/anrok_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/credit_notes/payloads/anrok_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Taxes::CreditNotes::Payloads::Anrok do
+before_all do
+  create_default(:organization)
+end
+
   describe "#body" do
     subject(:payload) { described_class.new(integration:, customer:, integration_customer:, credit_note:).body }
 

--- a/spec/services/integrations/aggregator/taxes/credit_notes/payloads/anrok_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/credit_notes/payloads/anrok_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Taxes::CreditNotes::Payloads::Anrok do
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   describe "#body" do
     subject(:payload) { described_class.new(integration:, customer:, integration_customer:, credit_note:).body }

--- a/spec/services/integrations/aggregator/taxes/credit_notes/payloads/avalara_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/credit_notes/payloads/avalara_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Integrations::Aggregator::Taxes::CreditNotes::Payloads::Avalara do
   subject(:payload) { described_class.new(integration:, customer:, integration_customer:, credit_note:).body }
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   describe "shipping address fallback" do
     let(:integration) { create(:avalara_integration) }

--- a/spec/services/integrations/aggregator/taxes/credit_notes/payloads/avalara_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/credit_notes/payloads/avalara_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe Integrations::Aggregator::Taxes::CreditNotes::Payloads::Avalara do
   subject(:payload) { described_class.new(integration:, customer:, integration_customer:, credit_note:).body }
 
+before_all do
+  create_default(:organization)
+end
+
   describe "shipping address fallback" do
     let(:integration) { create(:avalara_integration) }
     let(:customer) do

--- a/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
@@ -6,19 +6,9 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateDraftService do
   subject(:service_call) { described_class.call(invoice:) }
 
   let(:integration) { create(:anrok_integration, organization:) }
-  let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
-  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, :with_shipping_address, organization:) }
-
-before_all do
-  create_default(:plan)
-end
-
   let(:endpoint) { "https://api.nango.dev/v1/anrok/draft_invoices" }
-  let_it_be(:add_on) { create(:add_on, organization:) }
-  let_it_be(:add_on_two) { create(:add_on, organization:) }
   let(:current_time) { Time.current }
-
   let(:integration_collection_mapping1) do
     create(
       :netsuite_collection_mapping,
@@ -36,7 +26,6 @@ end
       settings: {external_id: "m1", external_account_code: "m11", external_name: ""}
     )
   end
-
   let(:invoice) do
     create(
       :invoice,
@@ -60,7 +49,6 @@ end
       created_at: current_time - 2.seconds
     )
   end
-
   let(:headers) do
     {
       "Connection-Id" => integration.connection_id,
@@ -69,7 +57,6 @@ end
     }
   end
   let(:response_status) { 200 }
-
   let(:params) do
     [
       {
@@ -103,6 +90,16 @@ end
       }
     ]
   end
+  let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+
+  before_all do
+    create_default(:plan)
+  end
+
+  let_it_be(:add_on) { create(:add_on, organization:) }
+  let_it_be(:add_on_two) { create(:add_on, organization:) }
 
   before do
     integration_customer

--- a/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
@@ -7,11 +7,16 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateDraftService do
 
   let(:integration) { create(:anrok_integration, organization:) }
   let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, :with_shipping_address, organization:) }
-  let(:organization) { create(:organization) }
+
+before_all do
+  create_default(:plan)
+end
+
   let(:endpoint) { "https://api.nango.dev/v1/anrok/draft_invoices" }
-  let(:add_on) { create(:add_on, organization:) }
-  let(:add_on_two) { create(:add_on, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
+  let_it_be(:add_on_two) { create(:add_on, organization:) }
   let(:current_time) { Time.current }
 
   let(:integration_collection_mapping1) do

--- a/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
@@ -6,19 +6,9 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
   subject(:service_call) { described_class.call(invoice:) }
 
   let(:integration) { create(:anrok_integration, organization:) }
-  let(:integration_customer) { create(:anrok_customer, integration:, customer:, external_customer_id: nil) }
-  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, organization:) }
-
-before_all do
-  create_default(:plan)
-end
-
   let(:endpoint) { "https://api.nango.dev/v1/anrok/finalized_invoices" }
-  let_it_be(:add_on) { create(:add_on, organization:) }
-  let_it_be(:add_on_two) { create(:add_on, organization:) }
   let(:current_time) { Time.current }
-
   let(:integration_collection_mapping1) do
     create(
       :netsuite_collection_mapping,
@@ -36,7 +26,6 @@ end
       settings: {external_id: "m1", external_account_code: "m11", external_name: ""}
     )
   end
-
   let(:invoice) do
     create(
       :invoice,
@@ -60,7 +49,6 @@ end
       created_at: current_time - 2.seconds
     )
   end
-
   let(:headers) do
     {
       "Connection-Id" => integration.connection_id,
@@ -69,7 +57,6 @@ end
     }
   end
   let(:response_status) { 200 }
-
   let(:params) do
     [
       {
@@ -104,6 +91,16 @@ end
       }
     ]
   end
+  let(:integration_customer) { create(:anrok_customer, integration:, customer:, external_customer_id: nil) }
+
+  let_it_be(:organization) { create_default(:organization) }
+
+  before_all do
+    create_default(:plan)
+  end
+
+  let_it_be(:add_on) { create(:add_on, organization:) }
+  let_it_be(:add_on_two) { create(:add_on, organization:) }
 
   before do
     integration_customer

--- a/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
@@ -7,11 +7,16 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
 
   let(:integration) { create(:anrok_integration, organization:) }
   let(:integration_customer) { create(:anrok_customer, integration:, customer:, external_customer_id: nil) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
+
+before_all do
+  create_default(:plan)
+end
+
   let(:endpoint) { "https://api.nango.dev/v1/anrok/finalized_invoices" }
-  let(:add_on) { create(:add_on, organization:) }
-  let(:add_on_two) { create(:add_on, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
+  let_it_be(:add_on_two) { create(:add_on, organization:) }
   let(:current_time) { Time.current }
 
   let(:integration_collection_mapping1) do

--- a/spec/services/integrations/aggregator/taxes/invoices/negate_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/negate_service_spec.rb
@@ -6,13 +6,10 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::NegateService do
   subject(:service_call) { described_class.call(invoice:) }
 
   let(:integration) { create(:anrok_integration, organization:) }
-  let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
-  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/anrok/negate_invoices" }
   let(:current_time) { Time.current }
-
   let(:integration_collection_mapping1) do
     create(
       :netsuite_collection_mapping,
@@ -21,7 +18,6 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::NegateService do
       settings: {external_id: "1", external_account_code: "11", external_name: ""}
     )
   end
-
   let(:invoice) do
     create(
       :invoice,
@@ -29,7 +25,6 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::NegateService do
       organization:
     )
   end
-
   let(:headers) do
     {
       "Connection-Id" => integration.connection_id,
@@ -37,7 +32,6 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::NegateService do
       "Provider-Config-Key" => "anrok"
     }
   end
-
   let(:params) do
     [
       {
@@ -46,6 +40,9 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::NegateService do
       }
     ]
   end
+  let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+
+  let_it_be(:organization) { create_default(:organization) }
 
   before do
     allow(LagoHttpClient::Client).to receive(:new)

--- a/spec/services/integrations/aggregator/taxes/invoices/negate_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/negate_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::NegateService do
 
   let(:integration) { create(:anrok_integration, organization:) }
   let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/anrok/negate_invoices" }
   let(:current_time) { Time.current }

--- a/spec/services/integrations/aggregator/taxes/invoices/payloads/anrok_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/payloads/anrok_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Taxes::Invoices::Payloads::Anrok do
+before_all do
+  create_default(:organization)
+end
+
   describe "#body" do
     subject(:payload) { described_class.new(integration:, customer:, invoice:, integration_customer:, fees:).body }
 

--- a/spec/services/integrations/aggregator/taxes/invoices/payloads/anrok_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/payloads/anrok_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Taxes::Invoices::Payloads::Anrok do
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   describe "#body" do
     subject(:payload) { described_class.new(integration:, customer:, invoice:, integration_customer:, fees:).body }

--- a/spec/services/integrations/aggregator/taxes/invoices/payloads/avalara_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/payloads/avalara_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Taxes::Invoices::Payloads::Avalara do
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   describe "#body" do
     subject(:payload) { described_class.new(integration:, customer:, invoice:, integration_customer:, fees:).body }

--- a/spec/services/integrations/aggregator/taxes/invoices/payloads/avalara_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/payloads/avalara_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Taxes::Invoices::Payloads::Avalara do
+before_all do
+  create_default(:organization)
+end
+
   describe "#body" do
     subject(:payload) { described_class.new(integration:, customer:, invoice:, integration_customer:, fees:).body }
 

--- a/spec/services/integrations/aggregator/taxes/invoices/void_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/void_service_spec.rb
@@ -6,13 +6,10 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::VoidService do
   subject(:service_call) { described_class.call(invoice:) }
 
   let(:integration) { create(:anrok_integration, organization:) }
-  let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
-  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/anrok/void_invoices" }
   let(:current_time) { Time.current }
-
   let(:integration_collection_mapping1) do
     create(
       :netsuite_collection_mapping,
@@ -21,7 +18,6 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::VoidService do
       settings: {external_id: "1", external_account_code: "11", external_name: ""}
     )
   end
-
   let(:invoice) do
     create(
       :invoice,
@@ -29,7 +25,6 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::VoidService do
       organization:
     )
   end
-
   let(:headers) do
     {
       "Connection-Id" => integration.connection_id,
@@ -37,7 +32,6 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::VoidService do
       "Provider-Config-Key" => "anrok"
     }
   end
-
   let(:params) do
     [
       {
@@ -45,6 +39,9 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::VoidService do
       }
     ]
   end
+  let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+
+  let_it_be(:organization) { create_default(:organization) }
 
   before do
     allow(LagoHttpClient::Client).to receive(:new)

--- a/spec/services/integrations/aggregator/taxes/invoices/void_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/void_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::VoidService do
 
   let(:integration) { create(:anrok_integration, organization:) }
   let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:organization) { create(:organization) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { "https://api.nango.dev/v1/anrok/void_invoices" }
   let(:current_time) { Time.current }

--- a/spec/services/integrations/anrok/create_service_spec.rb
+++ b/spec/services/integrations/anrok/create_service_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe Integrations::Anrok::CreateService do
   include_context "with mocked security logger"
 
   let(:service) { described_class.new(membership.user) }
+
   let_it_be(:membership) { create(:membership) }
   let_it_be(:membership) { create(:membership) }
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
 
   describe "#call" do
     subject(:service_call) { service.call(**create_args) }

--- a/spec/services/integrations/anrok/create_service_spec.rb
+++ b/spec/services/integrations/anrok/create_service_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe Integrations::Anrok::CreateService do
   include_context "with mocked security logger"
 
   let(:service) { described_class.new(membership.user) }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization)}
 
   describe "#call" do
     subject(:service_call) { service.call(**create_args) }

--- a/spec/services/integrations/anrok/update_service_spec.rb
+++ b/spec/services/integrations/anrok/update_service_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Integrations::Anrok::UpdateService do
   include_context "with mocked security logger"
 
   let(:integration) { create(:anrok_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization)}
+
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
 
   describe "#call" do

--- a/spec/services/integrations/anrok/update_service_spec.rb
+++ b/spec/services/integrations/anrok/update_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Integrations::Anrok::UpdateService do
   include_context "with mocked security logger"
 
   let(:integration) { create(:anrok_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
 
   describe "#call" do
     subject(:service_call) { described_class.call(integration:, params: update_args) }

--- a/spec/services/integrations/avalara/create_service_spec.rb
+++ b/spec/services/integrations/avalara/create_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Integrations::Avalara::CreateService do
   include_context "with mocked security logger"
 
+  let(:organization) { create_default(:organization)}
   let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
 
   describe "#call" do
     subject(:service_call) { described_class.call(params: create_args) }

--- a/spec/services/integrations/avalara/create_service_spec.rb
+++ b/spec/services/integrations/avalara/create_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Integrations::Avalara::CreateService do
   include_context "with mocked security logger"
 
-  let(:organization) { create_default(:organization)}
+  let(:organization) { create_default(:organization) }
   let(:membership) { create(:membership) }
 
   describe "#call" do

--- a/spec/services/integrations/avalara/fetch_company_id_service_spec.rb
+++ b/spec/services/integrations/avalara/fetch_company_id_service_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Avalara::FetchCompanyIdService do
+before_all do
+  create_default(:organization)
+end
+
   describe "#call" do
     let(:service_call) { described_class.call(integration:) }
     let(:company_id) { "abc-12345" }

--- a/spec/services/integrations/avalara/fetch_company_id_service_spec.rb
+++ b/spec/services/integrations/avalara/fetch_company_id_service_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Avalara::FetchCompanyIdService do
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   describe "#call" do
     let(:service_call) { described_class.call(integration:) }

--- a/spec/services/integrations/avalara/update_service_spec.rb
+++ b/spec/services/integrations/avalara/update_service_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Integrations::Avalara::UpdateService do
   include_context "with mocked security logger"
 
   let(:integration) { create(:avalara_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization)}
+
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
 
   describe "#call" do

--- a/spec/services/integrations/avalara/update_service_spec.rb
+++ b/spec/services/integrations/avalara/update_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Integrations::Avalara::UpdateService do
   include_context "with mocked security logger"
 
   let(:integration) { create(:avalara_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
 
   describe "#call" do
     subject(:service_call) { described_class.call(integration:, params: update_args) }

--- a/spec/services/integrations/destroy_service_spec.rb
+++ b/spec/services/integrations/destroy_service_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe Integrations::DestroyService do
 
   include_context "with mocked security logger"
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization)}
   let(:integration) { create(:netsuite_integration, organization:) }
 
   describe ".call" do

--- a/spec/services/integrations/destroy_service_spec.rb
+++ b/spec/services/integrations/destroy_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Integrations::DestroyService do
 
   let_it_be(:membership) { create(:membership) }
   let_it_be(:membership) { create(:membership) }
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let(:integration) { create(:netsuite_integration, organization:) }
 
   describe ".call" do

--- a/spec/services/integrations/entra_id/create_service_spec.rb
+++ b/spec/services/integrations/entra_id/create_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Integrations::EntraId::CreateService do
   include_context "with mocked security logger"
 
   let(:service) { described_class.new(membership.user) }
-  let(:organization) { create_default(:organization)}
+  let(:organization) { create_default(:organization) }
   let(:membership) { create(:membership) }
   let(:domain) { "foo.bar" }
   let(:tenant_id) { SecureRandom.uuid }

--- a/spec/services/integrations/entra_id/create_service_spec.rb
+++ b/spec/services/integrations/entra_id/create_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Integrations::EntraId::CreateService do
   include_context "with mocked security logger"
 
   let(:service) { described_class.new(membership.user) }
+  let(:organization) { create_default(:organization)}
   let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:domain) { "foo.bar" }
   let(:tenant_id) { SecureRandom.uuid }
   let(:host) { "login.microsoftonline.us" }

--- a/spec/services/integrations/entra_id/destroy_service_spec.rb
+++ b/spec/services/integrations/entra_id/destroy_service_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe Integrations::EntraId::DestroyService do
 
   include_context "with mocked security logger"
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization)}
   let(:integration) { create(:entra_id_integration, organization:) }
 
   describe ".call", :premium do

--- a/spec/services/integrations/entra_id/destroy_service_spec.rb
+++ b/spec/services/integrations/entra_id/destroy_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Integrations::EntraId::DestroyService do
 
   let_it_be(:membership) { create(:membership) }
   let_it_be(:membership) { create(:membership) }
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let(:integration) { create(:entra_id_integration, organization:) }
 
   describe ".call", :premium do

--- a/spec/services/integrations/entra_id/update_service_spec.rb
+++ b/spec/services/integrations/entra_id/update_service_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe Integrations::EntraId::UpdateService do
   include_context "with mocked security logger"
 
   let(:integration) { create(:entra_id_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization)}
-  let_it_be(:membership) { create(:membership) }
   let(:domain) { "foo.bar" }
   let(:tenant_id) { SecureRandom.uuid }
   let(:host) { "login.microsoftonline.us" }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
 
   describe "#call" do
     subject(:service_call) { described_class.call(integration:, params: update_args) }

--- a/spec/services/integrations/entra_id/update_service_spec.rb
+++ b/spec/services/integrations/entra_id/update_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Integrations::EntraId::UpdateService do
   include_context "with mocked security logger"
 
   let(:integration) { create(:entra_id_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
   let(:domain) { "foo.bar" }
   let(:tenant_id) { SecureRandom.uuid }
   let(:host) { "login.microsoftonline.us" }

--- a/spec/services/integrations/hubspot/companies/deploy_properties_service_spec.rb
+++ b/spec/services/integrations/hubspot/companies/deploy_properties_service_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Hubspot::Companies::DeployPropertiesService do
+before_all do
+  create_default(:organization)
+end
+
   subject(:deploy_properties_service) { described_class.new(integration:) }
 
   let(:integration) { create(:hubspot_integration) }

--- a/spec/services/integrations/hubspot/companies/deploy_properties_service_spec.rb
+++ b/spec/services/integrations/hubspot/companies/deploy_properties_service_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Hubspot::Companies::DeployPropertiesService do
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   subject(:deploy_properties_service) { described_class.new(integration:) }
 

--- a/spec/services/integrations/hubspot/contacts/deploy_properties_service_spec.rb
+++ b/spec/services/integrations/hubspot/contacts/deploy_properties_service_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Hubspot::Contacts::DeployPropertiesService do
+before_all do
+  create_default(:organization)
+end
+
   subject(:deploy_properties_service) { described_class.new(integration:) }
 
   let(:integration) { create(:hubspot_integration) }

--- a/spec/services/integrations/hubspot/contacts/deploy_properties_service_spec.rb
+++ b/spec/services/integrations/hubspot/contacts/deploy_properties_service_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Hubspot::Contacts::DeployPropertiesService do
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   subject(:deploy_properties_service) { described_class.new(integration:) }
 

--- a/spec/services/integrations/hubspot/create_service_spec.rb
+++ b/spec/services/integrations/hubspot/create_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Integrations::Hubspot::CreateService do
   include_context "with mocked security logger"
 
-  let(:organization) { create_default(:organization)}
+  let(:organization) { create_default(:organization) }
   let(:membership) { create(:membership) }
 
   describe "#call" do

--- a/spec/services/integrations/hubspot/create_service_spec.rb
+++ b/spec/services/integrations/hubspot/create_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Integrations::Hubspot::CreateService do
   include_context "with mocked security logger"
 
+  let(:organization) { create_default(:organization)}
   let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
 
   describe "#call" do
     subject(:service_call) { described_class.call(params: create_args) }

--- a/spec/services/integrations/hubspot/invoices/deploy_object_service_spec.rb
+++ b/spec/services/integrations/hubspot/invoices/deploy_object_service_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Hubspot::Invoices::DeployObjectService do
+before_all do
+  create_default(:organization)
+end
+
   subject(:deploy_object_service) { described_class.new(integration:) }
 
   let(:integration) { create(:hubspot_integration) }

--- a/spec/services/integrations/hubspot/invoices/deploy_object_service_spec.rb
+++ b/spec/services/integrations/hubspot/invoices/deploy_object_service_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Hubspot::Invoices::DeployObjectService do
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   subject(:deploy_object_service) { described_class.new(integration:) }
 

--- a/spec/services/integrations/hubspot/invoices/deploy_properties_service_spec.rb
+++ b/spec/services/integrations/hubspot/invoices/deploy_properties_service_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Hubspot::Invoices::DeployPropertiesService do
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   subject(:deploy_properties_service) { described_class.new(integration:) }
 

--- a/spec/services/integrations/hubspot/invoices/deploy_properties_service_spec.rb
+++ b/spec/services/integrations/hubspot/invoices/deploy_properties_service_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Hubspot::Invoices::DeployPropertiesService do
+before_all do
+  create_default(:organization)
+end
+
   subject(:deploy_properties_service) { described_class.new(integration:) }
 
   let(:integration) { create(:hubspot_integration) }

--- a/spec/services/integrations/hubspot/save_portal_id_service_spec.rb
+++ b/spec/services/integrations/hubspot/save_portal_id_service_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Hubspot::SavePortalIdService do
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   describe "#call" do
     let(:portal_id) { "123456" }

--- a/spec/services/integrations/hubspot/save_portal_id_service_spec.rb
+++ b/spec/services/integrations/hubspot/save_portal_id_service_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Hubspot::SavePortalIdService do
+before_all do
+  create_default(:organization)
+end
+
   describe "#call" do
     let(:portal_id) { "123456" }
     let(:integration) { create(:hubspot_integration) }

--- a/spec/services/integrations/hubspot/subscriptions/deploy_object_service_spec.rb
+++ b/spec/services/integrations/hubspot/subscriptions/deploy_object_service_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Hubspot::Subscriptions::DeployObjectService do
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   subject(:deploy_object_service) { described_class.new(integration:) }
 

--- a/spec/services/integrations/hubspot/subscriptions/deploy_object_service_spec.rb
+++ b/spec/services/integrations/hubspot/subscriptions/deploy_object_service_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Hubspot::Subscriptions::DeployObjectService do
+before_all do
+  create_default(:organization)
+end
+
   subject(:deploy_object_service) { described_class.new(integration:) }
 
   let(:integration) { create(:hubspot_integration) }

--- a/spec/services/integrations/hubspot/subscriptions/deploy_properties_service_spec.rb
+++ b/spec/services/integrations/hubspot/subscriptions/deploy_properties_service_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Hubspot::Subscriptions::DeployPropertiesService do
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   subject(:deploy_properties_service) { described_class.new(integration:) }
 

--- a/spec/services/integrations/hubspot/subscriptions/deploy_properties_service_spec.rb
+++ b/spec/services/integrations/hubspot/subscriptions/deploy_properties_service_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Hubspot::Subscriptions::DeployPropertiesService do
+before_all do
+  create_default(:organization)
+end
+
   subject(:deploy_properties_service) { described_class.new(integration:) }
 
   let(:integration) { create(:hubspot_integration) }

--- a/spec/services/integrations/hubspot/update_service_spec.rb
+++ b/spec/services/integrations/hubspot/update_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Integrations::Hubspot::UpdateService do
   include_context "with mocked security logger"
 
   let(:integration) { create(:hubspot_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
 
   describe "#call" do
     subject(:service_call) { described_class.call(integration:, params: update_args) }

--- a/spec/services/integrations/hubspot/update_service_spec.rb
+++ b/spec/services/integrations/hubspot/update_service_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Integrations::Hubspot::UpdateService do
   include_context "with mocked security logger"
 
   let(:integration) { create(:hubspot_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization)}
+
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
 
   describe "#call" do

--- a/spec/services/integrations/netsuite/create_service_spec.rb
+++ b/spec/services/integrations/netsuite/create_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Integrations::Netsuite::CreateService do
   include_context "with mocked security logger"
 
+  let(:organization) { create_default(:organization)}
   let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
 
   describe "#call" do
     subject(:service_call) { described_class.call(params: create_args) }

--- a/spec/services/integrations/netsuite/create_service_spec.rb
+++ b/spec/services/integrations/netsuite/create_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Integrations::Netsuite::CreateService do
   include_context "with mocked security logger"
 
-  let(:organization) { create_default(:organization)}
+  let(:organization) { create_default(:organization) }
   let(:membership) { create(:membership) }
 
   describe "#call" do

--- a/spec/services/integrations/netsuite/update_service_spec.rb
+++ b/spec/services/integrations/netsuite/update_service_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Integrations::Netsuite::UpdateService do
   include_context "with mocked security logger"
 
   let(:integration) { create(:netsuite_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization)}
+
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
 
   describe "#call" do

--- a/spec/services/integrations/netsuite/update_service_spec.rb
+++ b/spec/services/integrations/netsuite/update_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Integrations::Netsuite::UpdateService do
   include_context "with mocked security logger"
 
   let(:integration) { create(:netsuite_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
 
   describe "#call" do
     subject(:service_call) { described_class.call(integration:, params: update_args) }

--- a/spec/services/integrations/okta/create_service_spec.rb
+++ b/spec/services/integrations/okta/create_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Integrations::Okta::CreateService do
   include_context "with mocked security logger"
 
   let(:service) { described_class.new(membership.user) }
+  let(:organization) { create_default(:organization)}
   let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:domain) { "foo.bar" }
   let(:host) { "test.com" }
 

--- a/spec/services/integrations/okta/create_service_spec.rb
+++ b/spec/services/integrations/okta/create_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Integrations::Okta::CreateService do
   include_context "with mocked security logger"
 
   let(:service) { described_class.new(membership.user) }
-  let(:organization) { create_default(:organization)}
+  let(:organization) { create_default(:organization) }
   let(:membership) { create(:membership) }
   let(:domain) { "foo.bar" }
   let(:host) { "test.com" }

--- a/spec/services/integrations/okta/destroy_service_spec.rb
+++ b/spec/services/integrations/okta/destroy_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Integrations::Okta::DestroyService do
 
   let_it_be(:membership) { create(:membership) }
   let_it_be(:membership) { create(:membership) }
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let(:integration) { create(:okta_integration, organization:) }
 
   describe ".call", :premium do

--- a/spec/services/integrations/okta/destroy_service_spec.rb
+++ b/spec/services/integrations/okta/destroy_service_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe Integrations::Okta::DestroyService do
 
   include_context "with mocked security logger"
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization)}
   let(:integration) { create(:okta_integration, organization:) }
 
   describe ".call", :premium do

--- a/spec/services/integrations/okta/update_service_spec.rb
+++ b/spec/services/integrations/okta/update_service_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe Integrations::Okta::UpdateService do
   include_context "with mocked security logger"
 
   let(:integration) { create(:okta_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization)}
-  let_it_be(:membership) { create(:membership) }
   let(:domain) { "foo.bar" }
   let(:organization_name) { "Footest" }
   let(:host) { "test.com" }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
 
   describe "#call" do
     subject(:service_call) { described_class.call(integration:, params: update_args) }

--- a/spec/services/integrations/okta/update_service_spec.rb
+++ b/spec/services/integrations/okta/update_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Integrations::Okta::UpdateService do
   include_context "with mocked security logger"
 
   let(:integration) { create(:okta_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
   let(:domain) { "foo.bar" }
   let(:organization_name) { "Footest" }
   let(:host) { "test.com" }

--- a/spec/services/integrations/salesforce/create_service_spec.rb
+++ b/spec/services/integrations/salesforce/create_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Integrations::Salesforce::CreateService do
   include_context "with mocked security logger"
 
+  let(:organization) { create_default(:organization)}
   let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
 
   describe "#call" do
     subject(:service_call) { described_class.call(params: create_args) }

--- a/spec/services/integrations/salesforce/create_service_spec.rb
+++ b/spec/services/integrations/salesforce/create_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Integrations::Salesforce::CreateService do
   include_context "with mocked security logger"
 
-  let(:organization) { create_default(:organization)}
+  let(:organization) { create_default(:organization) }
   let(:membership) { create(:membership) }
 
   describe "#call" do

--- a/spec/services/integrations/salesforce/invoices/sync_service_spec.rb
+++ b/spec/services/integrations/salesforce/invoices/sync_service_spec.rb
@@ -3,6 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Salesforce::Invoices::SyncService do
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
   subject(:sync_service) { described_class.new(invoice) }
 
   describe "#call" do

--- a/spec/services/integrations/salesforce/invoices/sync_service_spec.rb
+++ b/spec/services/integrations/salesforce/invoices/sync_service_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Salesforce::Invoices::SyncService do
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
 
   subject(:sync_service) { described_class.new(invoice) }
 

--- a/spec/services/integrations/salesforce/update_service_spec.rb
+++ b/spec/services/integrations/salesforce/update_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Integrations::Salesforce::UpdateService do
   include_context "with mocked security logger"
 
   let(:integration) { create(:salesforce_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
 
   describe "#call" do
     subject(:service_call) { described_class.call(integration:, params: update_args) }

--- a/spec/services/integrations/salesforce/update_service_spec.rb
+++ b/spec/services/integrations/salesforce/update_service_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Integrations::Salesforce::UpdateService do
   include_context "with mocked security logger"
 
   let(:integration) { create(:salesforce_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization)}
+
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
 
   describe "#call" do

--- a/spec/services/integrations/xero/create_service_spec.rb
+++ b/spec/services/integrations/xero/create_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Integrations::Xero::CreateService do
   include_context "with mocked security logger"
 
   let(:service) { described_class.new(membership.user) }
+  let(:organization) { create_default(:organization)}
   let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
 
   describe "#call" do
     subject(:service_call) { service.call(**create_args) }

--- a/spec/services/integrations/xero/create_service_spec.rb
+++ b/spec/services/integrations/xero/create_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Integrations::Xero::CreateService do
   include_context "with mocked security logger"
 
   let(:service) { described_class.new(membership.user) }
-  let(:organization) { create_default(:organization)}
+  let(:organization) { create_default(:organization) }
   let(:membership) { create(:membership) }
 
   describe "#call" do

--- a/spec/services/integrations/xero/update_service_spec.rb
+++ b/spec/services/integrations/xero/update_service_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Integrations::Xero::UpdateService do
   include_context "with mocked security logger"
 
   let(:integration) { create(:xero_integration, organization:) }
-  let_it_be(:organization) { create_default(:organization)}
+
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
 
   describe "#call" do

--- a/spec/services/integrations/xero/update_service_spec.rb
+++ b/spec/services/integrations/xero/update_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Integrations::Xero::UpdateService do
   include_context "with mocked security logger"
 
   let(:integration) { create(:xero_integration, organization:) }
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
 
   describe "#call" do
     subject(:service_call) { described_class.call(integration:, params: update_args) }

--- a/spec/services/invites/accept_service_spec.rb
+++ b/spec/services/invites/accept_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Invites::AcceptService do
   subject(:accept_service) { described_class.new }
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let(:user) { create(:user) }
   let(:invite) { create(:invite, organization:, email: user.email) }

--- a/spec/services/invites/accept_service_spec.rb
+++ b/spec/services/invites/accept_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Invites::AcceptService do
   subject(:accept_service) { described_class.new }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
   let(:user) { create(:user) }
   let(:invite) { create(:invite, organization:, email: user.email) }
   let(:accept_args) do

--- a/spec/services/invites/create_service_spec.rb
+++ b/spec/services/invites/create_service_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Invites::CreateService do
   include_context "with mocked security logger"
 
   let(:admin_role) { create(:role, :admin) }
-  let_it_be(:organization) { create_default(:organization)}
+
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
 
   before { create(:membership_role, membership:, role: admin_role) }

--- a/spec/services/invites/create_service_spec.rb
+++ b/spec/services/invites/create_service_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Invites::CreateService do
   include_context "with mocked security logger"
 
   let(:admin_role) { create(:role, :admin) }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
 
   before { create(:membership_role, membership:, role: admin_role) }
 
@@ -33,7 +33,7 @@ RSpec.describe Invites::CreateService do
     end
 
     context "when non-admin invites with admin role" do
-      let(:non_admin_membership) { create(:membership, organization:) }
+      let_it_be(:non_admin_membership) { create(:membership, organization:) }
       let(:create_args) do
         {
           email: Faker::Internet.email,

--- a/spec/services/invites/revoke_service_spec.rb
+++ b/spec/services/invites/revoke_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Invites::RevokeService do
   subject(:revoke_service) { described_class.new(invite) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
   let(:invite) { create(:invite, organization:) }
 
   describe "#call" do

--- a/spec/services/invites/revoke_service_spec.rb
+++ b/spec/services/invites/revoke_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Invites::RevokeService do
   subject(:revoke_service) { described_class.new(invite) }
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let(:invite) { create(:invite, organization:) }
 

--- a/spec/services/invites/update_service_spec.rb
+++ b/spec/services/invites/update_service_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Invites::UpdateService do
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:acting_user) { create(:membership, organization:).user }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:acting_user) { create(:membership, organization:).user }
   let(:invite) { create(:invite, organization:) }
   let(:params) { {roles: %w[manager]} }
 

--- a/spec/services/invites/update_service_spec.rb
+++ b/spec/services/invites/update_service_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Invites::UpdateService do
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let_it_be(:acting_user) { create(:membership, organization:).user }
   let(:invite) { create(:invite, organization:) }

--- a/spec/services/invites/validate_service_spec.rb
+++ b/spec/services/invites/validate_service_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Invites::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { BaseService::Result.new }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
   let(:user) { membership.user }
   let(:args) do
     {

--- a/spec/services/invites/validate_service_spec.rb
+++ b/spec/services/invites/validate_service_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe Invites::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { BaseService::Result.new }
-  let_it_be(:organization) { create_default(:organization)}
-  let_it_be(:membership) { create(:membership) }
   let(:user) { membership.user }
   let(:args) do
     {
@@ -15,6 +13,9 @@ RSpec.describe Invites::ValidateService do
       roles: %w[admin]
     }
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
 
   before { create(:role, :admin) }
 

--- a/spec/services/invoice_custom_sections/attach_to_resource_service_spec.rb
+++ b/spec/services/invoice_custom_sections/attach_to_resource_service_spec.rb
@@ -7,22 +7,22 @@ RSpec.describe InvoiceCustomSections::AttachToResourceService do
     subject { service.call }
 
     let(:resource) { create(:subscription) }
+    let(:section_1) { create(:invoice_custom_section, organization:, code: "section_code_1") }
+    let(:section_2) { create(:invoice_custom_section, organization:, code: "section_code_2") }
+    let(:section_3) { create(:invoice_custom_section, organization:, code: "section_code_3") }
+    let(:section_4) { create(:invoice_custom_section, organization:, code: "section_code_4") }
     let(:params) do
       {invoice_custom_section: {}}
     end
 
     let(:service) { described_class.new(resource:, params:) }
-    let_it_be(:organization) { create_default(:organization)}
 
-before_all do
-  create_default(:customer)
-create_default(:plan)
-end
+    let_it_be(:organization) { create_default(:organization) }
 
-    let(:section_1) { create(:invoice_custom_section, organization:, code: "section_code_1") }
-    let(:section_2) { create(:invoice_custom_section, organization:, code: "section_code_2") }
-    let(:section_3) { create(:invoice_custom_section, organization:, code: "section_code_3") }
-    let(:section_4) { create(:invoice_custom_section, organization:, code: "section_code_4") }
+    before_all do
+      create_default(:customer)
+      create_default(:plan)
+    end
 
     before do
       CurrentContext.source = "api"

--- a/spec/services/invoice_custom_sections/attach_to_resource_service_spec.rb
+++ b/spec/services/invoice_custom_sections/attach_to_resource_service_spec.rb
@@ -12,7 +12,13 @@ RSpec.describe InvoiceCustomSections::AttachToResourceService do
     end
 
     let(:service) { described_class.new(resource:, params:) }
-    let(:organization) { resource.organization }
+    let_it_be(:organization) { create_default(:organization)}
+
+before_all do
+  create_default(:customer)
+create_default(:plan)
+end
+
     let(:section_1) { create(:invoice_custom_section, organization:, code: "section_code_1") }
     let(:section_2) { create(:invoice_custom_section, organization:, code: "section_code_2") }
     let(:section_3) { create(:invoice_custom_section, organization:, code: "section_code_3") }

--- a/spec/services/invoice_custom_sections/create_service_spec.rb
+++ b/spec/services/invoice_custom_sections/create_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe InvoiceCustomSections::CreateService do
   describe "#call" do
     subject(:service_result) { described_class.call(organization:, create_params:) }
 
-    let(:organization) { create(:organization) }
+    let_it_be(:organization) { create(:organization) }
     let(:create_params) { nil }
 
     context "with valid params" do

--- a/spec/services/invoice_custom_sections/deselect_all_service_spec.rb
+++ b/spec/services/invoice_custom_sections/deselect_all_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe InvoiceCustomSections::DeselectAllService do
   describe "#call" do
     subject(:service_result) { described_class.call(section:) }
 
-    let(:customer) { create(:customer) }
-    let(:organization) { customer.organization }
+    let_it_be(:organization) { create_default(:organization)}
+    let_it_be(:customer) { create(:customer) }
     let(:billing_entity) { customer.billing_entity }
     let(:section) { create(:invoice_custom_section, organization:) }
 

--- a/spec/services/invoice_custom_sections/deselect_all_service_spec.rb
+++ b/spec/services/invoice_custom_sections/deselect_all_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe InvoiceCustomSections::DeselectAllService do
   describe "#call" do
     subject(:service_result) { described_class.call(section:) }
 
-    let_it_be(:organization) { create_default(:organization)}
+    let_it_be(:organization) { create_default(:organization) }
     let_it_be(:customer) { create(:customer) }
     let(:billing_entity) { customer.billing_entity }
     let(:section) { create(:invoice_custom_section, organization:) }

--- a/spec/services/invoice_custom_sections/update_service_spec.rb
+++ b/spec/services/invoice_custom_sections/update_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe InvoiceCustomSections::UpdateService do
   subject(:service_result) { described_class.call(invoice_custom_section:, update_params:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:invoice_custom_section) { create(:invoice_custom_section, organization:) }
   let(:update_params) { nil }
 

--- a/spec/services/invoice_settlements/create_service_spec.rb
+++ b/spec/services/invoice_settlements/create_service_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe InvoiceSettlements::CreateService do
     )
   end
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:invoice) do
     create(
       :invoice,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,6 +76,10 @@ Sentry.init do |config|
   config.transport.transport_class = Sentry::DummyTransport
 end
 
+require "test_prof/recipes/rspec/sample"
+require "test_prof/recipes/rspec/let_it_be"
+require "test_prof/recipes/rspec/factory_default"
+
 RSpec.configure do |config|
   config.include ActiveJob::TestHelper
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
## Context

Currently, around **50% of the spec runtime** is spent preparing data and creating factories. A lot of this data is either duplicated or recreates the same objects multiple times, so we can get rid of a good chunk of it and significantly speed up the specs.

To avoid creating unnecessary factories, we can use `let_it_be`, `before_all`, and `create_default` from `test-prof`. More info [here](https://test-prof.evilmartians.io/guide/recipes/let_it_be).

## Description

This PR cleans up the services specs in folders `f-j` and removes unnecessary factory usage.

Here are the numbers before and after the cleanup. The times below are for running the specs in a single process:

| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 97,841 | 63,994 |
| Time spent creating factories |  11:51.790 | 07:40.512 |
| Total time | 18:00.870 | 14:22.880 |

## Overall results

This PR is part of a series of PRs focused on cleaning up factory usage across different specs.

Once all the changes are merged, we expect to:

- Reduce the number of factories by **~50k**
- Cut spec runtime by around **20%**
- Shave off roughly **1:15 min** from the CI runtime


| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 157,949 | 103,761 |
| Total time spent creating factories | 17:59.851  | 11:14.739 |
| Total time | 34:41.482 | 27:03.658 |

Here is [the CI run](https://github.com/getlago/lago-api/actions/runs/33399605547/job/99512391170?pr=6255) with all the changes merged together: