### PR TITLE
perf(specs): Clean up factories usage in spec/specs in directories k-o

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -167,6 +167,8 @@ group :test do
   # HTML testing (invoice rendering)
   gem "rspec-snapshot", "~> 2.0"
   gem "htmlbeautifier", "~> 1.4"
+
+  gem "test-prof", "~> 1.0"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1004,6 +1004,8 @@ GEM
     temple (0.10.4)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
+    test-prof (1.6.3)
+      logger
     thor (1.5.0)
     throttling (0.4.1)
       logger
@@ -1181,6 +1183,7 @@ DEPENDENCIES
   stripe
   strong_migrations
   super_diff (~> 0.19.0)
+  test-prof (~> 1.0)
   throttling
   timecop
   tzinfo-data

--- a/spec/services/lifetime_usages/calculate_service_spec.rb
+++ b/spec/services/lifetime_usages/calculate_service_spec.rb
@@ -6,17 +6,6 @@ RSpec.describe LifetimeUsages::CalculateService do
   subject(:service) { described_class.new(lifetime_usage: lifetime_usage) }
 
   let(:lifetime_usage) { create(:lifetime_usage, organization:, subscription:, recalculate_current_usage:, recalculate_invoiced_usage:) }
-  let(:recalculate_current_usage) { false }
-  let(:recalculate_invoiced_usage) { false }
-  let(:subscription) { create(:subscription, customer:, subscription_at:) }
-  let_it_be(:organization) { create_default(:organization)}
-  let_it_be(:billable_metric) { create(:billable_metric, organization:, aggregation_type: "count_agg") }
-  let_it_be(:customer) { create_default(:customer) }
-
-before_all do
-  create_default(:plan)
-end
-
   let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric:, properties: {amount: "10"}) }
   let(:timestamp) { Time.current }
   let(:subscription_at) { timestamp - 6.months }
@@ -32,7 +21,6 @@ end
       precise_coupons_amount_cents: 50
     )
   end
-
   let(:events) do
     create_list(
       :event,
@@ -43,6 +31,17 @@ end
       code: billable_metric.code,
       timestamp:
     )
+  end
+  let(:recalculate_current_usage) { false }
+  let(:recalculate_invoiced_usage) { false }
+  let(:subscription) { create(:subscription, customer:, subscription_at:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:, aggregation_type: "count_agg") }
+  let_it_be(:customer) { create_default(:customer) }
+
+  before_all do
+    create_default(:plan)
   end
 
   describe "#recalculate_invoiced_usage" do

--- a/spec/services/lifetime_usages/calculate_service_spec.rb
+++ b/spec/services/lifetime_usages/calculate_service_spec.rb
@@ -9,10 +9,14 @@ RSpec.describe LifetimeUsages::CalculateService do
   let(:recalculate_current_usage) { false }
   let(:recalculate_invoiced_usage) { false }
   let(:subscription) { create(:subscription, customer:, subscription_at:) }
-  let(:organization) { customer.organization }
-  let(:customer) { create(:customer) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:billable_metric) { create(:billable_metric, organization:, aggregation_type: "count_agg") }
+  let_it_be(:customer) { create_default(:customer) }
 
-  let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: "count_agg") }
+before_all do
+  create_default(:plan)
+end
+
   let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric:, properties: {amount: "10"}) }
   let(:timestamp) { Time.current }
   let(:subscription_at) { timestamp - 6.months }

--- a/spec/services/lifetime_usages/check_thresholds_service_spec.rb
+++ b/spec/services/lifetime_usages/check_thresholds_service_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe LifetimeUsages::CheckThresholdsService, transaction: false do
   let(:lifetime_usage) { create(:lifetime_usage, subscription:, recalculate_current_usage: true, recalculate_invoiced_usage: true, current_usage_amount_cents:) }
   let(:current_usage_amount_cents) { 0 }
   let(:subscription) { create(:subscription, customer_id: customer.id) }
-  let(:organization) { subscription.organization }
-  let(:customer) { create(:customer) }
+  let(:organization) { create_default(:organization)}
+  let(:customer) { create_default(:customer) }
+  let(:billable_metric) { create_default(:billable_metric, aggregation_type: "count_agg") }
 
-  let(:billable_metric) { create(:billable_metric, aggregation_type: "count_agg") }
   let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric:, properties: {amount: "10"}) }
   let(:timestamp) { Time.current }
 

--- a/spec/services/lifetime_usages/check_thresholds_service_spec.rb
+++ b/spec/services/lifetime_usages/check_thresholds_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe LifetimeUsages::CheckThresholdsService, transaction: false do
   let(:lifetime_usage) { create(:lifetime_usage, subscription:, recalculate_current_usage: true, recalculate_invoiced_usage: true, current_usage_amount_cents:) }
   let(:current_usage_amount_cents) { 0 }
   let(:subscription) { create(:subscription, customer_id: customer.id) }
-  let(:organization) { create_default(:organization)}
+  let(:organization) { create_default(:organization) }
   let(:customer) { create_default(:customer) }
   let(:billable_metric) { create_default(:billable_metric, aggregation_type: "count_agg") }
 

--- a/spec/services/lifetime_usages/find_last_and_next_thresholds_service_spec.rb
+++ b/spec/services/lifetime_usages/find_last_and_next_thresholds_service_spec.rb
@@ -8,9 +8,8 @@ RSpec.describe LifetimeUsages::FindLastAndNextThresholdsService do
   let(:lifetime_usage) { create(:lifetime_usage, subscription:, organization:, current_usage_amount_cents:) }
   let(:current_usage_amount_cents) { 0 }
 
+  let_it_be(:organization) { create_default(:organization)}
   let(:plan) { create(:plan) }
-  let(:organization) { plan.organization }
-
   let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, plan:, customer:) }
 

--- a/spec/services/lifetime_usages/find_last_and_next_thresholds_service_spec.rb
+++ b/spec/services/lifetime_usages/find_last_and_next_thresholds_service_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe LifetimeUsages::FindLastAndNextThresholdsService do
   subject(:lifetime_usage_result) { described_class.call(lifetime_usage:) }
 
   let(:lifetime_usage) { create(:lifetime_usage, subscription:, organization:, current_usage_amount_cents:) }
-  let(:current_usage_amount_cents) { 0 }
-
-  let_it_be(:organization) { create_default(:organization)}
   let(:plan) { create(:plan) }
   let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, plan:, customer:) }
+  let(:current_usage_amount_cents) { 0 }
+
+  let_it_be(:organization) { create_default(:organization) }
 
   it "computes the amounts" do
     expect(lifetime_usage_result.last_threshold_amount_cents).to be_nil

--- a/spec/services/lifetime_usages/flag_refresh_from_invoice_service_spec.rb
+++ b/spec/services/lifetime_usages/flag_refresh_from_invoice_service_spec.rb
@@ -8,8 +8,12 @@ RSpec.describe LifetimeUsages::FlagRefreshFromInvoiceService, :premium do
   let(:invoice) { create(:invoice, :subscription, subscriptions:, organization: customer.organization) }
   let(:lifetime_usage) { create(:lifetime_usage, subscription: invoice.subscriptions.first) }
 
-  let(:customer) { create(:customer) }
-  let(:plan) { create(:plan, organization: customer.organization) }
+before_all do
+  create_default(:organization)
+end
+
+  let_it_be(:customer) { create_default(:customer) }
+  let_it_be(:plan) { create_default(:plan, organization: customer.organization) }
   let(:subscriptions) { create_list(:subscription, 1, plan:) }
 
   let(:usage_threshold) { create(:usage_threshold, plan:) }

--- a/spec/services/lifetime_usages/flag_refresh_from_invoice_service_spec.rb
+++ b/spec/services/lifetime_usages/flag_refresh_from_invoice_service_spec.rb
@@ -6,17 +6,16 @@ RSpec.describe LifetimeUsages::FlagRefreshFromInvoiceService, :premium do
   subject(:flag_service) { described_class.new(invoice:) }
 
   let(:invoice) { create(:invoice, :subscription, subscriptions:, organization: customer.organization) }
+  let(:subscriptions) { create_list(:subscription, 1, plan:) }
+  let(:usage_threshold) { create(:usage_threshold, plan:) }
   let(:lifetime_usage) { create(:lifetime_usage, subscription: invoice.subscriptions.first) }
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let_it_be(:customer) { create_default(:customer) }
   let_it_be(:plan) { create_default(:plan, organization: customer.organization) }
-  let(:subscriptions) { create_list(:subscription, 1, plan:) }
-
-  let(:usage_threshold) { create(:usage_threshold, plan:) }
 
   before do
     usage_threshold

--- a/spec/services/lifetime_usages/flag_refresh_from_plan_update_service_spec.rb
+++ b/spec/services/lifetime_usages/flag_refresh_from_plan_update_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe LifetimeUsages::FlagRefreshFromPlanUpdateService do
   subject { described_class.call(plan:) }
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let_it_be(:plan) { create(:plan) }
   let(:result) { subject }

--- a/spec/services/lifetime_usages/flag_refresh_from_plan_update_service_spec.rb
+++ b/spec/services/lifetime_usages/flag_refresh_from_plan_update_service_spec.rb
@@ -5,7 +5,11 @@ require "rails_helper"
 RSpec.describe LifetimeUsages::FlagRefreshFromPlanUpdateService do
   subject { described_class.call(plan:) }
 
-  let(:plan) { create(:plan) }
+before_all do
+  create_default(:organization)
+end
+
+  let_it_be(:plan) { create(:plan) }
   let(:result) { subject }
 
   describe "#call" do

--- a/spec/services/lifetime_usages/update_service_spec.rb
+++ b/spec/services/lifetime_usages/update_service_spec.rb
@@ -5,11 +5,11 @@ require "rails_helper"
 RSpec.describe LifetimeUsages::UpdateService do
   subject(:update_service) { described_class.new(lifetime_usage:, params:) }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-create_default(:plan)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+  end
 
   let(:lifetime_usage) { create(:lifetime_usage) }
   let(:params) do

--- a/spec/services/lifetime_usages/update_service_spec.rb
+++ b/spec/services/lifetime_usages/update_service_spec.rb
@@ -5,6 +5,12 @@ require "rails_helper"
 RSpec.describe LifetimeUsages::UpdateService do
   subject(:update_service) { described_class.new(lifetime_usage:, params:) }
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+create_default(:plan)
+end
+
   let(:lifetime_usage) { create(:lifetime_usage) }
   let(:params) do
     {

--- a/spec/services/lifetime_usages/usage_thresholds/check_service_spec.rb
+++ b/spec/services/lifetime_usages/usage_thresholds/check_service_spec.rb
@@ -6,18 +6,18 @@ RSpec.describe LifetimeUsages::UsageThresholds::CheckService do
   subject(:service) { described_class.new(lifetime_usage:, progressive_billed_amount:) }
 
   let(:lifetime_usage) { create(:lifetime_usage, subscription:, historical_usage_amount_cents:, recalculate_current_usage:, recalculate_invoiced_usage:) }
+  let(:historical_usage_amount_cents) { 0 }
   let(:progressive_billed_amount) { 0 }
   let(:recalculate_current_usage) { true }
   let(:recalculate_invoiced_usage) { true }
   let(:subscription) { create(:subscription, customer_id: customer.id) }
-  let_it_be(:organization) { create_default(:organization)}
+
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:customer) { create_default(:customer) }
 
-before_all do
-  create_default(:plan)
-end
-
-  let(:historical_usage_amount_cents) { 0 }
+  before_all do
+    create_default(:plan)
+  end
 
   def create_thresholds(subscription, amounts:, attach_to:, recurring: nil)
     model = if attach_to == :subscription

--- a/spec/services/lifetime_usages/usage_thresholds/check_service_spec.rb
+++ b/spec/services/lifetime_usages/usage_thresholds/check_service_spec.rb
@@ -10,8 +10,13 @@ RSpec.describe LifetimeUsages::UsageThresholds::CheckService do
   let(:recalculate_current_usage) { true }
   let(:recalculate_invoiced_usage) { true }
   let(:subscription) { create(:subscription, customer_id: customer.id) }
-  let(:organization) { subscription.organization }
-  let(:customer) { create(:customer) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:customer) { create_default(:customer) }
+
+before_all do
+  create_default(:plan)
+end
+
   let(:historical_usage_amount_cents) { 0 }
 
   def create_thresholds(subscription, amounts:, attach_to:, recurring: nil)

--- a/spec/services/lifetime_usages/usage_thresholds_completion_service_spec.rb
+++ b/spec/services/lifetime_usages/usage_thresholds_completion_service_spec.rb
@@ -8,9 +8,8 @@ RSpec.describe LifetimeUsages::UsageThresholdsCompletionService do
   let(:lifetime_usage) { create(:lifetime_usage, subscription:, organization:, current_usage_amount_cents:) }
   let(:current_usage_amount_cents) { 0 }
 
+  let_it_be(:organization) { create_default(:organization)}
   let(:plan) { create(:plan) }
-  let(:organization) { plan.organization }
-
   let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, plan:, customer:) }
 

--- a/spec/services/lifetime_usages/usage_thresholds_completion_service_spec.rb
+++ b/spec/services/lifetime_usages/usage_thresholds_completion_service_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe LifetimeUsages::UsageThresholdsCompletionService do
   subject(:result) { described_class.call(lifetime_usage:) }
 
   let(:lifetime_usage) { create(:lifetime_usage, subscription:, organization:, current_usage_amount_cents:) }
-  let(:current_usage_amount_cents) { 0 }
-
-  let_it_be(:organization) { create_default(:organization)}
   let(:plan) { create(:plan) }
   let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, plan:, customer:) }
+  let(:current_usage_amount_cents) { 0 }
+
+  let_it_be(:organization) { create_default(:organization) }
 
   def create_threshold(attached_to:, **factory_args)
     if attached_to == :subscription

--- a/spec/services/memberships/create_service_spec.rb
+++ b/spec/services/memberships/create_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Memberships::CreateService do
   subject(:create_service) { described_class.new(user:, organization:) }
 
   let(:user) { create(:user) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
 
   describe "#call" do
     it "creates a membership" do

--- a/spec/services/memberships/create_service_spec.rb
+++ b/spec/services/memberships/create_service_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Memberships::CreateService do
   subject(:create_service) { described_class.new(user:, organization:) }
 
   let(:user) { create(:user) }
+
   let_it_be(:organization) { create(:organization) }
 
   describe "#call" do

--- a/spec/services/memberships/revoke_service_spec.rb
+++ b/spec/services/memberships/revoke_service_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe Memberships::RevokeService do
 
   let_it_be(:organization) { create(:organization) }
   let(:admin_role) { create(:role, :admin) }
+  let(:other_membership) { create(:membership, user:, organization:) }
   let(:finance_role) { create(:role, :finance) }
 
   let_it_be(:user) { create(:user) }
   let_it_be(:membership) { create(:membership, organization:) }
-  let(:other_membership) { create(:membership, user:, organization:) }
 
   describe "#call" do
     context "when revoking my own membership" do

--- a/spec/services/memberships/revoke_service_spec.rb
+++ b/spec/services/memberships/revoke_service_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe Memberships::RevokeService do
 
   include_context "with mocked security logger"
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:admin_role) { create(:role, :admin) }
   let(:finance_role) { create(:role, :finance) }
 
-  let(:user) { create(:user) }
-  let(:membership) { create(:membership, organization:) }
+  let_it_be(:user) { create(:user) }
+  let_it_be(:membership) { create(:membership, organization:) }
   let(:other_membership) { create(:membership, user:, organization:) }
 
   describe "#call" do

--- a/spec/services/memberships/update_service_spec.rb
+++ b/spec/services/memberships/update_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Memberships::UpdateService do
   include_context "with mocked security logger"
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:acting_user) { create(:membership, organization:).user }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:acting_user) { create(:membership, organization:).user }
   let(:admin_role) { create(:role, :admin) }
   let!(:manager_role) { create(:role, :manager) }
   let(:params) { {roles: %w[manager]} }
@@ -33,7 +33,7 @@ RSpec.describe Memberships::UpdateService do
     end
 
     context "when admin grants admin role to another member" do
-      let(:acting_membership) { create(:membership, organization:) }
+      let_it_be(:acting_membership) { create(:membership, organization:) }
       let(:acting_user) { acting_membership.user }
       let(:params) { {roles: %w[admin]} }
 

--- a/spec/services/memberships/update_service_spec.rb
+++ b/spec/services/memberships/update_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Memberships::UpdateService do
   include_context "with mocked security logger"
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let_it_be(:acting_user) { create(:membership, organization:).user }
   let(:admin_role) { create(:role, :admin) }

--- a/spec/services/metadata/delete_item_key_service_spec.rb
+++ b/spec/services/metadata/delete_item_key_service_spec.rb
@@ -5,7 +5,12 @@ require "rails_helper"
 RSpec.describe Metadata::DeleteItemKeyService do
   subject(:service) { described_class.new(item:, key:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
+
+before_all do
+  create_default(:customer)
+end
+
   let(:owner) { create(:credit_note, organization:) }
   let(:item) { create(:item_metadata, owner:, organization:, value:) }
   let(:value) { {"foo" => "bar", "baz" => "qux"} }

--- a/spec/services/metadata/delete_item_key_service_spec.rb
+++ b/spec/services/metadata/delete_item_key_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Metadata::DeleteItemKeyService do
 
   let_it_be(:organization) { create_default(:organization) }
 
-before_all do
-  create_default(:customer)
-end
+  before_all do
+    create_default(:customer)
+  end
 
   let(:owner) { create(:credit_note, organization:) }
   let(:item) { create(:item_metadata, owner:, organization:, value:) }

--- a/spec/services/metadata/update_item_service_spec.rb
+++ b/spec/services/metadata/update_item_service_spec.rb
@@ -5,7 +5,12 @@ require "rails_helper"
 RSpec.describe Metadata::UpdateItemService do
   subject(:service) { described_class.new(owner:, value:, partial:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
+
+before_all do
+  create_default(:customer)
+end
+
   let(:owner) { create(:credit_note, organization:) }
   let(:value) { nil }
   let(:partial) { false }

--- a/spec/services/metadata/update_item_service_spec.rb
+++ b/spec/services/metadata/update_item_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Metadata::UpdateItemService do
 
   let_it_be(:organization) { create_default(:organization) }
 
-before_all do
-  create_default(:customer)
-end
+  before_all do
+    create_default(:customer)
+  end
 
   let(:owner) { create(:credit_note, organization:) }
   let(:value) { nil }

--- a/spec/services/middlewares/activity_log_middleware_spec.rb
+++ b/spec/services/middlewares/activity_log_middleware_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe Middlewares::ActivityLogMiddleware do
     end
   end
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+create_default(:plan)
+end
+
+
   let(:subscription) { create(:subscription, name: "My Subscription") }
   let(:activity_loggable_after_commit) { false }
 

--- a/spec/services/middlewares/activity_log_middleware_spec.rb
+++ b/spec/services/middlewares/activity_log_middleware_spec.rb
@@ -26,16 +26,14 @@ RSpec.describe Middlewares::ActivityLogMiddleware do
       attr_reader :subscription
     end
   end
-
-before_all do
-  create_default(:organization)
-create_default(:customer)
-create_default(:plan)
-end
-
-
   let(:subscription) { create(:subscription, name: "My Subscription") }
   let(:activity_loggable_after_commit) { false }
+
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+  end
 
   def test_service_with_activity_loggable(after_commit:, action_match_updated: false)
     expect(service_class).to use_middleware(described_class)

--- a/spec/services/multi_customer_connections/backfill_connections_service_spec.rb
+++ b/spec/services/multi_customer_connections/backfill_connections_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe MultiCustomerConnections::BackfillConnectionsService do
   subject(:result) { described_class.call(organization:, dry_run:, batch_size: 1000) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:dry_run) { false }
 
   describe "#call" do

--- a/spec/services/order_forms/create_service_spec.rb
+++ b/spec/services/order_forms/create_service_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe OrderForms::CreateService do
 
   let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
 
-before_all do
-  create_default(:customer)
-create_default(:plan)
-end
+  before_all do
+    create_default(:customer)
+    create_default(:plan)
+  end
 
   let(:quote) { create(:quote, organization:) }
   let(:quote_version) { create(:quote_version, :approved, quote:, organization:) }

--- a/spec/services/order_forms/create_service_spec.rb
+++ b/spec/services/order_forms/create_service_spec.rb
@@ -5,7 +5,13 @@ require "rails_helper"
 RSpec.describe OrderForms::CreateService do
   subject(:create_service) { described_class.new(quote_version:) }
 
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
+
+before_all do
+  create_default(:customer)
+create_default(:plan)
+end
+
   let(:quote) { create(:quote, organization:) }
   let(:quote_version) { create(:quote_version, :approved, quote:, organization:) }
 

--- a/spec/services/order_forms/expire_service_spec.rb
+++ b/spec/services/order_forms/expire_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe OrderForms::ExpireService do
   subject(:service) { described_class.new(order_form:) }
 
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+      let_it_be(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:quote_version) { create(:quote_version, :approved, organization:, quote:) }
   let(:order_form) { create(:order_form, :expired_yesterday, customer:, organization:, quote_version:) }
@@ -23,6 +23,7 @@ RSpec.describe OrderForms::ExpireService do
     end
 
     context "when the order_forms feature flag is disabled", :premium do
+      let(:customer) { create(:customer, organization:) }
       let(:organization) { create(:organization) }
 
       it "returns a forbidden failure" do

--- a/spec/services/order_forms/expire_service_spec.rb
+++ b/spec/services/order_forms/expire_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe OrderForms::ExpireService do
   subject(:service) { described_class.new(order_form:) }
 
   let_it_be(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-      let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:quote_version) { create(:quote_version, :approved, organization:, quote:) }
   let(:order_form) { create(:order_form, :expired_yesterday, customer:, organization:, quote_version:) }

--- a/spec/services/order_forms/mark_as_signed_service_spec.rb
+++ b/spec/services/order_forms/mark_as_signed_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe OrderForms::MarkAsSignedService do
   subject(:service) { described_class.new(order_form:, signed_document:, execution_mode:, execute_at:) }
 
   let_it_be(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-        let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, customer:, organization:, order_type: :subscription_creation) }
   let(:order_form) { create(:order_form, customer:, organization:, quote:) }
   let(:signed_document) { nil }

--- a/spec/services/order_forms/mark_as_signed_service_spec.rb
+++ b/spec/services/order_forms/mark_as_signed_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe OrderForms::MarkAsSignedService do
   subject(:service) { described_class.new(order_form:, signed_document:, execution_mode:, execute_at:) }
 
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+        let_it_be(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, customer:, organization:, order_type: :subscription_creation) }
   let(:order_form) { create(:order_form, customer:, organization:, quote:) }
   let(:signed_document) { nil }
@@ -38,6 +38,7 @@ RSpec.describe OrderForms::MarkAsSignedService do
       end
 
       context "when the order_forms feature flag is disabled" do
+        let(:customer) { create(:customer, organization:) }
         let(:organization) { create(:organization) }
 
         it "returns a forbidden failure" do

--- a/spec/services/order_forms/void_service_spec.rb
+++ b/spec/services/order_forms/void_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe OrderForms::VoidService do
   subject(:service) { described_class.new(order_form:) }
 
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:quote_version) { create(:quote_version, :approved, organization:, quote:) }
   let(:order_form) { create(:order_form, customer:, organization:, quote_version:) }

--- a/spec/services/orders/execute_service_spec.rb
+++ b/spec/services/orders/execute_service_spec.rb
@@ -5,8 +5,13 @@ require "rails_helper"
 RSpec.describe Orders::ExecuteService do
   subject(:execute_service) { described_class.new(order:) }
 
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
+        let_it_be(:customer) { create(:customer, organization:) }
+
+before_all do
+  create_default(:plan)
+end
+
   let(:quote) { create(:quote, organization:, customer:, order_type:) }
   let(:quote_version) { create(:quote_version, :approved, quote:, organization:) }
   let(:order_form) { create(:order_form, :signed, organization:, customer:, quote_version:) }
@@ -38,6 +43,7 @@ RSpec.describe Orders::ExecuteService do
       end
 
       context "when the order_forms feature flag is disabled" do
+        let(:customer) { create(:customer, organization:) }
         let(:organization) { create(:organization) }
 
         it "returns a forbidden failure" do

--- a/spec/services/orders/execute_service_spec.rb
+++ b/spec/services/orders/execute_service_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Orders::ExecuteService do
   subject(:execute_service) { described_class.new(order:) }
 
   let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
-        let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
-before_all do
-  create_default(:plan)
-end
+  before_all do
+    create_default(:plan)
+  end
 
   let(:quote) { create(:quote, organization:, customer:, order_type:) }
   let(:quote_version) { create(:quote_version, :approved, quote:, organization:) }

--- a/spec/services/orders/one_off/execute_service_spec.rb
+++ b/spec/services/orders/one_off/execute_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe Orders::OneOff::ExecuteService do
   subject(:execute_service) { described_class.new(order:) }
 
-  let(:organization) { create(:organization) }
-  let(:billing_entity) { create(:billing_entity, organization:) }
-  let(:customer) { create(:customer, organization:, billing_entity:, currency: "EUR") }
-  let(:add_on) { create(:add_on, organization:, amount_cents: 10_000) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:billing_entity) { create(:billing_entity, organization:) }
+  let_it_be(:customer) { create(:customer, organization:, billing_entity:, currency: "EUR") }
+  let_it_be(:add_on) { create(:add_on, organization:, amount_cents: 10_000) }
   let(:add_on_item) do
     {
       "id" => add_on.id,

--- a/spec/services/orders/subscription_amendment/execute_service_spec.rb
+++ b/spec/services/orders/subscription_amendment/execute_service_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe Orders::SubscriptionAmendment::ExecuteService, :premium do
   subject(:execute_service) { described_class.new(order:) }
 
   let_it_be(:organization) { create(:organization) }
-        let_it_be(:billing_entity) { create(:billing_entity, organization:) }
-        let_it_be(:customer) { create(:customer, organization:, billing_entity:, currency: "EUR") }
+  let_it_be(:billing_entity) { create(:billing_entity, organization:) }
+  let_it_be(:customer) { create(:customer, organization:, billing_entity:, currency: "EUR") }
 
-        let_it_be(:target_plan) { create(:plan, organization:, amount_currency: "EUR", amount_cents: 50_000) }
+  let_it_be(:target_plan) { create(:plan, organization:, amount_currency: "EUR", amount_cents: 50_000) }
   let(:target_subscription) do
     create(
       :subscription,
@@ -26,11 +26,7 @@ RSpec.describe Orders::SubscriptionAmendment::ExecuteService, :premium do
       ending_at: 5.months.from_now
     )
   end
-
-        let_it_be(:plan) { create(:plan, organization:, amount_currency: "EUR", amount_cents: 100_000) }
-        let_it_be(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
   let(:charge) { create(:standard_charge, plan:, billable_metric:, properties: {"amount" => "50"}) }
-
   let(:plan_item) do
     {
       "id" => plan.id,
@@ -66,7 +62,6 @@ RSpec.describe Orders::SubscriptionAmendment::ExecuteService, :premium do
       ]
     }
   end
-
   let(:billing_items) { {"plans" => [plan_item]} }
   let(:quote) do
     create(
@@ -90,6 +85,9 @@ RSpec.describe Orders::SubscriptionAmendment::ExecuteService, :premium do
   let(:order_form) { create(:order_form, :signed, organization:, customer:, quote_version:) }
   let(:order) { create(:order, organization:, customer:, order_form:, execution_mode:) }
   let(:execution_mode) { :execute_in_lago }
+
+  let_it_be(:plan) { create(:plan, organization:, amount_currency: "EUR", amount_cents: 100_000) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
 
   # Records are resolved by id only outside api context, and CurrentContext leaks across spec
   # files (no global reset), so pin it. The order is built up front so the target subscription

--- a/spec/services/orders/subscription_amendment/execute_service_spec.rb
+++ b/spec/services/orders/subscription_amendment/execute_service_spec.rb
@@ -7,11 +7,11 @@ require "rails_helper"
 RSpec.describe Orders::SubscriptionAmendment::ExecuteService, :premium do
   subject(:execute_service) { described_class.new(order:) }
 
-  let(:organization) { create(:organization) }
-  let(:billing_entity) { create(:billing_entity, organization:) }
-  let(:customer) { create(:customer, organization:, billing_entity:, currency: "EUR") }
+  let_it_be(:organization) { create(:organization) }
+        let_it_be(:billing_entity) { create(:billing_entity, organization:) }
+        let_it_be(:customer) { create(:customer, organization:, billing_entity:, currency: "EUR") }
 
-  let(:target_plan) { create(:plan, organization:, amount_currency: "EUR", amount_cents: 50_000) }
+        let_it_be(:target_plan) { create(:plan, organization:, amount_currency: "EUR", amount_cents: 50_000) }
   let(:target_subscription) do
     create(
       :subscription,
@@ -27,8 +27,8 @@ RSpec.describe Orders::SubscriptionAmendment::ExecuteService, :premium do
     )
   end
 
-  let(:plan) { create(:plan, organization:, amount_currency: "EUR", amount_cents: 100_000) }
-  let(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
+        let_it_be(:plan) { create(:plan, organization:, amount_currency: "EUR", amount_cents: 100_000) }
+        let_it_be(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
   let(:charge) { create(:standard_charge, plan:, billable_metric:, properties: {"amount" => "50"}) }
 
   let(:plan_item) do
@@ -254,6 +254,11 @@ RSpec.describe Orders::SubscriptionAmendment::ExecuteService, :premium do
       end
 
       context "with usage thresholds" do
+        let(:plan) { create(:plan, organization:, amount_currency: "EUR", amount_cents: 100_000) }
+        let(:target_plan) { create(:plan, organization:, amount_currency: "EUR", amount_cents: 50_000) }
+        let(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
+        let(:billing_entity) { create(:billing_entity, organization:) }
+        let(:customer) { create(:customer, organization:, billing_entity:, currency: "EUR") }
         let(:organization) { create(:organization, premium_integrations: ["progressive_billing"]) }
         let(:plan_overrides) do
           super().merge(

--- a/spec/services/orders/subscription_creation/execute_service_spec.rb
+++ b/spec/services/orders/subscription_creation/execute_service_spec.rb
@@ -7,11 +7,11 @@ require "rails_helper"
 RSpec.describe Orders::SubscriptionCreation::ExecuteService, :premium do
   subject(:execute_service) { described_class.new(order:) }
 
-  let(:organization) { create(:organization) }
-  let(:billing_entity) { create(:billing_entity, organization:) }
-  let(:customer) { create(:customer, organization:, billing_entity:, currency: "EUR") }
-  let(:plan) { create(:plan, organization:, amount_currency: "EUR", amount_cents: 100_000) }
-  let(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
+  let_it_be(:organization) { create(:organization) }
+        let_it_be(:billing_entity) { create(:billing_entity, organization:) }
+        let_it_be(:customer) { create(:customer, organization:, billing_entity:, currency: "EUR") }
+        let_it_be(:plan) { create(:plan, organization:, amount_currency: "EUR", amount_cents: 100_000) }
+        let_it_be(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
   let(:charge) { create(:standard_charge, plan:, billable_metric:, properties: {"amount" => "50"}) }
 
   let(:plan_item) do
@@ -269,6 +269,10 @@ RSpec.describe Orders::SubscriptionCreation::ExecuteService, :premium do
       end
 
       context "with usage thresholds" do
+        let(:plan) { create(:plan, organization:, amount_currency: "EUR", amount_cents: 100_000) }
+        let(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
+        let(:billing_entity) { create(:billing_entity, organization:) }
+        let(:customer) { create(:customer, organization:, billing_entity:, currency: "EUR") }
         let(:organization) { create(:organization, premium_integrations: ["progressive_billing"]) }
         let(:plan_overrides) do
           super().merge(

--- a/spec/services/orders/subscription_creation/execute_service_spec.rb
+++ b/spec/services/orders/subscription_creation/execute_service_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe Orders::SubscriptionCreation::ExecuteService, :premium do
   subject(:execute_service) { described_class.new(order:) }
 
   let_it_be(:organization) { create(:organization) }
-        let_it_be(:billing_entity) { create(:billing_entity, organization:) }
-        let_it_be(:customer) { create(:customer, organization:, billing_entity:, currency: "EUR") }
-        let_it_be(:plan) { create(:plan, organization:, amount_currency: "EUR", amount_cents: 100_000) }
-        let_it_be(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
+  let_it_be(:billing_entity) { create(:billing_entity, organization:) }
+  let_it_be(:customer) { create(:customer, organization:, billing_entity:, currency: "EUR") }
+  let_it_be(:plan) { create(:plan, organization:, amount_currency: "EUR", amount_cents: 100_000) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
   let(:charge) { create(:standard_charge, plan:, billable_metric:, properties: {"amount" => "50"}) }
 
   let(:plan_item) do

--- a/spec/services/orders/update_service_spec.rb
+++ b/spec/services/orders/update_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Orders::UpdateService do
   subject(:service) { described_class.new(order:, params:) }
 
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+        let_it_be(:customer) { create(:customer, organization:) }
   let(:order) { create(:order, organization:, customer:) }
   let(:params) { {execution_mode: "execute_in_lago", execute_at: 1.month.from_now.iso8601} }
 
@@ -35,6 +35,7 @@ RSpec.describe Orders::UpdateService do
       end
 
       context "when the order_forms feature flag is disabled" do
+        let(:customer) { create(:customer, organization:) }
         let(:organization) { create(:organization) }
 
         it "returns a forbidden failure" do

--- a/spec/services/orders/update_service_spec.rb
+++ b/spec/services/orders/update_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Orders::UpdateService do
   subject(:service) { described_class.new(order:, params:) }
 
   let_it_be(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-        let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:order) { create(:order, organization:, customer:) }
   let(:params) { {execution_mode: "execute_in_lago", execute_at: 1.month.from_now.iso8601} }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,6 +76,10 @@ Sentry.init do |config|
   config.transport.transport_class = Sentry::DummyTransport
 end
 
+require "test_prof/recipes/rspec/sample"
+require "test_prof/recipes/rspec/let_it_be"
+require "test_prof/recipes/rspec/factory_default"
+
 RSpec.configure do |config|
   config.include ActiveJob::TestHelper
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
## Context

Currently, around **50% of the spec runtime** is spent preparing data and creating factories. A lot of this data is either duplicated or recreates the same objects multiple times, so we can get rid of a good chunk of it and significantly speed up the specs.

To avoid creating unnecessary factories, we can use `let_it_be`, `before_all`, and `create_default` from `test-prof`. More info [here](https://test-prof.evilmartians.io/guide/recipes/let_it_be).

## Description

This PR cleans up the services specs in folders `k-o` and removes unnecessary factory usage.

Here are the numbers before and after the cleanup. The times below are for running the specs in a single process:

| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 97,841 | 63,994 |
| Time spent creating factories |  11:51.790 | 07:40.512 |
| Total time | 18:00.870 | 14:22.880 |

## Overall results

This PR is part of a series of PRs focused on cleaning up factory usage across different specs.

Once all the changes are merged, we expect to:

- Reduce the number of factories by **~50k**
- Cut spec runtime by around **20%**
- Shave off roughly **1:15 min** from the CI runtime


| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 157,949 | 103,761 |
| Total time spent creating factories | 17:59.851  | 11:14.739 |
| Total time | 34:41.482 | 27:03.658 |

Here is [the CI run](https://github.com/getlago/lago-api/actions/runs/33399605547/job/99512391170?pr=6255) with all the changes merged together: