### PR TITLE
perf(specs): Clean up factories usage in spec/specs in directories s-w

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -167,6 +167,8 @@ group :test do
   # HTML testing (invoice rendering)
   gem "rspec-snapshot", "~> 2.0"
   gem "htmlbeautifier", "~> 1.4"
+
+  gem "test-prof", "~> 1.0"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1004,6 +1004,8 @@ GEM
     temple (0.10.4)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
+    test-prof (1.6.3)
+      logger
     thor (1.5.0)
     throttling (0.4.1)
       logger
@@ -1181,6 +1183,7 @@ DEPENDENCIES
   stripe
   strong_migrations
   super_diff (~> 0.19.0)
+  test-prof (~> 1.0)
   throttling
   timecop
   tzinfo-data

--- a/spec/services/subscriptions/activate_all_pending_service_spec.rb
+++ b/spec/services/subscriptions/activate_all_pending_service_spec.rb
@@ -5,12 +5,12 @@ require "rails_helper"
 RSpec.describe Subscriptions::ActivateAllPendingService, clickhouse: true do
   subject(:activate_service) { described_class.new(timestamp: timestamp.to_i) }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-create_default(:plan)
-create_default(:add_on)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+    create_default(:add_on)
+  end
 
   let(:timestamp) { Time.current }
 
@@ -112,7 +112,6 @@ end
 
     context "with customer timezone" do
       let(:timestamp) { DateTime.parse("2023-08-24 00:07:00") }
-      let_it_be(:customer) { create(:customer, :with_hubspot_integration, timezone: "America/Bogota") }
       let!(:pending_subscription) do
         create(
           :subscription,
@@ -121,6 +120,8 @@ end
           subscription_at: timestamp
         )
       end
+
+      let_it_be(:customer) { create(:customer, :with_hubspot_integration, timezone: "America/Bogota") }
 
       it "enqueues Integrations::Aggregator::Subscriptions::Hubspot::CreateJob" do
         activate_service.call

--- a/spec/services/subscriptions/activate_all_pending_service_spec.rb
+++ b/spec/services/subscriptions/activate_all_pending_service_spec.rb
@@ -5,6 +5,13 @@ require "rails_helper"
 RSpec.describe Subscriptions::ActivateAllPendingService, clickhouse: true do
   subject(:activate_service) { described_class.new(timestamp: timestamp.to_i) }
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+create_default(:plan)
+create_default(:add_on)
+end
+
   let(:timestamp) { Time.current }
 
   describe ".call" do
@@ -24,7 +31,7 @@ RSpec.describe Subscriptions::ActivateAllPendingService, clickhouse: true do
     end
 
     context "when plan is pay in advance has fixed charges" do
-      let(:plan) { create(:plan, pay_in_advance: true) }
+      let_it_be(:plan) { create(:plan, pay_in_advance: true) }
       let(:fixed_charge_1) { create(:fixed_charge, plan:) }
       let(:subscription) { create(:subscription, :pending, subscription_at: timestamp, plan:) }
 
@@ -64,7 +71,7 @@ RSpec.describe Subscriptions::ActivateAllPendingService, clickhouse: true do
     end
 
     context "when plan is not pay in advance has fixed charges" do
-      let(:plan) { create(:plan) }
+      let_it_be(:plan) { create(:plan) }
       let(:fixed_charge_1) { create(:fixed_charge, plan:) }
       let(:subscription) { create(:subscription, :pending, subscription_at: timestamp, plan:) }
 
@@ -105,7 +112,7 @@ RSpec.describe Subscriptions::ActivateAllPendingService, clickhouse: true do
 
     context "with customer timezone" do
       let(:timestamp) { DateTime.parse("2023-08-24 00:07:00") }
-      let(:customer) { create(:customer, :with_hubspot_integration, timezone: "America/Bogota") }
+      let_it_be(:customer) { create(:customer, :with_hubspot_integration, timezone: "America/Bogota") }
       let!(:pending_subscription) do
         create(
           :subscription,
@@ -128,7 +135,7 @@ RSpec.describe Subscriptions::ActivateAllPendingService, clickhouse: true do
     end
 
     context "with a subscription in trial" do
-      let(:plan_with_trial) { create(:plan, pay_in_advance: true, trial_period: 10) }
+      let_it_be(:plan_with_trial) { create(:plan, pay_in_advance: true, trial_period: 10) }
 
       before do
         create(:subscription, :pending, subscription_at: timestamp, plan: create(:plan, pay_in_advance: true))

--- a/spec/services/subscriptions/activate_service_spec.rb
+++ b/spec/services/subscriptions/activate_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Subscriptions::ActivateService do
   subject(:result) { described_class.call(subscription:, timestamp:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, :pending, organization:, customer:, plan:, subscription_at: Time.current) }
   let(:timestamp) { Time.current }
 
@@ -56,7 +56,7 @@ RSpec.describe Subscriptions::ActivateService do
     end
 
     context "when subscription should sync with hubspot" do
-      let(:customer) { create(:customer, :with_hubspot_integration, organization:) }
+      let_it_be(:customer) { create(:customer, :with_hubspot_integration, organization:) }
 
       it "enqueues hubspot create job" do
         result
@@ -73,7 +73,7 @@ RSpec.describe Subscriptions::ActivateService do
     end
 
     context "when plan is pay in advance and not in trial" do
-      let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+      let_it_be(:plan) { create(:plan, organization:, pay_in_advance: true) }
 
       it "enqueues BillSubscriptionJob with skip_charges true" do
         result
@@ -104,8 +104,8 @@ RSpec.describe Subscriptions::ActivateService do
     end
 
     context "when plan is pay in arrears with pay-in-advance fixed charges" do
-      let(:plan) { create(:plan, organization:, pay_in_advance: false) }
-      let(:add_on) { create(:add_on, organization:) }
+      let_it_be(:plan) { create(:plan, organization:, pay_in_advance: false) }
+      let_it_be(:add_on) { create(:add_on, organization:) }
 
       before { create(:fixed_charge, plan:, add_on:, pay_in_advance: true) }
 
@@ -137,7 +137,7 @@ RSpec.describe Subscriptions::ActivateService do
     end
 
     context "when plan is pay in advance with trial period" do
-      let(:plan) { create(:plan, organization:, pay_in_advance: true, trial_period: 30) }
+      let_it_be(:plan) { create(:plan, organization:, pay_in_advance: true, trial_period: 30) }
 
       it "does not enqueue BillSubscriptionJob" do
         result
@@ -146,7 +146,7 @@ RSpec.describe Subscriptions::ActivateService do
       end
 
       context "when plan has pay-in-advance fixed charges" do
-        let(:add_on) { create(:add_on, organization:) }
+        let_it_be(:add_on) { create(:add_on, organization:) }
 
         before { create(:fixed_charge, plan:, add_on:, pay_in_advance: true) }
 
@@ -166,7 +166,7 @@ RSpec.describe Subscriptions::ActivateService do
   end
 
   context "when subscription is pending with activation rules (payment, pay-in-advance plan)" do
-    let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+    let_it_be(:plan) { create(:plan, organization:, pay_in_advance: true) }
     let(:subscription) do
       create(:subscription, :pending, :with_activation_rules,
         activation_rules_config: [{type: "payment", timeout_hours: 48}],
@@ -217,8 +217,8 @@ RSpec.describe Subscriptions::ActivateService do
     end
 
     context "when plan is pay in arrears with pay-in-advance fixed charges" do
-      let(:plan) { create(:plan, organization:, pay_in_advance: false) }
-      let(:add_on) { create(:add_on, organization:) }
+      let_it_be(:plan) { create(:plan, organization:, pay_in_advance: false) }
+      let_it_be(:add_on) { create(:add_on, organization:) }
 
       before { create(:fixed_charge, plan:, add_on:, pay_in_advance: true) }
 
@@ -236,7 +236,7 @@ RSpec.describe Subscriptions::ActivateService do
     end
 
     context "when plan is pay in advance with trial period" do
-      let(:plan) { create(:plan, organization:, pay_in_advance: true, trial_period: 30) }
+      let_it_be(:plan) { create(:plan, organization:, pay_in_advance: true, trial_period: 30) }
 
       it "does not enqueue BillSubscriptionJob" do
         result
@@ -259,7 +259,7 @@ RSpec.describe Subscriptions::ActivateService do
   end
 
   context "when subscription is pending with activation rules that evaluate to not_applicable" do
-    let(:plan) { create(:plan, organization:, pay_in_advance: false) }
+    let_it_be(:plan) { create(:plan, organization:, pay_in_advance: false) }
     let(:subscription) do
       create(:subscription, :pending, :with_activation_rules,
         activation_rules_config: [{type: "payment", timeout_hours: 48}],
@@ -279,7 +279,7 @@ RSpec.describe Subscriptions::ActivateService do
   end
 
   context "when subscription is incomplete with satisfied payment rule (post-payment activation)" do
-    let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+    let_it_be(:plan) { create(:plan, organization:, pay_in_advance: true) }
     let(:subscription) do
       create(:subscription, :incomplete, :with_activation_rules,
         activation_rules_config: [{type: "payment", timeout_hours: 48, status: "satisfied"}],
@@ -326,7 +326,7 @@ RSpec.describe Subscriptions::ActivateService do
     end
 
     context "when subscription should sync with hubspot" do
-      let(:customer) { create(:customer, :with_hubspot_integration, organization:) }
+      let_it_be(:customer) { create(:customer, :with_hubspot_integration, organization:) }
 
       it "enqueues hubspot create job" do
         result
@@ -343,9 +343,9 @@ RSpec.describe Subscriptions::ActivateService do
     end
 
     context "when subscription comes from an upgrade" do
-      let(:customer) { create(:customer, :with_hubspot_integration, organization:) }
-      let(:previous_plan) { create(:plan, organization:, amount_cents: 50) }
-      let(:plan) { create(:plan, organization:, amount_cents: 100, pay_in_advance: true) }
+      let_it_be(:customer) { create(:customer, :with_hubspot_integration, organization:) }
+      let_it_be(:previous_plan) { create(:plan, organization:, amount_cents: 50) }
+      let_it_be(:plan) { create(:plan, organization:, amount_cents: 100, pay_in_advance: true) }
       let(:previous_subscription) do
         create(:subscription, organization:, customer:, plan: previous_plan,
           status: :active, started_at: 1.day.ago, subscription_at: 1.day.ago)
@@ -420,9 +420,9 @@ RSpec.describe Subscriptions::ActivateService do
     end
 
     context "when subscription comes from a downgrade" do
-      let(:customer) { create(:customer, :with_hubspot_integration, organization:) }
-      let(:previous_plan) { create(:plan, organization:, amount_cents: 100) }
-      let(:plan) { create(:plan, organization:, amount_cents: 50, pay_in_advance: true) }
+      let_it_be(:customer) { create(:customer, :with_hubspot_integration, organization:) }
+      let_it_be(:previous_plan) { create(:plan, organization:, amount_cents: 100) }
+      let_it_be(:plan) { create(:plan, organization:, amount_cents: 50, pay_in_advance: true) }
       let(:previous_subscription) do
         create(:subscription, organization:, customer:, plan: previous_plan,
           status: :active, started_at: 1.month.ago, subscription_at: 1.month.ago)
@@ -524,7 +524,7 @@ RSpec.describe Subscriptions::ActivateService do
   end
 
   context "when subscription is incomplete with no payment rules (future non-payment rule resolved)" do
-    let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+    let_it_be(:plan) { create(:plan, organization:, pay_in_advance: true) }
     let(:subscription) { create(:subscription, :incomplete, organization:, customer:, plan:) }
 
     it "activates and bills the subscription" do
@@ -587,9 +587,9 @@ RSpec.describe Subscriptions::ActivateService do
   end
 
   context "when subscription comes from an upgrade" do
-    let(:customer) { create(:customer, :with_hubspot_integration, organization:) }
-    let(:previous_plan) { create(:plan, organization:, amount_cents: 50) }
-    let(:plan) { create(:plan, organization:, amount_cents: 100) }
+    let_it_be(:customer) { create(:customer, :with_hubspot_integration, organization:) }
+    let_it_be(:previous_plan) { create(:plan, organization:, amount_cents: 50) }
+    let_it_be(:plan) { create(:plan, organization:, amount_cents: 100) }
     let(:previous_subscription) do
       create(
         :subscription,
@@ -669,7 +669,7 @@ RSpec.describe Subscriptions::ActivateService do
     end
 
     context "when the new plan is pay in advance" do
-      let(:plan) { create(:plan, organization:, amount_cents: 100, pay_in_advance: true) }
+      let_it_be(:plan) { create(:plan, organization:, amount_cents: 100, pay_in_advance: true) }
 
       it "includes both previous and new subscription in the upgrade bill" do
         result
@@ -710,7 +710,7 @@ RSpec.describe Subscriptions::ActivateService do
     end
 
     context "when activation_rules gate the new subscription" do
-      let(:plan) { create(:plan, organization:, amount_cents: 100, pay_in_advance: true) }
+      let_it_be(:plan) { create(:plan, organization:, amount_cents: 100, pay_in_advance: true) }
       let(:subscription) do
         create(
           :subscription,
@@ -772,9 +772,9 @@ RSpec.describe Subscriptions::ActivateService do
   end
 
   context "when subscription comes from a downgrade" do
-    let(:customer) { create(:customer, :with_hubspot_integration, organization:) }
-    let(:previous_plan) { create(:plan, organization:, amount_cents: 100) }
-    let(:plan) { create(:plan, organization:, amount_cents: 50) }
+    let_it_be(:customer) { create(:customer, :with_hubspot_integration, organization:) }
+    let_it_be(:previous_plan) { create(:plan, organization:, amount_cents: 100) }
+    let_it_be(:plan) { create(:plan, organization:, amount_cents: 50) }
     let(:previous_subscription) do
       create(
         :subscription,
@@ -911,7 +911,7 @@ RSpec.describe Subscriptions::ActivateService do
     end
 
     context "when activation_rules gate the new subscription" do
-      let(:plan) { create(:plan, organization:, amount_cents: 50, pay_in_advance: true) }
+      let_it_be(:plan) { create(:plan, organization:, amount_cents: 50, pay_in_advance: true) }
       let(:subscription) do
         create(
           :subscription,

--- a/spec/services/subscriptions/activation_rules/apply_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/apply_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Subscriptions::ActivationRules::ApplyService do
   subject(:apply_service) { described_class.new(subscription:, activation_rules:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, :pending, customer:, plan:, organization:) }
 
   describe "#call" do

--- a/spec/services/subscriptions/activation_rules/bill_current_period_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/bill_current_period_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 describe Subscriptions::ActivationRules::BillCurrentPeriodService do
   subject(:result) { described_class.call(subscription:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:, interval: :monthly, pay_in_advance: true) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:, interval: :monthly, pay_in_advance: true) }
   let(:started_at) { Time.zone.parse("2026-03-05 10:00:00") }
   let(:current_time) { Time.zone.parse("2026-04-10 12:00:00") }
   let(:subscription) do
@@ -147,7 +147,7 @@ describe Subscriptions::ActivationRules::BillCurrentPeriodService do
     end
 
     context "when the plan is yearly with monthly billed charges" do
-      let(:plan) { create(:plan, organization:, interval: :yearly, pay_in_advance: true, bill_charges_monthly: true) }
+      let_it_be(:plan) { create(:plan, organization:, interval: :yearly, pay_in_advance: true, bill_charges_monthly: true) }
       let(:current_time) { Time.zone.parse("2026-05-10 12:00:00") }
 
       it "enqueues a BillSubscriptionJob only for the latest monthly split boundary" do
@@ -190,7 +190,7 @@ describe Subscriptions::ActivationRules::BillCurrentPeriodService do
     end
 
     context "when the plan is yearly with monthly billed fixed charges" do
-      let(:plan) { create(:plan, organization:, interval: :yearly, pay_in_advance: true, bill_fixed_charges_monthly: true) }
+      let_it_be(:plan) { create(:plan, organization:, interval: :yearly, pay_in_advance: true, bill_fixed_charges_monthly: true) }
       let(:current_time) { Time.zone.parse("2026-05-10 12:00:00") }
 
       it "enqueues a BillSubscriptionJob only for the latest monthly split boundary" do

--- a/spec/services/subscriptions/activation_rules/cancel_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/cancel_service_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe Subscriptions::ActivationRules::CancelService do
   subject(:result) { described_class.call(subscription:, rule_status:, cancellation_reason:) }
 
   let(:rule_status) { :declined }
+  let(:subscription) { create(:subscription, :incomplete, customer:, organization:, plan:) }
+  let(:invoice) { create(:invoice, :open, customer:, organization:, invoice_type: :subscription) }
   let(:cancellation_reason) { :manual }
+
   let_it_be(:organization) { create(:organization) }
   let_it_be(:customer) { create_default(:customer, organization:) }
   let_it_be(:plan) { create(:plan, organization:, pay_in_advance: true) }
-  let(:subscription) { create(:subscription, :incomplete, customer:, organization:, plan:) }
-  let(:invoice) { create(:invoice, :open, customer:, organization:, invoice_type: :subscription) }
 
   before do
     create(:invoice_subscription, invoice:, subscription:) if invoice

--- a/spec/services/subscriptions/activation_rules/cancel_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/cancel_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Subscriptions::ActivationRules::CancelService do
 
   let(:rule_status) { :declined }
   let(:cancellation_reason) { :manual }
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:, pay_in_advance: true) }
   let(:subscription) { create(:subscription, :incomplete, customer:, organization:, plan:) }
   let(:invoice) { create(:invoice, :open, customer:, organization:, invoice_type: :subscription) }
 

--- a/spec/services/subscriptions/activation_rules/evaluate_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/evaluate_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Subscriptions::ActivationRules::EvaluateService do
   subject(:result) { described_class.call(subscription:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:, pay_in_advance: true) }
   let(:subscription) { create(:subscription, :incomplete, organization:, customer:, plan:) }
 
   context "when subscription has an inactive payment activation rule" do

--- a/spec/services/subscriptions/activation_rules/expire_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/expire_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Subscriptions::ActivationRules::ExpireService do
   subject(:result) { described_class.call(subscription:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:, pay_in_advance: true) }
   let(:subscription) { create(:subscription, :incomplete, customer:, organization:, plan:) }
   let(:invoice) do
     create(:invoice, :open, customer:, organization:, invoice_type: :subscription)

--- a/spec/services/subscriptions/activation_rules/payment/evaluate_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/payment/evaluate_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Subscriptions::ActivationRules::Payment::EvaluateService do
   subject(:result) { described_class.call(rule:, status:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:, pay_in_advance: true) }
   let(:subscription) { create(:subscription, :incomplete, organization:, customer:, plan:) }
   let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: rule_status, timeout_hours:) }
   let(:rule_status) { "inactive" }

--- a/spec/services/subscriptions/activation_rules/payment/resolve_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/payment/resolve_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Subscriptions::ActivationRules::Payment::ResolveService do
   subject(:result) { described_class.call(subscription:, invoice:, payment_status:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+  let_it_be(:organization) { create(:organization) }
+  let(:customer) { create_default(:customer, organization:) }
+  let(:plan) { create_default(:plan, organization:, pay_in_advance: true) }
   let(:subscription) { create(:subscription, :incomplete, organization:, customer:, plan:) }
   let(:rule) { create(:subscription_activation_rule, subscription:, status: "pending") }
   let(:invoice) do

--- a/spec/services/subscriptions/activation_rules/payment/validate_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/payment/validate_service_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { BaseService::Result.new }
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let(:customer) { create_default(:customer, organization:) }
+  let(:plan) { create_default(:plan, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:, organization:) }
   let(:rule) { {type: "payment", timeout_hours: 48} }
   let(:payment_method_params) { nil }

--- a/spec/services/subscriptions/activation_rules/payment/validate_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/payment/validate_service_spec.rb
@@ -6,13 +6,11 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { BaseService::Result.new }
-  let_it_be(:organization) { create_default(:organization) }
   let(:customer) { create_default(:customer, organization:) }
   let(:plan) { create_default(:plan, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:, organization:) }
   let(:rule) { {type: "payment", timeout_hours: 48} }
   let(:payment_method_params) { nil }
-
   let(:args) do
     {
       rule:,
@@ -21,6 +19,8 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ValidateService do
       customer:
     }
   end
+
+  let_it_be(:organization) { create_default(:organization) }
 
   describe "#valid?" do
     context "with valid payment rule" do

--- a/spec/services/subscriptions/activation_rules/resolve_subscription_status_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/resolve_subscription_status_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Subscriptions::ActivationRules::ResolveSubscriptionStatusService do
   subject(:result) { described_class.call(subscription:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:, pay_in_advance: true) }
   let(:subscription) { create(:subscription, :incomplete, organization:, customer:, plan:) }
 
   context "when all rules are satisfied" do

--- a/spec/services/subscriptions/activation_rules/validate_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/validate_service_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Subscriptions::ActivationRules::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { BaseService::Result.new }
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:, payment_provider: "stripe") }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:, payment_provider: "stripe") }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:subscription) { nil }
   let(:subscription_type) { "create" }
   let(:activation_rules) { nil }

--- a/spec/services/subscriptions/activation_rules/validate_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/validate_service_spec.rb
@@ -6,14 +6,10 @@ RSpec.describe Subscriptions::ActivationRules::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { BaseService::Result.new }
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:customer) { create(:customer, organization:, payment_provider: "stripe") }
-  let_it_be(:plan) { create(:plan, organization:) }
   let(:subscription) { nil }
   let(:subscription_type) { "create" }
   let(:activation_rules) { nil }
   let(:payment_method_params) { nil }
-
   let(:args) do
     {
       activation_rules:,
@@ -23,6 +19,10 @@ RSpec.describe Subscriptions::ActivationRules::ValidateService do
       customer:
     }
   end
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:, payment_provider: "stripe") }
+  let_it_be(:plan) { create(:plan, organization:) }
 
   before { create(:payment_method, customer:, organization:) }
 

--- a/spec/services/subscriptions/billing_date_query_spec.rb
+++ b/spec/services/subscriptions/billing_date_query_spec.rb
@@ -7,17 +7,17 @@ RSpec.describe Subscriptions::BillingDateQuery do
 
   let(:subscriptions) { Subscription.where(id: subscription.id) }
 
-  let(:billing_entity_timezone) { "UTC" }
-  let(:billing_entity) { create(:billing_entity, timezone: billing_entity_timezone) }
-  let(:organization) { billing_entity.organization }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:billing_entity_timezone) { "UTC" }
+  let_it_be(:billing_entity) { create(:billing_entity, timezone: billing_entity_timezone) }
 
-  let(:interval) { :monthly }
-  let(:bill_charges_monthly) { false }
-  let(:bill_fixed_charges_monthly) { false }
-  let(:plan) { create(:plan, organization:, interval:, bill_charges_monthly:, bill_fixed_charges_monthly:) }
+  let_it_be(:interval) { :monthly }
+  let_it_be(:bill_charges_monthly) { false }
+  let_it_be(:bill_fixed_charges_monthly) { false }
+  let_it_be(:plan) { create(:plan, organization:, interval:, bill_charges_monthly:, bill_fixed_charges_monthly:) }
 
-  let(:customer_timezone) { nil }
-  let(:customer) { create(:customer, organization:, billing_entity:, timezone: customer_timezone) }
+  let_it_be(:customer_timezone) { nil }
+        let_it_be(:customer) { create(:customer, organization:, billing_entity:, timezone: customer_timezone) }
 
   let(:subscription_at) { DateTime.parse("20 Feb 2021") }
   let(:billing_time) { :calendar }
@@ -232,6 +232,7 @@ RSpec.describe Subscriptions::BillingDateQuery do
         let(:interval) { case_interval }
         let(:billing_time) { case_billing_time }
         let(:bill_charges_monthly) { case_bcm }
+        let(:plan) { create(:plan, organization:, interval:, bill_charges_monthly:, bill_fixed_charges_monthly:) }
         let(:bill_fixed_charges_monthly) { case_bfcm }
         let(:subscription_at) { DateTime.parse(case_subscription_at) }
 
@@ -259,10 +260,12 @@ RSpec.describe Subscriptions::BillingDateQuery do
 
     describe "timezone handling" do
       # Monthly calendar plan bills on the 1st.
+        let(:plan) { create(:plan, organization:, interval:, bill_charges_monthly:, bill_fixed_charges_monthly:) }
       let(:interval) { :monthly }
       let(:billing_time) { :calendar }
 
       context "when it is not yet the billing day in the customer timezone" do
+        let(:customer) { create(:customer, organization:, billing_entity:, timezone: customer_timezone) }
         let(:customer_timezone) { "America/Chicago" }
         let(:timestamp) { DateTime.parse("01 Jul 2022 00:30") } # still 30 Jun in Chicago
 
@@ -272,6 +275,7 @@ RSpec.describe Subscriptions::BillingDateQuery do
       end
 
       context "when it is the billing day in the customer timezone" do
+        let(:customer) { create(:customer, organization:, billing_entity:, timezone: customer_timezone) }
         let(:customer_timezone) { "America/Chicago" }
         let(:timestamp) { DateTime.parse("01 Jul 2022 12:00") } # 1 Jul in Chicago
 
@@ -281,6 +285,7 @@ RSpec.describe Subscriptions::BillingDateQuery do
       end
 
       context "when it is already past the billing day in the customer timezone" do
+        let(:customer) { create(:customer, organization:, billing_entity:, timezone: customer_timezone) }
         let(:customer_timezone) { "Pacific/Auckland" }
         let(:timestamp) { DateTime.parse("01 Jul 2022 18:00") } # 2 Jul in Auckland
 
@@ -291,6 +296,8 @@ RSpec.describe Subscriptions::BillingDateQuery do
 
       context "when the customer has no timezone" do
         let(:customer_timezone) { nil }
+        let(:customer) { create(:customer, organization:, billing_entity:, timezone: customer_timezone) }
+  let(:billing_entity) { create(:billing_entity, timezone: billing_entity_timezone) }
         let(:billing_entity_timezone) { "America/Chicago" }
         let(:timestamp) { DateTime.parse("01 Jul 2022 00:30") } # still 30 Jun in the billing entity tz
 
@@ -301,6 +308,7 @@ RSpec.describe Subscriptions::BillingDateQuery do
     end
 
     context "when the subscription does not bill on the given day" do
+        let(:plan) { create(:plan, organization:, interval:, bill_charges_monthly:, bill_fixed_charges_monthly:) }
       let(:interval) { :monthly }
       let(:billing_time) { :calendar }
       let(:timestamp) { DateTime.parse("15 Jul 2022 12:00") }

--- a/spec/services/subscriptions/billing_date_query_spec.rb
+++ b/spec/services/subscriptions/billing_date_query_spec.rb
@@ -6,8 +6,14 @@ RSpec.describe Subscriptions::BillingDateQuery do
   subject(:result) { described_class.call(subscriptions:, timestamp:) }
 
   let(:subscriptions) { Subscription.where(id: subscription.id) }
+  let(:subscription_at) { DateTime.parse("20 Feb 2021") }
+  let(:billing_time) { :calendar }
+  let(:timestamp) { DateTime.parse("20 Jun 2022 12:00") }
+  let(:subscription) do
+    create(:subscription, customer:, plan:, subscription_at:, billing_time:, started_at: DateTime.parse("10 Jun 2022"))
+  end
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:billing_entity_timezone) { "UTC" }
   let_it_be(:billing_entity) { create(:billing_entity, timezone: billing_entity_timezone) }
 
@@ -17,14 +23,7 @@ RSpec.describe Subscriptions::BillingDateQuery do
   let_it_be(:plan) { create(:plan, organization:, interval:, bill_charges_monthly:, bill_fixed_charges_monthly:) }
 
   let_it_be(:customer_timezone) { nil }
-        let_it_be(:customer) { create(:customer, organization:, billing_entity:, timezone: customer_timezone) }
-
-  let(:subscription_at) { DateTime.parse("20 Feb 2021") }
-  let(:billing_time) { :calendar }
-  let(:timestamp) { DateTime.parse("20 Jun 2022 12:00") }
-  let(:subscription) do
-    create(:subscription, customer:, plan:, subscription_at:, billing_time:, started_at: DateTime.parse("10 Jun 2022"))
-  end
+  let_it_be(:customer) { create(:customer, organization:, billing_entity:, timezone: customer_timezone) }
 
   before { subscription }
 
@@ -260,7 +259,7 @@ RSpec.describe Subscriptions::BillingDateQuery do
 
     describe "timezone handling" do
       # Monthly calendar plan bills on the 1st.
-        let(:plan) { create(:plan, organization:, interval:, bill_charges_monthly:, bill_fixed_charges_monthly:) }
+      let(:plan) { create(:plan, organization:, interval:, bill_charges_monthly:, bill_fixed_charges_monthly:) }
       let(:interval) { :monthly }
       let(:billing_time) { :calendar }
 
@@ -297,7 +296,7 @@ RSpec.describe Subscriptions::BillingDateQuery do
       context "when the customer has no timezone" do
         let(:customer_timezone) { nil }
         let(:customer) { create(:customer, organization:, billing_entity:, timezone: customer_timezone) }
-  let(:billing_entity) { create(:billing_entity, timezone: billing_entity_timezone) }
+        let(:billing_entity) { create(:billing_entity, timezone: billing_entity_timezone) }
         let(:billing_entity_timezone) { "America/Chicago" }
         let(:timestamp) { DateTime.parse("01 Jul 2022 00:30") } # still 30 Jun in the billing entity tz
 
@@ -308,7 +307,7 @@ RSpec.describe Subscriptions::BillingDateQuery do
     end
 
     context "when the subscription does not bill on the given day" do
-        let(:plan) { create(:plan, organization:, interval:, bill_charges_monthly:, bill_fixed_charges_monthly:) }
+      let(:plan) { create(:plan, organization:, interval:, bill_charges_monthly:, bill_fixed_charges_monthly:) }
       let(:interval) { :monthly }
       let(:billing_time) { :calendar }
       let(:timestamp) { DateTime.parse("15 Jul 2022 12:00") }

--- a/spec/services/subscriptions/charge_cache_middleware_spec.rb
+++ b/spec/services/subscriptions/charge_cache_middleware_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe Subscriptions::ChargeCacheMiddleware do
     described_class.new(subscription:, charge:, to_datetime:, cache: cache_enabled, last_seen_at:)
   end
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-create_default(:plan)
-create_default(:billable_metric)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+    create_default(:billable_metric)
+  end
 
   let(:subscription) { create(:subscription) }
   let(:charge) { create(:standard_charge, plan: subscription.plan) }

--- a/spec/services/subscriptions/charge_cache_middleware_spec.rb
+++ b/spec/services/subscriptions/charge_cache_middleware_spec.rb
@@ -7,6 +7,13 @@ RSpec.describe Subscriptions::ChargeCacheMiddleware do
     described_class.new(subscription:, charge:, to_datetime:, cache: cache_enabled, last_seen_at:)
   end
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+create_default(:plan)
+create_default(:billable_metric)
+end
+
   let(:subscription) { create(:subscription) }
   let(:charge) { create(:standard_charge, plan: subscription.plan) }
   let(:to_datetime) { Time.current + 1.day }

--- a/spec/services/subscriptions/charge_cache_service_spec.rb
+++ b/spec/services/subscriptions/charge_cache_service_spec.rb
@@ -5,12 +5,12 @@ require "rails_helper"
 RSpec.describe Subscriptions::ChargeCacheService do
   subject(:cache_service) { described_class.new(subscription:, charge:, charge_filter:) }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-create_default(:plan)
-create_default(:billable_metric)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+    create_default(:billable_metric)
+  end
 
   let(:subscription) { create(:subscription) }
   let(:charge) { create(:standard_charge, plan: subscription.plan) }

--- a/spec/services/subscriptions/charge_cache_service_spec.rb
+++ b/spec/services/subscriptions/charge_cache_service_spec.rb
@@ -5,6 +5,13 @@ require "rails_helper"
 RSpec.describe Subscriptions::ChargeCacheService do
   subject(:cache_service) { described_class.new(subscription:, charge:, charge_filter:) }
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+create_default(:plan)
+create_default(:billable_metric)
+end
+
   let(:subscription) { create(:subscription) }
   let(:charge) { create(:standard_charge, plan: subscription.plan) }
   let(:charge_filter) { nil }

--- a/spec/services/subscriptions/charge_filters/create_service_spec.rb
+++ b/spec/services/subscriptions/charge_filters/create_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe Subscriptions::ChargeFilters::CreateService do
   subject(:service) { described_class.new(subscription:, charge:, params:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:billable_metric_filter) { create(:billable_metric_filter, billable_metric:) }
   let(:subscription) { create(:subscription, customer:, plan:) }
   let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }

--- a/spec/services/subscriptions/charge_filters/destroy_service_spec.rb
+++ b/spec/services/subscriptions/charge_filters/destroy_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe Subscriptions::ChargeFilters::DestroyService do
   subject(:service) { described_class.new(subscription:, charge:, charge_filter:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
   let(:billable_metric_filter) { create(:billable_metric_filter, billable_metric:) }
   let(:subscription) { create(:subscription, customer:, plan:) }
   let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }

--- a/spec/services/subscriptions/charge_filters/update_or_override_service_spec.rb
+++ b/spec/services/subscriptions/charge_filters/update_or_override_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe Subscriptions::ChargeFilters::UpdateOrOverrideService do
   subject(:service) { described_class.new(subscription:, charge:, charge_filter:, params:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
   let(:billable_metric_filter) { create(:billable_metric_filter, billable_metric:) }
   let(:subscription) { create(:subscription, customer:, plan:) }
   let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }

--- a/spec/services/subscriptions/concerns/fixed_charge_units_override_promotion_concern_spec.rb
+++ b/spec/services/subscriptions/concerns/fixed_charge_units_override_promotion_concern_spec.rb
@@ -13,9 +13,14 @@ RSpec.describe Subscriptions::Concerns::FixedChargeUnitsOverridePromotionConcern
     end.new
   end
 
+before_all do
+  create_default(:customer)
+create_default(:add_on)
+end
+
   describe "#promote_units_overrides_to_fixed_charges_params" do
-    let(:organization) { create(:organization) }
-    let(:plan) { create(:plan, organization:) }
+    let_it_be(:organization) { create_default(:organization) }
+    let_it_be(:plan) { create(:plan, organization:) }
     let(:fc1) { create(:fixed_charge, plan:, organization:, units: 5) }
     let(:fc2) { create(:fixed_charge, plan:, organization:, units: 10) }
     let(:subscription) { create(:subscription, plan:) }

--- a/spec/services/subscriptions/concerns/fixed_charge_units_override_promotion_concern_spec.rb
+++ b/spec/services/subscriptions/concerns/fixed_charge_units_override_promotion_concern_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe Subscriptions::Concerns::FixedChargeUnitsOverridePromotionConcern
     end.new
   end
 
-before_all do
-  create_default(:customer)
-create_default(:add_on)
-end
+  before_all do
+    create_default(:customer)
+    create_default(:add_on)
+  end
 
   describe "#promote_units_overrides_to_fixed_charges_params" do
     let_it_be(:organization) { create_default(:organization) }

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Subscriptions::CreateService do
   let_it_be(:plan) { create(:plan, amount_cents: 100, organization:, amount_currency: "EUR") }
   let_it_be(:customer) { create_default(:customer, organization:, currency: "EUR") }
 
-before_all do
-  create_default(:add_on)
-end
+  before_all do
+    create_default(:add_on)
+  end
 
   let(:external_id) { SecureRandom.uuid }
   let(:billing_time) { "anniversary" }

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -5,9 +5,13 @@ require "rails_helper"
 RSpec.describe Subscriptions::CreateService do
   subject(:create_service) { described_class.new(customer:, plan:, params:) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, amount_cents: 100, organization:, amount_currency: "EUR") }
-  let(:customer) { create(:customer, organization:, currency: "EUR") }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create(:plan, amount_cents: 100, organization:, amount_currency: "EUR") }
+  let_it_be(:customer) { create_default(:customer, organization:, currency: "EUR") }
+
+before_all do
+  create_default(:add_on)
+end
 
   let(:external_id) { SecureRandom.uuid }
   let(:billing_time) { "anniversary" }
@@ -123,7 +127,7 @@ RSpec.describe Subscriptions::CreateService do
     end
 
     context "when subscription should sync with Hubspot" do
-      let(:customer) { create(:customer, :with_hubspot_integration, organization:, currency: "EUR") }
+      let_it_be(:customer) { create(:customer, :with_hubspot_integration, organization:, currency: "EUR") }
 
       it "enqueues the Hubspot create job for a new subscription" do
         create_service.call
@@ -565,7 +569,7 @@ RSpec.describe Subscriptions::CreateService do
       end
 
       context "when an entry references a fixed_charge id not on the plan" do
-        let(:other_plan) { create(:plan, organization:) }
+        let_it_be(:other_plan) { create(:plan, organization:) }
         let(:foreign_fixed_charge) { create(:fixed_charge, plan: other_plan) }
         let(:params) do
           {
@@ -693,7 +697,7 @@ RSpec.describe Subscriptions::CreateService do
     end
 
     context "when plan is pay_in_advance" do
-      let(:plan) { create(:plan, amount_cents: 100, organization:, pay_in_advance: true) }
+      let_it_be(:plan) { create(:plan, amount_cents: 100, organization:, pay_in_advance: true) }
 
       context "when subscription_at is current date" do
         it "enqueues a job to bill the subscription" do
@@ -710,7 +714,7 @@ RSpec.describe Subscriptions::CreateService do
       end
 
       context "when subscription_at is current date but there is a trial period" do
-        let(:plan) { create(:plan, amount_cents: 100, organization:, pay_in_advance: true, trial_period: 10) }
+        let_it_be(:plan) { create(:plan, amount_cents: 100, organization:, pay_in_advance: true, trial_period: 10) }
 
         it "does not enqueue a job to bill the subscription" do
           expect { create_service.call }.not_to have_enqueued_job(BillSubscriptionJob)
@@ -747,7 +751,7 @@ RSpec.describe Subscriptions::CreateService do
     end
 
     context "when plan is not pay_in_advance, subscription_at is current date and there are fixed charges" do
-      let(:plan) { create(:plan, amount_cents: 100, organization:, pay_in_advance: false) }
+      let_it_be(:plan) { create(:plan, amount_cents: 100, organization:, pay_in_advance: false) }
       let(:fixed_charge) { create(:fixed_charge, plan:, pay_in_advance:) }
 
       before do
@@ -766,7 +770,7 @@ RSpec.describe Subscriptions::CreateService do
         end
 
         context "when plan has a trial period" do
-          let(:plan) { create(:plan, amount_cents: 100, organization:, pay_in_advance: true, trial_period: 10) }
+          let_it_be(:plan) { create(:plan, amount_cents: 100, organization:, pay_in_advance: true, trial_period: 10) }
 
           it "does not queue a job to bill the subscription" do
             expect { create_service.call }.not_to have_enqueued_job(BillSubscriptionJob)
@@ -1137,9 +1141,9 @@ RSpec.describe Subscriptions::CreateService do
 
       context "when plan is not the same" do
         context "when we upgrade the plan" do
-          let(:customer) { create(:customer, :with_hubspot_integration, organization:, currency: "EUR") }
-          let(:plan) { create(:plan, amount_cents: 200, organization:) }
-          let(:old_plan) { create(:plan, amount_cents: 100, organization:) }
+          let_it_be(:customer) { create(:customer, :with_hubspot_integration, organization:, currency: "EUR") }
+          let_it_be(:plan) { create(:plan, amount_cents: 200, organization:) }
+          let_it_be(:old_plan) { create(:plan, amount_cents: 100, organization:) }
           let(:name) { "invoice display name new" }
 
           before do
@@ -1433,8 +1437,8 @@ RSpec.describe Subscriptions::CreateService do
             subscription.mark_as_active!
           end
 
-          let(:plan) { create(:plan, amount_cents: 50, organization:) }
-          let(:old_plan) { create(:plan, amount_cents: 100, organization:) }
+          let_it_be(:plan) { create(:plan, amount_cents: 50, organization:) }
+          let_it_be(:old_plan) { create(:plan, amount_cents: 100, organization:) }
           let(:name) { "invoice display name new" }
 
           it "creates a new subscription" do
@@ -1743,7 +1747,7 @@ RSpec.describe Subscriptions::CreateService do
     end
 
     context "with activation_rules" do
-      let(:customer) { create(:customer, organization:, payment_provider: "stripe") }
+      let_it_be(:customer) { create(:customer, organization:, payment_provider: "stripe") }
 
       let(:params) do
         {
@@ -1787,7 +1791,7 @@ RSpec.describe Subscriptions::CreateService do
         end
 
         context "when plan is pay in advance" do
-          let(:plan) { create(:plan, amount_cents: 100, organization:, amount_currency: "EUR", pay_in_advance: true) }
+          let_it_be(:plan) { create(:plan, amount_cents: 100, organization:, amount_currency: "EUR", pay_in_advance: true) }
 
           it "creates incomplete subscription with pending activation rule" do
             result = create_service.call
@@ -1821,7 +1825,7 @@ RSpec.describe Subscriptions::CreateService do
         end
 
         context "when plan is pay in arrears with pay-in-advance fixed charges" do
-          let(:add_on) { create(:add_on, organization:) }
+          let_it_be(:add_on) { create(:add_on, organization:) }
 
           before { create(:fixed_charge, plan:, add_on:, pay_in_advance: true) }
 
@@ -1841,7 +1845,7 @@ RSpec.describe Subscriptions::CreateService do
         end
 
         context "when plan is pay in advance with trial period" do
-          let(:plan) { create(:plan, amount_cents: 100, organization:, amount_currency: "EUR", pay_in_advance: true, trial_period: 30) }
+          let_it_be(:plan) { create(:plan, amount_cents: 100, organization:, amount_currency: "EUR", pay_in_advance: true, trial_period: 30) }
 
           it "creates active subscription with not_applicable activation rule" do
             result = create_service.call
@@ -2012,7 +2016,7 @@ RSpec.describe Subscriptions::CreateService do
     end
 
     describe "billing entity binding" do
-      let(:billing_entity) { create(:billing_entity, organization:) }
+      let_it_be(:billing_entity) { create(:billing_entity, organization:) }
 
       context "when binding a billing entity" do
         it "persists nil when no billing entity reference is provided" do
@@ -2074,10 +2078,10 @@ RSpec.describe Subscriptions::CreateService do
     end
 
     describe "billing entity binding on downgrade" do
-      let(:current_entity) { create(:billing_entity, organization:, code: "entity-x") }
-      let(:target_entity) { create(:billing_entity, organization:, code: "entity-y") }
-      let(:old_plan) { create(:plan, amount_cents: 100, organization:) }
-      let(:plan) { create(:plan, amount_cents: 50, organization:) }
+      let_it_be(:current_entity) { create(:billing_entity, organization:, code: "entity-x") }
+      let_it_be(:target_entity) { create(:billing_entity, organization:, code: "entity-y") }
+      let_it_be(:old_plan) { create(:plan, amount_cents: 100, organization:) }
+      let_it_be(:plan) { create(:plan, amount_cents: 50, organization:) }
 
       let(:subscription) do
         create(

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe Subscriptions::Dates::MonthlyService do
   subject(:date_service) { described_class.new(subscription, billing_at, false) }
 
+before_all do
+  create_default(:organization)
+end
+
   let(:subscription) do
     create(
       :subscription,
@@ -17,9 +21,9 @@ RSpec.describe Subscriptions::Dates::MonthlyService do
     )
   end
 
-  let(:billing_entity) { create(:billing_entity) }
-  let(:customer) { create(:customer, timezone:, billing_entity:) }
-  let(:plan) { create(:plan, interval: :monthly, pay_in_advance:) }
+  let(:billing_entity) { create_default(:billing_entity) }
+  let(:customer) { create_default(:customer, timezone:, billing_entity:) }
+  let(:plan) { create_default(:plan, interval: :monthly, pay_in_advance:) }
   let(:pay_in_advance) { false }
 
   let(:subscription_at) { Time.zone.parse("02 Feb 2021") }

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Subscriptions::Dates::MonthlyService do
   subject(:date_service) { described_class.new(subscription, billing_at, false) }
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let(:subscription) do
     create(

--- a/spec/services/subscriptions/dates/quarterly_service_spec.rb
+++ b/spec/services/subscriptions/dates/quarterly_service_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe Subscriptions::Dates::QuarterlyService do
   subject(:date_service) { described_class.new(subscription, billing_at, current_usage) }
 
+before_all do
+  create_default(:organization)
+end
+
   let(:subscription) do
     create(
       :subscription,
@@ -16,8 +20,8 @@ RSpec.describe Subscriptions::Dates::QuarterlyService do
     )
   end
 
-  let(:customer) { create(:customer, timezone:) }
-  let(:plan) { create(:plan, interval: :monthly, pay_in_advance:) }
+  let(:customer) { create_default(:customer, timezone:) }
+  let(:plan) { create_default(:plan, interval: :monthly, pay_in_advance:) }
   let(:pay_in_advance) { false }
   let(:current_usage) { false }
 

--- a/spec/services/subscriptions/dates/quarterly_service_spec.rb
+++ b/spec/services/subscriptions/dates/quarterly_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Subscriptions::Dates::QuarterlyService do
   subject(:date_service) { described_class.new(subscription, billing_at, current_usage) }
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let(:subscription) do
     create(

--- a/spec/services/subscriptions/dates/semiannual_service_spec.rb
+++ b/spec/services/subscriptions/dates/semiannual_service_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe Subscriptions::Dates::SemiannualService do
   subject(:date_service) { described_class.new(subscription, billing_at, current_usage) }
 
+before_all do
+  create_default(:organization)
+end
+
   let(:subscription) do
     create(
       :subscription,
@@ -16,8 +20,8 @@ RSpec.describe Subscriptions::Dates::SemiannualService do
     )
   end
 
-  let(:customer) { create(:customer, timezone:) }
-  let(:plan) { create(:plan, interval: :semiannual, pay_in_advance:) }
+  let(:customer) { create_default(:customer, timezone:) }
+  let(:plan) { create_default(:plan, interval: :semiannual, pay_in_advance:) }
   let(:pay_in_advance) { false }
   let(:current_usage) { false }
 

--- a/spec/services/subscriptions/dates/semiannual_service_spec.rb
+++ b/spec/services/subscriptions/dates/semiannual_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Subscriptions::Dates::SemiannualService do
   subject(:date_service) { described_class.new(subscription, billing_at, current_usage) }
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let(:subscription) do
     create(

--- a/spec/services/subscriptions/dates/weekly_service_spec.rb
+++ b/spec/services/subscriptions/dates/weekly_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Subscriptions::Dates::WeeklyService do
   subject(:date_service) { described_class.new(subscription, billing_at, false) }
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let(:subscription) do
     create(

--- a/spec/services/subscriptions/dates/weekly_service_spec.rb
+++ b/spec/services/subscriptions/dates/weekly_service_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe Subscriptions::Dates::WeeklyService do
   subject(:date_service) { described_class.new(subscription, billing_at, false) }
 
+before_all do
+  create_default(:organization)
+end
+
   let(:subscription) do
     create(
       :subscription,
@@ -16,8 +20,8 @@ RSpec.describe Subscriptions::Dates::WeeklyService do
     )
   end
 
-  let(:customer) { create(:customer, timezone:) }
-  let(:plan) { create(:plan, interval: :weekly, pay_in_advance:) }
+  let(:customer) { create_default(:customer, timezone:) }
+  let(:plan) { create_default(:plan, interval: :weekly, pay_in_advance:) }
   let(:pay_in_advance) { false }
 
   let(:subscription_at) { Time.zone.parse("02 Feb 2021") }

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -15,20 +15,18 @@ RSpec.describe Subscriptions::Dates::YearlyService do
       started_at:
     )
   end
-
-  before_all do
-    create_default(:organization)
-  end
-
   let(:customer) { create_default(:customer, timezone:) }
   let(:plan) { create_default(:plan, interval: :yearly, pay_in_advance:) }
   let(:pay_in_advance) { false }
   let(:current_usage) { false }
-
   let(:subscription_at) { Time.zone.parse("02 Feb 2021") }
   let(:billing_at) { Time.zone.parse("07 Mar 2022") }
   let(:started_at) { subscription_at }
   let(:timezone) { "UTC" }
+
+  before_all do
+    create_default(:organization)
+  end
 
   describe "from_datetime" do
     let(:result) { date_service.from_datetime.to_s }

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -16,8 +16,12 @@ RSpec.describe Subscriptions::Dates::YearlyService do
     )
   end
 
-  let(:customer) { create(:customer, timezone:) }
-  let(:plan) { create(:plan, interval: :yearly, pay_in_advance:) }
+  before_all do
+    create_default(:organization)
+  end
+
+  let(:customer) { create_default(:customer, timezone:) }
+  let(:plan) { create_default(:plan, interval: :yearly, pay_in_advance:) }
   let(:pay_in_advance) { false }
   let(:current_usage) { false }
 

--- a/spec/services/subscriptions/dates_service_spec.rb
+++ b/spec/services/subscriptions/dates_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe Subscriptions::DatesService do
   subject(:date_service) { described_class.new(subscription, billing_date, false) }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
 
   let(:subscription) do
     create(

--- a/spec/services/subscriptions/dates_service_spec.rb
+++ b/spec/services/subscriptions/dates_service_spec.rb
@@ -5,6 +5,11 @@ require "rails_helper"
 RSpec.describe Subscriptions::DatesService do
   subject(:date_service) { described_class.new(subscription, billing_date, false) }
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
   let(:subscription) do
     create(
       :subscription,
@@ -15,7 +20,7 @@ RSpec.describe Subscriptions::DatesService do
     )
   end
 
-  let(:plan) { create(:plan, interval:, pay_in_advance:) }
+  let(:plan) { create_default(:plan, interval:, pay_in_advance:) }
   let(:pay_in_advance) { false }
 
   let(:subscription_at) { DateTime.parse("02 Feb 2021") }

--- a/spec/services/subscriptions/emit_fixed_charge_events_service_spec.rb
+++ b/spec/services/subscriptions/emit_fixed_charge_events_service_spec.rb
@@ -6,20 +6,19 @@ RSpec.describe Subscriptions::EmitFixedChargeEventsService do
   subject(:service) { described_class.new(subscriptions:, timestamp:) }
 
   let(:timestamp) { Time.current }
+  let(:fixed_charge_1) { create(:fixed_charge, plan:, add_on:) }
+  let(:fixed_charge_2) { create(:fixed_charge, plan:, add_on:) }
+  let(:subscription_1) { create(:subscription, :active, plan:) }
+  let(:subscription_2) { create(:subscription, :active, plan:) }
+  let(:subscriptions) { [subscription_1, subscription_2] }
+
   let_it_be(:organization) { create_default(:organization) }
   let_it_be(:plan) { create(:plan, organization:) }
   let_it_be(:add_on) { create(:add_on, organization:) }
 
-before_all do
-  create_default(:customer)
-end
-
-  let(:fixed_charge_1) { create(:fixed_charge, plan:, add_on:) }
-  let(:fixed_charge_2) { create(:fixed_charge, plan:, add_on:) }
-
-  let(:subscription_1) { create(:subscription, :active, plan:) }
-  let(:subscription_2) { create(:subscription, :active, plan:) }
-  let(:subscriptions) { [subscription_1, subscription_2] }
+  before_all do
+    create_default(:customer)
+  end
 
   before do
     fixed_charge_1

--- a/spec/services/subscriptions/emit_fixed_charge_events_service_spec.rb
+++ b/spec/services/subscriptions/emit_fixed_charge_events_service_spec.rb
@@ -6,9 +6,13 @@ RSpec.describe Subscriptions::EmitFixedChargeEventsService do
   subject(:service) { described_class.new(subscriptions:, timestamp:) }
 
   let(:timestamp) { Time.current }
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
-  let(:add_on) { create(:add_on, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
+
+before_all do
+  create_default(:customer)
+end
 
   let(:fixed_charge_1) { create(:fixed_charge, plan:, add_on:) }
   let(:fixed_charge_2) { create(:fixed_charge, plan:, add_on:) }

--- a/spec/services/subscriptions/fixed_charge_units_overrides/write_service_spec.rb
+++ b/spec/services/subscriptions/fixed_charge_units_overrides/write_service_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe Subscriptions::FixedChargeUnitsOverrides::WriteService do
   let_it_be(:organization) { create_default(:organization) }
   let_it_be(:plan) { create(:plan, organization:) }
 
-before_all do
-  create_default(:customer)
-create_default(:add_on)
-end
+  before_all do
+    create_default(:customer)
+    create_default(:add_on)
+  end
 
   let(:fixed_charge) { create(:fixed_charge, plan:, organization:, units: 5) }
   let(:subscription) { create(:subscription, plan:) }

--- a/spec/services/subscriptions/fixed_charge_units_overrides/write_service_spec.rb
+++ b/spec/services/subscriptions/fixed_charge_units_overrides/write_service_spec.rb
@@ -13,8 +13,14 @@ RSpec.describe Subscriptions::FixedChargeUnitsOverrides::WriteService do
     )
   end
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
+
+before_all do
+  create_default(:customer)
+create_default(:add_on)
+end
+
   let(:fixed_charge) { create(:fixed_charge, plan:, organization:, units: 5) }
   let(:subscription) { create(:subscription, plan:) }
   let(:units) { 15 }

--- a/spec/services/subscriptions/flag_refreshed_service_spec.rb
+++ b/spec/services/subscriptions/flag_refreshed_service_spec.rb
@@ -3,9 +3,13 @@
 require "rails_helper"
 
 RSpec.describe Subscriptions::FlagRefreshedService, :premium do
-  let(:organization) { create(:organization, premium_integrations: %w[lifetime_usage]) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization, premium_integrations: %w[lifetime_usage]) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:) }
+
+before_all do
+  create_default(:plan)
+end
 
   before do
     allow(UsageMonitoring::TrackSubscriptionActivityService).to receive(:call).and_call_original

--- a/spec/services/subscriptions/flag_refreshed_service_spec.rb
+++ b/spec/services/subscriptions/flag_refreshed_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Subscriptions::FlagRefreshedService, :premium do
   let_it_be(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:) }
 
-before_all do
-  create_default(:plan)
-end
+  before_all do
+    create_default(:plan)
+  end
 
   before do
     allow(UsageMonitoring::TrackSubscriptionActivityService).to receive(:call).and_call_original

--- a/spec/services/subscriptions/free_trial_billing_service_spec.rb
+++ b/spec/services/subscriptions/free_trial_billing_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Subscriptions::FreeTrialBillingService do
   subject(:service) { described_class.new(timestamp:) }
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   let(:timestamp) { Time.zone.now }
 

--- a/spec/services/subscriptions/free_trial_billing_service_spec.rb
+++ b/spec/services/subscriptions/free_trial_billing_service_spec.rb
@@ -5,10 +5,14 @@ require "rails_helper"
 RSpec.describe Subscriptions::FreeTrialBillingService do
   subject(:service) { described_class.new(timestamp:) }
 
+before_all do
+  create_default(:organization)
+end
+
   let(:timestamp) { Time.zone.now }
 
   describe "#call" do
-    let(:plan) { create(:plan, trial_period: 10, pay_in_advance: true) }
+    let_it_be(:plan) { create(:plan, trial_period: 10, pay_in_advance: true) }
 
     context "with a plan witout trial period" do
       it "does not set trial_ended_at" do
@@ -74,7 +78,7 @@ RSpec.describe Subscriptions::FreeTrialBillingService do
     end
 
     context "with plan pay in arrears" do
-      let(:plan) { create(:plan, trial_period: 10, pay_in_advance: false) }
+      let_it_be(:plan) { create(:plan, trial_period: 10, pay_in_advance: false) }
 
       context "when plan has fixed charges" do
         context "when fixed_charges are not pay in advance" do

--- a/spec/services/subscriptions/organization_billing_service_spec.rb
+++ b/spec/services/subscriptions/organization_billing_service_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Subscriptions::OrganizationBillingService do
   subject(:billing_service) { described_class.new(organization:, billing_at:) }
 
   describe ".call" do
+    let_it_be(:organization) { create_default(:organization) }
     let(:billing_entity_timezone) { "UTC" }
     let(:billing_entity) { create(:billing_entity, timezone: billing_entity_timezone) }
-    let(:organization) { billing_entity.organization }
 
     let(:interval) { :monthly }
     let(:bill_charges_monthly) { false }

--- a/spec/services/subscriptions/plan_downgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_downgrade_service_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe Subscriptions::PlanDowngradeService do
     )
   end
 
-  let(:old_plan) { create(:plan, amount_cents: 100, organization:, amount_currency: currency) }
-  let(:customer) { create(:customer, :with_hubspot_integration, organization:, currency:) }
-  let(:organization) { create(:organization) }
-  let(:currency) { "EUR" }
-  let(:plan) { create(:plan, amount_cents: 50, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create(:customer, :with_hubspot_integration, organization:, currency:) }
+  let_it_be(:currency) { "EUR" }
+  let_it_be(:old_plan) { create(:plan, amount_cents: 100, organization:, amount_currency: currency) }
+  let_it_be(:plan) { create(:plan, amount_cents: 50, organization:) }
   let(:params) { {name: subscription_name} }
   let(:subscription_name) { "new invoice display name" }
 

--- a/spec/services/subscriptions/plan_downgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_downgrade_service_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe Subscriptions::PlanDowngradeService do
       external_id: SecureRandom.uuid
     )
   end
+  let(:params) { {name: subscription_name} }
+  let(:subscription_name) { "new invoice display name" }
 
   let_it_be(:organization) { create_default(:organization) }
   let_it_be(:customer) { create(:customer, :with_hubspot_integration, organization:, currency:) }
   let_it_be(:currency) { "EUR" }
   let_it_be(:old_plan) { create(:plan, amount_cents: 100, organization:, amount_currency: currency) }
   let_it_be(:plan) { create(:plan, amount_cents: 50, organization:) }
-  let(:params) { {name: subscription_name} }
-  let(:subscription_name) { "new invoice display name" }
 
   describe "#call" do
     it "creates a new pending next subscription" do

--- a/spec/services/subscriptions/plan_upgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_upgrade_service_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe Subscriptions::PlanUpgradeService do
     )
   end
 
-  let(:old_plan) { create(:plan, amount_cents: 100, organization:, amount_currency: currency) }
-  let(:customer) { create(:customer, :with_hubspot_integration, organization:, currency:) }
-  let(:organization) { create(:organization) }
-  let(:currency) { "EUR" }
-  let(:plan) { create(:plan, amount_cents: 100, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:currency) { "EUR" }
+  let_it_be(:old_plan) { create(:plan, amount_cents: 100, organization:, amount_currency: currency) }
+  let_it_be(:customer) { create(:customer, :with_hubspot_integration, organization:, currency:) }
+  let_it_be(:plan) { create(:plan, amount_cents: 100, organization:) }
   let(:params) { {name: subscription_name} }
   let(:subscription_name) { "new invoice display name" }
 
@@ -252,7 +252,7 @@ RSpec.describe Subscriptions::PlanUpgradeService do
       end
 
       context "when the plan is pay-in-advance" do
-        let(:plan) { create(:plan, amount_cents: 200, organization:, pay_in_advance: true) }
+        let_it_be(:plan) { create(:plan, amount_cents: 200, organization:, pay_in_advance: true) }
 
         it "keeps the current subscription active" do
           result
@@ -298,7 +298,7 @@ RSpec.describe Subscriptions::PlanUpgradeService do
       end
 
       context "when the plan has no upfront billing" do
-        let(:plan) { create(:plan, amount_cents: 100, organization:, pay_in_advance: false) }
+        let_it_be(:plan) { create(:plan, amount_cents: 100, organization:, pay_in_advance: false) }
 
         it "marks the activation rule as not_applicable" do
           expect(result).to be_success
@@ -431,7 +431,7 @@ RSpec.describe Subscriptions::PlanUpgradeService do
     end
 
     context "when new subscription is pay in advance and has trial period" do
-      let(:plan) { create(:plan, amount_cents: 200, organization:, pay_in_advance: true, trial_period: 3) }
+      let_it_be(:plan) { create(:plan, amount_cents: 200, organization:, pay_in_advance: true, trial_period: 3) }
 
       context "without pay in advance fixed charges" do
         it "does not include new subscription in BillSubscriptionJob" do
@@ -476,8 +476,8 @@ RSpec.describe Subscriptions::PlanUpgradeService do
     end
 
     describe "billing entity binding" do
-      let(:billing_entity) { create(:billing_entity, organization:) }
-      let(:other_entity) { create(:billing_entity, organization:) }
+      let_it_be(:billing_entity) { create(:billing_entity, organization:) }
+      let_it_be(:other_entity) { create(:billing_entity, organization:) }
 
       context "when binding a billing entity" do
         it "carries over the current subscription's billing_entity_id when no param is provided" do
@@ -534,7 +534,7 @@ RSpec.describe Subscriptions::PlanUpgradeService do
       end
 
       context "when bill_subscriptions runs after the upgrade" do
-        let(:plan) { create(:plan, amount_cents: 200, organization:, pay_in_advance: true) }
+        let_it_be(:plan) { create(:plan, amount_cents: 200, organization:, pay_in_advance: true) }
 
         it "carries the current subscription's entity into termination and new-period billing context" do
           subscription.update!(billing_entity:)

--- a/spec/services/subscriptions/plan_upgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_upgrade_service_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe Subscriptions::PlanUpgradeService do
       external_id: SecureRandom.uuid
     )
   end
+  let(:params) { {name: subscription_name} }
+  let(:subscription_name) { "new invoice display name" }
 
   let_it_be(:organization) { create_default(:organization) }
   let_it_be(:currency) { "EUR" }
   let_it_be(:old_plan) { create(:plan, amount_cents: 100, organization:, amount_currency: currency) }
   let_it_be(:customer) { create(:customer, :with_hubspot_integration, organization:, currency:) }
   let_it_be(:plan) { create(:plan, amount_cents: 100, organization:) }
-  let(:params) { {name: subscription_name} }
-  let(:subscription_name) { "new invoice display name" }
 
   describe "#call" do
     before do

--- a/spec/services/subscriptions/progressive_billed_amount_spec.rb
+++ b/spec/services/subscriptions/progressive_billed_amount_spec.rb
@@ -5,10 +5,16 @@ require "rails_helper"
 RSpec.describe Subscriptions::ProgressiveBilledAmount do
   subject(:service) { described_class.new(subscription:, timestamp:) }
 
+before_all do
+  create_default(:organization)
+create_default(:plan)
+create_default(:billable_metric)
+end
+
   let(:timestamp) { Time.current }
   let(:subscription) { create(:subscription, customer_id: customer.id) }
   let(:organization) { subscription.organization }
-  let(:customer) { create(:customer) }
+  let_it_be(:customer) { create_default(:customer) }
 
   let(:charges_to_datetime) { timestamp + 1.week }
   let(:charges_from_datetime) { timestamp - 1.week }

--- a/spec/services/subscriptions/progressive_billed_amount_spec.rb
+++ b/spec/services/subscriptions/progressive_billed_amount_spec.rb
@@ -5,20 +5,20 @@ require "rails_helper"
 RSpec.describe Subscriptions::ProgressiveBilledAmount do
   subject(:service) { described_class.new(subscription:, timestamp:) }
 
-before_all do
-  create_default(:organization)
-create_default(:plan)
-create_default(:billable_metric)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:plan)
+    create_default(:billable_metric)
+  end
 
   let(:timestamp) { Time.current }
-  let(:subscription) { create(:subscription, customer_id: customer.id) }
-  let(:organization) { subscription.organization }
-  let_it_be(:customer) { create_default(:customer) }
-
   let(:charges_to_datetime) { timestamp + 1.week }
   let(:charges_from_datetime) { timestamp - 1.week }
   let(:invoice_type) { :progressive_billing }
+  let(:subscription) { create(:subscription, customer_id: customer.id) }
+  let(:organization) { subscription.organization }
+
+  let_it_be(:customer) { create_default(:customer) }
 
   context "without previous progressive billing invoices" do
     it "returns 0" do

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -5,11 +5,11 @@ require "rails_helper"
 RSpec.describe Subscriptions::TerminateService do
   subject(:terminate_service) { described_class.new(subscription:) }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-create_default(:plan)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+  end
 
   let(:on_termination_credit_note) { nil }
 

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -5,6 +5,12 @@ require "rails_helper"
 RSpec.describe Subscriptions::TerminateService do
   subject(:terminate_service) { described_class.new(subscription:) }
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+create_default(:plan)
+end
+
   let(:on_termination_credit_note) { nil }
 
   describe ".call" do
@@ -111,9 +117,9 @@ RSpec.describe Subscriptions::TerminateService do
     end
 
     context "when subscription is incomplete" do
-      let(:organization) { create(:organization) }
-      let(:customer) { create(:customer, organization:) }
-      let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+      let_it_be(:organization) { create(:organization) }
+      let_it_be(:customer) { create(:customer, organization:) }
+      let_it_be(:plan) { create(:plan, organization:, pay_in_advance: true) }
       let(:subscription) { create(:subscription, :incomplete, customer:, organization:, plan:) }
       let(:invoice) { create(:invoice, :open, customer:, organization:, invoice_type: :subscription) }
 
@@ -259,7 +265,7 @@ RSpec.describe Subscriptions::TerminateService do
     end
 
     context "when subscription was paid in advance" do
-      let(:plan) { create(:plan, :pay_in_advance) }
+      let_it_be(:plan) { create(:plan, :pay_in_advance) }
       let(:subscription) do
         create(
           :subscription,

--- a/spec/services/subscriptions/terminated_dates_service_spec.rb
+++ b/spec/services/subscriptions/terminated_dates_service_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Subscriptions::TerminatedDatesService do
   let_it_be(:organization) { create_default(:organization) }
   let_it_be(:plan) { create(:plan, organization:, interval: :monthly) }
 
-before_all do
-  create_default(:customer)
-end
+  before_all do
+    create_default(:customer)
+  end
 
   let(:subscription_at) { DateTime.parse("02 Feb 2021") }
   let(:started_at) { subscription_at }

--- a/spec/services/subscriptions/terminated_dates_service_spec.rb
+++ b/spec/services/subscriptions/terminated_dates_service_spec.rb
@@ -5,8 +5,13 @@ require "rails_helper"
 RSpec.describe Subscriptions::TerminatedDatesService do
   subject(:terminated_date_service) { described_class.new(subscription:, invoice:, date_service:, match_invoice_subscription:) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:, interval: :monthly) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create(:plan, organization:, interval: :monthly) }
+
+before_all do
+  create_default(:customer)
+end
+
   let(:subscription_at) { DateTime.parse("02 Feb 2021") }
   let(:started_at) { subscription_at }
   let(:billing_date) { DateTime.parse("2022-03-07 04:20:46.011") }

--- a/spec/services/subscriptions/update_or_override_charge_service_spec.rb
+++ b/spec/services/subscriptions/update_or_override_charge_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe Subscriptions::UpdateOrOverrideChargeService do
   subject(:service) { described_class.new(subscription:, charge:, params:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:) }
   let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
   let(:params) do
@@ -75,7 +75,7 @@ RSpec.describe Subscriptions::UpdateOrOverrideChargeService do
       end
 
       context "when subscription already has a plan override" do
-        let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+        let_it_be(:overridden_plan) { create(:plan, organization:, parent: plan) }
         let(:subscription) { create(:subscription, customer:, plan: overridden_plan) }
 
         it "does not create a new plan" do
@@ -91,7 +91,7 @@ RSpec.describe Subscriptions::UpdateOrOverrideChargeService do
       end
 
       context "when charge override already exists" do
-        let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+        let_it_be(:overridden_plan) { create(:plan, organization:, parent: plan) }
         let(:subscription) { create(:subscription, customer:, plan: overridden_plan) }
         let!(:existing_override) { create(:standard_charge, plan: overridden_plan, organization:, billable_metric:, parent: charge, code: charge.code) }
 
@@ -109,7 +109,7 @@ RSpec.describe Subscriptions::UpdateOrOverrideChargeService do
       end
 
       context "when the charge passed is itself an override" do
-        let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+        let_it_be(:overridden_plan) { create(:plan, organization:, parent: plan) }
         let(:subscription) { create(:subscription, customer:, plan: overridden_plan) }
         let(:parent_charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
         let!(:charge) { create(:standard_charge, plan: overridden_plan, organization:, billable_metric:, parent: parent_charge, code: parent_charge.code) }
@@ -127,7 +127,7 @@ RSpec.describe Subscriptions::UpdateOrOverrideChargeService do
       end
 
       context "when the charge passed lives directly on the overridden plan with parent_id: nil" do
-        let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+        let_it_be(:overridden_plan) { create(:plan, organization:, parent: plan) }
         let(:subscription) { create(:subscription, customer:, plan: overridden_plan) }
         let!(:charge) do
           create(:standard_charge, plan: overridden_plan, organization:, billable_metric:)

--- a/spec/services/subscriptions/update_or_override_fixed_charge_service_spec.rb
+++ b/spec/services/subscriptions/update_or_override_fixed_charge_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe Subscriptions::UpdateOrOverrideFixedChargeService do
   subject(:service) { described_class.new(subscription:, fixed_charge:, params:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
-  let(:add_on) { create(:add_on, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
+  let_it_be(:add_on) { create(:add_on, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:) }
   let(:fixed_charge) { create(:fixed_charge, plan:, organization:, add_on:) }
   let(:params) do
@@ -176,7 +176,7 @@ RSpec.describe Subscriptions::UpdateOrOverrideFixedChargeService do
       end
 
       context "when subscription already has a plan override" do
-        let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+        let_it_be(:overridden_plan) { create(:plan, organization:, parent: plan) }
         let(:subscription) { create(:subscription, customer:, plan: overridden_plan) }
 
         it "does not create a new plan" do
@@ -192,7 +192,7 @@ RSpec.describe Subscriptions::UpdateOrOverrideFixedChargeService do
       end
 
       context "when fixed charge override already exists" do
-        let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+        let_it_be(:overridden_plan) { create(:plan, organization:, parent: plan) }
         let(:subscription) { create(:subscription, customer:, plan: overridden_plan) }
         let!(:existing_override) { create(:fixed_charge, plan: overridden_plan, organization:, add_on:, parent: fixed_charge, code: fixed_charge.code) }
 
@@ -244,7 +244,7 @@ RSpec.describe Subscriptions::UpdateOrOverrideFixedChargeService do
       end
 
       context "when the fixed charge passed is itself an override" do
-        let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+        let_it_be(:overridden_plan) { create(:plan, organization:, parent: plan) }
         let(:subscription) { create(:subscription, customer:, plan: overridden_plan) }
         let(:parent_fixed_charge) { create(:fixed_charge, plan:, organization:, add_on:) }
         let!(:fixed_charge) { create(:fixed_charge, plan: overridden_plan, organization:, add_on:, parent: parent_fixed_charge, code: parent_fixed_charge.code) }

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -5,7 +5,14 @@ require "rails_helper"
 RSpec.describe Subscriptions::UpdateService do
   subject(:update_service) { described_class.new(subscription:, params:) }
 
-  let(:membership) { create(:membership) }
+before_all do
+  create_default(:organization)
+create_default(:customer)
+create_default(:plan)
+create_default(:add_on)
+end
+
+  let_it_be(:membership) { create(:membership) }
   let(:subscription) { create(:subscription) }
 
   describe "#call" do
@@ -237,7 +244,7 @@ RSpec.describe Subscriptions::UpdateService do
         let(:params) { {on_termination_credit_note: "credit"} }
 
         context "with pay_in_advance plan" do
-          let(:plan) { create(:plan, :pay_in_advance) }
+          let_it_be(:plan) { create(:plan, :pay_in_advance) }
           let(:subscription) { create(:subscription, plan:) }
 
           %w[credit skip].each do |value|
@@ -433,7 +440,7 @@ RSpec.describe Subscriptions::UpdateService do
       end
 
       context "when subscription is pay_in_advance" do
-        let(:plan) { create(:plan, :pay_in_advance) }
+        let_it_be(:plan) { create(:plan, :pay_in_advance) }
         let(:subscription) { create(:subscription, :pending, plan:) }
 
         context "when subscription_at is set to past date" do
@@ -719,7 +726,7 @@ RSpec.describe Subscriptions::UpdateService do
     end
 
     context "when plan_overrides" do
-      let(:plan) { create(:plan, organization: membership.organization) }
+      let_it_be(:plan) { create(:plan, organization: membership.organization) }
       let(:subscription) { create(:subscription, plan:) }
       let(:params) do
         {
@@ -759,8 +766,8 @@ RSpec.describe Subscriptions::UpdateService do
         end
 
         context "with overriden plan" do
-          let(:parent_plan) { create(:plan, organization: membership.organization) }
-          let(:plan) { create(:plan, organization: membership.organization, parent_id: parent_plan.id) }
+          let_it_be(:parent_plan) { create(:plan, organization: membership.organization) }
+          let_it_be(:plan) { create(:plan, organization: membership.organization, parent_id: parent_plan.id) }
 
           it "updates the plan accordingly" do
             update_service.call
@@ -900,11 +907,11 @@ RSpec.describe Subscriptions::UpdateService do
       end
 
       context "with fixed charge overrides and apply_units_immediately true", :premium do
-        let(:organization) { membership.organization }
-        let(:plan) { create(:plan, organization:, interval: :weekly) }
+        let_it_be(:organization) { membership.organization }
+        let_it_be(:plan) { create(:plan, organization:, interval: :weekly) }
         let(:fixed_charge1) { create(:fixed_charge, plan:, units: 5) }
         let(:fixed_charge2) { create(:fixed_charge, plan:, units: 10) }
-        let(:customer) { create(:customer, organization:) }
+        let_it_be(:customer) { create(:customer, organization:) }
         let(:subscription) do
           create(
             :subscription,
@@ -979,11 +986,11 @@ RSpec.describe Subscriptions::UpdateService do
       end
 
       context "with fixed charge overrides and apply_units_immediately false", :premium do
-        let(:organization) { membership.organization }
-        let(:plan) { create(:plan, organization:, interval: :weekly) }
+        let_it_be(:organization) { membership.organization }
+        let_it_be(:plan) { create(:plan, organization:, interval: :weekly) }
         let(:fixed_charge1) { create(:fixed_charge, plan:, units: 5) }
         let(:fixed_charge2) { create(:fixed_charge, plan:, units: 10) }
-        let(:customer) { create(:customer, organization:) }
+        let_it_be(:customer) { create(:customer, organization:) }
         let(:subscription) do
           create(
             :subscription,
@@ -1063,11 +1070,11 @@ RSpec.describe Subscriptions::UpdateService do
       end
 
       context "with pending subscription, fixed charge overrides and mixed apply_units_immediately", :premium do
-        let(:organization) { membership.organization }
-        let(:plan) { create(:plan, organization:, interval: :weekly) }
+        let_it_be(:organization) { membership.organization }
+        let_it_be(:plan) { create(:plan, organization:, interval: :weekly) }
         let(:fixed_charge1) { create(:fixed_charge, plan:, units: 5) }
         let(:fixed_charge2) { create(:fixed_charge, plan:, units: 10) }
-        let(:customer) { create(:customer, organization:) }
+        let_it_be(:customer) { create(:customer, organization:) }
         let(:subscription_at) { 7.days.from_now }
 
         let(:subscription) do
@@ -1156,10 +1163,10 @@ RSpec.describe Subscriptions::UpdateService do
       end
 
       context "when apply_units_immediately is true on a pay-in-advance fixed charge", :premium do
-        let(:organization) { membership.organization }
-        let(:plan) { create(:plan, organization:) }
+        let_it_be(:organization) { membership.organization }
+        let_it_be(:plan) { create(:plan, organization:) }
         let(:fixed_charge) { create(:fixed_charge, plan:, units: 5, pay_in_advance: true) }
-        let(:customer) { create(:customer, organization:) }
+        let_it_be(:customer) { create(:customer, organization:) }
         let(:subscription) { create(:subscription, plan:, customer:) }
         let(:params) do
           {plan_overrides: {fixed_charges: [{id: fixed_charge.id, units: 25, apply_units_immediately: true}]}}
@@ -1496,11 +1503,11 @@ RSpec.describe Subscriptions::UpdateService do
     end
 
     context "when updating billing_entity" do
-      let(:organization) { create(:organization) }
-      let(:customer) { create(:customer, organization:) }
-      let(:plan) { create(:plan, organization:) }
+      let_it_be(:organization) { create(:organization) }
+      let_it_be(:customer) { create(:customer, organization:) }
+      let_it_be(:plan) { create(:plan, organization:) }
       let(:subscription) { create(:subscription, customer:, plan:, organization:) }
-      let(:new_billing_entity) { create(:billing_entity, organization:) }
+      let_it_be(:new_billing_entity) { create(:billing_entity, organization:) }
 
       context "with multi_entity_billing feature flag enabled" do
         context "with billing_entity_id" do
@@ -1585,8 +1592,8 @@ RSpec.describe Subscriptions::UpdateService do
         end
 
         context "when the subscription already has a billing_entity attached" do
-          let(:current_entity) { create(:billing_entity, organization:) }
-          let(:other_entity) { create(:billing_entity, organization:) }
+          let_it_be(:current_entity) { create(:billing_entity, organization:) }
+          let_it_be(:other_entity) { create(:billing_entity, organization:) }
           let(:subscription) { create(:subscription, customer:, plan:, organization:, billing_entity: current_entity) }
 
           context "when billing_entity_id is nil" do

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -5,12 +5,12 @@ require "rails_helper"
 RSpec.describe Subscriptions::UpdateService do
   subject(:update_service) { described_class.new(subscription:, params:) }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-create_default(:plan)
-create_default(:add_on)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+    create_default(:add_on)
+  end
 
   let_it_be(:membership) { create(:membership) }
   let(:subscription) { create(:subscription) }
@@ -910,8 +910,6 @@ end
         let_it_be(:organization) { membership.organization }
         let_it_be(:plan) { create(:plan, organization:, interval: :weekly) }
         let(:fixed_charge1) { create(:fixed_charge, plan:, units: 5) }
-        let(:fixed_charge2) { create(:fixed_charge, plan:, units: 10) }
-        let_it_be(:customer) { create(:customer, organization:) }
         let(:subscription) do
           create(
             :subscription,
@@ -924,7 +922,6 @@ end
         end
         let(:subscription_at) { Date.new(2023, 9, 2) }
         let(:started_at) { Date.new(2025, 5, 17) }
-
         let(:params) do
           {
             plan_overrides: {
@@ -938,6 +935,9 @@ end
             }
           }
         end
+        let(:fixed_charge2) { create(:fixed_charge, plan:, units: 10) }
+
+        let_it_be(:customer) { create(:customer, organization:) }
 
         before do
           fixed_charge1
@@ -989,8 +989,6 @@ end
         let_it_be(:organization) { membership.organization }
         let_it_be(:plan) { create(:plan, organization:, interval: :weekly) }
         let(:fixed_charge1) { create(:fixed_charge, plan:, units: 5) }
-        let(:fixed_charge2) { create(:fixed_charge, plan:, units: 10) }
-        let_it_be(:customer) { create(:customer, organization:) }
         let(:subscription) do
           create(
             :subscription,
@@ -1003,7 +1001,6 @@ end
         end
         let(:subscription_at) { Date.new(2023, 9, 2) }
         let(:started_at) { Date.new(2025, 5, 17) }
-
         let(:params) do
           {
             plan_overrides: {
@@ -1020,6 +1017,9 @@ end
             }
           }
         end
+        let(:fixed_charge2) { create(:fixed_charge, plan:, units: 10) }
+
+        let_it_be(:customer) { create(:customer, organization:) }
 
         before do
           fixed_charge1
@@ -1073,10 +1073,7 @@ end
         let_it_be(:organization) { membership.organization }
         let_it_be(:plan) { create(:plan, organization:, interval: :weekly) }
         let(:fixed_charge1) { create(:fixed_charge, plan:, units: 5) }
-        let(:fixed_charge2) { create(:fixed_charge, plan:, units: 10) }
-        let_it_be(:customer) { create(:customer, organization:) }
         let(:subscription_at) { 7.days.from_now }
-
         let(:subscription) do
           create(
             :subscription,
@@ -1087,7 +1084,6 @@ end
             status: :pending
           )
         end
-
         let(:params) do
           {
             plan_overrides: {
@@ -1106,6 +1102,9 @@ end
             }
           }
         end
+        let(:fixed_charge2) { create(:fixed_charge, plan:, units: 10) }
+
+        let_it_be(:customer) { create(:customer, organization:) }
 
         before do
           fixed_charge1
@@ -1166,11 +1165,12 @@ end
         let_it_be(:organization) { membership.organization }
         let_it_be(:plan) { create(:plan, organization:) }
         let(:fixed_charge) { create(:fixed_charge, plan:, units: 5, pay_in_advance: true) }
-        let_it_be(:customer) { create(:customer, organization:) }
         let(:subscription) { create(:subscription, plan:, customer:) }
         let(:params) do
           {plan_overrides: {fixed_charges: [{id: fixed_charge.id, units: 25, apply_units_immediately: true}]}}
         end
+
+        let_it_be(:customer) { create(:customer, organization:) }
 
         before do
           fixed_charge
@@ -1507,6 +1507,7 @@ end
       let_it_be(:customer) { create(:customer, organization:) }
       let_it_be(:plan) { create(:plan, organization:) }
       let(:subscription) { create(:subscription, customer:, plan:, organization:) }
+
       let_it_be(:new_billing_entity) { create(:billing_entity, organization:) }
 
       context "with multi_entity_billing feature flag enabled" do

--- a/spec/services/subscriptions/update_usage_thresholds_service_spec.rb
+++ b/spec/services/subscriptions/update_usage_thresholds_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe Subscriptions::UpdateUsageThresholdsService, :premium do
   subject(:service) { described_class.new(subscription:, usage_thresholds_params:, partial:) }
 
-  let(:organization) { create(:organization, premium_integrations:) }
-  let(:premium_integrations) { ["progressive_billing"] }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:premium_integrations) { ["progressive_billing"] }
+      let_it_be(:organization) { create(:organization, premium_integrations:) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:, organization:) }
   let(:lifetime_usage) { create(:lifetime_usage, subscription:, organization:) }
   let(:usage_thresholds_params) { [{amount_cents: 1000, threshold_display_name: "Test"}] }
@@ -21,7 +21,8 @@ RSpec.describe Subscriptions::UpdateUsageThresholdsService, :premium do
 
   describe "#call" do
     context "when progressive_billing is not enabled" do
-      let(:premium_integrations) { [] }
+      let_it_be(:premium_integrations) { [] }
+      let_it_be(:organization) { create(:organization, premium_integrations:) }
 
       it "returns early without calling UsageThresholds::UpdateService" do
         result = service.call

--- a/spec/services/subscriptions/update_usage_thresholds_service_spec.rb
+++ b/spec/services/subscriptions/update_usage_thresholds_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Subscriptions::UpdateUsageThresholdsService, :premium do
   subject(:service) { described_class.new(subscription:, usage_thresholds_params:, partial:) }
 
   let_it_be(:premium_integrations) { ["progressive_billing"] }
-      let_it_be(:organization) { create(:organization, premium_integrations:) }
+  let_it_be(:organization) { create(:organization, premium_integrations:) }
   let_it_be(:customer) { create(:customer, organization:) }
   let_it_be(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:, organization:) }

--- a/spec/services/subscriptions/validate_service_spec.rb
+++ b/spec/services/subscriptions/validate_service_spec.rb
@@ -6,13 +6,8 @@ RSpec.describe Subscriptions::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { Subscriptions::CreateService::Result.new }
-  let_it_be(:organization) { create_default(:organization)}
-  let_it_be(:membership) { create(:membership) }
-  let_it_be(:customer) { create_default(:customer, organization:) }
-  let_it_be(:plan) { create(:plan, organization:) }
   let(:subscription_at) { Time.current.iso8601 }
   let(:ending_at) { (Time.current + 1.year).iso8601 }
-
   let(:args) do
     {
       customer:,
@@ -25,11 +20,15 @@ RSpec.describe Subscriptions::ValidateService do
       subscription_type:
     }
   end
-
   let(:on_termination_credit_note) { nil }
   let(:on_termination_invoice) { nil }
   let(:subscription) { nil }
   let(:subscription_type) { "create" }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
 
   describe "#ending_at" do
     subject(:method_call) { validate_service.__send__(:ending_at) }

--- a/spec/services/subscriptions/validate_service_spec.rb
+++ b/spec/services/subscriptions/validate_service_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe Subscriptions::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { Subscriptions::CreateService::Result.new }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:subscription_at) { Time.current.iso8601 }
   let(:ending_at) { (Time.current + 1.year).iso8601 }
 
@@ -342,7 +342,7 @@ RSpec.describe Subscriptions::ValidateService do
         }
       end
 
-      let(:customer) { create(:customer, organization:, payment_provider: "stripe") }
+      let_it_be(:customer) { create(:customer, organization:, payment_provider: "stripe") }
 
       context "when activation_rules contains valid payment rule" do
         let(:activation_rules) { [{type: "payment", timeout_hours: 48}] }

--- a/spec/services/taxes/auto_generate_service_spec.rb
+++ b/spec/services/taxes/auto_generate_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Taxes::AutoGenerateService do
   subject(:auto_generate_service) { described_class.new(organization:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
 
   describe ".call" do
     it "creates eu taxes for organization" do

--- a/spec/services/taxes/create_service_spec.rb
+++ b/spec/services/taxes/create_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Taxes::CreateService do
   subject(:create_service) { described_class.new(organization:, params:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:billing_entity) { organization.default_billing_entity }
   let(:code) { "tax_code" }
   let(:params) do

--- a/spec/services/taxes/destroy_service_spec.rb
+++ b/spec/services/taxes/destroy_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Taxes::DestroyService do
   subject(:destroy_service) { described_class.new(tax:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:billing_entity) { organization.default_billing_entity }
   let(:tax) { create(:tax, :applied_to_billing_entity, organization:) }
   let(:customer) { create(:customer, organization:) }

--- a/spec/services/taxes/update_service_spec.rb
+++ b/spec/services/taxes/update_service_spec.rb
@@ -5,11 +5,10 @@ require "rails_helper"
 RSpec.describe Taxes::UpdateService do
   subject(:update_service) { described_class.new(tax:, params:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:billing_entity) { organization.default_billing_entity }
   let(:tax) { create(:tax, :applied_to_billing_entity, organization:) }
-
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   describe "#call" do
     before { tax }

--- a/spec/services/taxes/update_service_spec.rb
+++ b/spec/services/taxes/update_service_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Taxes::UpdateService do
   let_it_be(:organization) { create(:organization) }
   let(:billing_entity) { organization.default_billing_entity }
   let(:tax) { create(:tax, :applied_to_billing_entity, organization:) }
+
   let_it_be(:customer) { create(:customer, organization:) }
 
   describe "#call" do

--- a/spec/services/usage_monitoring/alerts/create_batch_service_spec.rb
+++ b/spec/services/usage_monitoring/alerts/create_batch_service_spec.rb
@@ -8,13 +8,6 @@ RSpec.describe UsageMonitoring::Alerts::CreateBatchService do
 
     let_it_be(:organization) { create_default(:organization) }
     let(:alertable) { create(:subscription, organization:) }
-    let_it_be(:billable_metrics) { create_list(:billable_metric, 2, organization:) }
-
-before_all do
-  create_default(:customer)
-create_default(:plan)
-end
-
     let(:alerts_params) do
       [
         {
@@ -32,6 +25,13 @@ end
           thresholds: [{code: "critical", value: 100}]
         }
       ]
+    end
+
+    let_it_be(:billable_metrics) { create_list(:billable_metric, 2, organization:) }
+
+    before_all do
+      create_default(:customer)
+      create_default(:plan)
     end
 
     it "creates multiple alerts" do

--- a/spec/services/usage_monitoring/alerts/create_batch_service_spec.rb
+++ b/spec/services/usage_monitoring/alerts/create_batch_service_spec.rb
@@ -6,9 +6,15 @@ RSpec.describe UsageMonitoring::Alerts::CreateBatchService do
   describe ".call" do
     subject(:result) { described_class.call(organization:, alertable:, alerts_params:) }
 
-    let(:organization) { create(:organization) }
+    let_it_be(:organization) { create_default(:organization) }
     let(:alertable) { create(:subscription, organization:) }
-    let(:billable_metrics) { create_list(:billable_metric, 2, organization:) }
+    let_it_be(:billable_metrics) { create_list(:billable_metric, 2, organization:) }
+
+before_all do
+  create_default(:customer)
+create_default(:plan)
+end
+
     let(:alerts_params) do
       [
         {

--- a/spec/services/usage_monitoring/alerts/destroy_all_service_spec.rb
+++ b/spec/services/usage_monitoring/alerts/destroy_all_service_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe UsageMonitoring::Alerts::DestroyAllService do
     let_it_be(:organization) { create_default(:organization) }
     let(:alertable) { create(:subscription, organization:) }
 
-before_all do
-  create_default(:customer)
-create_default(:plan)
-end
+    before_all do
+      create_default(:customer)
+      create_default(:plan)
+    end
 
     context "when alertable is a subscription" do
       let!(:alert1) do

--- a/spec/services/usage_monitoring/alerts/destroy_all_service_spec.rb
+++ b/spec/services/usage_monitoring/alerts/destroy_all_service_spec.rb
@@ -6,8 +6,13 @@ RSpec.describe UsageMonitoring::Alerts::DestroyAllService do
   describe ".call" do
     subject(:result) { described_class.call(alertable: alertable) }
 
-    let(:organization) { create(:organization) }
+    let_it_be(:organization) { create_default(:organization) }
     let(:alertable) { create(:subscription, organization:) }
+
+before_all do
+  create_default(:customer)
+create_default(:plan)
+end
 
     context "when alertable is a subscription" do
       let!(:alert1) do

--- a/spec/services/usage_monitoring/create_alert_service_spec.rb
+++ b/spec/services/usage_monitoring/create_alert_service_spec.rb
@@ -6,12 +6,17 @@ RSpec.describe UsageMonitoring::CreateAlertService do
   describe ".call" do
     subject(:result) { described_class.call(organization:, alertable: subscription, params:) }
 
-    let(:organization) { create(:organization, premium_integrations:) }
+    let(:organization) { create_default(:organization, premium_integrations:) }
     let(:premium_integrations) { [] }
     let(:thresholds) { [{code: "warning", value: 80}, {code: "critical", value: 120}] }
     let(:params) { {alert_type: "current_usage_amount", name: "Main", thresholds:, code: "first", billable_metric_id: billable_metric&.id} }
     let(:subscription) { create(:subscription, organization:) }
     let(:billable_metric) { nil }
+
+before do
+  create_default(:customer)
+create_default(:plan)
+end
 
     it "creates a new alert" do
       expect(result).to be_success

--- a/spec/services/usage_monitoring/create_alert_service_spec.rb
+++ b/spec/services/usage_monitoring/create_alert_service_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe UsageMonitoring::CreateAlertService do
     let(:subscription) { create(:subscription, organization:) }
     let(:billable_metric) { nil }
 
-before do
-  create_default(:customer)
-create_default(:plan)
-end
+    before do
+      create_default(:customer)
+      create_default(:plan)
+    end
 
     it "creates a new alert" do
       expect(result).to be_success

--- a/spec/services/usage_monitoring/process_alert_service_spec.rb
+++ b/spec/services/usage_monitoring/process_alert_service_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe UsageMonitoring::ProcessAlertService do
     let(:alert) { create(:usage_current_amount_alert, recurring_threshold: 35, thresholds: [10, 20], previous_value: 4, code: "test", organization:, subscription_external_id: subscription.external_id) }
     let(:subscription) { create(:subscription, organization:) }
 
-before_all do
-  create_default(:customer)
-create_default(:plan)
-end
+    before_all do
+      create_default(:customer)
+      create_default(:plan)
+    end
 
     context "when no thresholds are crossed" do
       let(:current_metrics) { instance_double(SubscriptionUsage, amount_cents: 5) }

--- a/spec/services/usage_monitoring/process_alert_service_spec.rb
+++ b/spec/services/usage_monitoring/process_alert_service_spec.rb
@@ -6,9 +6,14 @@ RSpec.describe UsageMonitoring::ProcessAlertService do
   describe "#call" do
     subject(:result) { described_class.call(alert:, alertable: subscription, current_metrics:) }
 
-    let(:organization) { create(:organization) }
+    let_it_be(:organization) { create_default(:organization) }
     let(:alert) { create(:usage_current_amount_alert, recurring_threshold: 35, thresholds: [10, 20], previous_value: 4, code: "test", organization:, subscription_external_id: subscription.external_id) }
     let(:subscription) { create(:subscription, organization:) }
+
+before_all do
+  create_default(:customer)
+create_default(:plan)
+end
 
     context "when no thresholds are crossed" do
       let(:current_metrics) { instance_double(SubscriptionUsage, amount_cents: 5) }

--- a/spec/services/usage_monitoring/process_organization_subscription_activities_service_spec.rb
+++ b/spec/services/usage_monitoring/process_organization_subscription_activities_service_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe UsageMonitoring::ProcessOrganizationSubscriptionActivitiesService do
   describe "#call" do
-    let(:organization) { create(:organization) }
+    let_it_be(:organization) { create(:organization) }
     let(:service) { described_class.new(organization:) }
 
     it "enqueues jobs for subscription activities that are not yet enqueued" do

--- a/spec/services/usage_monitoring/process_subscription_activity_service_spec.rb
+++ b/spec/services/usage_monitoring/process_subscription_activity_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe UsageMonitoring::ProcessSubscriptionActivityService, :premium do
   subject(:service) { described_class.new(subscription_activity:) }
 
-  let(:organization) { create(:organization, premium_integrations:) }
+  let(:organization) { create_default(:organization, premium_integrations:) }
   let(:mocked_current_usage) { double("current_usage") } # rubocop:disable RSpec/VerifiedDoubles
-  let(:customer) { create(:customer, organization:) }
-  let(:subscription) { create(:subscription, customer:) }
+  let(:customer) { create_default(:customer, organization:) }
+  let(:subscription) { create_default(:subscription, customer:) }
   let(:subscription_activity) { create(:subscription_activity, subscription:, organization:) }
 
   before do

--- a/spec/services/usage_monitoring/process_wallet_alerts_service_spec.rb
+++ b/spec/services/usage_monitoring/process_wallet_alerts_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe UsageMonitoring::ProcessWalletAlertsService do
   describe "#call" do
     subject(:result) { described_class.call(wallet:) }
 
-    let(:organization) { create(:organization) }
-    let(:customer) { create(:customer, organization:) }
+    let_it_be(:organization) { create(:organization) }
+    let_it_be(:customer) { create(:customer, organization:) }
     let(:wallet) { create(:wallet, organization:, customer:, balance_cents: 400, ongoing_balance_cents: 400, credits_balance: 4.0, credits_ongoing_balance: 4.0) }
 
     context "when wallet has no alerts" do

--- a/spec/services/usage_monitoring/track_subscription_activity_service_spec.rb
+++ b/spec/services/usage_monitoring/track_subscription_activity_service_spec.rb
@@ -5,10 +5,14 @@ require "rails_helper"
 RSpec.describe UsageMonitoring::TrackSubscriptionActivityService, :premium do
   subject { described_class.new(organization:, subscription:, date:) }
 
-  let(:organization) { create(:organization, premium_integrations: %w[lifetime_usage]) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization, premium_integrations: %w[lifetime_usage]) }
+    let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:) }
   let(:date) { Date.new(2025, 1, 15) }
+
+before_all do
+  create_default(:plan)
+end
 
   context "when the plan has usage_thresholds" do
     it "tracks activity" do

--- a/spec/services/usage_monitoring/track_subscription_activity_service_spec.rb
+++ b/spec/services/usage_monitoring/track_subscription_activity_service_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe UsageMonitoring::TrackSubscriptionActivityService, :premium do
   subject { described_class.new(organization:, subscription:, date:) }
 
   let_it_be(:organization) { create_default(:organization, premium_integrations: %w[lifetime_usage]) }
-    let(:customer) { create(:customer, organization:) }
+  let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:) }
   let(:date) { Date.new(2025, 1, 15) }
 
-before_all do
-  create_default(:plan)
-end
+  before_all do
+    create_default(:plan)
+  end
 
   context "when the plan has usage_thresholds" do
     it "tracks activity" do

--- a/spec/services/usage_monitoring/update_alert_service_spec.rb
+++ b/spec/services/usage_monitoring/update_alert_service_spec.rb
@@ -5,9 +5,14 @@ require "rails_helper"
 RSpec.describe UsageMonitoring::UpdateAlertService do
   subject(:result) { described_class.call(alert:, params:) }
 
-  let(:organization) { create(:organization, premium_integrations:) }
-  let(:premium_integrations) { [] }
+  let_it_be(:premium_integrations) { [] }
+  let_it_be(:organization) { create_default(:organization, premium_integrations:) }
   let(:alert) { create(:alert, thresholds: [1, 50], organization: organization) }
+
+before_all do
+  create_default(:customer)
+create_default(:plan)
+end
 
   describe "#call" do
     let(:params) do
@@ -29,7 +34,7 @@ RSpec.describe UsageMonitoring::UpdateAlertService do
 
     context "with a billable_metric_id" do
       let(:alert) { create(:billable_metric_current_usage_amount_alert, thresholds: [50]) }
-      let(:billable_metric) { create(:billable_metric, organization: alert.organization) }
+      let(:billable_metric) { create_default(:billable_metric)}
       let(:params) do
         {code: "new_code", name: "Renamed", billable_metric_id: billable_metric.id, thresholds: [
           {value: 40},

--- a/spec/services/usage_monitoring/update_alert_service_spec.rb
+++ b/spec/services/usage_monitoring/update_alert_service_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe UsageMonitoring::UpdateAlertService do
   let_it_be(:organization) { create_default(:organization, premium_integrations:) }
   let(:alert) { create(:alert, thresholds: [1, 50], organization: organization) }
 
-before_all do
-  create_default(:customer)
-create_default(:plan)
-end
+  before_all do
+    create_default(:customer)
+    create_default(:plan)
+  end
 
   describe "#call" do
     let(:params) do
@@ -34,7 +34,7 @@ end
 
     context "with a billable_metric_id" do
       let(:alert) { create(:billable_metric_current_usage_amount_alert, thresholds: [50]) }
-      let(:billable_metric) { create_default(:billable_metric)}
+      let(:billable_metric) { create_default(:billable_metric) }
       let(:params) do
         {code: "new_code", name: "Renamed", billable_metric_id: billable_metric.id, thresholds: [
           {value: 40},

--- a/spec/services/usage_thresholds/override_service_spec.rb
+++ b/spec/services/usage_thresholds/override_service_spec.rb
@@ -5,12 +5,12 @@ require "rails_helper"
 RSpec.describe UsageThresholds::OverrideService do
   subject(:override_service) { described_class.new(usage_thresholds_params:, new_plan: plan) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
 
   describe "#call" do
     let(:threshold) { create(:usage_threshold, plan:) }
-    let(:plan) { create(:plan, organization:) }
+    let_it_be(:plan) { create(:plan, organization:) }
 
     let(:usage_thresholds_params) do
       [

--- a/spec/services/usage_thresholds/override_service_spec.rb
+++ b/spec/services/usage_thresholds/override_service_spec.rb
@@ -5,13 +5,11 @@ require "rails_helper"
 RSpec.describe UsageThresholds::OverrideService do
   subject(:override_service) { described_class.new(usage_thresholds_params:, new_plan: plan) }
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
 
   describe "#call" do
     let(:threshold) { create(:usage_threshold, plan:) }
-    let_it_be(:plan) { create(:plan, organization:) }
-
     let(:usage_thresholds_params) do
       [
         {
@@ -21,6 +19,8 @@ RSpec.describe UsageThresholds::OverrideService do
         }
       ]
     end
+
+    let_it_be(:plan) { create(:plan, organization:) }
 
     before { threshold }
 

--- a/spec/services/usage_thresholds/update_service_table_spec.rb
+++ b/spec/services/usage_thresholds/update_service_table_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe UsageThresholds::UpdateService, premium: true do
   subject(:result) { described_class.call(model:, usage_thresholds_params:, partial:) }
 
-  let(:organization) { create(:organization, premium_integrations: ["progressive_billing"]) }
+  let_it_be(:organization) { create(:organization, premium_integrations: ["progressive_billing"]) }
   let(:model) { create(:plan, organization:) }
 
   # Helper to build threshold attributes for comparison

--- a/spec/services/user_devices/register_service_spec.rb
+++ b/spec/services/user_devices/register_service_spec.rb
@@ -8,8 +8,6 @@ RSpec.describe UserDevices::RegisterService do
   include_context "with mocked security logger"
 
   let(:user) { membership.user }
-  let_it_be(:organization) { create_default(:organization)}
-  let_it_be(:membership) { create(:membership) }
   let(:skip_log) { false }
   let(:device_info) do
     {
@@ -20,6 +18,9 @@ RSpec.describe UserDevices::RegisterService do
       device_type: "desktop"
     }
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
 
   before do
     membership

--- a/spec/services/user_devices/register_service_spec.rb
+++ b/spec/services/user_devices/register_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe UserDevices::RegisterService do
 
   include_context "with mocked security logger"
 
-  let(:membership) { create(:membership) }
   let(:user) { membership.user }
-  let(:organization) { membership.organization }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
   let(:skip_log) { false }
   let(:device_info) do
     {

--- a/spec/services/users_service_spec.rb
+++ b/spec/services/users_service_spec.rb
@@ -159,9 +159,9 @@ RSpec.describe UsersService do
   describe ".call(:login)" do
     subject(:result) { described_class.call(:login, email, password) }
 
-before_all do
-  create_default(:organization)
-end
+    before_all do
+      create_default(:organization)
+    end
 
     let_it_be(:membership) { create(:membership, :revoked) }
     let_it_be(:user) { membership.user }

--- a/spec/services/users_service_spec.rb
+++ b/spec/services/users_service_spec.rb
@@ -159,8 +159,12 @@ RSpec.describe UsersService do
   describe ".call(:login)" do
     subject(:result) { described_class.call(:login, email, password) }
 
-    let!(:membership) { create(:membership, :revoked) }
-    let(:user) { membership.user }
+before_all do
+  create_default(:organization)
+end
+
+    let_it_be(:membership) { create(:membership, :revoked) }
+    let_it_be(:user) { membership.user }
 
     context "when user with given email exists" do
       let(:email) { user.email }
@@ -169,7 +173,7 @@ RSpec.describe UsersService do
         let(:password) { user.password }
 
         context "when user has active membership" do
-          let!(:active_membership) { create(:membership, user:, organization: membership.organization) }
+          let_it_be(:active_membership) { create(:membership, user:, organization: membership.organization) }
 
           before { allow(UserDevices::RegisterService).to receive(:call!) }
 

--- a/spec/services/utils/activity_log_spec.rb
+++ b/spec/services/utils/activity_log_spec.rb
@@ -3,11 +3,14 @@
 RSpec.describe Utils::ActivityLog, :capture_kafka_messages do
   subject(:activity_log) { described_class }
 
-  let(:membership) { create(:membership) }
   let(:api_key) { create(:api_key) }
-
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
   let(:coupon) { create(:coupon, organization:) }
+
+before_all do
+  create_default(:customer)
+end
 
   let(:serialized_coupon) do
     {
@@ -380,7 +383,7 @@ RSpec.describe Utils::ActivityLog, :capture_kafka_messages do
     end
 
     context "when the object is a plan" do
-      let(:object) { create(:plan, organization:) }
+      let_it_be(:object) { create(:plan, organization:) }
 
       let(:serialized_object) do
         V1::PlanSerializer.new(
@@ -414,7 +417,7 @@ RSpec.describe Utils::ActivityLog, :capture_kafka_messages do
 
     context "when the object is a subscription" do
       let(:object) { create(:subscription, organization:, plan:) }
-      let(:plan) { create(:plan, organization:) }
+      let_it_be(:plan) { create(:plan, organization:) }
 
       let(:serialized_object) do
         V1::SubscriptionSerializer.new(
@@ -511,7 +514,7 @@ RSpec.describe Utils::ActivityLog, :capture_kafka_messages do
     end
 
     context "when object is a plan" do
-      let(:object) { create(:plan, organization:) }
+      let_it_be(:object) { create(:plan, organization:) }
 
       context "when plan has more charges than the limit" do
         let(:serializer_includes) { Utils::ActivityLog::SERIALIZED_INCLUDED_OBJECTS[:plan] - [:charges] }
@@ -566,7 +569,7 @@ RSpec.describe Utils::ActivityLog, :capture_kafka_messages do
 
     context "when object is a subscription" do
       let(:object) { create(:subscription, organization:, plan:) }
-      let(:plan) { create(:plan, organization:) }
+      let_it_be(:plan) { create(:plan, organization:) }
 
       context "when subscription's plan has more charges than the limit" do
         let(:serializer_includes) { [{plan: Utils::ActivityLog::SERIALIZED_INCLUDED_OBJECTS[:plan] - [:charges]}] }

--- a/spec/services/utils/activity_log_spec.rb
+++ b/spec/services/utils/activity_log_spec.rb
@@ -4,14 +4,7 @@ RSpec.describe Utils::ActivityLog, :capture_kafka_messages do
   subject(:activity_log) { described_class }
 
   let(:api_key) { create(:api_key) }
-  let_it_be(:organization) { create_default(:organization) }
-  let_it_be(:membership) { create(:membership) }
   let(:coupon) { create(:coupon, organization:) }
-
-before_all do
-  create_default(:customer)
-end
-
   let(:serialized_coupon) do
     {
       topic: "activity_logs",
@@ -38,6 +31,13 @@ end
       external_customer_id: nil,
       external_subscription_id: nil
     }
+  end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
+
+  before_all do
+    create_default(:customer)
   end
 
   before do
@@ -417,13 +417,13 @@ end
 
     context "when the object is a subscription" do
       let(:object) { create(:subscription, organization:, plan:) }
-      let_it_be(:plan) { create(:plan, organization:) }
-
       let(:serialized_object) do
         V1::SubscriptionSerializer.new(
           object, root_name: :invoice, includes: [{plan: Utils::ActivityLog::SERIALIZED_INCLUDED_OBJECTS[:plan] - [:charges]}]
         ).serialize
       end
+
+      let_it_be(:plan) { create(:plan, organization:) }
 
       context "with many charges" do
         before do
@@ -569,6 +569,7 @@ end
 
     context "when object is a subscription" do
       let(:object) { create(:subscription, organization:, plan:) }
+
       let_it_be(:plan) { create(:plan, organization:) }
 
       context "when subscription's plan has more charges than the limit" do

--- a/spec/services/utils/api_log_spec.rb
+++ b/spec/services/utils/api_log_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Utils::ApiLog do
   end
 
   describe ".produce", :capture_kafka_messages do
-    let(:organization) { create(:organization) }
+    let_it_be(:organization) { create_default(:organization) }
 
     context "when kafka is configured" do
       before do

--- a/spec/services/utils/auth_token_spec.rb
+++ b/spec/services/utils/auth_token_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Utils::AuthToken do
-  let(:user) { create(:user) }
+  let_it_be(:user) { create_default(:user) }
   let(:user_id) { user.id }
   let(:extra) { {login_method: Organizations::AuthenticationMethods::EMAIL_PASSWORD} }
   let(:token) { described_class.encode(user:, **extra) }

--- a/spec/services/utils/email_activity_log_spec.rb
+++ b/spec/services/utils/email_activity_log_spec.rb
@@ -4,8 +4,8 @@ require "rails_helper"
 
 RSpec.describe Utils::EmailActivityLog, :capture_kafka_messages do
   let(:invoice) { create(:invoice) }
-  let(:organization) { invoice.organization }
-  let(:customer) { invoice.customer }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:customer) { create_default(:customer)}
 
   let(:message) do
     instance_double(

--- a/spec/services/utils/email_activity_log_spec.rb
+++ b/spec/services/utils/email_activity_log_spec.rb
@@ -4,9 +4,6 @@ require "rails_helper"
 
 RSpec.describe Utils::EmailActivityLog, :capture_kafka_messages do
   let(:invoice) { create(:invoice) }
-  let_it_be(:organization) { create_default(:organization)}
-  let_it_be(:customer) { create_default(:customer)}
-
   let(:message) do
     instance_double(
       Mail::Message,
@@ -19,6 +16,9 @@ RSpec.describe Utils::EmailActivityLog, :capture_kafka_messages do
       body: instance_double(Mail::Body, decoded: "")
     )
   end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   before do
     stub_const("#{described_class}::AVAILABLE", true)

--- a/spec/services/utils/security_log_spec.rb
+++ b/spec/services/utils/security_log_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Utils::SecurityLog do
     end
 
     let_it_be(:organization) { create(:organization, premium_integrations: ["security_logs"]) }
-      let_it_be(:membership) { create(:membership, organization:) }
+    let_it_be(:membership) { create(:membership, organization:) }
     let(:user) { membership.user }
     let(:api_key) { create(:api_key, organization:) }
 

--- a/spec/services/utils/security_log_spec.rb
+++ b/spec/services/utils/security_log_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe Utils::SecurityLog do
       )
     end
 
-    let(:organization) { create(:organization, premium_integrations: ["security_logs"]) }
-    let(:membership) { create(:membership, organization:) }
+    let_it_be(:organization) { create(:organization, premium_integrations: ["security_logs"]) }
+      let_it_be(:membership) { create(:membership, organization:) }
     let(:user) { membership.user }
     let(:api_key) { create(:api_key, organization:) }
 
@@ -98,6 +98,7 @@ RSpec.describe Utils::SecurityLog do
     end
 
     context "when security_logs is not enabled for organization" do
+      let(:membership) { create(:membership, organization:) }
       let(:organization) { create(:organization, premium_integrations: []) }
 
       it "does not produce and returns false" do
@@ -119,6 +120,7 @@ RSpec.describe Utils::SecurityLog do
         )
       end
 
+      let(:membership) { create(:membership, organization:) }
       let(:organization) { create(:organization, premium_integrations: []) }
 
       it "produces the event on kafka" do

--- a/spec/services/validators/wallet_transaction_amount_limits_validator_spec.rb
+++ b/spec/services/validators/wallet_transaction_amount_limits_validator_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe Validators::WalletTransactionAmountLimitsValidator do
   let(:credits_amount) { "1.0" }
   let(:ignore_validation) { false }
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
   describe "#raise_if_invalid!" do
     context "when invalid" do
       subject { described_class.new(result, wallet:, credits_amount:, ignore_validation:).raise_if_invalid! }

--- a/spec/services/validators/wallet_transaction_amount_limits_validator_spec.rb
+++ b/spec/services/validators/wallet_transaction_amount_limits_validator_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe Validators::WalletTransactionAmountLimitsValidator do
   let(:credits_amount) { "1.0" }
   let(:ignore_validation) { false }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
 
   describe "#raise_if_invalid!" do
     context "when invalid" do

--- a/spec/services/wallet_transactions/create_from_params_service_spec.rb
+++ b/spec/services/wallet_transactions/create_from_params_service_spec.rb
@@ -3,9 +3,14 @@
 require "rails_helper"
 
 RSpec.describe WalletTransactions::CreateFromParamsService do
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:, currency:) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:currency) { "EUR" }
+  let(:customer) { create_default(:customer, organization:, currency:) }
+
+before_all do
+  create_default(:plan)
+end
+
   let(:subscription) { create(:subscription, customer:) }
   let(:wallet) do
     create(
@@ -472,7 +477,8 @@ RSpec.describe WalletTransactions::CreateFromParamsService do
 
     context "with decimal value and currency without digits" do
       let(:paid_credits) { "4.39999" }
-      let(:currency) { "JPY" }
+      let_it_be(:currency) { "JPY" }
+  let_it_be(:customer) { create_default(:customer, organization:, currency:) }
 
       it "creates wallet transaction with rounded value" do
         expect(result.wallet_transactions.first.credit_amount).to eq(4)

--- a/spec/services/wallet_transactions/create_from_params_service_spec.rb
+++ b/spec/services/wallet_transactions/create_from_params_service_spec.rb
@@ -5,12 +5,6 @@ require "rails_helper"
 RSpec.describe WalletTransactions::CreateFromParamsService do
   let_it_be(:organization) { create_default(:organization) }
   let(:currency) { "EUR" }
-  let(:customer) { create_default(:customer, organization:, currency:) }
-
-before_all do
-  create_default(:plan)
-end
-
   let(:subscription) { create(:subscription, customer:) }
   let(:wallet) do
     create(
@@ -27,6 +21,11 @@ end
   end
   let(:wallet_invoice_requires_successful_payment) { false }
   let(:rate_amount) { 1 }
+  let(:customer) { create_default(:customer, organization:, currency:) }
+
+  before_all do
+    create_default(:plan)
+  end
 
   before do
     subscription
@@ -477,8 +476,9 @@ end
 
     context "with decimal value and currency without digits" do
       let(:paid_credits) { "4.39999" }
+
       let_it_be(:currency) { "JPY" }
-  let_it_be(:customer) { create_default(:customer, organization:, currency:) }
+      let_it_be(:customer) { create_default(:customer, organization:, currency:) }
 
       it "creates wallet transaction with rounded value" do
         expect(result.wallet_transactions.first.credit_amount).to eq(4)

--- a/spec/services/wallet_transactions/create_service_spec.rb
+++ b/spec/services/wallet_transactions/create_service_spec.rb
@@ -186,10 +186,8 @@ RSpec.describe WalletTransactions::CreateService do
 
     context "with billing entity snapshotting" do
       let(:credit_amount) { 100 }
-      let_it_be(:wallet_billing_entity) { create(:billing_entity, organization:) }
       let(:explicit_billing_entity) { create(:billing_entity, organization:) }
       let(:wallet) { create(:wallet, customer:, currency:, billing_entity: wallet_billing_entity) }
-
       let(:transaction_params) do
         {
           status: :pending,
@@ -197,6 +195,8 @@ RSpec.describe WalletTransactions::CreateService do
           transaction_status: :purchased
         }
       end
+
+      let_it_be(:wallet_billing_entity) { create(:billing_entity, organization:) }
 
       it "snapshots the wallet's effective billing entity on the transaction" do
         wallet_transaction = result.wallet_transaction

--- a/spec/services/wallet_transactions/create_service_spec.rb
+++ b/spec/services/wallet_transactions/create_service_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe WalletTransactions::CreateService do
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:, currency:) }
-  let(:currency) { "EUR" }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:currency) { "EUR" }
+  let_it_be(:customer) { create_default(:customer, organization:, currency:) }
   let(:wallet_credit) { WalletCredit.new(wallet:, credit_amount:) }
 
   let(:wallet) do
@@ -186,7 +186,7 @@ RSpec.describe WalletTransactions::CreateService do
 
     context "with billing entity snapshotting" do
       let(:credit_amount) { 100 }
-      let(:wallet_billing_entity) { create(:billing_entity, organization:) }
+      let_it_be(:wallet_billing_entity) { create(:billing_entity, organization:) }
       let(:explicit_billing_entity) { create(:billing_entity, organization:) }
       let(:wallet) { create(:wallet, customer:, currency:, billing_entity: wallet_billing_entity) }
 

--- a/spec/services/wallet_transactions/mark_as_failed_service_spec.rb
+++ b/spec/services/wallet_transactions/mark_as_failed_service_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe WalletTransactions::MarkAsFailedService do
 
   let(:wallet_transaction) { create(:wallet_transaction, status: "pending") }
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
   describe ".call" do
     context "when wallet_transaction is nil" do
       let(:wallet_transaction) { nil }

--- a/spec/services/wallet_transactions/mark_as_failed_service_spec.rb
+++ b/spec/services/wallet_transactions/mark_as_failed_service_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe WalletTransactions::MarkAsFailedService do
 
   let(:wallet_transaction) { create(:wallet_transaction, status: "pending") }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
 
   describe ".call" do
     context "when wallet_transaction is nil" do

--- a/spec/services/wallet_transactions/recredit_service_spec.rb
+++ b/spec/services/wallet_transactions/recredit_service_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe WalletTransactions::RecreditService do
 
   let(:wallet_transaction) { create(:wallet_transaction, wallet:) }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
 
   context "when wallet is terminated" do
     let(:wallet) { create(:wallet, :terminated) }

--- a/spec/services/wallet_transactions/recredit_service_spec.rb
+++ b/spec/services/wallet_transactions/recredit_service_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe WalletTransactions::RecreditService do
 
   let(:wallet_transaction) { create(:wallet_transaction, wallet:) }
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
   context "when wallet is terminated" do
     let(:wallet) { create(:wallet, :terminated) }
 

--- a/spec/services/wallet_transactions/settle_service_spec.rb
+++ b/spec/services/wallet_transactions/settle_service_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe WalletTransactions::SettleService do
 
   let(:wallet_transaction) { create(:wallet_transaction, status: "pending", settled_at: nil) }
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
   describe ".call" do
     it "updates wallet_transaction status" do
       expect {

--- a/spec/services/wallet_transactions/settle_service_spec.rb
+++ b/spec/services/wallet_transactions/settle_service_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe WalletTransactions::SettleService do
 
   let(:wallet_transaction) { create(:wallet_transaction, status: "pending", settled_at: nil) }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
 
   describe ".call" do
     it "updates wallet_transaction status" do

--- a/spec/services/wallet_transactions/track_consumption_service_spec.rb
+++ b/spec/services/wallet_transactions/track_consumption_service_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe WalletTransactions::TrackConsumptionService do
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:wallet) { create(:wallet, customer:, organization:, balance_cents: 10000, credits_balance: 100.0) }
 
   describe "#call" do

--- a/spec/services/wallet_transactions/validate_service_spec.rb
+++ b/spec/services/wallet_transactions/validate_service_spec.rb
@@ -6,9 +6,14 @@ RSpec.describe WalletTransactions::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { BaseResult[:current_wallet, :payment_method, :voided_wallet_transaction].new }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+
+before_all do
+  create_default(:plan)
+end
+
   let(:subscription) { create(:subscription, customer:) }
   let(:wallet) { create(:wallet, customer:) }
   let(:wallet_id) { wallet.id }

--- a/spec/services/wallet_transactions/validate_service_spec.rb
+++ b/spec/services/wallet_transactions/validate_service_spec.rb
@@ -6,14 +6,6 @@ RSpec.describe WalletTransactions::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { BaseResult[:current_wallet, :payment_method, :voided_wallet_transaction].new }
-  let_it_be(:organization) { create_default(:organization)}
-  let_it_be(:membership) { create(:membership) }
-  let_it_be(:customer) { create_default(:customer, organization:) }
-
-before_all do
-  create_default(:plan)
-end
-
   let(:subscription) { create(:subscription, customer:) }
   let(:wallet) { create(:wallet, customer:) }
   let(:wallet_id) { wallet.id }
@@ -32,6 +24,14 @@ end
     }
   end
   let(:name) { :undefined }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+
+  before_all do
+    create_default(:plan)
+  end
 
   before { subscription }
 

--- a/spec/services/wallets/apply_paid_credits_service_spec.rb
+++ b/spec/services/wallets/apply_paid_credits_service_spec.rb
@@ -5,6 +5,11 @@ require "rails_helper"
 RSpec.describe Wallets::ApplyPaidCreditsService do
   subject(:service) { described_class.new(wallet_transaction:) }
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
   describe ".call" do
     let(:wallet) { create(:wallet, balance_cents: 1000, credits_balance: 10.0) }
     let(:wallet_transaction) do

--- a/spec/services/wallets/apply_paid_credits_service_spec.rb
+++ b/spec/services/wallets/apply_paid_credits_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe Wallets::ApplyPaidCreditsService do
   subject(:service) { described_class.new(wallet_transaction:) }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
 
   describe ".call" do
     let(:wallet) { create(:wallet, balance_cents: 1000, credits_balance: 10.0) }

--- a/spec/services/wallets/balance/allocate_ongoing_usage_by_wallets_service_spec.rb
+++ b/spec/services/wallets/balance/allocate_ongoing_usage_by_wallets_service_spec.rb
@@ -14,8 +14,13 @@ RSpec.describe Wallets::Balance::AllocateOngoingUsageByWalletsService do
     )
   end
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+
+before_all do
+  create_default(:plan)
+end
+
   let(:subscription) { create(:subscription, customer:, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:) }
 
@@ -287,6 +292,7 @@ RSpec.describe Wallets::Balance::AllocateOngoingUsageByWalletsService do
     context "when a fee targets a wallet code that matches no wallet" do
       around { |test| lago_premium! { test.run } }
 
+      let(:customer) { create(:customer, organization:) }
       let(:organization) { create(:organization, premium_integrations: ["events_targeting_wallets"]) }
       let(:charge) { create(:standard_charge, organization:, accepts_target_wallet: true) }
       let(:current_usage_fees) do
@@ -303,6 +309,7 @@ RSpec.describe Wallets::Balance::AllocateOngoingUsageByWalletsService do
     context "when a fee targets a wallet whose balance is smaller than the fee" do
       around { |test| lago_premium! { test.run } }
 
+      let(:customer) { create(:customer, organization:) }
       let(:organization) { create(:organization, premium_integrations: ["events_targeting_wallets"]) }
       let(:charge) { create(:standard_charge, organization:, accepts_target_wallet: true) }
       let(:wallet_b) { create(:wallet, customer:, organization:, code: "wallet-b", balance_cents: 50, priority: 1) }

--- a/spec/services/wallets/balance/allocate_ongoing_usage_by_wallets_service_spec.rb
+++ b/spec/services/wallets/balance/allocate_ongoing_usage_by_wallets_service_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe Wallets::Balance::AllocateOngoingUsageByWalletsService do
   let_it_be(:organization) { create_default(:organization) }
   let_it_be(:customer) { create_default(:customer, organization:) }
 
-before_all do
-  create_default(:plan)
-end
+  before_all do
+    create_default(:plan)
+  end
 
   let(:subscription) { create(:subscription, customer:, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:) }

--- a/spec/services/wallets/balance/decrease_service_spec.rb
+++ b/spec/services/wallets/balance/decrease_service_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe Wallets::Balance::DecreaseService do
     create(:wallet_transaction, wallet:, amount: "4.5", credit_amount: BigDecimal("4.5"))
   end
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
 
   before do
     wallet

--- a/spec/services/wallets/balance/decrease_service_spec.rb
+++ b/spec/services/wallets/balance/decrease_service_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe Wallets::Balance::DecreaseService do
     create(:wallet_transaction, wallet:, amount: "4.5", credit_amount: BigDecimal("4.5"))
   end
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
   before do
     wallet
     wallet_transaction

--- a/spec/services/wallets/balance/increase_service_spec.rb
+++ b/spec/services/wallets/balance/increase_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe Wallets::Balance::IncreaseService do
   subject(:create_service) { described_class.new(wallet:, wallet_transaction:) }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
 
   let(:credits_amount) { BigDecimal("4.5") }
   let(:wallet) do

--- a/spec/services/wallets/balance/increase_service_spec.rb
+++ b/spec/services/wallets/balance/increase_service_spec.rb
@@ -5,6 +5,11 @@ require "rails_helper"
 RSpec.describe Wallets::Balance::IncreaseService do
   subject(:create_service) { described_class.new(wallet:, wallet_transaction:) }
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
   let(:credits_amount) { BigDecimal("4.5") }
   let(:wallet) do
     create(

--- a/spec/services/wallets/balance/refresh_ongoing_usage_service_spec.rb
+++ b/spec/services/wallets/balance/refresh_ongoing_usage_service_spec.rb
@@ -18,12 +18,13 @@ RSpec.describe Wallets::Balance::RefreshOngoingUsageService do
       credits_ongoing_usage_balance: 2.0
     )
   end
+  let(:ongoing_usage_amount_cents) { 1100 }
 
   let(:depleted_ongoing_balance) { false }
   let(:skip_single_wallet_update) { false }
+
   let_it_be(:organization) { create(:organization) }
   let_it_be(:customer) { create(:customer, organization:) }
-  let(:ongoing_usage_amount_cents) { 1100 }
 
   describe ".call" do
     it "writes the precomputed ongoing usage onto the wallet" do

--- a/spec/services/wallets/balance/refresh_ongoing_usage_service_spec.rb
+++ b/spec/services/wallets/balance/refresh_ongoing_usage_service_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Wallets::Balance::RefreshOngoingUsageService do
 
   let(:depleted_ongoing_balance) { false }
   let(:skip_single_wallet_update) { false }
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:ongoing_usage_amount_cents) { 1100 }
 
   describe ".call" do

--- a/spec/services/wallets/balance/update_ongoing_service_spec.rb
+++ b/spec/services/wallets/balance/update_ongoing_service_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Wallets::Balance::UpdateOngoingService do
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:, awaiting_wallet_refresh: true) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:, awaiting_wallet_refresh: true) }
 
   let(:wallet) do
     create(

--- a/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
+++ b/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
@@ -5,15 +5,13 @@ require "rails_helper"
 RSpec.describe Wallets::CreateIntervalWalletTransactionsService do
   subject(:create_interval_transactions_service) { described_class.new }
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   describe ".call" do
     let(:created_at) { DateTime.parse("20 Feb 2021") }
-    let_it_be(:customer) { create(:customer) }
     let(:started_at) { nil }
-
     let(:wallet) do
       create(
         :wallet,
@@ -23,7 +21,6 @@ end
         paid_top_up_min_amount_cents: 200_00
       )
     end
-
     let(:recurring_transaction_rule) do
       create(
         :recurring_transaction_rule,
@@ -34,6 +31,8 @@ end
         started_at:
       )
     end
+
+    let_it_be(:customer) { create(:customer) }
 
     before { recurring_transaction_rule }
 

--- a/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
+++ b/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
@@ -5,9 +5,13 @@ require "rails_helper"
 RSpec.describe Wallets::CreateIntervalWalletTransactionsService do
   subject(:create_interval_transactions_service) { described_class.new }
 
+before_all do
+  create_default(:organization)
+end
+
   describe ".call" do
     let(:created_at) { DateTime.parse("20 Feb 2021") }
-    let(:customer) { create(:customer) }
+    let_it_be(:customer) { create(:customer) }
     let(:started_at) { nil }
 
     let(:wallet) do
@@ -354,7 +358,6 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService do
       end
 
       context "with customer timezone" do
-        let(:customer) { create(:customer, timezone:) }
         let(:timezone) { "Pacific/Noumea" }
 
         it "does not enqueue a job" do

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Wallets::CreateService do
   subject(:create_service) { described_class.new(params:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:, external_id: "foobar", currency: customer_currency) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let(:customer) { create_default(:customer, organization:, external_id: "foobar", currency: customer_currency) }
   let(:customer_currency) { "EUR" }
 
   describe "#call" do

--- a/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
@@ -5,6 +5,11 @@ require "rails_helper"
 RSpec.describe Wallets::RecurringTransactionRules::CreateService do
   subject(:create_service) { described_class.new(wallet:, wallet_params:) }
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
   let(:wallet) { create(:wallet, paid_top_up_min_amount_cents: 15_00) }
   let(:wallet_params) do
     {

--- a/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe Wallets::RecurringTransactionRules::CreateService do
   subject(:create_service) { described_class.new(wallet:, wallet_params:) }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
 
   let(:wallet) { create(:wallet, paid_top_up_min_amount_cents: 15_00) }
   let(:wallet_params) do

--- a/spec/services/wallets/recurring_transaction_rules/terminate_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/terminate_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Wallets::RecurringTransactionRules::TerminateService do
   subject(:terminate_service) { described_class.new(recurring_transaction_rule:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:wallet) { create(:wallet, customer:) }
   let(:recurring_transaction_rule) do
     create(

--- a/spec/services/wallets/recurring_transaction_rules/terminate_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/terminate_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Wallets::RecurringTransactionRules::TerminateService do
   subject(:terminate_service) { described_class.new(recurring_transaction_rule:) }
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let_it_be(:customer) { create(:customer, organization:) }
   let(:wallet) { create(:wallet, customer:) }

--- a/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
   end
   let(:transaction_metadata) { [] }
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
   describe "#call" do
     subject(:result) { described_class.call(wallet:, params:) }
 

--- a/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
   end
   let(:transaction_metadata) { [] }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
 
   describe "#call" do
     subject(:result) { described_class.call(wallet:, params:) }

--- a/spec/services/wallets/terminate_service_spec.rb
+++ b/spec/services/wallets/terminate_service_spec.rb
@@ -5,11 +5,11 @@ require "rails_helper"
 RSpec.describe Wallets::TerminateService do
   subject(:terminate_service) { described_class.new(wallet:) }
 
-before_all do
-  create_default(:plan)
-end
+  before_all do
+    create_default(:plan)
+  end
 
-  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:organization) { create_default(:organization) }
   let_it_be(:membership) { create(:membership) }
   let_it_be(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:) }

--- a/spec/services/wallets/terminate_service_spec.rb
+++ b/spec/services/wallets/terminate_service_spec.rb
@@ -5,9 +5,13 @@ require "rails_helper"
 RSpec.describe Wallets::TerminateService do
   subject(:terminate_service) { described_class.new(wallet:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
+before_all do
+  create_default(:plan)
+end
+
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:) }
   let(:wallet) { create(:wallet, customer:) }
 

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -5,6 +5,11 @@ require "rails_helper"
 RSpec.describe Wallets::ThresholdTopUpService do
   subject(:top_up_service) { described_class.new(wallet:) }
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
   let(:paid_top_up_min_amount_cents) { 205_50 }
   let(:paid_top_up_max_amount_cents) { nil }
   let(:wallet) do

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe Wallets::ThresholdTopUpService do
   subject(:top_up_service) { described_class.new(wallet:) }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
 
   let(:paid_top_up_min_amount_cents) { 205_50 }
   let(:paid_top_up_max_amount_cents) { nil }

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -5,13 +5,17 @@ require "rails_helper"
 RSpec.describe Wallets::UpdateService do
   subject(:result) { described_class.call(wallet:, params:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:subscription) { create(:subscription, customer:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create_default(:membership) }
+  let(:customer) { create_default(:customer, organization:) }
+  let(:subscription) { create_default(:subscription, customer:) }
   let(:wallet) { create(:wallet, customer:, allowed_fee_types: []) }
   let(:expiration_at) { (Time.current + 1.year).iso8601 }
   let(:priority) { 5 }
+
+before_all do
+  create_default(:plan)
+end
 
   describe "#call" do
     before do

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Wallets::UpdateService do
   let(:expiration_at) { (Time.current + 1.year).iso8601 }
   let(:priority) { 5 }
 
-before_all do
-  create_default(:plan)
-end
+  before_all do
+    create_default(:plan)
+  end
 
   describe "#call" do
     before do

--- a/spec/services/wallets/validate_service_spec.rb
+++ b/spec/services/wallets/validate_service_spec.rb
@@ -6,14 +6,6 @@ RSpec.describe Wallets::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { Wallets::CreateService::Result.new }
-  let_it_be(:organization) { create_default(:organization)}
-  let_it_be(:membership) { create(:membership) }
-  let_it_be(:customer) { create_default(:customer, organization:) }
-
-before_all do
-  create_default(:plan)
-end
-
   let(:subscription) { create(:subscription, customer:) }
   let(:customer_id) { customer.external_id }
   let(:paid_credits) { "1.00" }
@@ -27,6 +19,14 @@ end
       granted_credits:,
       expiration_at:
     }
+  end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+
+  before_all do
+    create_default(:plan)
   end
 
   before { subscription }

--- a/spec/services/wallets/validate_service_spec.rb
+++ b/spec/services/wallets/validate_service_spec.rb
@@ -6,9 +6,14 @@ RSpec.describe Wallets::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { Wallets::CreateService::Result.new }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization)}
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+
+before_all do
+  create_default(:plan)
+end
+
   let(:subscription) { create(:subscription, customer:) }
   let(:customer_id) { customer.external_id }
   let(:paid_credits) { "1.00" }

--- a/spec/services/webhook_endpoints/create_service_spec.rb
+++ b/spec/services/webhook_endpoints/create_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe WebhookEndpoints::CreateService do
   subject(:create_service) { described_class.new(organization:, params: create_params) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:create_params) do
     {
       webhook_url: "http://foo.bar",

--- a/spec/services/webhook_endpoints/destroy_service_spec.rb
+++ b/spec/services/webhook_endpoints/destroy_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe WebhookEndpoints::DestroyService do
   subject(:destroy_service) { described_class.new(webhook_endpoint:) }
 
-before_all do
-  create_default(:organization)
-end
+  before_all do
+    create_default(:organization)
+  end
 
   include_context "with mocked security logger"
 

--- a/spec/services/webhook_endpoints/destroy_service_spec.rb
+++ b/spec/services/webhook_endpoints/destroy_service_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe WebhookEndpoints::DestroyService do
   subject(:destroy_service) { described_class.new(webhook_endpoint:) }
 
+before_all do
+  create_default(:organization)
+end
+
   include_context "with mocked security logger"
 
   context "when endpoint exists" do

--- a/spec/services/webhook_endpoints/update_service_spec.rb
+++ b/spec/services/webhook_endpoints/update_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe WebhookEndpoints::UpdateService do
 
   include_context "with mocked security logger"
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let!(:webhook_endpoint) { create(:webhook_endpoint, organization:, name: "Original Webhook", event_types: ["customer.created"]) }
   let(:update_params) do
     {

--- a/spec/services/webhooks/base_service_spec.rb
+++ b/spec/services/webhooks/base_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Webhooks::BaseService do
   subject(:webhook_service) { WebhooksSpec::DummyClass.new(object:) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:) }
   let(:object) { invoice }
@@ -57,6 +57,7 @@ RSpec.describe Webhooks::BaseService do
     end
 
     context "without webhook endpoint" do
+      let(:customer) { create(:customer, organization:) }
       let(:organization) { create(:organization) }
 
       before do

--- a/spec/services/webhooks/invoices/created_service_spec.rb
+++ b/spec/services/webhooks/invoices/created_service_spec.rb
@@ -5,8 +5,14 @@ require "rails_helper"
 RSpec.describe Webhooks::Invoices::CreatedService do
   subject(:webhook_service) { described_class.new(object: invoice) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+
+before_all do
+  create_default(:billable_metric)
+create_default(:plan)
+end
+
   let(:subscription) { create(:subscription, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:) }
 

--- a/spec/services/webhooks/invoices/created_service_spec.rb
+++ b/spec/services/webhooks/invoices/created_service_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe Webhooks::Invoices::CreatedService do
   let_it_be(:organization) { create_default(:organization) }
   let_it_be(:customer) { create(:customer, organization:) }
 
-before_all do
-  create_default(:billable_metric)
-create_default(:plan)
-end
+  before_all do
+    create_default(:billable_metric)
+    create_default(:plan)
+  end
 
   let(:subscription) { create(:subscription, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:) }

--- a/spec/services/webhooks/invoices/resynced_service_spec.rb
+++ b/spec/services/webhooks/invoices/resynced_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Webhooks::Invoices::ResyncedService do
   subject(:webhook_service) { described_class.new(object: invoice) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:) }
 
   describe ".call" do

--- a/spec/services/webhooks/order_forms/created_service_spec.rb
+++ b/spec/services/webhooks/order_forms/created_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Webhooks::OrderForms::CreatedService do
   subject(:webhook_service) { described_class.new(object: order_form) }
 
-  let(:organization) { create(:organization, webhook_url: "http://foo.bar", feature_flags: ["order_forms"]) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization, webhook_url: "http://foo.bar", feature_flags: ["order_forms"]) }
+      let_it_be(:customer) { create(:customer, organization:) }
   let(:order_form) { create(:order_form, organization:, customer:) }
 
   describe ".call", :premium do
@@ -31,6 +31,7 @@ RSpec.describe Webhooks::OrderForms::CreatedService do
     end
 
     context "when the order_forms feature flag is disabled", :premium do
+      let(:customer) { create(:customer, organization:) }
       let(:organization) { create(:organization, webhook_url: "http://foo.bar") }
 
       it "does not create a webhook" do

--- a/spec/services/webhooks/order_forms/created_service_spec.rb
+++ b/spec/services/webhooks/order_forms/created_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Webhooks::OrderForms::CreatedService do
   subject(:webhook_service) { described_class.new(object: order_form) }
 
   let_it_be(:organization) { create(:organization, webhook_url: "http://foo.bar", feature_flags: ["order_forms"]) }
-      let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:order_form) { create(:order_form, organization:, customer:) }
 
   describe ".call", :premium do

--- a/spec/services/webhooks/orders/created_service_spec.rb
+++ b/spec/services/webhooks/orders/created_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Webhooks::Orders::CreatedService do
   subject(:webhook_service) { described_class.new(object: order) }
 
   let_it_be(:organization) { create(:organization, webhook_url: "http://foo.bar", feature_flags: ["order_forms"]) }
-      let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:order) { create(:order, organization:, customer:) }
 
   describe ".call", :premium do

--- a/spec/services/webhooks/orders/created_service_spec.rb
+++ b/spec/services/webhooks/orders/created_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Webhooks::Orders::CreatedService do
   subject(:webhook_service) { described_class.new(object: order) }
 
-  let(:organization) { create(:organization, webhook_url: "http://foo.bar", feature_flags: ["order_forms"]) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization, webhook_url: "http://foo.bar", feature_flags: ["order_forms"]) }
+      let_it_be(:customer) { create(:customer, organization:) }
   let(:order) { create(:order, organization:, customer:) }
 
   describe ".call", :premium do
@@ -37,6 +37,7 @@ RSpec.describe Webhooks::Orders::CreatedService do
     end
 
     context "when the order_forms feature flag is disabled", :premium do
+      let(:customer) { create(:customer, organization:) }
       let(:organization) { create(:organization, webhook_url: "http://foo.bar") }
 
       it "does not create a webhook" do

--- a/spec/services/webhooks/quotes/approved_service_spec.rb
+++ b/spec/services/webhooks/quotes/approved_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Webhooks::Quotes::ApprovedService do
   subject(:webhook_service) { described_class.new(object: quote_version) }
 
-  let(:organization) { create(:organization, webhook_url: "http://foo.bar", feature_flags: ["order_forms"]) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization, webhook_url: "http://foo.bar", feature_flags: ["order_forms"]) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:quote_version) { create(:quote_version, :approved, organization:, quote:) }
 

--- a/spec/services/webhooks/quotes/created_service_spec.rb
+++ b/spec/services/webhooks/quotes/created_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Webhooks::Quotes::CreatedService do
   subject(:webhook_service) { described_class.new(object: quote_version) }
 
-  let(:organization) { create(:organization, webhook_url: "http://foo.bar", feature_flags: ["order_forms"]) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization, webhook_url: "http://foo.bar", feature_flags: ["order_forms"]) }
+      let_it_be(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:quote_version) { create(:quote_version, organization:, quote:, content: "<p>Terms</p>") }
 
@@ -43,6 +43,7 @@ RSpec.describe Webhooks::Quotes::CreatedService do
     end
 
     context "when the order_forms feature flag is disabled", :premium do
+      let(:customer) { create(:customer, organization:) }
       let(:organization) { create(:organization, webhook_url: "http://foo.bar") }
 
       it "does not create a webhook" do

--- a/spec/services/webhooks/quotes/created_service_spec.rb
+++ b/spec/services/webhooks/quotes/created_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Webhooks::Quotes::CreatedService do
   subject(:webhook_service) { described_class.new(object: quote_version) }
 
   let_it_be(:organization) { create(:organization, webhook_url: "http://foo.bar", feature_flags: ["order_forms"]) }
-      let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:quote_version) { create(:quote_version, organization:, quote:, content: "<p>Terms</p>") }
 

--- a/spec/services/webhooks/quotes/voided_service_spec.rb
+++ b/spec/services/webhooks/quotes/voided_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Webhooks::Quotes::VoidedService do
   subject(:webhook_service) { described_class.new(object: quote_version) }
 
-  let(:organization) { create(:organization, webhook_url: "http://foo.bar", feature_flags: ["order_forms"]) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization, webhook_url: "http://foo.bar", feature_flags: ["order_forms"]) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:quote_version) { create(:quote_version, :voided, organization:, quote:) }
 

--- a/spec/services/webhooks/retry_service_spec.rb
+++ b/spec/services/webhooks/retry_service_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe Webhooks::RetryService do
 
   let(:webhook) { create(:webhook, :failed) }
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
   it "enqueues a SendWebhookJob" do
     expect { retry_service.call }.to have_enqueued_job(SendHttpWebhookJob).with(webhook)
   end

--- a/spec/services/webhooks/retry_service_spec.rb
+++ b/spec/services/webhooks/retry_service_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe Webhooks::RetryService do
 
   let(:webhook) { create(:webhook, :failed) }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
 
   it "enqueues a SendWebhookJob" do
     expect { retry_service.call }.to have_enqueued_job(SendHttpWebhookJob).with(webhook)

--- a/spec/services/webhooks/send_http_service_spec.rb
+++ b/spec/services/webhooks/send_http_service_spec.rb
@@ -6,10 +6,10 @@ require "aws-sdk-s3"
 RSpec.describe Webhooks::SendHttpService do
   subject(:service) { described_class.new(webhook:) }
 
-before_all do
-  create_default(:organization)
-create_default(:customer)
-end
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
 
   let(:webhook_endpoint) { create(:webhook_endpoint, webhook_url: "https://wh.test.com") }
   let(:webhook) { create(:webhook, webhook_endpoint:) }

--- a/spec/services/webhooks/send_http_service_spec.rb
+++ b/spec/services/webhooks/send_http_service_spec.rb
@@ -6,6 +6,11 @@ require "aws-sdk-s3"
 RSpec.describe Webhooks::SendHttpService do
   subject(:service) { described_class.new(webhook:) }
 
+before_all do
+  create_default(:organization)
+create_default(:customer)
+end
+
   let(:webhook_endpoint) { create(:webhook_endpoint, webhook_url: "https://wh.test.com") }
   let(:webhook) { create(:webhook, webhook_endpoint:) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }

--- a/spec/services/webhooks/subscriptions/started_service_spec.rb
+++ b/spec/services/webhooks/subscriptions/started_service_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Webhooks::Subscriptions::StartedService do
   subject(:webhook_service) { described_class.new(object: subscription) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:, organization:) }
 
   describe ".call" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,6 +76,10 @@ Sentry.init do |config|
   config.transport.transport_class = Sentry::DummyTransport
 end
 
+require "test_prof/recipes/rspec/sample"
+require "test_prof/recipes/rspec/let_it_be"
+require "test_prof/recipes/rspec/factory_default"
+
 RSpec.configure do |config|
   config.include ActiveJob::TestHelper
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
## Context

Currently, around **50% of the spec runtime** is spent preparing data and creating factories. A lot of this data is either duplicated or recreates the same objects multiple times, so we can get rid of a good chunk of it and significantly speed up the specs.

To avoid creating unnecessary factories, we can use `let_it_be`, `before_all`, and `create_default` from `test-prof`. More info [here](https://test-prof.evilmartians.io/guide/recipes/let_it_be).

## Description

This PR cleans up the services specs in folders `s-w` and removes unnecessary factory usage.

Here are the numbers before and after the cleanup. The times below are for running the specs in a single process:

| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 97,841 | 63,994 |
| Time spent creating factories |  11:51.790 | 07:40.512 |
| Total time | 18:00.870 | 14:22.880 |

## Overall results

This PR is part of a series of PRs focused on cleaning up factory usage across different specs.

Once all the changes are merged, we expect to:

- Reduce the number of factories by **~50k**
- Cut spec runtime by around **20%**
- Shave off roughly **1:15 min** from the CI runtime


| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 157,949 | 103,761 |
| Total time spent creating factories | 17:59.851  | 11:14.739 |
| Total time | 34:41.482 | 27:03.658 |

Here is [the CI run](https://github.com/getlago/lago-api/actions/runs/33399605547/job/99512391170?pr=6255) with all the changes merged together: