### PR TITLE
perf(specs): Clean up factories usage in spec/specs in directories p-r

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -167,6 +167,8 @@ group :test do
   # HTML testing (invoice rendering)
   gem "rspec-snapshot", "~> 2.0"
   gem "htmlbeautifier", "~> 1.4"
+
+  gem "test-prof", "~> 1.0"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1004,6 +1004,8 @@ GEM
     temple (0.10.4)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
+    test-prof (1.6.3)
+      logger
     thor (1.5.0)
     throttling (0.4.1)
       logger
@@ -1181,6 +1183,7 @@ DEPENDENCIES
   stripe
   strong_migrations
   super_diff (~> 0.19.0)
+  test-prof (~> 1.0)
   throttling
   timecop
   tzinfo-data

--- a/spec/services/password_resets/create_service_spec.rb
+++ b/spec/services/password_resets/create_service_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe PasswordResets::CreateService do
   include_context "with mocked security logger"
 
   describe "#call" do
-    let(:organization) { create(:organization) }
-    let(:membership) { create(:membership, organization:) }
+    let_it_be(:organization) { create(:organization) }
+    let_it_be(:membership) { create(:membership, organization:) }
     let(:user) { membership.user }
     let(:create_args) do
       {

--- a/spec/services/password_resets/reset_service_spec.rb
+++ b/spec/services/password_resets/reset_service_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe PasswordResets::ResetService do
   include_context "with mocked security logger"
 
   describe "#call" do
-    let(:organization) { create(:organization) }
-    let(:membership) { create(:membership, organization:) }
+    let_it_be(:organization) { create(:organization) }
+    let_it_be(:membership) { create(:membership, organization:) }
     let(:user) { membership.user }
     let(:password_reset) { create(:password_reset, user:) }
     let(:reset_args) do

--- a/spec/services/payment_intents/expire_service_spec.rb
+++ b/spec/services/payment_intents/expire_service_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe PaymentIntents::ExpireService do
   describe ".call" do
     subject(:result) { described_class.call(invoice:) }
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
     let(:invoice) { create(:invoice) }
     let(:payment_provider_service) { class_double(Invoices::Payments::StripeService) }
 

--- a/spec/services/payment_intents/expire_service_spec.rb
+++ b/spec/services/payment_intents/expire_service_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe PaymentIntents::ExpireService do
   describe ".call" do
     subject(:result) { described_class.call(invoice:) }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+    before_all do
+      create_default(:organization)
+      create_default(:customer)
+    end
 
     let(:invoice) { create(:invoice) }
     let(:payment_provider_service) { class_double(Invoices::Payments::StripeService) }

--- a/spec/services/payment_intents/fetch_service_spec.rb
+++ b/spec/services/payment_intents/fetch_service_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe PaymentIntents::FetchService do
   describe ".call" do
     subject(:result) { described_class.call(invoice:) }
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
     context "when invoice does not exist" do
       let(:invoice) { nil }
 

--- a/spec/services/payment_intents/fetch_service_spec.rb
+++ b/spec/services/payment_intents/fetch_service_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe PaymentIntents::FetchService do
   describe ".call" do
     subject(:result) { described_class.call(invoice:) }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+    before_all do
+      create_default(:organization)
+      create_default(:customer)
+    end
 
     context "when invoice does not exist" do
       let(:invoice) { nil }

--- a/spec/services/payment_methods/create_from_provider_service_spec.rb
+++ b/spec/services/payment_methods/create_from_provider_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe PaymentMethods::CreateFromProviderService do
   subject(:create_service) { described_class.new(customer:, params:, provider_method_id:, payment_provider_id:, payment_provider_customer:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
-  let(:customer) { create(:customer, organization:) }
   let(:params) {}
   let(:provider_method_id) { "i_cant_be_nil" }
   let(:payment_provider_id) { nil }

--- a/spec/services/payment_methods/create_from_provider_service_spec.rb
+++ b/spec/services/payment_methods/create_from_provider_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentMethods::CreateFromProviderService do
   subject(:create_service) { described_class.new(customer:, params:, provider_method_id:, payment_provider_id:, payment_provider_customer:) }
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let_it_be(:customer) { create(:customer, organization:) }
 

--- a/spec/services/payment_methods/destroy_service_spec.rb
+++ b/spec/services/payment_methods/destroy_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe PaymentMethods::DestroyService do
   subject(:destroy_service) { described_class.new(payment_method:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:membership) { create(:membership, organization:) }
 
   let(:payment_method) { create(:payment_method, organization:, customer:, is_default: true) }

--- a/spec/services/payment_methods/determine_service_spec.rb
+++ b/spec/services/payment_methods/determine_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentMethods::DetermineService do
   subject(:service) { described_class.new(invoice:, customer:, payment_method_params:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:default_payment_method) { create(:payment_method, customer:, is_default: true) }
   let(:payment_method_params) { {} }

--- a/spec/services/payment_methods/find_or_create_from_provider_service_spec.rb
+++ b/spec/services/payment_methods/find_or_create_from_provider_service_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe PaymentMethods::FindOrCreateFromProviderService do
     )
   end
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:payment_provider_customer) { create(:stripe_customer, customer:) }
   let(:provider_method_id) { "pm_123456" }
   let(:params) { {} }

--- a/spec/services/payment_methods/set_as_default_service_spec.rb
+++ b/spec/services/payment_methods/set_as_default_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe PaymentMethods::SetAsDefaultService do
   subject(:default_service) { described_class.new(payment_method:) }
 
   let(:required_permission) { "payment_methods:update" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
   let(:customer) { create(:customer, organization:) }
   let(:user) { membership.user }
   let(:payment_method) { create(:payment_method, customer:, organization:, is_default: false) }

--- a/spec/services/payment_methods/set_as_default_service_spec.rb
+++ b/spec/services/payment_methods/set_as_default_service_spec.rb
@@ -6,13 +6,14 @@ RSpec.describe PaymentMethods::SetAsDefaultService do
   subject(:default_service) { described_class.new(payment_method:) }
 
   let(:required_permission) { "payment_methods:update" }
-  let_it_be(:organization) { create_default(:organization)}
-  let_it_be(:membership) { create(:membership) }
   let(:customer) { create(:customer, organization:) }
   let(:user) { membership.user }
   let(:payment_method) { create(:payment_method, customer:, organization:, is_default: false) }
   let(:payment_method2) { create(:payment_method, customer:, organization:, is_default: true) }
   let(:payment_method3) { create(:payment_method, customer:, organization:, is_default: false) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
 
   describe "#call" do
     context "when payment method exists" do

--- a/spec/services/payment_methods/update_details_service_spec.rb
+++ b/spec/services/payment_methods/update_details_service_spec.rb
@@ -5,7 +5,11 @@ require "rails_helper"
 RSpec.describe PaymentMethods::UpdateDetailsService do
   subject(:create_service) { described_class.new(payment_method:, insert:, delete:) }
 
-  let(:customer) { create(:customer) }
+before_all do
+  create_default(:organization)
+end
+
+  let_it_be(:customer) { create_default(:customer) }
   let(:payment_method) { create(:payment_method, customer:) }
   let(:insert) { {} }
   let(:delete) { {} }

--- a/spec/services/payment_methods/update_details_service_spec.rb
+++ b/spec/services/payment_methods/update_details_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe PaymentMethods::UpdateDetailsService do
   subject(:create_service) { described_class.new(payment_method:, insert:, delete:) }
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let_it_be(:customer) { create_default(:customer) }
   let(:payment_method) { create(:payment_method, customer:) }

--- a/spec/services/payment_methods/validate_service_spec.rb
+++ b/spec/services/payment_methods/validate_service_spec.rb
@@ -6,13 +6,6 @@ RSpec.describe PaymentMethods::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { BaseResult[:payment_method].new }
-  let_it_be(:organization) { create_default(:organization)}
-  let_it_be(:membership) { create(:membership) }
-
-before_all do
-  create_default(:customer)
-end
-
   let(:payment_method) { create(:payment_method, organization:) }
   let(:payment_method_params) do
     {
@@ -24,6 +17,13 @@ end
     {
       payment_method: payment_method_params
     }
+  end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
+
+  before_all do
+    create_default(:customer)
   end
 
   describe ".valid?" do

--- a/spec/services/payment_methods/validate_service_spec.rb
+++ b/spec/services/payment_methods/validate_service_spec.rb
@@ -6,8 +6,13 @@ RSpec.describe PaymentMethods::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { BaseResult[:payment_method].new }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+
+before_all do
+  create_default(:customer)
+end
+
   let(:payment_method) { create(:payment_method, organization:) }
   let(:payment_method_params) do
     {

--- a/spec/services/payment_provider_customers/create_connection_service_spec.rb
+++ b/spec/services/payment_provider_customers/create_connection_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviderCustomers::CreateConnectionService do
   subject(:create_service) { described_class.new(customer:, params:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:stripe_provider) { create(:stripe_provider, organization:, code: "stripe_eu") }
   let(:params) { {payment_provider: "stripe", provider_customer_id: "cus_123"} }

--- a/spec/services/payment_provider_customers/destroy_service_spec.rb
+++ b/spec/services/payment_provider_customers/destroy_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe PaymentProviderCustomers::DestroyService do
   subject(:destroy_service) { described_class.new(payment_provider_customer:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   let(:payment_provider_customer) do
     create(:stripe_customer, organization:, customer:, is_default: true)

--- a/spec/services/payment_provider_customers/flutterwave_service_spec.rb
+++ b/spec/services/payment_provider_customers/flutterwave_service_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe PaymentProviderCustomers::FlutterwaveService do
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization: organization) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization: organization) }
   let(:flutterwave_provider) { create(:flutterwave_provider, organization: organization) }
   let(:flutterwave_customer) { create(:flutterwave_customer, customer: customer, payment_provider: flutterwave_provider) }
 

--- a/spec/services/payment_provider_customers/set_as_default_service_spec.rb
+++ b/spec/services/payment_provider_customers/set_as_default_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe PaymentProviderCustomers::SetAsDefaultService do
   subject(:set_as_default_service) { described_class.new(payment_provider_customer:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   let(:stripe_customer) { create(:stripe_customer, customer:, organization:, code: "stripe_eu", is_default: true) }
   let(:gocardless_customer) { create(:gocardless_customer, customer:, organization:, code: "gocardless_eu", is_default: false) }

--- a/spec/services/payment_provider_customers/stripe/check_payment_method_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/check_payment_method_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviderCustomers::Stripe::CheckPaymentMethodService do
   subject(:check_service) { described_class.new(stripe_customer:, payment_method_id:) }
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:customer) { create(:customer, organization:) }
   let_it_be(:stripe_provider) { create(:stripe_provider) }
   let_it_be(:customer) { create(:customer, organization:) }

--- a/spec/services/payment_provider_customers/stripe/check_payment_method_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/check_payment_method_service_spec.rb
@@ -5,9 +5,10 @@ require "rails_helper"
 RSpec.describe PaymentProviderCustomers::Stripe::CheckPaymentMethodService do
   subject(:check_service) { described_class.new(stripe_customer:, payment_method_id:) }
 
-  let(:customer) { create(:customer, organization:) }
-  let(:stripe_provider) { create(:stripe_provider) }
-  let(:organization) { stripe_provider.organization }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:stripe_provider) { create(:stripe_provider) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   let(:stripe_customer) do
     create(

--- a/spec/services/payment_provider_customers/stripe/retrieve_latest_payment_method_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/retrieve_latest_payment_method_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe PaymentProviderCustomers::Stripe::RetrieveLatestPaymentMethodService do
   subject { described_class.new(provider_customer:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:provider_customer_id) { "cus_Rw5Qso78STEap3" }
   let(:provider_customer) { create(:stripe_customer, customer:, provider_customer_id:, payment_provider: create(:stripe_provider, organization:), payment_method_id: nil) }
 

--- a/spec/services/payment_provider_customers/stripe/sync_funding_instructions_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/sync_funding_instructions_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe PaymentProviderCustomers::Stripe::SyncFundingInstructionsService do
   subject(:sync_funding_service) { described_class.new(stripe_customer) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:, currency: "USD") }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:, currency: "USD") }
   let(:provider_customer_id) { "cus_Rw5Qso78STEap3" }
   let(:stripe_customer) {
     create(:stripe_customer, customer:, provider_payment_methods:,

--- a/spec/services/payment_provider_customers/stripe/update_payment_method_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/update_payment_method_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe PaymentProviderCustomers::Stripe::UpdatePaymentMethodService do
   subject(:update_service) { described_class.new(stripe_customer:, payment_method_id:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   let(:stripe_customer) { create(:stripe_customer, customer:) }
   let(:payment_method_id) { "pm_123456" }

--- a/spec/services/payment_provider_customers/update_connection_service_spec.rb
+++ b/spec/services/payment_provider_customers/update_connection_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe PaymentProviderCustomers::UpdateConnectionService do
   subject(:update_service) { described_class.new(payment_provider_customer:, params:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:params) { {} }
 
   describe "#call" do

--- a/spec/services/payment_providers/adyen/customers/create_service_spec.rb
+++ b/spec/services/payment_providers/adyen/customers/create_service_spec.rb
@@ -4,16 +4,16 @@ require "rails_helper"
 
 RSpec.describe PaymentProviders::Adyen::Customers::CreateService do
   let(:create_service) { described_class.new(customer:, payment_provider_id:, params:, async:) }
-
-before_all do
-  create_default(:organization)
-end
-
-  let_it_be(:customer) { create(:customer) }
   let(:adyen_provider) { create(:adyen_provider, organization: customer.organization) }
   let(:payment_provider_id) { adyen_provider.id }
   let(:params) { {provider_customer_id: "id", sync_with_provider: true} }
   let(:async) { true }
+
+  before_all do
+    create_default(:organization)
+  end
+
+  let_it_be(:customer) { create(:customer) }
 
   describe ".call" do
     it "creates a payment_provider_customer" do

--- a/spec/services/payment_providers/adyen/customers/create_service_spec.rb
+++ b/spec/services/payment_providers/adyen/customers/create_service_spec.rb
@@ -5,7 +5,11 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Adyen::Customers::CreateService do
   let(:create_service) { described_class.new(customer:, payment_provider_id:, params:, async:) }
 
-  let(:customer) { create(:customer) }
+before_all do
+  create_default(:organization)
+end
+
+  let_it_be(:customer) { create(:customer) }
   let(:adyen_provider) { create(:adyen_provider, organization: customer.organization) }
   let(:payment_provider_id) { adyen_provider.id }
   let(:params) { {provider_customer_id: "id", sync_with_provider: true} }

--- a/spec/services/payment_providers/adyen/handle_event_service_spec.rb
+++ b/spec/services/payment_providers/adyen/handle_event_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Adyen::HandleEventService do
   subject(:event_service) { described_class.new(organization:, event_json:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
 
   describe "#call" do
     let(:payment_service) { instance_double(Invoices::Payments::AdyenService) }

--- a/spec/services/payment_providers/adyen/handle_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/adyen/handle_incoming_webhook_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Adyen::HandleIncomingWebhookService do
   let(:webhook_service) { described_class.new(organization_id:, body:, code:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:organization_id) { organization.id }
   let(:adyen_provider) { create(:adyen_provider, organization:, hmac_key:) }
   let(:hmac_key) { "a1b2c3d4e5f6" }

--- a/spec/services/payment_providers/adyen/handle_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/adyen/handle_incoming_webhook_service_spec.rb
@@ -4,21 +4,19 @@ require "rails_helper"
 
 RSpec.describe PaymentProviders::Adyen::HandleIncomingWebhookService do
   let(:webhook_service) { described_class.new(organization_id:, body:, code:) }
-
-  let_it_be(:organization) { create(:organization) }
   let(:organization_id) { organization.id }
   let(:adyen_provider) { create(:adyen_provider, organization:, hmac_key:) }
   let(:hmac_key) { "a1b2c3d4e5f6" }
   let(:code) { nil }
-
   let(:body) do
     JSON.parse(event_response_json)["notificationItems"].first&.dig("NotificationRequestItem")
   end
-
   let(:event_response_json) do
     path = Rails.root.join("spec/fixtures/adyen/webhook_authorisation_response.json")
     File.read(path)
   end
+
+  let_it_be(:organization) { create(:organization) }
 
   before { adyen_provider }
 

--- a/spec/services/payment_providers/adyen/payments/cancel_service_spec.rb
+++ b/spec/services/payment_providers/adyen/payments/cancel_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Adyen::Payments::CancelService do
   subject(:result) { described_class.call(payment:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:) }
   let(:payment_provider) do
     create(:adyen_provider, organization:, api_key: "AQEx...test", merchant_account: "LagoTest")

--- a/spec/services/payment_providers/adyen/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/adyen/payments/create_service_spec.rb
@@ -235,7 +235,6 @@ RSpec.describe PaymentProviders::Adyen::Payments::CreateService do
         create(:subscription, organization:, customer:)
       end
 
-      let(:customer) { create(:customer, organization:, payment_provider_code: code) }
       let(:organization) do
         create(:organization, webhook_url: "https://webhook.com")
       end

--- a/spec/services/payment_providers/adyen/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/adyen/payments/create_service_spec.rb
@@ -5,13 +5,13 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Adyen::Payments::CreateService do
   subject(:create_service) { described_class.new(payment:, reference:, metadata:) }
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:code) { "adyen_1" }
   let_it_be(:customer) { create(:customer, payment_provider_code: code) }
 
-before_all do
-  create_default(:plan)
-end
+  before_all do
+    create_default(:plan)
+  end
 
   let(:adyen_payment_provider) { create(:adyen_provider, organization:, code:) }
   let(:adyen_customer) { create(:adyen_customer, customer:, payment_provider: adyen_payment_provider) }

--- a/spec/services/payment_providers/adyen/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/adyen/payments/create_service_spec.rb
@@ -5,8 +5,14 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Adyen::Payments::CreateService do
   subject(:create_service) { described_class.new(payment:, reference:, metadata:) }
 
-  let(:customer) { create(:customer, payment_provider_code: code) }
-  let(:organization) { customer.organization }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:code) { "adyen_1" }
+  let_it_be(:customer) { create(:customer, payment_provider_code: code) }
+
+before_all do
+  create_default(:plan)
+end
+
   let(:adyen_payment_provider) { create(:adyen_provider, organization:, code:) }
   let(:adyen_customer) { create(:adyen_customer, customer:, payment_provider: adyen_payment_provider) }
   let(:adyen_client) { instance_double(Adyen::Client) }
@@ -16,7 +22,6 @@ RSpec.describe PaymentProviders::Adyen::Payments::CreateService do
   let(:checkout) { Adyen::Checkout.new(adyen_client, 70) }
   let(:payments_response) { generate(:adyen_payments_response) }
   let(:payment_methods_response) { generate(:adyen_payment_methods_response) }
-  let(:code) { "adyen_1" }
   let(:reference) { "organization.name - Invoice #{invoice.number}" }
   let(:metadata) do
     {
@@ -167,13 +172,14 @@ RSpec.describe PaymentProviders::Adyen::Payments::CreateService do
     end
 
     context "with validation error on adyen" do
-      let(:customer) { create(:customer, organization:, payment_provider_code: code) }
+      let_it_be(:customer) { create(:customer, organization:, payment_provider_code: code) }
 
       let(:subscription) do
         create(:subscription, organization:, customer:)
       end
 
-      let(:organization) do
+      let_it_be(:customer) { create(:customer, organization:, payment_provider_code: code) }
+      let_it_be(:organization) do
         create(:organization, webhook_url: "https://webhook.com")
       end
 
@@ -229,6 +235,7 @@ RSpec.describe PaymentProviders::Adyen::Payments::CreateService do
         create(:subscription, organization:, customer:)
       end
 
+      let(:customer) { create(:customer, organization:, payment_provider_code: code) }
       let(:organization) do
         create(:organization, webhook_url: "https://webhook.com")
       end

--- a/spec/services/payment_providers/adyen/webhooks/chargeback_service_spec.rb
+++ b/spec/services/payment_providers/adyen/webhooks/chargeback_service_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe PaymentProviders::Adyen::Webhooks::ChargebackService do
   subject(:service) { described_class.new(organization_id:, event_json:) }
 
   let(:organization_id) { organization.id }
-  let_it_be(:organization) { create_default(:organization) }
   let(:membership) { create(:membership, organization:) }
-  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:payment) { create(:payment, payable: invoice, provider_payment_id: "9915555555555555") }
   let(:invoice) { create(:invoice, customer:, organization:, status:, payment_status: "succeeded") }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   describe "#call" do
     before { payment }

--- a/spec/services/payment_providers/adyen/webhooks/chargeback_service_spec.rb
+++ b/spec/services/payment_providers/adyen/webhooks/chargeback_service_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe PaymentProviders::Adyen::Webhooks::ChargebackService do
   subject(:service) { described_class.new(organization_id:, event_json:) }
 
   let(:organization_id) { organization.id }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:membership) { create(:membership, organization:) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:payment) { create(:payment, payable: invoice, provider_payment_id: "9915555555555555") }
   let(:invoice) { create(:invoice, customer:, organization:, status:, payment_status: "succeeded") }
 

--- a/spec/services/payment_providers/adyen_service_spec.rb
+++ b/spec/services/payment_providers/adyen_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PaymentProviders::AdyenService do
 
   include_context "with mocked security logger"
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let(:api_key) { "test_api_key_1" }
   let(:code) { "code_1" }

--- a/spec/services/payment_providers/adyen_service_spec.rb
+++ b/spec/services/payment_providers/adyen_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe PaymentProviders::AdyenService do
 
   include_context "with mocked security logger"
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
   let(:api_key) { "test_api_key_1" }
   let(:code) { "code_1" }
   let(:name) { "Name 1" }

--- a/spec/services/payment_providers/cancel_payment_service_spec.rb
+++ b/spec/services/payment_providers/cancel_payment_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe PaymentProviders::CancelPaymentService do
   subject(:result) { described_class.call(payment:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:) }
 
   before do

--- a/spec/services/payment_providers/cashfree/handle_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/cashfree/handle_incoming_webhook_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Cashfree::HandleIncomingWebhookService do
   let(:webhook_service) { described_class.new(organization_id:, body:, code:, timestamp:, signature:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:organization_id) { organization.id }
   let(:cashfree_provider) { create(:cashfree_provider, organization:, client_secret:) }
   let(:client_secret) { "cfsk_ma_prod_abc_123456" }

--- a/spec/services/payment_providers/cashfree/handle_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/cashfree/handle_incoming_webhook_service_spec.rb
@@ -4,19 +4,18 @@ require "rails_helper"
 
 RSpec.describe PaymentProviders::Cashfree::HandleIncomingWebhookService do
   let(:webhook_service) { described_class.new(organization_id:, body:, code:, timestamp:, signature:) }
-
-  let_it_be(:organization) { create(:organization) }
   let(:organization_id) { organization.id }
   let(:cashfree_provider) { create(:cashfree_provider, organization:, client_secret:) }
   let(:client_secret) { "cfsk_ma_prod_abc_123456" }
   let(:code) { nil }
   let(:timestamp) { "1629271506" }
   let(:signature) { "MFB3Rkubs4jB97ROS/I4iu9llAAP5ykJ3GZYp95o/Mw=" }
-
   let(:body) do
     path = Rails.root.join("spec/fixtures/cashfree/payment_link_event_payment.json")
     JSON.parse(File.read(path)).to_json # NOTE: Ensure valid sha256 signature
   end
+
+  let_it_be(:organization) { create(:organization) }
 
   before { cashfree_provider }
 

--- a/spec/services/payment_providers/cashfree/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/cashfree/payments/create_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Cashfree::Payments::CreateService do
   subject(:create_service) { described_class.new(payment:) }
 
+  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, payment_provider_code: code) }
-  let(:organization) { customer.organization }
   let(:chasfree_payment_provider) { create(:cashfree_provider, organization:, code:) }
   let(:cashfree_customer) { create(:cashfree_customer, customer:, payment_provider: chasfree_payment_provider) }
   let(:code) { "stripe_1" }

--- a/spec/services/payment_providers/cashfree/webhooks/payment_link_event_service_spec.rb
+++ b/spec/services/payment_providers/cashfree/webhooks/payment_link_event_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Cashfree::Webhooks::PaymentLinkEventService do
   subject(:webhook_service) { described_class.new(organization_id: organization.id, event_json:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:event_json) { File.read("spec/fixtures/cashfree/payment_link_event_payment.json") }
 
   let(:payment_service) { instance_double(Invoices::Payments::CashfreeService) }

--- a/spec/services/payment_providers/cashfree_service_spec.rb
+++ b/spec/services/payment_providers/cashfree_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PaymentProviders::CashfreeService do
 
   include_context "with mocked security logger"
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let(:code) { "code_1" }
   let(:name) { "Name 1" }

--- a/spec/services/payment_providers/cashfree_service_spec.rb
+++ b/spec/services/payment_providers/cashfree_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe PaymentProviders::CashfreeService do
 
   include_context "with mocked security logger"
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
   let(:code) { "code_1" }
   let(:name) { "Name 1" }
   let(:client_id) { "123456_abc" }

--- a/spec/services/payment_providers/create_customer_factory_spec.rb
+++ b/spec/services/payment_providers/create_customer_factory_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe PaymentProviders::CreateCustomerFactory do
   subject(:new_instance) { described_class.new_instance(provider:, customer:, payment_provider_id:, params:, async:) }
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let_it_be(:customer) { create(:customer) }
   let(:payment_provider_id) { create(:stripe_provider, organization: customer.organization).id }

--- a/spec/services/payment_providers/create_customer_factory_spec.rb
+++ b/spec/services/payment_providers/create_customer_factory_spec.rb
@@ -5,7 +5,11 @@ require "rails_helper"
 RSpec.describe PaymentProviders::CreateCustomerFactory do
   subject(:new_instance) { described_class.new_instance(provider:, customer:, payment_provider_id:, params:, async:) }
 
-  let(:customer) { create(:customer) }
+before_all do
+  create_default(:organization)
+end
+
+  let_it_be(:customer) { create(:customer) }
   let(:payment_provider_id) { create(:stripe_provider, organization: customer.organization).id }
   let(:params) { {provider_customer_id: "id", sync_with_provider: true} }
   let(:async) { true }

--- a/spec/services/payment_providers/create_payment_factory_spec.rb
+++ b/spec/services/payment_providers/create_payment_factory_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe PaymentProviders::CreatePaymentFactory do
   subject(:new_instance) { described_class.new_instance(provider:, payment:, reference: "", metadata: {}) }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
 
   let(:provider) { "stripe" }
   let(:payment) { create(:payment) }

--- a/spec/services/payment_providers/create_payment_factory_spec.rb
+++ b/spec/services/payment_providers/create_payment_factory_spec.rb
@@ -5,6 +5,11 @@ require "rails_helper"
 RSpec.describe PaymentProviders::CreatePaymentFactory do
   subject(:new_instance) { described_class.new_instance(provider:, payment:, reference: "", metadata: {}) }
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
   let(:provider) { "stripe" }
   let(:payment) { create(:payment) }
 

--- a/spec/services/payment_providers/destroy_service_spec.rb
+++ b/spec/services/payment_providers/destroy_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PaymentProviders::DestroyService do
 
   include_context "with mocked security logger"
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
 
   let(:payment_provider) { create(:stripe_provider, organization:) }

--- a/spec/services/payment_providers/destroy_service_spec.rb
+++ b/spec/services/payment_providers/destroy_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe PaymentProviders::DestroyService do
 
   include_context "with mocked security logger"
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
 
   let(:payment_provider) { create(:stripe_provider, organization:) }
 
@@ -25,7 +25,7 @@ RSpec.describe PaymentProviders::DestroyService do
     end
 
     context "with attached payment provider customers" do
-      let(:customer) { create(:customer, organization:) }
+      let_it_be(:customer) { create(:customer, organization:) }
       let(:payment_provider_customer) { create(:stripe_customer, customer:, organization:, payment_provider:) }
 
       before { payment_provider_customer }

--- a/spec/services/payment_providers/find_service_spec.rb
+++ b/spec/services/payment_providers/find_service_spec.rb
@@ -4,9 +4,10 @@ require "rails_helper"
 
 RSpec.describe PaymentProviders::FindService do
   let(:service) { described_class.new(organization_id:, code:, id:) }
-  let(:payment_provider) { create(:adyen_provider, organization:) }
-  let_it_be(:organization) { create(:organization) }
   let(:id) { nil }
+  let(:payment_provider) { create(:adyen_provider, organization:) }
+
+  let_it_be(:organization) { create(:organization) }
 
   before { payment_provider }
 

--- a/spec/services/payment_providers/find_service_spec.rb
+++ b/spec/services/payment_providers/find_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviders::FindService do
   let(:service) { described_class.new(organization_id:, code:, id:) }
   let(:payment_provider) { create(:adyen_provider, organization:) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:id) { nil }
 
   before { payment_provider }

--- a/spec/services/payment_providers/flutterwave/handle_event_service_spec.rb
+++ b/spec/services/payment_providers/flutterwave/handle_event_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Flutterwave::HandleEventService do
   subject(:handle_event_service) { described_class.new(organization:, event_json:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:event_json) { payload.to_json }
 
   let(:payload) do

--- a/spec/services/payment_providers/flutterwave/handle_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/flutterwave/handle_incoming_webhook_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Flutterwave::HandleIncomingWebhookService do
   subject(:webhook_service) { described_class.new(organization_id:, body:, secret:, code:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:organization_id) { organization.id }
   let(:flutterwave_provider) { create(:flutterwave_provider, organization:, webhook_secret:) }
   let(:webhook_secret) { "webhook_secret_hash" }

--- a/spec/services/payment_providers/flutterwave/webhooks/charge_completed_service_spec.rb
+++ b/spec/services/payment_providers/flutterwave/webhooks/charge_completed_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe PaymentProviders::Flutterwave::Webhooks::ChargeCompletedService d
 
   let_it_be(:organization) { create_default(:organization) }
 
-before_all do
-  create_default(:customer)
-end
+  before_all do
+    create_default(:customer)
+  end
 
   let(:invoice) { create(:invoice, organization:) }
   let(:payment_request) { create(:payment_request, organization:) }

--- a/spec/services/payment_providers/flutterwave/webhooks/charge_completed_service_spec.rb
+++ b/spec/services/payment_providers/flutterwave/webhooks/charge_completed_service_spec.rb
@@ -5,7 +5,12 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Flutterwave::Webhooks::ChargeCompletedService do
   subject(:charge_completed_service) { described_class.new(organization_id: organization.id, event_json:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
+
+before_all do
+  create_default(:customer)
+end
+
   let(:invoice) { create(:invoice, organization:) }
   let(:payment_request) { create(:payment_request, organization:) }
   let(:flutterwave_provider) { create(:flutterwave_provider, organization:) }

--- a/spec/services/payment_providers/flutterwave_service_spec.rb
+++ b/spec/services/payment_providers/flutterwave_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PaymentProviders::FlutterwaveService do
 
   include_context "with mocked security logger"
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
 
   describe "#create_or_update" do
     let(:args) do

--- a/spec/services/payment_providers/gocardless/customers/create_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/customers/create_service_spec.rb
@@ -5,7 +5,11 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Gocardless::Customers::CreateService do
   let(:create_service) { described_class.new(customer:, payment_provider_id:, params:, async:) }
 
-  let(:customer) { create(:customer) }
+before_all do
+  create_default(:organization)
+end
+
+  let_it_be(:customer) { create(:customer) }
   let(:gocardless_provider) { create(:gocardless_provider, organization: customer.organization) }
   let(:payment_provider_id) { gocardless_provider.id }
 

--- a/spec/services/payment_providers/gocardless/customers/create_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/customers/create_service_spec.rb
@@ -4,20 +4,18 @@ require "rails_helper"
 
 RSpec.describe PaymentProviders::Gocardless::Customers::CreateService do
   let(:create_service) { described_class.new(customer:, payment_provider_id:, params:, async:) }
-
-before_all do
-  create_default(:organization)
-end
-
-  let_it_be(:customer) { create(:customer) }
   let(:gocardless_provider) { create(:gocardless_provider, organization: customer.organization) }
   let(:payment_provider_id) { gocardless_provider.id }
-
   let(:params) do
     {provider_customer_id: "id", sync_with_provider: true}
   end
-
   let(:async) { true }
+
+  before_all do
+    create_default(:organization)
+  end
+
+  let_it_be(:customer) { create(:customer) }
 
   describe ".call" do
     it "creates a payment_provider_customer" do

--- a/spec/services/payment_providers/gocardless/handle_event_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/handle_event_service_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Gocardless::HandleEventService do
   subject(:event_service) { described_class.new(payment_provider:, event_json:) }
 
+before_all do
+  create_default(:organization)
+end
+
   let(:event_json) do
     path = Rails.root.join("spec/fixtures/gocardless/events.json")
     JSON.parse(File.read(path))["events"].first.to_json

--- a/spec/services/payment_providers/gocardless/handle_event_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/handle_event_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Gocardless::HandleEventService do
   subject(:event_service) { described_class.new(payment_provider:, event_json:) }
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let(:event_json) do
     path = Rails.root.join("spec/fixtures/gocardless/events.json")

--- a/spec/services/payment_providers/gocardless/handle_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/handle_incoming_webhook_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Gocardless::HandleIncomingWebhookService do
   let(:webhook_service) { described_class.new(organization_id: organization.id, body:, signature:, code:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:gocardless_provider) { create(:gocardless_provider, organization:) }
 
   let(:events) do

--- a/spec/services/payment_providers/gocardless/handle_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/handle_incoming_webhook_service_spec.rb
@@ -4,19 +4,17 @@ require "rails_helper"
 
 RSpec.describe PaymentProviders::Gocardless::HandleIncomingWebhookService do
   let(:webhook_service) { described_class.new(organization_id: organization.id, body:, signature:, code:) }
-
-  let_it_be(:organization) { create(:organization) }
   let(:gocardless_provider) { create(:gocardless_provider, organization:) }
-
   let(:events) do
     path = Rails.root.join("spec/fixtures/gocardless/events.json")
     JSON.parse(File.read(path))
   end
-
   let(:body) { events.to_json }
   let(:events_result) { events["events"].map { |event| GoCardlessPro::Resources::Event.new(event) } }
   let(:signature) { "signature" }
   let(:code) { nil }
+
+  let_it_be(:organization) { create(:organization) }
 
   before { gocardless_provider }
 

--- a/spec/services/payment_providers/gocardless/payments/cancel_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/payments/cancel_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Gocardless::Payments::CancelService do
   subject(:result) { described_class.call(payment:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:) }
   let(:payment_provider) { create(:gocardless_provider, organization:, access_token: "gc_test_token") }
   let(:provider_customer) { create(:gocardless_customer, customer:, payment_provider:) }

--- a/spec/services/payment_providers/gocardless/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/payments/create_service_spec.rb
@@ -5,15 +5,15 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Gocardless::Payments::CreateService do
   subject(:create_service) { described_class.new(payment:, reference:, metadata:) }
 
-  let(:customer) { create(:customer, payment_provider_code: code) }
-  let(:organization) { customer.organization }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:code) { "gocardless_1" }
+  let_it_be(:customer) { create(:customer, payment_provider_code: code) }
   let(:gocardless_payment_provider) { create(:gocardless_provider, organization:, code:) }
   let(:gocardless_customer) { create(:gocardless_customer, customer:, payment_provider: gocardless_payment_provider) }
   let(:gocardless_client) { instance_double(GoCardlessPro::Client) }
   let(:gocardless_payments_service) { instance_double(GoCardlessPro::Services::PaymentsService) }
   let(:gocardless_mandates_service) { instance_double(GoCardlessPro::Services::MandatesService) }
   let(:gocardless_list_response) { instance_double(GoCardlessPro::ListResponse) }
-  let(:code) { "gocardless_1" }
   let(:reference) { "organization.name - Invoice #{invoice.number}" }
   let(:metadata) do
     {
@@ -95,6 +95,7 @@ RSpec.describe PaymentProviders::Gocardless::Payments::CreateService do
         create(:subscription, organization:, customer:)
       end
 
+      let(:customer) { create(:customer, organization:, payment_provider_code: code) }
       let(:organization) do
         create(:organization, webhook_url: "https://webhook.com")
       end
@@ -122,6 +123,7 @@ RSpec.describe PaymentProviders::Gocardless::Payments::CreateService do
     end
 
     context "when customer has no mandate to make a payment" do
+      let(:customer) { create(:customer, organization:, payment_provider_code: code) }
       let(:customer) { create(:customer, organization:, payment_provider_code: code) }
       let(:organization) { create(:organization, webhook_url: "https://webhook.com") }
 

--- a/spec/services/payment_providers/gocardless/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/payments/create_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Gocardless::Payments::CreateService do
   subject(:create_service) { described_class.new(payment:, reference:, metadata:) }
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:code) { "gocardless_1" }
   let_it_be(:customer) { create(:customer, payment_provider_code: code) }
   let(:gocardless_payment_provider) { create(:gocardless_provider, organization:, code:) }

--- a/spec/services/payment_providers/gocardless/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/payments/create_service_spec.rb
@@ -95,7 +95,6 @@ RSpec.describe PaymentProviders::Gocardless::Payments::CreateService do
         create(:subscription, organization:, customer:)
       end
 
-      let(:customer) { create(:customer, organization:, payment_provider_code: code) }
       let(:organization) do
         create(:organization, webhook_url: "https://webhook.com")
       end
@@ -123,7 +122,6 @@ RSpec.describe PaymentProviders::Gocardless::Payments::CreateService do
     end
 
     context "when customer has no mandate to make a payment" do
-      let(:customer) { create(:customer, organization:, payment_provider_code: code) }
       let(:customer) { create(:customer, organization:, payment_provider_code: code) }
       let(:organization) { create(:organization, webhook_url: "https://webhook.com") }
 

--- a/spec/services/payment_providers/gocardless/webhooks/mandate_cancelled_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/webhooks/mandate_cancelled_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Gocardless::Webhooks::MandateCancelledService do
   subject(:mandate_cancelled_service) { described_class.new(payment_provider:, mandate_id:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:payment_provider) { create(:gocardless_provider, organization:) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:gocardless_customer) do
     create(
       :gocardless_customer,

--- a/spec/services/payment_providers/gocardless/webhooks/mandate_cancelled_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/webhooks/mandate_cancelled_service_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe PaymentProviders::Gocardless::Webhooks::MandateCancelledService d
 
   let_it_be(:organization) { create(:organization) }
   let(:payment_provider) { create(:gocardless_provider, organization:) }
-  let_it_be(:customer) { create(:customer, organization:) }
   let(:gocardless_customer) do
     create(
       :gocardless_customer,
@@ -26,9 +25,10 @@ RSpec.describe PaymentProviders::Gocardless::Webhooks::MandateCancelledService d
       payment_provider:
     )
   end
-
   let(:mandate_id) { "index_ID_123" }
   let(:provider_customer_id) { "CU123456" }
+
+  let_it_be(:customer) { create(:customer, organization:) }
 
   describe "#call" do
     before do

--- a/spec/services/payment_providers/gocardless/webhooks/mandate_created_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/webhooks/mandate_created_service_spec.rb
@@ -7,14 +7,11 @@ RSpec.describe PaymentProviders::Gocardless::Webhooks::MandateCreatedService do
 
   let_it_be(:organization) { create(:organization) }
   let(:payment_provider) { create(:gocardless_provider, organization:) }
-  let_it_be(:customer) { create(:customer, organization:) }
   let(:gocardless_customer) do
     create(:gocardless_customer, customer:, payment_provider:, provider_customer_id:)
   end
-
   let(:gocardless_client) { instance_double(GoCardlessPro::Client) }
   let(:gocardless_mandates_service) { instance_double(GoCardlessPro::Services::MandatesService) }
-
   let(:mandate_id) { "index_ID_123" }
   let(:provider_customer_id) { "CU123456" }
   let(:mandate) do
@@ -24,6 +21,8 @@ RSpec.describe PaymentProviders::Gocardless::Webhooks::MandateCreatedService do
       "links" => {"customer" => provider_customer_id}
     )
   end
+
+  let_it_be(:customer) { create(:customer, organization:) }
 
   describe "#call" do
     before do

--- a/spec/services/payment_providers/gocardless/webhooks/mandate_created_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/webhooks/mandate_created_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Gocardless::Webhooks::MandateCreatedService do
   subject(:mandate_created_service) { described_class.new(payment_provider:, mandate_id:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:payment_provider) { create(:gocardless_provider, organization:) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:gocardless_customer) do
     create(:gocardless_customer, customer:, payment_provider:, provider_customer_id:)
   end

--- a/spec/services/payment_providers/gocardless_service_spec.rb
+++ b/spec/services/payment_providers/gocardless_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PaymentProviders::GocardlessService do
 
   include_context "with mocked security logger"
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let(:access_code) { "1234567!abc" }
   let(:code) { "code_1" }

--- a/spec/services/payment_providers/gocardless_service_spec.rb
+++ b/spec/services/payment_providers/gocardless_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe PaymentProviders::GocardlessService do
 
   include_context "with mocked security logger"
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
   let(:access_code) { "1234567!abc" }
   let(:code) { "code_1" }
   let(:name) { "Name 1" }

--- a/spec/services/payment_providers/moneyhash/handle_event_service_spec.rb
+++ b/spec/services/payment_providers/moneyhash/handle_event_service_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe PaymentProviders::Moneyhash::HandleEventService do
 
   let_it_be(:organization) { create(:organization) }
   let(:moneyhash_provider) { create(:moneyhash_provider, organization:) }
-  let_it_be(:customer) { create(:customer, organization:) }
   let(:moneyhash_customer) { create(:moneyhash_customer, customer:) }
+
+  let_it_be(:customer) { create(:customer, organization:) }
 
   # Intent
   # handle event - intent.processed <-

--- a/spec/services/payment_providers/moneyhash/handle_event_service_spec.rb
+++ b/spec/services/payment_providers/moneyhash/handle_event_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Moneyhash::HandleEventService do
   subject(:event_service) { described_class.new(organization:, event_json:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:moneyhash_provider) { create(:moneyhash_provider, organization:) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:moneyhash_customer) { create(:moneyhash_customer, customer:) }
 
   # Intent

--- a/spec/services/payment_providers/moneyhash/handle_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/moneyhash/handle_incoming_webhook_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Moneyhash::HandleIncomingWebhookService do
   subject(:result) { described_class.call(inbound_webhook:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:code) { "mh-test" }
   let(:moneyhash_provider) { create(:moneyhash_provider, code:, organization:) }
   let(:intent_processed_payload) { JSON.parse(Rails.root.join("spec/fixtures/moneyhash/intent.processed.json").read) }

--- a/spec/services/payment_providers/moneyhash/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/moneyhash/payments/create_service_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe PaymentProviders::Moneyhash::Payments::CreateService do
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:moneyhash_provider) { create(:moneyhash_provider, organization:) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:moneyhash_customer) { create(:moneyhash_customer, customer:, payment_provider: moneyhash_provider) }
 
   let(:reference) { "1234567890" }

--- a/spec/services/payment_providers/moneyhash/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/moneyhash/payments/create_service_spec.rb
@@ -5,21 +5,18 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Moneyhash::Payments::CreateService do
   let_it_be(:organization) { create(:organization) }
   let(:moneyhash_provider) { create(:moneyhash_provider, organization:) }
-  let_it_be(:customer) { create(:customer, organization:) }
   let(:moneyhash_customer) { create(:moneyhash_customer, customer:, payment_provider: moneyhash_provider) }
-
   let(:reference) { "1234567890" }
   let(:metadata) { {} }
-
   let(:invoice) { create(:invoice, organization:, customer:, invoice_type: :subscription) }
   let(:payment) { create(:payment, payable: invoice, payment_provider: moneyhash_provider, payment_provider_customer: moneyhash_customer) }
-
   let(:failure_response) { JSON.parse(File.read("spec/fixtures/moneyhash/recurring_mit_payment_failure_response.json")) }
   let(:success_response) { JSON.parse(File.read("spec/fixtures/moneyhash/recurring_mit_payment_success_response.json")) }
-
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:response) { instance_double(Net::HTTPOK) }
   let(:endpoint) { "#{PaymentProviders::MoneyhashProvider.api_base_url}/api/v1.1/payments/intent/" }
+
+  let_it_be(:customer) { create(:customer, organization:) }
 
   describe "#call" do
     before do

--- a/spec/services/payment_providers/moneyhash/validate_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/moneyhash/validate_incoming_webhook_service_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe PaymentProviders::Moneyhash::ValidateIncomingWebhookService do
     described_class.call(payload:, signature:, payment_provider:)
   end
 
+before_all do
+  create_default(:organization)
+end
+
   let(:payload) { "webhook_payload" }
   let(:signature) { "t=1743090080,v1=placeholder,v2=placeholder,v3=ca13480c8142f2f2b44822c764909027974e84b3e8c94457a314f129d8d60148" }
   let(:payment_provider) { create(:moneyhash_provider, signature_key: "test_signature_key") }

--- a/spec/services/payment_providers/moneyhash/validate_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/moneyhash/validate_incoming_webhook_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe PaymentProviders::Moneyhash::ValidateIncomingWebhookService do
     described_class.call(payload:, signature:, payment_provider:)
   end
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let(:payload) { "webhook_payload" }
   let(:signature) { "t=1743090080,v1=placeholder,v2=placeholder,v3=ca13480c8142f2f2b44822c764909027974e84b3e8c94457a314f129d8d60148" }

--- a/spec/services/payment_providers/moneyhash_service_spec.rb
+++ b/spec/services/payment_providers/moneyhash_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviders::MoneyhashService do
   include_context "with mocked security logger"
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:moneyhash_provider) { create(:moneyhash_provider, organization:) }
   let(:customer) { create(:customer, organization:) }
   let(:moneyhash_customer) { create(:moneyhash_customer, customer:) }

--- a/spec/services/payment_providers/stripe/customers/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/customers/create_service_spec.rb
@@ -5,7 +5,11 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Stripe::Customers::CreateService do
   let(:create_service) { described_class.new(customer:, payment_provider_id:, params:, async:) }
 
-  let(:customer) { create(:customer) }
+before_all do
+  create_default(:organization)
+end
+
+  let_it_be(:customer) { create(:customer) }
   let(:stripe_provider) { create(:stripe_provider, organization: customer.organization) }
   let(:payment_provider_id) { stripe_provider.id }
   let(:params) { {provider_customer_id: "id", sync_with_provider: true, provider_payment_methods:} }

--- a/spec/services/payment_providers/stripe/customers/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/customers/create_service_spec.rb
@@ -4,18 +4,17 @@ require "rails_helper"
 
 RSpec.describe PaymentProviders::Stripe::Customers::CreateService do
   let(:create_service) { described_class.new(customer:, payment_provider_id:, params:, async:) }
-
-before_all do
-  create_default(:organization)
-end
-
-  let_it_be(:customer) { create(:customer) }
   let(:stripe_provider) { create(:stripe_provider, organization: customer.organization) }
   let(:payment_provider_id) { stripe_provider.id }
   let(:params) { {provider_customer_id: "id", sync_with_provider: true, provider_payment_methods:} }
   let(:async) { true }
-
   let(:provider_payment_methods) { %w[card] }
+
+  before_all do
+    create_default(:organization)
+  end
+
+  let_it_be(:customer) { create(:customer) }
 
   describe ".call" do
     it "creates a payment_provider_customer" do

--- a/spec/services/payment_providers/stripe/customers/fetch_default_payment_method_service_spec.rb
+++ b/spec/services/payment_providers/stripe/customers/fetch_default_payment_method_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Stripe::Customers::FetchDefaultPaymentMethodService do
   subject(:service) { described_class.new(provider_customer:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:stripe_provider) { create(:stripe_provider, organization:) }
   let(:provider_customer_id) { "cus_123456" }
   let(:provider_customer) do

--- a/spec/services/payment_providers/stripe/expire_payment_intents_service_spec.rb
+++ b/spec/services/payment_providers/stripe/expire_payment_intents_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Stripe::ExpirePaymentIntentsService do
   subject(:result) { described_class.call(payment_provider) }
 
-  let(:payment_provider) { create(:stripe_provider) }
-  let(:organization) { payment_provider.organization }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:payment_provider) { create(:stripe_provider) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:) }
   let(:payment_intent) { create(:payment_intent, invoice:) }
 

--- a/spec/services/payment_providers/stripe/expire_payment_intents_service_spec.rb
+++ b/spec/services/payment_providers/stripe/expire_payment_intents_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Stripe::ExpirePaymentIntentsService do
   subject(:result) { described_class.call(payment_provider) }
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:payment_provider) { create(:stripe_provider) }
   let_it_be(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:) }

--- a/spec/services/payment_providers/stripe/handle_event_service_spec.rb
+++ b/spec/services/payment_providers/stripe/handle_event_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Stripe::HandleEventService do
   subject(:event_service) { described_class.new(organization:, event_json:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
 
   let(:payment_service) { instance_double(Invoices::Payments::StripeService) }
   let(:service_result) { BaseService::Result.new }

--- a/spec/services/payment_providers/stripe/payments/authorize_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/authorize_service_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Stripe::Payments::AuthorizeService do
   subject(:authorize_service) { described_class.new(amount:, currency:, provider_customer:, payment_method:, unique_id:, metadata:) }
 
+before_all do
+  create_default(:organization)
+end
+
   let(:amount) { 0.20 }
   let(:currency) { "USD" }
   let(:provider_customer) { create(:stripe_customer, payment_provider: create(:stripe_provider), customer:, payment_method_id:) }
@@ -12,7 +16,7 @@ RSpec.describe PaymentProviders::Stripe::Payments::AuthorizeService do
   let(:unique_id) { SecureRandom.uuid }
   let(:metadata) { {} }
 
-  let(:customer) { create(:customer) }
+  let_it_be(:customer) { create(:customer) }
   let(:provider_method_id) { "pm_from_payment_method" }
   let(:payment_method_id) { "pm_from_provider_customer" }
   let(:stripe_result) do

--- a/spec/services/payment_providers/stripe/payments/authorize_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/authorize_service_spec.rb
@@ -5,18 +5,11 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Stripe::Payments::AuthorizeService do
   subject(:authorize_service) { described_class.new(amount:, currency:, provider_customer:, payment_method:, unique_id:, metadata:) }
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let(:amount) { 0.20 }
-  let(:currency) { "USD" }
-  let(:provider_customer) { create(:stripe_customer, payment_provider: create(:stripe_provider), customer:, payment_method_id:) }
-  let(:payment_method) { create(:payment_method, payment_provider_customer: provider_customer, provider_method_id:) }
-  let(:unique_id) { SecureRandom.uuid }
-  let(:metadata) { {} }
-
-  let_it_be(:customer) { create(:customer) }
   let(:provider_method_id) { "pm_from_payment_method" }
   let(:payment_method_id) { "pm_from_provider_customer" }
   let(:stripe_result) do
@@ -24,6 +17,13 @@ end
     result.payment_method_id = "pm_from_stripe"
     result
   end
+  let(:currency) { "USD" }
+  let(:provider_customer) { create(:stripe_customer, payment_provider: create(:stripe_provider), customer:, payment_method_id:) }
+  let(:payment_method) { create(:payment_method, payment_provider_customer: provider_customer, provider_method_id:) }
+  let(:unique_id) { SecureRandom.uuid }
+  let(:metadata) { {} }
+
+  let_it_be(:customer) { create(:customer) }
 
   before do
     allow(PaymentProviderCustomers::Stripe::RetrieveLatestPaymentMethodService).to receive(:call!).and_return(stripe_result)

--- a/spec/services/payment_providers/stripe/payments/cancel_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/cancel_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Stripe::Payments::CancelService do
   subject(:result) { described_class.call(payment:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:) }
   let(:payment_provider) { create(:stripe_provider, organization:, secret_key: "sk_test_123") }
   let(:payment) do

--- a/spec/services/payment_providers/stripe/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/create_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService do
 
   let(:customer) { create(:customer, payment_provider_code: code, country:) }
   let(:country) { "CA" }
-  let(:organization) { customer.organization }
+  let_it_be(:organization) { create_default(:organization) }
   let(:stripe_payment_provider) { create(:stripe_provider, organization:, code:) }
   let(:stripe_customer) { create(:stripe_customer, customer:, payment_method_id: "pm_123456", payment_provider: stripe_payment_provider) }
   let(:code) { "stripe_1" }

--- a/spec/services/payment_providers/stripe/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/create_service_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService do
   subject(:create_service) { described_class.new(payment:, reference:, metadata:) }
 
   let(:customer) { create(:customer, payment_provider_code: code, country:) }
-  let(:country) { "CA" }
-  let_it_be(:organization) { create_default(:organization) }
   let(:stripe_payment_provider) { create(:stripe_provider, organization:, code:) }
   let(:stripe_customer) { create(:stripe_customer, customer:, payment_method_id: "pm_123456", payment_provider: stripe_payment_provider) }
   let(:code) { "stripe_1" }
@@ -26,7 +24,6 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService do
       lago_billing_entity_id: payment.payable.billing_entity.id
     }
   end
-
   let(:invoice) do
     create(
       :invoice,
@@ -37,9 +34,7 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService do
       ready_for_payment_processing: true
     )
   end
-
   let(:payment_method) { create(:payment_method, customer:, provider_method_id: "pm_123456") }
-
   let(:payment) do
     create(
       :payment,
@@ -53,6 +48,9 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService do
       provider_payment_id: nil
     )
   end
+  let(:country) { "CA" }
+
+  let_it_be(:organization) { create_default(:organization) }
 
   describe ".call" do
     let(:provider_customer_service_result) do

--- a/spec/services/payment_providers/stripe/payments/update_reference_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/update_reference_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Stripe::Payments::UpdateReferenceService do
   subject(:service_result) { described_class.call(payment:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:, status: :finalized, number: "INV-2026-001") }
   let(:payment_provider) { create(:stripe_provider, organization:, secret_key: "sk_test_123") }
   let(:stripe_customer) { create(:stripe_customer, customer:, payment_provider:) }

--- a/spec/services/payment_providers/stripe/refresh_webhook_service_spec.rb
+++ b/spec/services/payment_providers/stripe/refresh_webhook_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Stripe::RefreshWebhookService do
   subject(:provider_service) { described_class.new(payment_provider) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:payment_provider) { create(:stripe_provider, organization:, code: "stripe_sandbox", webhook_id: "we_1QzHw4Q8iJWBZFaMg54WCeIn") }
 
   describe ".call" do

--- a/spec/services/payment_providers/stripe/register_webhook_service_spec.rb
+++ b/spec/services/payment_providers/stripe/register_webhook_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Stripe::RegisterWebhookService do
   subject(:provider_service) { described_class.new(payment_provider) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:payment_provider) { create(:stripe_provider, organization:, code: "stripe_sandbox") }
 
   describe ".call" do

--- a/spec/services/payment_providers/stripe/validate_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/stripe/validate_incoming_webhook_service_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe PaymentProviders::Stripe::ValidateIncomingWebhookService do
     described_class.call(payload:, signature:, payment_provider:)
   end
 
+before_all do
+  create_default(:organization)
+end
+
   let(:payload) { "webhook_payload" }
   let(:signature) { "signature" }
   let(:payment_provider) { create(:stripe_provider, webhook_secret:) }

--- a/spec/services/payment_providers/stripe/validate_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/stripe/validate_incoming_webhook_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe PaymentProviders::Stripe::ValidateIncomingWebhookService do
     described_class.call(payload:, signature:, payment_provider:)
   end
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let(:payload) { "webhook_payload" }
   let(:signature) { "signature" }

--- a/spec/services/payment_providers/stripe/webhooks/charge_dispute_closed_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/charge_dispute_closed_service_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::ChargeDisputeClosedService do
   subject(:service) { described_class.new(organization_id:, event:) }
 
   let(:organization_id) { organization.id }
-  let_it_be(:organization) { create_default(:organization) }
   let(:membership) { create(:membership, organization:) }
-  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:intent_id) { "pi_3OzgpDH4tiDZlIUa0Ezzggtg" }
   let(:payment) { create(:payment, payable:, provider_payment_id: intent_id) }
   let(:event) { ::Stripe::Event.construct_from(JSON.parse(event_json)) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before { allow(::Payments::LoseDisputeService).to receive(:call).and_call_original }
 

--- a/spec/services/payment_providers/stripe/webhooks/charge_dispute_closed_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/charge_dispute_closed_service_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::ChargeDisputeClosedService do
   subject(:service) { described_class.new(organization_id:, event:) }
 
   let(:organization_id) { organization.id }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:membership) { create(:membership, organization:) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:intent_id) { "pi_3OzgpDH4tiDZlIUa0Ezzggtg" }
   let(:payment) { create(:payment, payable:, provider_payment_id: intent_id) }
   let(:event) { ::Stripe::Event.construct_from(JSON.parse(event_json)) }

--- a/spec/services/payment_providers/stripe/webhooks/customer_updated_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/customer_updated_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerUpdatedService do
   subject(:webhook_service) { described_class.new(organization_id: organization.id, event:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   let(:event) { Stripe::Event.construct_from(JSON.parse(event_json)) }
   let(:provider_customer_id) { event.data.object.id }

--- a/spec/services/payment_providers/stripe/webhooks/payment_intent_payment_failed_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/payment_intent_payment_failed_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentPaymentFailedSer
   subject(:event_service) { described_class.new(organization_id: organization.id, event:) }
 
   let(:event) { ::Stripe::Event.construct_from(JSON.parse(event_json)) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
 
   ["2020-08-27", "2024-09-30.acacia", "2025-04-30.basil"].each do |version|
     context "when payment intent event" do

--- a/spec/services/payment_providers/stripe/webhooks/payment_intent_payment_failed_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/payment_intent_payment_failed_service_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentPaymentFailedSer
   subject(:event_service) { described_class.new(organization_id: organization.id, event:) }
 
   let(:event) { ::Stripe::Event.construct_from(JSON.parse(event_json)) }
+
   let_it_be(:organization) { create(:organization) }
 
   ["2020-08-27", "2024-09-30.acacia", "2025-04-30.basil"].each do |version|

--- a/spec/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service_spec.rb
@@ -68,9 +68,9 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentSucceededService
     end
 
     context "when payment intent event for a payment request" do
-before_all do
-  create_default(:customer)
-end
+      before_all do
+        create_default(:customer)
+      end
 
       let(:event_json) do
         get_stripe_fixtures("webhooks/payment_intent_succeeded.json", version:) do |h|

--- a/spec/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentSucceededService
   subject(:event_service) { described_class.new(organization_id: organization.id, event:) }
 
   let(:event) { ::Stripe::Event.construct_from(JSON.parse(event_json)) }
-  let(:organization) { create(:organization) }
+  let(:organization) { create_default(:organization) }
 
   ["2020-08-27", "2024-09-30.acacia", "2025-04-30.basil"].each do |version|
     context "when payment intent event (api_version: #{version})" do
@@ -68,6 +68,10 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentSucceededService
     end
 
     context "when payment intent event for a payment request" do
+before_all do
+  create_default(:customer)
+end
+
       let(:event_json) do
         get_stripe_fixtures("webhooks/payment_intent_succeeded.json", version:) do |h|
           h["data"]["object"]["id"] = "pi_12345"

--- a/spec/services/payment_providers/stripe/webhooks/setup_intent_succeeded_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/setup_intent_succeeded_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Stripe::Webhooks::SetupIntentSucceededService do
   subject(:webhook_service) { described_class.new(organization_id: organization.id, event:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   let(:event) { Stripe::Event.construct_from(JSON.parse(event_json)) }
   let(:provider_customer_id) { event.data.object.customer }

--- a/spec/services/payment_providers/stripe_service_spec.rb
+++ b/spec/services/payment_providers/stripe_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe PaymentProviders::StripeService do
 
   include_context "with mocked security logger"
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
 
   let(:code) { "code_1" }
   let(:name) { "Name 1" }

--- a/spec/services/payment_providers/stripe_service_spec.rb
+++ b/spec/services/payment_providers/stripe_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PaymentProviders::StripeService do
 
   include_context "with mocked security logger"
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
 
   let(:code) { "code_1" }

--- a/spec/services/payment_providers/update_payment_reference_service_spec.rb
+++ b/spec/services/payment_providers/update_payment_reference_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe PaymentProviders::UpdatePaymentReferenceService do
   subject(:service_result) { described_class.call(payment:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:, status: :finalized, number: "INV-2026-001") }
   let(:payment_provider) { create(:stripe_provider, organization:) }
   let(:stripe_customer) { create(:stripe_customer, customer:, payment_provider:) }

--- a/spec/services/payment_receipts/create_service_spec.rb
+++ b/spec/services/payment_receipts/create_service_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 RSpec.describe PaymentReceipts::CreateService do
   let(:invoice) { create(:invoice, customer:, organization:, total_amount_cents: 10000, status: :finalized) }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:billing_entity) { organization.default_billing_entity }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:payment) { create(:payment, payable: invoice) }
 
   describe "#call" do

--- a/spec/services/payment_receipts/create_service_spec.rb
+++ b/spec/services/payment_receipts/create_service_spec.rb
@@ -4,10 +4,11 @@ require "rails_helper"
 
 RSpec.describe PaymentReceipts::CreateService do
   let(:invoice) { create(:invoice, customer:, organization:, total_amount_cents: 10000, status: :finalized) }
-  let_it_be(:organization) { create_default(:organization) }
   let(:billing_entity) { organization.default_billing_entity }
-  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:payment) { create(:payment, payable: invoice) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   describe "#call" do
     context "when issuing receipts is not enabled" do

--- a/spec/services/payment_receipts/generate_pdf_service_spec.rb
+++ b/spec/services/payment_receipts/generate_pdf_service_spec.rb
@@ -6,8 +6,13 @@ RSpec.describe PaymentReceipts::GeneratePdfService do
   subject(:payment_receipt_generate_service) { described_class.new(payment_receipt:, context:) }
 
   let(:context) { "graphql" }
-  let(:organization) { create(:organization, name: "LAGO") }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization, name: "LAGO") }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+
+before_all do
+  create_default(:plan)
+end
+
   let(:subscription) { create(:subscription, organization:, customer:) }
   let(:invoice) { create(:invoice, customer:, status: :finalized, organization:) }
   let(:payment) { create(:payment, payable: invoice) }

--- a/spec/services/payment_receipts/generate_pdf_service_spec.rb
+++ b/spec/services/payment_receipts/generate_pdf_service_spec.rb
@@ -6,18 +6,18 @@ RSpec.describe PaymentReceipts::GeneratePdfService do
   subject(:payment_receipt_generate_service) { described_class.new(payment_receipt:, context:) }
 
   let(:context) { "graphql" }
-  let_it_be(:organization) { create_default(:organization, name: "LAGO") }
-  let_it_be(:customer) { create_default(:customer, organization:) }
-
-before_all do
-  create_default(:plan)
-end
-
   let(:subscription) { create(:subscription, organization:, customer:) }
   let(:invoice) { create(:invoice, customer:, status: :finalized, organization:) }
   let(:payment) { create(:payment, payable: invoice) }
   let(:payment_receipt) { create(:payment_receipt, payment:, organization:) }
   let(:blank_pdf_path) { Rails.root.join("spec/fixtures/blank.pdf") }
+
+  let_it_be(:organization) { create_default(:organization, name: "LAGO") }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+
+  before_all do
+    create_default(:plan)
+  end
 
   before do
     billing_entity = organization.default_billing_entity

--- a/spec/services/payment_receipts/generate_xml_service_spec.rb
+++ b/spec/services/payment_receipts/generate_xml_service_spec.rb
@@ -4,9 +4,10 @@ require "rails_helper"
 
 RSpec.describe PaymentReceipts::GenerateXmlService do
   let(:context) { "graphql" }
-  let(:organization) { create(:organization, name: "LAGO") }
-  let(:billing_entity) { create(:billing_entity, organization:, country: "FR", einvoicing:) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization, name: "LAGO") }
+  let_it_be(:einvoicing) { true }
+  let_it_be(:billing_entity) { create(:billing_entity, organization:, country: "FR", einvoicing:) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:invoice) { create(:invoice, total_amount_cents: 1000, number: "INV-24680-OIC-E") }
   let(:payment) do
     create(:payment,
@@ -20,7 +21,6 @@ RSpec.describe PaymentReceipts::GenerateXmlService do
   end
   let(:payment_receipt) { create(:payment_receipt, payment:, organization:, billing_entity:) }
   let(:status) { :finalized }
-  let(:einvoicing) { true }
   let(:blank_xml_path) { Rails.root.join("spec/fixtures/blank.xml") }
   let(:fake_xml) { "<xml>content</xml>" }
   let(:create_xml_result) { EInvoices::Invoices::Ubl::CreateService::Result.new.tap { |result| result.xml = fake_xml } }
@@ -115,6 +115,7 @@ RSpec.describe PaymentReceipts::GenerateXmlService do
 
       context "when einvoicing is disabled" do
         let(:einvoicing) { false }
+  let(:billing_entity) { create(:billing_entity, organization:, country: "FR", einvoicing:) }
 
         it_behaves_like "dont generate"
       end

--- a/spec/services/payment_receipts/generate_xml_service_spec.rb
+++ b/spec/services/payment_receipts/generate_xml_service_spec.rb
@@ -4,10 +4,6 @@ require "rails_helper"
 
 RSpec.describe PaymentReceipts::GenerateXmlService do
   let(:context) { "graphql" }
-  let_it_be(:organization) { create_default(:organization, name: "LAGO") }
-  let_it_be(:einvoicing) { true }
-  let_it_be(:billing_entity) { create(:billing_entity, organization:, country: "FR", einvoicing:) }
-  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:invoice) { create(:invoice, total_amount_cents: 1000, number: "INV-24680-OIC-E") }
   let(:payment) do
     create(:payment,
@@ -25,6 +21,11 @@ RSpec.describe PaymentReceipts::GenerateXmlService do
   let(:fake_xml) { "<xml>content</xml>" }
   let(:create_xml_result) { EInvoices::Invoices::Ubl::CreateService::Result.new.tap { |result| result.xml = fake_xml } }
   let(:xml_service) { EInvoices::Invoices::Ubl::CreateService }
+
+  let_it_be(:organization) { create_default(:organization, name: "LAGO") }
+  let_it_be(:einvoicing) { true }
+  let_it_be(:billing_entity) { create(:billing_entity, organization:, country: "FR", einvoicing:) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     payment
@@ -115,7 +116,7 @@ RSpec.describe PaymentReceipts::GenerateXmlService do
 
       context "when einvoicing is disabled" do
         let(:einvoicing) { false }
-  let(:billing_entity) { create(:billing_entity, organization:, country: "FR", einvoicing:) }
+        let(:billing_entity) { create(:billing_entity, organization:, country: "FR", einvoicing:) }
 
         it_behaves_like "dont generate"
       end

--- a/spec/services/payment_requests/create_service_spec.rb
+++ b/spec/services/payment_requests/create_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentRequests::CreateService, :premium do
   subject(:create_service) { described_class.new(organization:, params:) }
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let_it_be(:customer) { create(:customer, organization:) }
 

--- a/spec/services/payment_requests/create_service_spec.rb
+++ b/spec/services/payment_requests/create_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe PaymentRequests::CreateService, :premium do
   subject(:create_service) { described_class.new(organization:, params:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   let(:first_invoice) do
     create(:invoice, customer:, payment_overdue: true, total_amount_cents: 200, total_paid_amount_cents: 100)

--- a/spec/services/payment_requests/payments/adyen_service_spec.rb
+++ b/spec/services/payment_requests/payments/adyen_service_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe PaymentRequests::Payments::AdyenService do
+  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, payment_provider_code: code) }
-  let(:organization) { customer.organization }
   let(:adyen_payment_provider) { create(:adyen_provider, organization:, code:) }
   let(:adyen_customer) { create(:adyen_customer, customer:) }
   let(:adyen_client) { instance_double(Adyen::Client) }

--- a/spec/services/payment_requests/payments/cashfree_service_spec.rb
+++ b/spec/services/payment_requests/payments/cashfree_service_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe PaymentRequests::Payments::CashfreeService do
+  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, payment_provider_code: code) }
-  let(:organization) { customer.organization }
   let(:cashfree_payment_provider) { create(:cashfree_provider, organization:, code:) }
   let(:cashfree_customer) { create(:cashfree_customer, customer:) }
   let(:cashfree_client) { instance_double(LagoHttpClient::Client) }

--- a/spec/services/payment_requests/payments/create_service_spec.rb
+++ b/spec/services/payment_requests/payments/create_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentRequests::Payments::CreateService do
   subject(:create_service) { described_class.new(payable: payment_request, payment_provider: provider, payment_method_params:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:billing_entity) { organization.default_billing_entity }
   let(:customer) { create(:customer, organization:, payment_provider: provider, payment_provider_code:) }
   let(:provider) { "stripe" }

--- a/spec/services/payment_requests/payments/flutterwave_service_spec.rb
+++ b/spec/services/payment_requests/payments/flutterwave_service_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe PaymentRequests::Payments::FlutterwaveService do
-  let(:organization) { create(:organization, name: "Test Organization") }
+  let_it_be(:organization) { create(:organization, name: "Test Organization") }
   let(:customer) { create(:customer, organization: organization, email: "customer@example.com", name: "John Doe") }
   let(:flutterwave_provider) { create(:flutterwave_provider, organization: organization, secret_key: "FLWSECK_TEST-secret") }
   let(:flutterwave_customer) { create(:flutterwave_customer, customer: customer, payment_provider: flutterwave_provider) }

--- a/spec/services/payment_requests/payments/generate_payment_url_service_spec.rb
+++ b/spec/services/payment_requests/payments/generate_payment_url_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentRequests::Payments::GeneratePaymentUrlService do
   subject(:generate_payment_url_service) { described_class.new(payable: payment_request) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, organization:, payment_provider: provider, payment_provider_code: code) }
   let(:payment_request) { create(:payment_request, customer:) }
   let(:provider) { "stripe" }

--- a/spec/services/payment_requests/payments/gocardless_service_spec.rb
+++ b/spec/services/payment_requests/payments/gocardless_service_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe PaymentRequests::Payments::GocardlessService do
-  let(:organization) { create(:organization, webhook_url: "https://webhook.com") }
+  let_it_be(:organization) { create_default(:organization, webhook_url: "https://webhook.com") }
   let(:customer) { create(:customer, organization:, payment_provider_code: code) }
   let(:gocardless_payment_provider) { create(:gocardless_provider, organization:, code:) }
   let(:gocardless_customer) { create(:gocardless_customer, customer:) }

--- a/spec/services/payment_requests/payments/moneyhash_service_spec.rb
+++ b/spec/services/payment_requests/payments/moneyhash_service_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe PaymentRequests::Payments::MoneyhashService do
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:moneyhash_provider) { create(:moneyhash_provider, organization:) }
   let(:moneyhash_customer) { create(:moneyhash_customer, customer:, payment_provider: moneyhash_provider) }

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe PaymentRequests::Payments::StripeService do
+  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create(:customer, payment_provider_code: code) }
-  let(:organization) { customer.organization }
   let(:billing_entity) { organization.default_billing_entity }
   let(:stripe_payment_provider) { create(:stripe_provider, organization:, code:) }
   let(:stripe_customer) {

--- a/spec/services/payments/lose_dispute_service_spec.rb
+++ b/spec/services/payments/lose_dispute_service_spec.rb
@@ -5,6 +5,11 @@ require "rails_helper"
 RSpec.describe Payments::LoseDisputeService do
   subject(:lose_dispute_service) { described_class.new(payment:) }
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
   describe "#call" do
     context "when payment does not exist" do
       let(:payment) { nil }

--- a/spec/services/payments/lose_dispute_service_spec.rb
+++ b/spec/services/payments/lose_dispute_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe Payments::LoseDisputeService do
   subject(:lose_dispute_service) { described_class.new(payment:) }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
 
   describe "#call" do
     context "when payment does not exist" do

--- a/spec/services/payments/manual_create_service_spec.rb
+++ b/spec/services/payments/manual_create_service_spec.rb
@@ -7,8 +7,13 @@ RSpec.describe Payments::ManualCreateService do
 
   let(:invoice) { create(:invoice, customer:, organization:, total_amount_cents: 10000, status: :finalized) }
   let(:invoice_id) { invoice.id }
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+
+before_all do
+  create_default(:billing_entity)
+end
+
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:params) { {invoice_id:, amount_cents:, reference: "ref1", paid_at:} }
   let(:paid_at) { 1.year.ago.iso8601 }
   let(:amount_cents) { 10000 }

--- a/spec/services/payments/manual_create_service_spec.rb
+++ b/spec/services/payments/manual_create_service_spec.rb
@@ -6,17 +6,18 @@ RSpec.describe Payments::ManualCreateService do
   subject(:service) { described_class.new(organization:, params:) }
 
   let(:invoice) { create(:invoice, customer:, organization:, total_amount_cents: 10000, status: :finalized) }
-  let(:invoice_id) { invoice.id }
-  let_it_be(:organization) { create_default(:organization) }
-
-before_all do
-  create_default(:billing_entity)
-end
-
-  let_it_be(:customer) { create(:customer, organization:) }
   let(:params) { {invoice_id:, amount_cents:, reference: "ref1", paid_at:} }
   let(:paid_at) { 1.year.ago.iso8601 }
   let(:amount_cents) { 10000 }
+  let(:invoice_id) { invoice.id }
+
+  let_it_be(:organization) { create_default(:organization) }
+
+  before_all do
+    create_default(:billing_entity)
+  end
+
+  let_it_be(:customer) { create(:customer, organization:) }
 
   describe "#call" do
     context "when organization is not premium" do

--- a/spec/services/payments/set_payment_method_data_service_spec.rb
+++ b/spec/services/payments/set_payment_method_data_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Payments::SetPaymentMethodDataService do
   subject(:service) { described_class.new(payment:, provider_payment_method_id:) }
 
   let(:provider_payment_method_id) { "pm_1R2DFsQ8iJWBZFaMw3LLbR0r" }
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
 
   describe "#call" do
     context "with Stripe" do

--- a/spec/services/payments/set_payment_method_data_service_spec.rb
+++ b/spec/services/payments/set_payment_method_data_service_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Payments::SetPaymentMethodDataService do
   subject(:service) { described_class.new(payment:, provider_payment_method_id:) }
 
   let(:provider_payment_method_id) { "pm_1R2DFsQ8iJWBZFaMw3LLbR0r" }
+
   let_it_be(:organization) { create_default(:organization) }
 
   describe "#call" do

--- a/spec/services/plan_rate_cards/create_service_spec.rb
+++ b/spec/services/plan_rate_cards/create_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe PlanRateCards::CreateService do
 
   let_it_be(:organization) { create(:organization) }
 
-before_all do
-  create_default(:billable_metric)
-end
+  before_all do
+    create_default(:billable_metric)
+  end
 
   let_it_be(:plan) { create(:plan, :product_catalog, organization:) }
   let(:rate_card) { create(:rate_card, organization:) }

--- a/spec/services/plan_rate_cards/create_service_spec.rb
+++ b/spec/services/plan_rate_cards/create_service_spec.rb
@@ -5,8 +5,13 @@ require "rails_helper"
 RSpec.describe PlanRateCards::CreateService do
   subject(:result) { described_class.call(plan:, params:) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, :product_catalog, organization:) }
+  let_it_be(:organization) { create(:organization) }
+
+before_all do
+  create_default(:billable_metric)
+end
+
+  let_it_be(:plan) { create(:plan, :product_catalog, organization:) }
   let(:rate_card) { create(:rate_card, organization:) }
 
   let(:params) { {rate_card_code: rate_card.code, units: "10"} }

--- a/spec/services/plan_rate_cards/destroy_service_spec.rb
+++ b/spec/services/plan_rate_cards/destroy_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe PlanRateCards::DestroyService do
 
   let_it_be(:organization) { create(:organization) }
 
-before_all do
-  create_default(:billable_metric)
-end
+  before_all do
+    create_default(:billable_metric)
+  end
 
   let_it_be(:plan) { create(:plan, organization:) }
   let(:plan_rate_card) { create(:plan_rate_card, organization:, plan:) }

--- a/spec/services/plan_rate_cards/destroy_service_spec.rb
+++ b/spec/services/plan_rate_cards/destroy_service_spec.rb
@@ -5,8 +5,13 @@ require "rails_helper"
 RSpec.describe PlanRateCards::DestroyService do
   subject(:result) { described_class.call(plan_rate_card:) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create(:organization) }
+
+before_all do
+  create_default(:billable_metric)
+end
+
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:plan_rate_card) { create(:plan_rate_card, organization:, plan:) }
 
   it "soft deletes the entry" do

--- a/spec/services/plan_rate_cards/update_service_spec.rb
+++ b/spec/services/plan_rate_cards/update_service_spec.rb
@@ -5,8 +5,13 @@ require "rails_helper"
 RSpec.describe PlanRateCards::UpdateService do
   subject(:result) { described_class.call(plan_rate_card:, params:) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create(:organization) }
+
+before_all do
+  create_default(:billable_metric)
+end
+
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:plan_rate_card) { create(:plan_rate_card, organization:, plan:, units: 5) }
 
   let(:params) { {units: "12"} }

--- a/spec/services/plan_rate_cards/update_service_spec.rb
+++ b/spec/services/plan_rate_cards/update_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe PlanRateCards::UpdateService do
 
   let_it_be(:organization) { create(:organization) }
 
-before_all do
-  create_default(:billable_metric)
-end
+  before_all do
+    create_default(:billable_metric)
+  end
 
   let_it_be(:plan) { create(:plan, organization:) }
   let(:plan_rate_card) { create(:plan_rate_card, organization:, plan:, units: 5) }

--- a/spec/services/plans/apply_taxes_service_spec.rb
+++ b/spec/services/plans/apply_taxes_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Plans::ApplyTaxesService do
   subject(:apply_service) { described_class.new(plan:, tax_codes:) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:tax1) { create(:tax, organization:, code: "tax1") }
   let(:tax2) { create(:tax, organization:, code: "tax2") }
   let(:tax_codes) { [tax1.code, tax2.code] }

--- a/spec/services/plans/chargeables_validation_service_spec.rb
+++ b/spec/services/plans/chargeables_validation_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Plans::ChargeablesValidationService do
   subject(:validation_service) { described_class.call(organization:, charges:, fixed_charges:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:charges) { nil }
   let(:fixed_charges) { nil }
 
@@ -17,7 +17,7 @@ RSpec.describe Plans::ChargeablesValidationService do
     end
 
     context "when validating billable metrics" do
-      let(:billable_metric) { create(:billable_metric, organization:) }
+      let_it_be(:billable_metric) { create(:billable_metric, organization:) }
       let(:charges) do
         [
           {billable_metric_id: billable_metric.id}
@@ -60,7 +60,7 @@ RSpec.describe Plans::ChargeablesValidationService do
     end
 
     context "when validating add ons by id" do
-      let(:add_on) { create(:add_on, organization:) }
+      let_it_be(:add_on) { create(:add_on, organization:) }
       let(:fixed_charges) do
         [
           {add_on_id: add_on.id}
@@ -151,8 +151,8 @@ RSpec.describe Plans::ChargeablesValidationService do
     end
 
     context "when validating both charges and fixed_charges" do
-      let(:billable_metric) { create(:billable_metric, organization:) }
-      let(:add_on) { create(:add_on, organization:) }
+      let_it_be(:billable_metric) { create(:billable_metric, organization:) }
+      let_it_be(:add_on) { create(:add_on, organization:) }
       let(:charges) do
         [
           {billable_metric_id: billable_metric.id}

--- a/spec/services/plans/destroy_service_spec.rb
+++ b/spec/services/plans/destroy_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Plans::DestroyService do
   subject(:destroy_service) { described_class.new(plan:) }
 
+  let(:organization) { create_default(:organization)}
   let(:plan) { create(:plan, organization:, pending_deletion: true) }
-  let(:organization) { membership.organization }
   let(:membership) { create(:membership) }
 
   before do

--- a/spec/services/plans/destroy_service_spec.rb
+++ b/spec/services/plans/destroy_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Plans::DestroyService do
   subject(:destroy_service) { described_class.new(plan:) }
 
-  let(:organization) { create_default(:organization)}
+  let(:organization) { create_default(:organization) }
   let(:plan) { create(:plan, organization:, pending_deletion: true) }
   let(:membership) { create(:membership) }
 

--- a/spec/services/plans/override_service_spec.rb
+++ b/spec/services/plans/override_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Plans::OverrideService do
   subject(:override_service) { described_class.new(plan: parent_plan, params:, subscription:) }
 
-  let(:organization) { membership.organization }
-  let(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
   let(:subscription) { nil }
 
   describe "product catalog gating", :premium do
@@ -22,9 +22,9 @@ RSpec.describe Plans::OverrideService do
   end
 
   describe "#call", :premium do
-    let(:parent_plan) { create(:plan, organization:) }
-    let(:billable_metric) { create(:billable_metric, organization:) }
-    let(:add_on) { create(:add_on, organization:) }
+    let_it_be(:parent_plan) { create(:plan, organization:) }
+    let_it_be(:billable_metric) { create(:billable_metric, organization:) }
+    let_it_be(:add_on) { create(:add_on, organization:) }
     let(:billable_metric_filter) { create(:billable_metric_filter, billable_metric:) }
     let(:tax) { create(:tax, organization:) }
 
@@ -276,7 +276,7 @@ RSpec.describe Plans::OverrideService do
     end
 
     context "when subscription parameter is provided" do
-      let(:customer) { create(:customer, organization:) }
+      let_it_be(:customer) { create(:customer, organization:) }
       let(:subscription) { create(:subscription, plan: parent_plan, customer:) }
 
       it "creates a plan successfully with subscription parameter" do

--- a/spec/services/plans/override_service_spec.rb
+++ b/spec/services/plans/override_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Plans::OverrideService do
   subject(:override_service) { described_class.new(plan: parent_plan, params:, subscription:) }
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let(:subscription) { nil }
 

--- a/spec/services/plans/prepare_destroy_service_spec.rb
+++ b/spec/services/plans/prepare_destroy_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Plans::PrepareDestroyService do
   subject(:prepare_destroy_service) { described_class.new(plan:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:plan) { create(:plan, organization:) }
 
   describe "#call" do
     it "sets pending_deletion to true" do

--- a/spec/services/plans/prepare_destroy_service_spec.rb
+++ b/spec/services/plans/prepare_destroy_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Plans::PrepareDestroyService do
   subject(:prepare_destroy_service) { described_class.new(plan:) }
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let_it_be(:plan) { create(:plan, organization:) }
 

--- a/spec/services/plans/update_amount_service_spec.rb
+++ b/spec/services/plans/update_amount_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Plans::UpdateAmountService do
   subject(:update_service) { described_class.new(plan:, amount_cents:, expected_amount_cents:) }
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let(:plan) { create(:plan, organization:, amount_cents: 111) }
   let(:amount_cents) { 222 }

--- a/spec/services/plans/update_amount_service_spec.rb
+++ b/spec/services/plans/update_amount_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Plans::UpdateAmountService do
   subject(:update_service) { described_class.new(plan:, amount_cents:, expected_amount_cents:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
   let(:plan) { create(:plan, organization:, amount_cents: 111) }
   let(:amount_cents) { 222 }
   let(:expected_amount_cents) { 111 }

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Plans::UpdateService do
   subject(:plans_service) { described_class.new(plan:, params: update_args) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let(:membership) { create_default(:membership) }
+  let(:plan) { create_default(:plan, organization:) }
   let(:plan_name) { "Updated plan name" }
   let(:plan_invoice_display_name) { "Updated plan invoice display name" }
   let(:sum_billable_metric) { create(:sum_billable_metric, organization:, recurring: true) }
@@ -724,6 +724,7 @@ RSpec.describe Plans::UpdateService do
     end
 
     context "with metrics from other organization" do
+      let(:organization) { create(:organization) }
       let(:billable_metric) { create(:billable_metric) }
 
       it "returns an error" do

--- a/spec/services/plans/update_usage_thresholds_service_spec.rb
+++ b/spec/services/plans/update_usage_thresholds_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Plans::UpdateUsageThresholdsService do
   subject { described_class.call(plan:, usage_thresholds_params:) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
 
   context "when usage_thresholds_params is empty" do
     let(:usage_thresholds_params) { [] }

--- a/spec/services/pricing_units/create_service_spec.rb
+++ b/spec/services/pricing_units/create_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PricingUnits::CreateService do
   describe "#call" do
     subject(:result) { described_class.call(params) }
 
-    let(:organization) { create(:organization) }
+    let_it_be(:organization) { create(:organization) }
     let(:name) { "Cloud tokens" }
     let(:short_name) { "CT" }
     let(:description) { "description" }

--- a/spec/services/pricing_units/update_service_spec.rb
+++ b/spec/services/pricing_units/update_service_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe PricingUnits::UpdateService do
   describe "#call" do
     subject(:result) { described_class.call(pricing_unit:, params:) }
 
-before_all do
-  create_default(:organization)
-end
+    before_all do
+      create_default(:organization)
+    end
 
     let(:name) { "Cloud tokens" }
     let(:short_name) { "CT" }

--- a/spec/services/pricing_units/update_service_spec.rb
+++ b/spec/services/pricing_units/update_service_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe PricingUnits::UpdateService do
   describe "#call" do
     subject(:result) { described_class.call(pricing_unit:, params:) }
 
+before_all do
+  create_default(:organization)
+end
+
     let(:name) { "Cloud tokens" }
     let(:short_name) { "CT" }
     let(:description) { "description" }

--- a/spec/services/product_categories/create_service_spec.rb
+++ b/spec/services/product_categories/create_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe ProductCategories::CreateService do
   subject(:result) { described_class.call(organization:, params:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:params) do
     {
       name: "Cards",

--- a/spec/services/product_categories/destroy_service_spec.rb
+++ b/spec/services/product_categories/destroy_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe ProductCategories::DestroyService do
   subject(:result) { described_class.call(product_category:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:product_category) { create(:product_category, organization:) }
 
   before do

--- a/spec/services/product_categories/update_service_spec.rb
+++ b/spec/services/product_categories/update_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe ProductCategories::UpdateService do
   subject(:result) { described_class.call(product_category:, params:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:product_category) { create(:product_category, organization:, name: "Before", code: "before") }
 
   let(:params) { {name: "After", description: "new", invoice_display_name: "Display"} }

--- a/spec/services/product_filters/create_service_spec.rb
+++ b/spec/services/product_filters/create_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe ProductFilters::CreateService do
   subject(:result) { described_class.call(product:, params:) }
 
-  let(:organization) { create(:organization) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
   let(:product) { create(:product, organization:, billable_metric:) }
   let(:region_filter) { create(:billable_metric_filter, organization:, billable_metric:, key: "region", values: %w[us eu]) }
   let(:scheme_filter) { create(:billable_metric_filter, organization:, billable_metric:, key: "scheme", values: %w[visa mastercard]) }

--- a/spec/services/product_filters/destroy_service_spec.rb
+++ b/spec/services/product_filters/destroy_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe ProductFilters::DestroyService do
 
   let_it_be(:organization) { create(:organization) }
 
-before_all do
-  create_default(:billable_metric)
-end
+  before_all do
+    create_default(:billable_metric)
+  end
 
   let(:product_filter) { create(:product_filter, :with_values, organization:) }
 

--- a/spec/services/product_filters/destroy_service_spec.rb
+++ b/spec/services/product_filters/destroy_service_spec.rb
@@ -5,7 +5,12 @@ require "rails_helper"
 RSpec.describe ProductFilters::DestroyService do
   subject(:result) { described_class.call(product_filter:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
+
+before_all do
+  create_default(:billable_metric)
+end
+
   let(:product_filter) { create(:product_filter, :with_values, organization:) }
 
   it "soft deletes the filter and its values" do

--- a/spec/services/product_filters/update_service_spec.rb
+++ b/spec/services/product_filters/update_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe ProductFilters::UpdateService do
   subject(:result) { described_class.call(product_filter:, params:) }
 
-  let(:organization) { create(:organization) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
   let(:product) { create(:product, organization:, billable_metric:) }
   let(:region_filter) { create(:billable_metric_filter, organization:, billable_metric:, key: "region", values: %w[us eu]) }
 

--- a/spec/services/products/create_service_spec.rb
+++ b/spec/services/products/create_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Products::CreateService do
   subject(:result) { described_class.call(organization:, params:) }
 
-  let(:organization) { create(:organization) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
   let(:product_category) { create(:product_category, organization:) }
 
   let(:params) do

--- a/spec/services/products/destroy_service_spec.rb
+++ b/spec/services/products/destroy_service_spec.rb
@@ -5,7 +5,12 @@ require "rails_helper"
 RSpec.describe Products::DestroyService do
   subject(:result) { described_class.call(product:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
+
+before_all do
+  create_default(:billable_metric)
+end
+
   let(:product) { create(:product, :with_filters, organization:) }
 
   before do

--- a/spec/services/products/destroy_service_spec.rb
+++ b/spec/services/products/destroy_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Products::DestroyService do
 
   let_it_be(:organization) { create(:organization) }
 
-before_all do
-  create_default(:billable_metric)
-end
+  before_all do
+    create_default(:billable_metric)
+  end
 
   let(:product) { create(:product, :with_filters, organization:) }
 

--- a/spec/services/products/update_service_spec.rb
+++ b/spec/services/products/update_service_spec.rb
@@ -5,9 +5,13 @@ require "rails_helper"
 RSpec.describe Products::UpdateService do
   subject(:result) { described_class.call(product:, params:) }
 
-  let(:organization) { create(:organization) }
-  let(:product) { create(:product, organization:, name: "Before", code: "before") }
+  let_it_be(:organization) { create(:organization) }
 
+before_all do
+  create_default(:billable_metric)
+end
+
+  let(:product) { create(:product, organization:, name: "Before", code: "before") }
   let(:params) { {name: "After", description: "new", invoice_display_name: "Display"} }
 
   it "updates the mutable attributes" do

--- a/spec/services/products/update_service_spec.rb
+++ b/spec/services/products/update_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Products::UpdateService do
 
   let_it_be(:organization) { create(:organization) }
 
-before_all do
-  create_default(:billable_metric)
-end
+  before_all do
+    create_default(:billable_metric)
+  end
 
   let(:product) { create(:product, organization:, name: "Before", code: "before") }
   let(:params) { {name: "After", description: "new", invoice_display_name: "Display"} }

--- a/spec/services/quote_versions/approve_service_spec.rb
+++ b/spec/services/quote_versions/approve_service_spec.rb
@@ -3,9 +3,14 @@
 require "rails_helper"
 
 RSpec.describe QuoteVersions::ApproveService do
+before_all do
+  create_default(:customer)
+create_default(:plan)
+end
+
   subject(:approve_service) { described_class.new(quote_version:) }
 
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
   let(:quote) { create(:quote, organization:) }
   let(:quote_version) do
     create(

--- a/spec/services/quote_versions/approve_service_spec.rb
+++ b/spec/services/quote_versions/approve_service_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 RSpec.describe QuoteVersions::ApproveService do
-before_all do
-  create_default(:customer)
-create_default(:plan)
-end
+  before_all do
+    create_default(:customer)
+    create_default(:plan)
+  end
 
   subject(:approve_service) { described_class.new(quote_version:) }
 

--- a/spec/services/quote_versions/clone_service_spec.rb
+++ b/spec/services/quote_versions/clone_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe QuoteVersions::CloneService do
 
   let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
 
-before_all do
-  create_default(:customer)
-end
+  before_all do
+    create_default(:customer)
+  end
 
   let!(:quote) { create(:quote, organization:) }
   let!(:versions) do

--- a/spec/services/quote_versions/clone_service_spec.rb
+++ b/spec/services/quote_versions/clone_service_spec.rb
@@ -5,7 +5,12 @@ require "rails_helper"
 RSpec.describe QuoteVersions::CloneService do
   subject(:clone_service) { described_class.new(quote_version:) }
 
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
+
+before_all do
+  create_default(:customer)
+end
+
   let!(:quote) { create(:quote, organization:) }
   let!(:versions) do
     QuoteVersion.transaction do

--- a/spec/services/quote_versions/compute_mention_variables_service_spec.rb
+++ b/spec/services/quote_versions/compute_mention_variables_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe QuoteVersions::ComputeMentionVariablesService do
   subject(:service) { described_class.new(quote_version:) }
 
-  let(:organization) { create(:organization, name: "Lago") }
-  let(:billing_entity) do
-    create(
+  let_it_be(:organization) { create_default(:organization, name: "Lago") }
+  let_it_be(:billing_entity) do
+    create_default(
       :billing_entity,
       organization:,
       name: "Globex SARL",
@@ -26,7 +26,7 @@ RSpec.describe QuoteVersions::ComputeMentionVariablesService do
   let(:customer_net_payment_term) { nil }
   let(:customer_document_locale) { nil }
   let(:customer) do
-    create(
+    create_default(
       :customer,
       organization:,
       billing_entity:,

--- a/spec/services/quote_versions/create_service_spec.rb
+++ b/spec/services/quote_versions/create_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe QuoteVersions::CreateService do
     described_class.new(quote:, params: create_params)
   end
 
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+      let_it_be(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:create_params) do
     {
@@ -133,6 +133,7 @@ RSpec.describe QuoteVersions::CreateService do
     end
 
     context "when feature flag is disabled", :premium do
+      let(:customer) { create(:customer, organization:) }
       let(:organization) { create(:organization) }
 
       it "returns forbidden status" do

--- a/spec/services/quote_versions/create_service_spec.rb
+++ b/spec/services/quote_versions/create_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe QuoteVersions::CreateService do
   end
 
   let_it_be(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-      let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:create_params) do
     {

--- a/spec/services/quote_versions/deal_expiration_spec.rb
+++ b/spec/services/quote_versions/deal_expiration_spec.rb
@@ -3,7 +3,12 @@
 require "rails_helper"
 
 RSpec.describe QuoteVersions::DealExpiration do
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
+
+before_all do
+  create_default(:customer)
+end
+
   let(:quote) { create(:quote, organization:) }
   let(:billing_items) { {"plans" => [{"payload" => {"endDate" => "2026-06-01T00:00:00Z"}}]} }
   let(:quote_version) { build(:quote_version, quote:, organization:, billing_items:) }

--- a/spec/services/quote_versions/deal_expiration_spec.rb
+++ b/spec/services/quote_versions/deal_expiration_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe QuoteVersions::DealExpiration do
   let_it_be(:organization) { create_default(:organization) }
 
-before_all do
-  create_default(:customer)
-end
+  before_all do
+    create_default(:customer)
+  end
 
   let(:quote) { create(:quote, organization:) }
   let(:billing_items) { {"plans" => [{"payload" => {"endDate" => "2026-06-01T00:00:00Z"}}]} }

--- a/spec/services/quote_versions/validators/one_off/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/one_off/business_validator_spec.rb
@@ -6,11 +6,8 @@ RSpec.describe QuoteVersions::Validators::OneOff::BusinessValidator do
   subject(:validator) { described_class.new(result, quote_version:, billing_items:, scope:) }
 
   let(:result) { BaseService::Result.new }
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:, order_type: :one_off) }
   let(:quote_version) { create(:quote_version, quote:, organization:, currency: "EUR") }
-  let_it_be(:add_on) { create(:add_on, organization:) }
   let(:scope) { :update }
   let(:add_on_item) do
     {
@@ -28,6 +25,10 @@ RSpec.describe QuoteVersions::Validators::OneOff::BusinessValidator do
     }
   end
   let(:billing_items) { {"addOns" => [add_on_item]} }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
 
   describe "#valid?" do
     context "with a valid quote version" do

--- a/spec/services/quote_versions/validators/one_off/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/one_off/business_validator_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe QuoteVersions::Validators::OneOff::BusinessValidator do
   subject(:validator) { described_class.new(result, quote_version:, billing_items:, scope:) }
 
   let(:result) { BaseService::Result.new }
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:, order_type: :one_off) }
   let(:quote_version) { create(:quote_version, quote:, organization:, currency: "EUR") }
-  let(:add_on) { create(:add_on, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
   let(:scope) { :update }
   let(:add_on_item) do
     {

--- a/spec/services/quote_versions/validators/one_off_validator_spec.rb
+++ b/spec/services/quote_versions/validators/one_off_validator_spec.rb
@@ -6,11 +6,8 @@ RSpec.describe QuoteVersions::Validators::OneOffValidator do
   subject(:validator) { described_class.new(result, quote_version:, scope:) }
 
   let(:result) { BaseService::Result.new }
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:, order_type: :one_off) }
   let(:quote_version) { create(:quote_version, quote:, organization:, currency: "EUR", billing_items:) }
-  let_it_be(:add_on) { create(:add_on, organization:) }
   let(:scope) { :approve }
   let(:add_on_item) do
     {
@@ -29,6 +26,10 @@ RSpec.describe QuoteVersions::Validators::OneOffValidator do
     }
   end
   let(:billing_items) { {"addOns" => [add_on_item]} }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
 
   describe "#valid?" do
     context "with a complete valid quote version" do

--- a/spec/services/quote_versions/validators/one_off_validator_spec.rb
+++ b/spec/services/quote_versions/validators/one_off_validator_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe QuoteVersions::Validators::OneOffValidator do
   subject(:validator) { described_class.new(result, quote_version:, scope:) }
 
   let(:result) { BaseService::Result.new }
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:, order_type: :one_off) }
   let(:quote_version) { create(:quote_version, quote:, organization:, currency: "EUR", billing_items:) }
-  let(:add_on) { create(:add_on, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
   let(:scope) { :approve }
   let(:add_on_item) do
     {

--- a/spec/services/quote_versions/validators/subscription_amendment/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_amendment/business_validator_spec.rb
@@ -6,13 +6,8 @@ RSpec.describe QuoteVersions::Validators::SubscriptionAmendment::BusinessValidat
   subject(:validator) { described_class.new(result, quote_version:, billing_items:, scope:) }
 
   let(:result) { BaseService::Result.new }
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:customer) { create(:customer, organization:) }
-  let_it_be(:target_plan) { create(:plan, organization:, amount_cents: 10_000) }
   let(:subscription) { create(:subscription, customer:, organization:, plan: target_plan) }
-  let_it_be(:plan) { create(:plan, organization:, amount_cents: 20_000) }
   let(:scope) { :approve }
-
   let(:quote) do
     create(:quote, organization:, customer:, subscription:, order_type: :subscription_amendment)
   end
@@ -31,6 +26,11 @@ RSpec.describe QuoteVersions::Validators::SubscriptionAmendment::BusinessValidat
     }.compact
   end
   let(:billing_items) { {"plans" => [plan_item]} }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:target_plan) { create(:plan, organization:, amount_cents: 10_000) }
+  let_it_be(:plan) { create(:plan, organization:, amount_cents: 20_000) }
 
   describe "#valid?" do
     it "is valid and leaves the result untouched" do

--- a/spec/services/quote_versions/validators/subscription_amendment/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_amendment/business_validator_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe QuoteVersions::Validators::SubscriptionAmendment::BusinessValidat
   subject(:validator) { described_class.new(result, quote_version:, billing_items:, scope:) }
 
   let(:result) { BaseService::Result.new }
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:target_plan) { create(:plan, organization:, amount_cents: 10_000) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:target_plan) { create(:plan, organization:, amount_cents: 10_000) }
   let(:subscription) { create(:subscription, customer:, organization:, plan: target_plan) }
-  let(:plan) { create(:plan, organization:, amount_cents: 20_000) }
+  let_it_be(:plan) { create(:plan, organization:, amount_cents: 20_000) }
   let(:scope) { :approve }
 
   let(:quote) do

--- a/spec/services/quote_versions/validators/subscription_amendment_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_amendment_validator_spec.rb
@@ -6,13 +6,8 @@ RSpec.describe QuoteVersions::Validators::SubscriptionAmendmentValidator do
   subject(:validator) { described_class.new(result, quote_version:, scope:) }
 
   let(:result) { BaseService::Result.new }
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:customer) { create(:customer, organization:) }
-  let_it_be(:target_plan) { create(:plan, organization:, amount_cents: 10_000) }
   let(:subscription) { create(:subscription, customer:, organization:, plan: target_plan) }
-  let_it_be(:plan) { create(:plan, organization:, amount_cents: 20_000) }
   let(:scope) { :approve }
-
   let(:quote) do
     create(:quote, organization:, customer:, subscription:, order_type: :subscription_amendment)
   end
@@ -34,6 +29,11 @@ RSpec.describe QuoteVersions::Validators::SubscriptionAmendmentValidator do
     }
   end
   let(:billing_items) { {"plans" => [plan_item]} }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:target_plan) { create(:plan, organization:, amount_cents: 10_000) }
+  let_it_be(:plan) { create(:plan, organization:, amount_cents: 20_000) }
 
   describe "#valid?" do
     context "with a complete valid quote version" do

--- a/spec/services/quote_versions/validators/subscription_amendment_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_amendment_validator_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe QuoteVersions::Validators::SubscriptionAmendmentValidator do
   subject(:validator) { described_class.new(result, quote_version:, scope:) }
 
   let(:result) { BaseService::Result.new }
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:target_plan) { create(:plan, organization:, amount_cents: 10_000) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:target_plan) { create(:plan, organization:, amount_cents: 10_000) }
   let(:subscription) { create(:subscription, customer:, organization:, plan: target_plan) }
-  let(:plan) { create(:plan, organization:, amount_cents: 20_000) }
+  let_it_be(:plan) { create(:plan, organization:, amount_cents: 20_000) }
   let(:scope) { :approve }
 
   let(:quote) do

--- a/spec/services/quote_versions/validators/subscription_creation_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation_validator_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreationValidator do
   subject(:validator) { described_class.new(result, quote_version:, scope:) }
 
   let(:result) { BaseService::Result.new }
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:, order_type: :subscription_creation) }
   let(:quote_version) do
     create(
@@ -18,10 +16,8 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreationValidator do
       billing_items:
     )
   end
-  let_it_be(:plan) { create(:plan, organization:) }
   let(:coupon) { create(:coupon, organization:) }
   let(:scope) { :approve }
-
   let(:plan_item) do
     {
       "id" => plan.id,
@@ -52,6 +48,10 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreationValidator do
       "walletCredits" => [wallet_credit_item]
     }
   end
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
 
   describe "#valid?" do
     context "with a complete valid quote version" do

--- a/spec/services/quote_versions/validators/subscription_creation_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation_validator_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreationValidator do
   subject(:validator) { described_class.new(result, quote_version:, scope:) }
 
   let(:result) { BaseService::Result.new }
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:, order_type: :subscription_creation) }
   let(:quote_version) do
     create(
@@ -18,7 +18,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreationValidator do
       billing_items:
     )
   end
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:coupon) { create(:coupon, organization:) }
   let(:scope) { :approve }
 

--- a/spec/services/quote_versions/void_service_spec.rb
+++ b/spec/services/quote_versions/void_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe QuoteVersions::VoidService do
 
   let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
 
-before_all do
-  create_default(:customer)
-end
+  before_all do
+    create_default(:customer)
+  end
 
   let(:quote_version) { create(:quote_version, organization:) }
   let(:reason) { "manual" }

--- a/spec/services/quote_versions/void_service_spec.rb
+++ b/spec/services/quote_versions/void_service_spec.rb
@@ -5,7 +5,12 @@ require "rails_helper"
 RSpec.describe QuoteVersions::VoidService do
   subject(:void_service) { described_class.new(quote_version:, reason:) }
 
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
+
+before_all do
+  create_default(:customer)
+end
+
   let(:quote_version) { create(:quote_version, organization:) }
   let(:reason) { "manual" }
 

--- a/spec/services/quotes/add_image_service_spec.rb
+++ b/spec/services/quotes/add_image_service_spec.rb
@@ -7,13 +7,12 @@ RSpec.describe Quotes::AddImageService do
 
   let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
   let(:quote) { create(:quote, organization:) }
-
-before_all do
-  create_default(:customer)
-end
-
   let(:png_bytes) { "\x89PNG\r\n\x1A\n".b }
   let(:image) { "data:image/png;base64,#{Base64.strict_encode64(png_bytes)}" }
+
+  before_all do
+    create_default(:customer)
+  end
 
   describe ".call" do
     let(:result) { service.call }

--- a/spec/services/quotes/add_image_service_spec.rb
+++ b/spec/services/quotes/add_image_service_spec.rb
@@ -5,8 +5,12 @@ require "rails_helper"
 RSpec.describe Quotes::AddImageService do
   subject(:service) { described_class.new(quote:, image:) }
 
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
   let(:quote) { create(:quote, organization:) }
+
+before_all do
+  create_default(:customer)
+end
 
   let(:png_bytes) { "\x89PNG\r\n\x1A\n".b }
   let(:image) { "data:image/png;base64,#{Base64.strict_encode64(png_bytes)}" }

--- a/spec/services/quotes/create_service_spec.rb
+++ b/spec/services/quotes/create_service_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Quotes::CreateService do
   let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
   let_it_be(:membership) { create_default(:membership, organization:) }
   let(:owner) { membership.user }
-  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:subscription) { nil }
   let(:create_params) do
     {
@@ -25,6 +24,8 @@ RSpec.describe Quotes::CreateService do
       owners: [owner.id]
     }
   end
+
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   describe ".call" do
     let(:result) { create_service.call }

--- a/spec/services/quotes/create_service_spec.rb
+++ b/spec/services/quotes/create_service_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe Quotes::CreateService do
     )
   end
 
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-  let(:membership) { create(:membership, organization:) }
+  let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
+  let_it_be(:membership) { create_default(:membership, organization:) }
   let(:owner) { membership.user }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
   let(:subscription) { nil }
   let(:create_params) do
     {

--- a/spec/services/quotes/update_service_spec.rb
+++ b/spec/services/quotes/update_service_spec.rb
@@ -3,10 +3,14 @@
 require "rails_helper"
 
 RSpec.describe Quotes::UpdateService do
+before_all do
+  create_default(:customer)
+end
+
   subject(:update_service) { described_class.new(quote:, params: update_params) }
 
-  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
-  let(:membership) { create(:membership, organization:) }
+  let_it_be(:organization) { create_default(:organization, feature_flags: ["order_forms"]) }
+  let_it_be(:membership) { create(:membership, organization:) }
   let(:owner) { membership.user }
   let(:quote) { create(:quote, organization:) }
   let(:update_params) { {owners: [owner.id]} }

--- a/spec/services/quotes/update_service_spec.rb
+++ b/spec/services/quotes/update_service_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Quotes::UpdateService do
-before_all do
-  create_default(:customer)
-end
+  before_all do
+    create_default(:customer)
+  end
 
   subject(:update_service) { described_class.new(quote:, params: update_params) }
 

--- a/spec/services/rate_card_rates/create_service_spec.rb
+++ b/spec/services/rate_card_rates/create_service_spec.rb
@@ -7,11 +7,6 @@ RSpec.describe RateCardRates::CreateService do
 
   let_it_be(:organization) { create(:organization) }
   let(:rate_card) { create(:rate_card, organization:) }
-
-before_all do
-  create_default(:billable_metric)
-end
-
   let(:params) do
     {
       code: "standard_price",
@@ -21,6 +16,10 @@ end
       billing_interval_count: 1,
       billing_interval_unit: "month"
     }
+  end
+
+  before_all do
+    create_default(:billable_metric)
   end
 
   it "creates an active rate when effective now" do

--- a/spec/services/rate_card_rates/create_service_spec.rb
+++ b/spec/services/rate_card_rates/create_service_spec.rb
@@ -5,8 +5,12 @@ require "rails_helper"
 RSpec.describe RateCardRates::CreateService do
   subject(:result) { described_class.call(rate_card:, params:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:rate_card) { create(:rate_card, organization:) }
+
+before_all do
+  create_default(:billable_metric)
+end
 
   let(:params) do
     {

--- a/spec/services/rate_card_rates/destroy_service_spec.rb
+++ b/spec/services/rate_card_rates/destroy_service_spec.rb
@@ -5,8 +5,12 @@ require "rails_helper"
 RSpec.describe RateCardRates::DestroyService do
   subject(:result) { described_class.call(rate_card_rate:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:rate_card) { create(:rate_card, organization:) }
+
+before_all do
+  create_default(:billable_metric)
+end
 
   context "with a pending rate" do
     let(:rate_card_rate) do

--- a/spec/services/rate_card_rates/destroy_service_spec.rb
+++ b/spec/services/rate_card_rates/destroy_service_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe RateCardRates::DestroyService do
   let_it_be(:organization) { create(:organization) }
   let(:rate_card) { create(:rate_card, organization:) }
 
-before_all do
-  create_default(:billable_metric)
-end
+  before_all do
+    create_default(:billable_metric)
+  end
 
   context "with a pending rate" do
     let(:rate_card_rate) do

--- a/spec/services/rate_card_rates/update_service_spec.rb
+++ b/spec/services/rate_card_rates/update_service_spec.rb
@@ -5,8 +5,12 @@ require "rails_helper"
 RSpec.describe RateCardRates::UpdateService do
   subject(:result) { described_class.call(rate_card_rate:, params:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:rate_card) { create(:rate_card, organization:) }
+
+before_all do
+  create_default(:billable_metric)
+end
 
   context "with a pending rate" do
     let(:rate_card_rate) do

--- a/spec/services/rate_card_rates/update_service_spec.rb
+++ b/spec/services/rate_card_rates/update_service_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe RateCardRates::UpdateService do
   let_it_be(:organization) { create(:organization) }
   let(:rate_card) { create(:rate_card, organization:) }
 
-before_all do
-  create_default(:billable_metric)
-end
+  before_all do
+    create_default(:billable_metric)
+  end
 
   context "with a pending rate" do
     let(:rate_card_rate) do

--- a/spec/services/rate_cards/create_service_spec.rb
+++ b/spec/services/rate_cards/create_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe RateCards::CreateService do
   subject(:result) { described_class.call(product:, params:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   # The shared params set proration: true, which requires a recurring metric.
-  let(:metric) { create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount") }
+  let_it_be(:metric) { create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount") }
   let(:product) { create(:product, organization:, billable_metric: metric) }
 
   let(:params) do
@@ -75,7 +75,7 @@ RSpec.describe RateCards::CreateService do
 
   context "with nested rates" do
     # A prorated card requires a recurring metric for its rates to be valid.
-    let(:product) do
+    let_it_be(:product) do
       metric = create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
       create(:product, organization:, billable_metric: metric)
     end

--- a/spec/services/rate_cards/destroy_service_spec.rb
+++ b/spec/services/rate_cards/destroy_service_spec.rb
@@ -5,8 +5,12 @@ require "rails_helper"
 RSpec.describe RateCards::DestroyService do
   subject(:result) { described_class.call(rate_card:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:rate_card) { create(:rate_card, organization:) }
+
+before_all do
+  create_default(:billable_metric)
+end
 
   before do
     create(:rate_card_rate, organization:, rate_card:) if rate_card

--- a/spec/services/rate_cards/destroy_service_spec.rb
+++ b/spec/services/rate_cards/destroy_service_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe RateCards::DestroyService do
   let_it_be(:organization) { create(:organization) }
   let(:rate_card) { create(:rate_card, organization:) }
 
-before_all do
-  create_default(:billable_metric)
-end
+  before_all do
+    create_default(:billable_metric)
+  end
 
   before do
     create(:rate_card_rate, organization:, rate_card:) if rate_card

--- a/spec/services/rate_cards/update_service_spec.rb
+++ b/spec/services/rate_cards/update_service_spec.rb
@@ -7,12 +7,11 @@ RSpec.describe RateCards::UpdateService do
 
   let_it_be(:organization) { create(:organization) }
   let(:rate_card) { create(:rate_card, organization:, name: "Before", currency: "EUR") }
-
-before_all do
-  create_default(:billable_metric)
-end
-
   let(:params) { {name: "After", description: "new", billing_timing: "advance"} }
+
+  before_all do
+    create_default(:billable_metric)
+  end
 
   it "updates the attributes" do
     expect(result).to be_success

--- a/spec/services/rate_cards/update_service_spec.rb
+++ b/spec/services/rate_cards/update_service_spec.rb
@@ -5,8 +5,12 @@ require "rails_helper"
 RSpec.describe RateCards::UpdateService do
   subject(:result) { described_class.call(rate_card:, params:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:rate_card) { create(:rate_card, organization:, name: "Before", currency: "EUR") }
+
+before_all do
+  create_default(:billable_metric)
+end
 
   let(:params) { {name: "After", description: "new", billing_timing: "advance"} }
 

--- a/spec/services/rate_overrides/create_service_spec.rb
+++ b/spec/services/rate_overrides/create_service_spec.rb
@@ -7,11 +7,6 @@ RSpec.describe RateOverrides::CreateService do
 
   let_it_be(:organization) { create(:organization) }
   let(:rate_card) { create(:rate_card, organization:) }
-
-before_all do
-  create_default(:billable_metric)
-end
-
   let(:params) do
     {
       rate_model: "standard",
@@ -20,6 +15,10 @@ end
       billing_interval_count: 1,
       billing_interval_unit: "month"
     }
+  end
+
+  before_all do
+    create_default(:billable_metric)
   end
 
   it "creates a rate override" do

--- a/spec/services/rate_overrides/create_service_spec.rb
+++ b/spec/services/rate_overrides/create_service_spec.rb
@@ -5,8 +5,12 @@ require "rails_helper"
 RSpec.describe RateOverrides::CreateService do
   subject(:result) { described_class.call(rate_card:, params:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:rate_card) { create(:rate_card, organization:) }
+
+before_all do
+  create_default(:billable_metric)
+end
 
   let(:params) do
     {

--- a/spec/services/rate_phases/create_service_spec.rb
+++ b/spec/services/rate_phases/create_service_spec.rb
@@ -7,13 +7,12 @@ RSpec.describe RatePhases::CreateService do
 
   let_it_be(:organization) { create(:organization) }
   let(:plan_rate_card) { create(:plan_rate_card, organization:) }
-
-before_all do
-  create_default(:plan)
-create_default(:billable_metric)
-end
-
   let(:params) { {code: "trial", position: 1, billing_interval_cycle_count: 6, name: "Trial period"} }
+
+  before_all do
+    create_default(:plan)
+    create_default(:billable_metric)
+  end
 
   it "creates a rate phase" do
     expect { result }.to change(RatePhase, :count).by(1)

--- a/spec/services/rate_phases/create_service_spec.rb
+++ b/spec/services/rate_phases/create_service_spec.rb
@@ -5,8 +5,13 @@ require "rails_helper"
 RSpec.describe RatePhases::CreateService do
   subject(:result) { described_class.call(plan_rate_card:, params:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:plan_rate_card) { create(:plan_rate_card, organization:) }
+
+before_all do
+  create_default(:plan)
+create_default(:billable_metric)
+end
 
   let(:params) { {code: "trial", position: 1, billing_interval_cycle_count: 6, name: "Trial period"} }
 

--- a/spec/services/rate_phases/destroy_service_spec.rb
+++ b/spec/services/rate_phases/destroy_service_spec.rb
@@ -7,15 +7,14 @@ RSpec.describe RatePhases::DestroyService do
 
   let_it_be(:organization) { create(:organization) }
   let(:plan_rate_card) { create(:plan_rate_card, organization:) }
-
-before_all do
-  create_default(:plan)
-create_default(:billable_metric)
-end
-
   let!(:launch) { create(:rate_phase, plan_rate_card:, organization:, position: 1, billing_interval_cycle_count: 3) }
   let!(:ramp) { create(:rate_phase, plan_rate_card:, organization:, position: 2, billing_interval_cycle_count: 6) }
   let!(:terminal) { create(:rate_phase, plan_rate_card:, organization:, position: 3, billing_interval_cycle_count: nil) }
+
+  before_all do
+    create_default(:plan)
+    create_default(:billable_metric)
+  end
 
   context "when deleting a middle phase" do
     let(:rate_phase) { ramp }

--- a/spec/services/rate_phases/destroy_service_spec.rb
+++ b/spec/services/rate_phases/destroy_service_spec.rb
@@ -5,8 +5,13 @@ require "rails_helper"
 RSpec.describe RatePhases::DestroyService do
   subject(:result) { described_class.call(rate_phase:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:plan_rate_card) { create(:plan_rate_card, organization:) }
+
+before_all do
+  create_default(:plan)
+create_default(:billable_metric)
+end
 
   let!(:launch) { create(:rate_phase, plan_rate_card:, organization:, position: 1, billing_interval_cycle_count: 3) }
   let!(:ramp) { create(:rate_phase, plan_rate_card:, organization:, position: 2, billing_interval_cycle_count: 6) }

--- a/spec/services/rate_phases/replace_service_spec.rb
+++ b/spec/services/rate_phases/replace_service_spec.rb
@@ -5,10 +5,14 @@ require "rails_helper"
 RSpec.describe RatePhases::ReplaceService do
   subject(:result) { described_class.call(plan_rate_card:, phases_params:) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:rate_card) { create(:rate_card, organization:) }
   let(:plan_rate_card) { create(:plan_rate_card, organization:, plan:, rate_card:) }
+
+before_all do
+  create_default(:billable_metric)
+end
 
   let(:phases_params) do
     [

--- a/spec/services/rate_phases/replace_service_spec.rb
+++ b/spec/services/rate_phases/replace_service_spec.rb
@@ -8,17 +8,16 @@ RSpec.describe RatePhases::ReplaceService do
   let_it_be(:organization) { create(:organization) }
   let_it_be(:plan) { create(:plan, organization:) }
   let(:rate_card) { create(:rate_card, organization:) }
-  let(:plan_rate_card) { create(:plan_rate_card, organization:, plan:, rate_card:) }
-
-before_all do
-  create_default(:billable_metric)
-end
-
   let(:phases_params) do
     [
       {code: "trial", position: 1, name: "trial", billing_interval_cycle_count: 3},
       {code: "standard", position: 2, name: "standard", billing_interval_cycle_count: nil}
     ]
+  end
+  let(:plan_rate_card) { create(:plan_rate_card, organization:, plan:, rate_card:) }
+
+  before_all do
+    create_default(:billable_metric)
   end
 
   it "replaces the phase sequence and discards the superseded overrides" do

--- a/spec/services/rate_phases/update_service_spec.rb
+++ b/spec/services/rate_phases/update_service_spec.rb
@@ -5,9 +5,14 @@ require "rails_helper"
 RSpec.describe RatePhases::UpdateService do
   subject(:result) { described_class.call(rate_phase:, params:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:plan_rate_card) { create(:plan_rate_card, organization:) }
   let(:rate_phase) { create(:rate_phase, plan_rate_card:, organization:, position: 1, billing_interval_cycle_count: 3, name: "Before") }
+
+before_all do
+  create_default(:plan)
+create_default(:billable_metric)
+end
 
   let(:params) { {name: "After", billing_interval_cycle_count: 6} }
 

--- a/spec/services/rate_phases/update_service_spec.rb
+++ b/spec/services/rate_phases/update_service_spec.rb
@@ -7,14 +7,13 @@ RSpec.describe RatePhases::UpdateService do
 
   let_it_be(:organization) { create(:organization) }
   let(:plan_rate_card) { create(:plan_rate_card, organization:) }
+  let(:params) { {name: "After", billing_interval_cycle_count: 6} }
   let(:rate_phase) { create(:rate_phase, plan_rate_card:, organization:, position: 1, billing_interval_cycle_count: 3, name: "Before") }
 
-before_all do
-  create_default(:plan)
-create_default(:billable_metric)
-end
-
-  let(:params) { {name: "After", billing_interval_cycle_count: 6} }
+  before_all do
+    create_default(:plan)
+    create_default(:billable_metric)
+  end
 
   it "updates the phase" do
     expect(result).to be_success

--- a/spec/services/roles/create_service_spec.rb
+++ b/spec/services/roles/create_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Roles::CreateService do
   describe "#call" do
     subject(:result) { described_class.call(organization:, code:, name:, description:, permissions:) }
 
-    let(:organization) { create(:organization) }
+    let_it_be(:organization) { create(:organization) }
     let(:code) { "custom_role" }
     let(:name) { "Custom Role" }
     let(:description) { "A custom role description" }

--- a/spec/services/roles/destroy_service_spec.rb
+++ b/spec/services/roles/destroy_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Roles::DestroyService do
   describe "#call" do
     subject(:result) { described_class.call(role:) }
 
-    let(:organization) { create(:organization) }
+    let_it_be(:organization) { create(:organization) }
     let(:role) { create(:role, organization:) }
 
     context "when role exists and has no assigned members" do
@@ -59,7 +59,7 @@ RSpec.describe Roles::DestroyService do
     end
 
     context "when role has assigned members" do
-      let(:membership) { create(:membership, organization:) }
+      let_it_be(:membership) { create(:membership, organization:) }
 
       before { create(:membership_role, membership:, role:) }
 

--- a/spec/services/roles/update_service_spec.rb
+++ b/spec/services/roles/update_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Roles::UpdateService do
   describe "#call" do
     subject(:result) { described_class.call(role:, params:) }
 
-    let(:organization) { create(:organization) }
+    let_it_be(:organization) { create(:organization) }
     let(:role) { create(:role, organization:, code: "old_role", name: "Old Name", description: "Old description", permissions: %w[customers:view addons:view]) }
     let(:params) { {name: "New Name", description: "New description", permissions: %w[customers:view plans:view]} }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,6 +76,10 @@ Sentry.init do |config|
   config.transport.transport_class = Sentry::DummyTransport
 end
 
+require "test_prof/recipes/rspec/sample"
+require "test_prof/recipes/rspec/let_it_be"
+require "test_prof/recipes/rspec/factory_default"
+
 RSpec.configure do |config|
   config.include ActiveJob::TestHelper
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
## Context

Currently, around **50% of the spec runtime** is spent preparing data and creating factories. A lot of this data is either duplicated or recreates the same objects multiple times, so we can get rid of a good chunk of it and significantly speed up the specs.

To avoid creating unnecessary factories, we can use `let_it_be`, `before_all`, and `create_default` from `test-prof`. More info [here](https://test-prof.evilmartians.io/guide/recipes/let_it_be).

## Description

This PR cleans up the services specs in folders `p-r` and removes unnecessary factory usage.

Here are the numbers before and after the cleanup. The times below are for running the specs in a single process:

| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 97,841 | 63,994 |
| Time spent creating factories |  11:51.790 | 07:40.512 |
| Total time | 18:00.870 | 14:22.880 |

## Overall results

This PR is part of a series of PRs focused on cleaning up factory usage across different specs.

Once all the changes are merged, we expect to:

- Reduce the number of factories by **~50k**
- Cut spec runtime by around **20%**
- Shave off roughly **1:15 min** from the CI runtime


| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 157,949 | 103,761 |
| Total time spent creating factories | 17:59.851  | 11:14.739 |
| Total time | 34:41.482 | 27:03.658 |

Here is [the CI run](https://github.com/getlago/lago-api/actions/runs/33399605547/job/99512391170?pr=6255) with all the changes merged together: