### PR TITLE
perf(specs): Clean up factories usage in spec/jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -167,6 +167,8 @@ group :test do
   # HTML testing (invoice rendering)
   gem "rspec-snapshot", "~> 2.0"
   gem "htmlbeautifier", "~> 1.4"
+
+  gem "test-prof", "~> 1.0"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1004,6 +1004,8 @@ GEM
     temple (0.10.4)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
+    test-prof (1.6.3)
+      logger
     thor (1.5.0)
     throttling (0.4.1)
       logger
@@ -1181,6 +1183,7 @@ DEPENDENCIES
   stripe
   strong_migrations
   super_diff (~> 0.19.0)
+  test-prof (~> 1.0)
   throttling
   timecop
   tzinfo-data

--- a/spec/jobs/applied_coupons/recredit_job_spec.rb
+++ b/spec/jobs/applied_coupons/recredit_job_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 describe AppliedCoupons::RecreditJob do
   subject(:perform_job) { described_class.perform_now(credit) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:invoice) { create(:invoice, organization:, customer:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:invoice) { create(:invoice, organization:, customer:) }
   let(:applied_coupon) { create(:applied_coupon, organization:, customer:) }
   let(:credit) { create(:credit, organization:, invoice:, applied_coupon:) }
 

--- a/spec/jobs/bill_paid_credit_job_spec.rb
+++ b/spec/jobs/bill_paid_credit_job_spec.rb
@@ -3,6 +3,11 @@
 require "rails_helper"
 
 RSpec.describe BillPaidCreditJob do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
+
   let(:wallet_transaction) { create(:wallet_transaction) }
   let(:timestamp) { Time.current.to_i }
 

--- a/spec/jobs/bill_subscription_job_spec.rb
+++ b/spec/jobs/bill_subscription_job_spec.rb
@@ -3,6 +3,12 @@
 require "rails_helper"
 
 RSpec.describe BillSubscriptionJob do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+  end
+
   let(:subscriptions) { [create(:subscription)] }
   let(:timestamp) { Time.zone.now.to_i }
 
@@ -39,7 +45,7 @@ RSpec.describe BillSubscriptionJob do
       end
 
       context "with a previously created invoice" do
-        let(:invoice) { create(:invoice, :generating) }
+        let_it_be(:invoice) { create(:invoice, :generating) }
 
         it "raises an error" do
           expect do
@@ -73,7 +79,7 @@ RSpec.describe BillSubscriptionJob do
       end
 
       context "when a not generating invoice is attached to the result" do
-        let(:result_invoice) { create(:invoice, :draft) }
+        let_it_be(:result_invoice) { create(:invoice, :draft) }
 
         before { result.invoice = result_invoice }
 
@@ -98,7 +104,7 @@ RSpec.describe BillSubscriptionJob do
   end
 
   describe "#lock_key_arguments" do
-    let(:customer) { create(:customer, timezone: "Europe/Paris") }
+    let_it_be(:customer) { create(:customer, timezone: "Europe/Paris") }
     let(:subscription) { create(:subscription, customer:) }
     let(:subscriptions) { [subscription] }
 

--- a/spec/jobs/charge_filters/cascade_job_spec.rb
+++ b/spec/jobs/charge_filters/cascade_job_spec.rb
@@ -3,6 +3,12 @@
 require "rails_helper"
 
 RSpec.describe ChargeFilters::CascadeJob do
+  before_all do
+    create_default(:organization)
+    create_default(:billable_metric)
+    create_default(:plan)
+  end
+
   let(:charge) { create(:standard_charge) }
   let(:filter_values) { {"region" => ["us"]} }
   let(:old_properties) { {"amount" => "10"} }

--- a/spec/jobs/clock/expire_incomplete_subscriptions_job_spec.rb
+++ b/spec/jobs/clock/expire_incomplete_subscriptions_job_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 describe Clock::ExpireIncompleteSubscriptionsJob, job: true do
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:, pay_in_advance: true) }
 
   it_behaves_like "a unique job" do
     let(:job_args) { [] }

--- a/spec/jobs/clock/finalize_invoices_job_spec.rb
+++ b/spec/jobs/clock/finalize_invoices_job_spec.rb
@@ -3,11 +3,15 @@
 require "rails_helper"
 
 describe Clock::FinalizeInvoicesJob, job: true do
+  before_all do
+    create_default(:organization)
+  end
+
   subject { described_class }
 
   describe ".perform" do
-    let(:customer) { create(:customer, invoice_grace_period: 3) }
-    let(:draft_invoice) do
+    let_it_be(:customer) { create(:customer, invoice_grace_period: 3) }
+    let_it_be(:draft_invoice) do
       create(
         :invoice,
         status: :draft,
@@ -17,7 +21,7 @@ describe Clock::FinalizeInvoicesJob, job: true do
         organization: customer.organization
       )
     end
-    let(:finalized_invoice) do
+    let_it_be(:finalized_invoice) do
       create(
         :invoice,
         status: :finalized,

--- a/spec/jobs/clock/process_dedicated_orgs_subscription_activities_job_spec.rb
+++ b/spec/jobs/clock/process_dedicated_orgs_subscription_activities_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Clock::ProcessDedicatedOrgsSubscriptionActivitiesJob, job: true d
   describe "#perform" do
     subject { described_class.perform_now }
 
-    let(:target_organization) { create(:organization) }
+    let_it_be(:target_organization) { create(:organization) }
     let(:other_organization) { create(:organization) }
 
     context "when the dedicated org list is empty" do

--- a/spec/jobs/clock/refresh_dedicated_org_wallets_ongoing_balance_job_spec.rb
+++ b/spec/jobs/clock/refresh_dedicated_org_wallets_ongoing_balance_job_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe Clock::RefreshDedicatedOrgWalletsOngoingBalanceJob, job: true do
   describe "#perform" do
     subject { described_class.perform_now }
 
-    let(:target_organization) { create(:organization) }
-    let(:other_organization) { create(:organization) }
-    let(:target_customer) { create(:customer, organization: target_organization, awaiting_wallet_refresh: true) }
-    let(:other_customer) { create(:customer, organization: other_organization, awaiting_wallet_refresh: true) }
-    let(:customer_without_wallet) do
+    let_it_be(:target_organization) { create(:organization) }
+    let_it_be(:other_organization) { create(:organization) }
+    let_it_be(:target_customer) { create(:customer, organization: target_organization, awaiting_wallet_refresh: true) }
+    let_it_be(:other_customer) { create(:customer, organization: other_organization, awaiting_wallet_refresh: true) }
+    let_it_be(:customer_without_wallet) do
       create(:customer, organization: target_organization, awaiting_wallet_refresh: true)
     end
-    let(:customer_with_terminated_wallet) do
+    let_it_be(:customer_with_terminated_wallet) do
       create(:customer, organization: target_organization, awaiting_wallet_refresh: true) do |customer|
         create(:wallet, customer:, status: :terminated)
       end

--- a/spec/jobs/clock/refresh_draft_invoices_jobs_spec.rb
+++ b/spec/jobs/clock/refresh_draft_invoices_jobs_spec.rb
@@ -3,6 +3,12 @@
 require "rails_helper"
 
 describe Clock::RefreshDraftInvoicesJob, job: true do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+  end
+
   subject { described_class }
 
   describe ".perform" do

--- a/spec/jobs/clock/refresh_lifetime_usages_job_spec.rb
+++ b/spec/jobs/clock/refresh_lifetime_usages_job_spec.rb
@@ -3,10 +3,15 @@
 require "rails_helper"
 
 describe Clock::RefreshLifetimeUsagesJob, job: true do
+  before_all do
+    create_default(:customer)
+    create_default(:plan)
+  end
+
   subject { described_class }
 
   describe ".perform" do
-    let(:organization) { create(:organization) }
+    let_it_be(:organization) { create_default(:organization) }
     let(:lifetime_usage1) { create(:lifetime_usage, organization:, recalculate_invoiced_usage: true) }
     let(:lifetime_usage2) { create(:lifetime_usage, organization:, recalculate_invoiced_usage: false) }
 

--- a/spec/jobs/clock/refresh_wallets_ongoing_balance_job_spec.rb
+++ b/spec/jobs/clock/refresh_wallets_ongoing_balance_job_spec.rb
@@ -6,12 +6,13 @@ describe Clock::RefreshWalletsOngoingBalanceJob, job: true do
   describe "#perform" do
     subject { described_class.perform_now }
 
-    let(:organization) { create(:organization) }
-    let(:customer) { create(:customer, organization:, awaiting_wallet_refresh: true) }
+    let_it_be(:organization) { create(:organization) }
+    let_it_be(:customer) { create(:customer, organization:, awaiting_wallet_refresh: true) }
     let(:wallet) { create(:wallet, customer:) }
-    let(:customer_without_wallet) { create(:customer, organization:, awaiting_wallet_refresh: true) }
 
-    let(:customer_with_terminated_wallet) do
+    let_it_be(:customer_without_wallet) { create(:customer, organization:, awaiting_wallet_refresh: true) }
+
+    let_it_be(:customer_with_terminated_wallet) do
       create(:customer, organization:, awaiting_wallet_refresh: true) do |customer|
         create(:wallet, customer:, status: :terminated)
       end

--- a/spec/jobs/clock/retry_failed_invoices_job_spec.rb
+++ b/spec/jobs/clock/retry_failed_invoices_job_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 describe Clock::RetryFailedInvoicesJob, job: true do
+  before_all do
+    create_default(:organization)
+  end
+
   subject { described_class }
 
   it_behaves_like "a unique job" do
@@ -10,8 +14,8 @@ describe Clock::RetryFailedInvoicesJob, job: true do
   end
 
   describe ".perform" do
-    let(:customer) { create(:customer) }
-    let(:failed_invoice) do
+    let_it_be(:customer) { create(:customer) }
+    let_it_be(:failed_invoice) do
       create(
         :invoice,
         status: :failed,
@@ -32,7 +36,8 @@ describe Clock::RetryFailedInvoicesJob, job: true do
         }
       )
     end
-    let(:finalized_invoice) do
+
+    let_it_be(:finalized_invoice) do
       create(
         :invoice,
         status: :finalized,

--- a/spec/jobs/clock/retry_generating_subscription_invoices_job_spec.rb
+++ b/spec/jobs/clock/retry_generating_subscription_invoices_job_spec.rb
@@ -3,6 +3,12 @@
 require "rails_helper"
 
 describe Clock::RetryGeneratingSubscriptionInvoicesJob, job: true do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+  end
+
   subject { described_class }
 
   it_behaves_like "a unique job" do
@@ -23,7 +29,7 @@ describe Clock::RetryGeneratingSubscriptionInvoicesJob, job: true do
     end
 
     context "with an actual invoice that should be retried" do
-      let(:old_generating_invoice) { create(:invoice, :subscription, created_at: 5.days.ago) }
+      let_it_be(:old_generating_invoice) { create(:invoice, :subscription, created_at: 5.days.ago) }
 
       before do
         old_generating_invoice.update(status: :generating)

--- a/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
+++ b/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
@@ -10,8 +10,8 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
   end
 
   describe ".perform" do
-    let(:organization) { create(:organization) }
-    let(:customer) { create(:customer, organization:) }
+    let_it_be(:organization) { create(:organization) }
+    let_it_be(:customer) { create(:customer, organization:) }
     let!(:webhook_endpoint) { create(:webhook_endpoint, organization:) }
     let(:current_date) { DateTime.parse("2026-06-01") }
     let(:ending_at_15_days) { (current_date + 15.days).beginning_of_day }

--- a/spec/jobs/clock/terminate_ended_subscriptions_job_spec.rb
+++ b/spec/jobs/clock/terminate_ended_subscriptions_job_spec.rb
@@ -3,6 +3,12 @@
 require "rails_helper"
 
 describe Clock::TerminateEndedSubscriptionsJob, job: true do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+  end
+
   subject { described_class }
 
   let(:ending_at) { (Time.current + 2.months).beginning_of_day }

--- a/spec/jobs/clock/terminate_recurring_transaction_rules_job_spec.rb
+++ b/spec/jobs/clock/terminate_recurring_transaction_rules_job_spec.rb
@@ -3,6 +3,11 @@
 require "rails_helper"
 
 describe Clock::TerminateRecurringTransactionRulesJob, job: true do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
+
   it_behaves_like "a unique job" do
     let(:job_args) { [] }
   end

--- a/spec/jobs/clock/terminate_wallets_job_spec.rb
+++ b/spec/jobs/clock/terminate_wallets_job_spec.rb
@@ -3,6 +3,11 @@
 require "rails_helper"
 
 describe Clock::TerminateWalletsJob, job: true do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
+
   it_behaves_like "a unique job" do
     let(:job_args) { [] }
   end

--- a/spec/jobs/credit_notes/provider_taxes/report_job_spec.rb
+++ b/spec/jobs/credit_notes/provider_taxes/report_job_spec.rb
@@ -3,9 +3,13 @@
 require "rails_helper"
 
 RSpec.describe CreditNotes::ProviderTaxes::ReportJob do
-  let(:organization) { create(:organization) }
+  before_all do
+    create_default(:invoice)
+  end
+
+  let_it_be(:organization) { create(:organization) }
   let(:credit_note) { create(:credit_note, customer:) }
-  let(:customer) { create(:customer, organization:) }
+  let(:customer) { create_default(:customer, organization:) }
 
   let(:result) { CreditNotes::ProviderTaxes::ReportService::Result.new }
 

--- a/spec/jobs/credit_notes/recredit_job_spec.rb
+++ b/spec/jobs/credit_notes/recredit_job_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 describe CreditNotes::RecreditJob do
   subject(:perform_job) { described_class.perform_now(credit) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:invoice) { create(:invoice, organization:, customer:) }
-  let(:source_invoice) { create(:invoice, organization:, customer:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:invoice) { create(:invoice, organization:, customer:) }
+  let_it_be(:source_invoice) { create(:invoice, organization:, customer:) }
   let(:credit_note) do
     create(:credit_note, organization:, customer:, invoice: source_invoice, credit_status: :available)
   end

--- a/spec/jobs/customers/refresh_invoices_search_terms_job_spec.rb
+++ b/spec/jobs/customers/refresh_invoices_search_terms_job_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Customers::RefreshInvoicesSearchTermsJob do
   subject(:perform_job) { described_class.perform_now(customer_id) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:customer_id) { customer.id }
 
   before do

--- a/spec/jobs/customers/refresh_wallet_job_spec.rb
+++ b/spec/jobs/customers/refresh_wallet_job_spec.rb
@@ -3,8 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Customers::RefreshWalletJob do
+  before_all do
+    create_default(:organization)
+  end
+
   describe "queue routing" do
-    let(:customer) { create(:customer) }
+    let_it_be(:customer) { create(:customer) }
 
     context "when the customer's organization is in the dedicated list" do
       before { stub_const("Utils::DedicatedWorkerConfig::ORGANIZATION_IDS", [customer.organization_id]) }
@@ -38,7 +42,6 @@ RSpec.describe Customers::RefreshWalletJob do
   describe "#perform" do
     subject { described_class.perform_now(customer, wallet_ids:) }
 
-    let(:customer) { create(:customer, awaiting_wallet_refresh:) }
     let(:organization) { customer.organization }
     let(:result) { Customers::RefreshWalletsService::Result.new }
     let(:wallet_ids) { nil }
@@ -48,7 +51,8 @@ RSpec.describe Customers::RefreshWalletJob do
     end
 
     context "when customer is not awaiting wallet refresh" do
-      let(:awaiting_wallet_refresh) { false }
+      let_it_be(:awaiting_wallet_refresh) { false }
+      let_it_be(:customer) { create(:customer, awaiting_wallet_refresh:) }
 
       it "does not call the Customers::RefreshWalletsService service" do
         subject
@@ -66,7 +70,8 @@ RSpec.describe Customers::RefreshWalletJob do
     end
 
     context "when customer is awaiting wallet refresh" do
-      let(:awaiting_wallet_refresh) { true }
+      let_it_be(:awaiting_wallet_refresh) { true }
+      let_it_be(:customer) { create(:customer, awaiting_wallet_refresh:) }
 
       context "when refresh customer's wallets succeeds" do
         it "calls the Customers::RefreshWalletsService service" do

--- a/spec/jobs/customers/reindex_invoices_job_spec.rb
+++ b/spec/jobs/customers/reindex_invoices_job_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Customers::ReindexInvoicesJob do
   subject(:perform) { described_class.perform_now(customer.id) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, organization:, customer:) }
   let(:other_invoice) { create(:invoice, organization:) }

--- a/spec/jobs/customers/vies_check_job_spec.rb
+++ b/spec/jobs/customers/vies_check_job_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Customers::ViesCheckJob do
-  let(:customer) { create(:customer, tax_identification_number: "IE6388047V") }
+  before_all do
+    create_default(:organization)
+  end
+
+  let_it_be(:customer) { create(:customer, tax_identification_number: "IE6388047V") }
   let(:vies_response) do
     {
       country_code: "FR"
@@ -39,13 +43,13 @@ RSpec.describe Customers::ViesCheckJob do
     end
 
     context "when customer has pending invoices blocked by VIES" do
-      let(:pending_invoice) do
+      let_it_be(:pending_invoice) do
         create(:invoice, :pending, customer:, organization: customer.organization, tax_status: :pending)
       end
-      let(:finalized_invoice) do
+      let_it_be(:finalized_invoice) do
         create(:invoice, :finalized, customer:, organization: customer.organization)
       end
-      let(:pending_but_tax_succeeded_invoice) do
+      let_it_be(:pending_but_tax_succeeded_invoice) do
         create(:invoice, :pending, customer:, organization: customer.organization, tax_status: :succeeded)
       end
 
@@ -92,7 +96,7 @@ RSpec.describe Customers::ViesCheckJob do
   end
 
   context "when valvat has an error" do
-    let(:pending_invoice) do
+    let_it_be(:pending_invoice) do
       create(:invoice, :pending, customer:, organization: customer.organization, tax_status: :pending)
     end
 

--- a/spec/jobs/daily_usages/compute_job_spec.rb
+++ b/spec/jobs/daily_usages/compute_job_spec.rb
@@ -3,6 +3,11 @@
 require "rails_helper"
 
 RSpec.describe DailyUsages::ComputeJob do
+  before_all do
+    create_default(:organization)
+    create_default(:plan)
+  end
+
   subject(:compute_job) { described_class }
 
   let(:subscription) { create(:subscription) }
@@ -24,7 +29,7 @@ RSpec.describe DailyUsages::ComputeJob do
   end
 
   describe "#lock_key_arguments" do
-    let(:customer) { create(:customer, timezone: "Europe/Paris") }
+    let_it_be(:customer) { create(:customer, timezone: "Europe/Paris") }
     let(:subscription) { create(:subscription, customer:) }
 
     it "returns subscription id and date in customer timezone" do

--- a/spec/jobs/daily_usages/fill_history_job_spec.rb
+++ b/spec/jobs/daily_usages/fill_history_job_spec.rb
@@ -3,6 +3,12 @@
 require "rails_helper"
 
 RSpec.describe DailyUsages::FillHistoryJob do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+  end
+
   let(:subscription) { create(:subscription) }
   let(:from_date) { Time.current.beginning_of_month }
   let(:to_date) { from_date.end_of_month }

--- a/spec/jobs/database_migrations/backfill_adyen_payment_methods_job_spec.rb
+++ b/spec/jobs/database_migrations/backfill_adyen_payment_methods_job_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe DatabaseMigrations::BackfillAdyenPaymentMethodsJob do
   subject(:perform_job) { described_class.perform_now }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:adyen_provider) { create(:adyen_provider, organization:) }
   let(:adyen_customer) do
     create(:adyen_customer, customer:, payment_provider: adyen_provider).tap do |c|

--- a/spec/jobs/database_migrations/backfill_charge_filter_codes_job_spec.rb
+++ b/spec/jobs/database_migrations/backfill_charge_filter_codes_job_spec.rb
@@ -5,15 +5,14 @@ require "rails_helper"
 RSpec.describe DatabaseMigrations::BackfillChargeFilterCodesJob do
   subject(:perform) { described_class.perform_now(charge.id) }
 
-  let(:organization) { create(:organization) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
   let(:bm_filter) { create(:billable_metric_filter, billable_metric:, key: "region", values: %w[us eu]) }
-
-  let(:plan) { create(:plan, organization:) }
   let(:charge) { create(:standard_charge, plan:, billable_metric:) }
-
   let(:us_code) { ChargeFilter.generate_code({"region" => ["us"]}) }
   let(:eu_code) { ChargeFilter.generate_code({"region" => ["eu"]}) }
+
+  let_it_be(:plan) { create(:plan, organization:) }
 
   def build_filter(on, values, **attrs)
     filter = create(:charge_filter, charge: on, **attrs)
@@ -56,7 +55,7 @@ RSpec.describe DatabaseMigrations::BackfillChargeFilterCodesJob do
   # Handed one directly it must still refuse: an override's code comes from the filter it was
   # copied from, and deriving one here would claim a link that was never checked.
   context "when the charge sits on a plan that overrides another" do
-    let(:child_plan) { create(:plan, organization:, parent: plan) }
+    let_it_be(:child_plan) { create(:plan, organization:, parent: plan) }
 
     it "does nothing" do
       child_charge = create(:standard_charge, plan: child_plan, billable_metric:, parent: charge)

--- a/spec/jobs/database_migrations/backfill_child_charge_filter_codes_job_spec.rb
+++ b/spec/jobs/database_migrations/backfill_child_charge_filter_codes_job_spec.rb
@@ -5,18 +5,17 @@ require "rails_helper"
 RSpec.describe DatabaseMigrations::BackfillChildChargeFilterCodesJob do
   subject(:perform) { described_class.perform_now(parent_charge.id) }
 
-  let(:organization) { create(:organization) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:billable_metric) { create(:billable_metric, organization:) }
   let(:bm_filter) { create(:billable_metric_filter, billable_metric:, key: "region", values: %w[us eu]) }
-
-  let(:plan) { create(:plan, organization:) }
   let(:parent_charge) { create(:standard_charge, plan:, billable_metric:) }
-
-  let(:child_plan) { create(:plan, organization:, parent: plan) }
   let(:child_charge) { create(:standard_charge, plan: child_plan, billable_metric:, parent: parent_charge) }
-
   let(:us_code) { ChargeFilter.generate_code({"region" => ["us"]}) }
   let(:eu_code) { ChargeFilter.generate_code({"region" => ["eu"]}) }
+
+  let_it_be(:plan) { create(:plan, organization:) }
+
+  let_it_be(:child_plan) { create(:plan, organization:, parent: plan) }
 
   def build_filter(on, values, code: nil, **attrs)
     filter = create(:charge_filter, charge: on, **attrs)

--- a/spec/jobs/database_migrations/backfill_gocardless_payment_methods_job_spec.rb
+++ b/spec/jobs/database_migrations/backfill_gocardless_payment_methods_job_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe DatabaseMigrations::BackfillGocardlessPaymentMethodsJob do
   subject(:perform_job) { described_class.perform_now }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:gocardless_provider) { create(:gocardless_provider, organization:) }
   let(:gocardless_customer) do
     create(:gocardless_customer, customer:, payment_provider: gocardless_provider).tap do |c|

--- a/spec/jobs/database_migrations/backfill_invoices_search_terms_job_spec.rb
+++ b/spec/jobs/database_migrations/backfill_invoices_search_terms_job_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe DatabaseMigrations::BackfillInvoicesSearchTermsJob do
   subject(:perform_job) { described_class.perform_now }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:, name: "Acme Inc") }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:, name: "Acme Inc") }
 
-  let!(:invoice) { create(:invoice, organization:, customer:, number: "INV-001") }
+  let_it_be(:invoice) { create(:invoice, organization:, customer:, number: "INV-001") }
 
   before do
     Invoice.where(id: invoice.id).update_all(search_terms: nil) # rubocop:disable Rails/SkipsModelValidations

--- a/spec/jobs/database_migrations/backfill_moneyhash_payment_methods_job_spec.rb
+++ b/spec/jobs/database_migrations/backfill_moneyhash_payment_methods_job_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe DatabaseMigrations::BackfillMoneyhashPaymentMethodsJob do
   subject(:perform_job) { described_class.perform_now }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:moneyhash_provider) { create(:moneyhash_provider, organization:) }
   let(:moneyhash_customer) do
     create(:moneyhash_customer, customer:, payment_provider: moneyhash_provider).tap do |c|

--- a/spec/jobs/database_migrations/backfill_prepaid_credit_breakdown_job_spec.rb
+++ b/spec/jobs/database_migrations/backfill_prepaid_credit_breakdown_job_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe DatabaseMigrations::BackfillPrepaidCreditBreakdownJob do
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   # Builds an invoice that consumed prepaid credit, with consumption rows linking
   # its outbound transaction to granted/purchased inbound transactions.

--- a/spec/jobs/database_migrations/backfill_stripe_payment_method_card_details_job_spec.rb
+++ b/spec/jobs/database_migrations/backfill_stripe_payment_method_card_details_job_spec.rb
@@ -5,12 +5,9 @@ require "rails_helper"
 RSpec.describe DatabaseMigrations::BackfillStripePaymentMethodCardDetailsJob do
   subject(:perform_job) { described_class.perform_now }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:stripe_provider) { create(:stripe_provider, organization:) }
-  let(:stripe_customer) { create(:stripe_customer, customer:, payment_provider: stripe_provider) }
-  let(:invoice) { create(:invoice, customer:, organization:) }
-
   let(:migration_payment_method) do
     create(
       :payment_method,
@@ -21,7 +18,6 @@ RSpec.describe DatabaseMigrations::BackfillStripePaymentMethodCardDetailsJob do
       details: {"from_migration" => true}
     )
   end
-
   let(:payment_with_card_details) do
     create(
       :payment,
@@ -39,6 +35,9 @@ RSpec.describe DatabaseMigrations::BackfillStripePaymentMethodCardDetailsJob do
       }
     )
   end
+  let(:stripe_customer) { create(:stripe_customer, customer:, payment_provider: stripe_provider) }
+
+  let_it_be(:invoice) { create(:invoice, customer:, organization:) }
 
   context "when payment method has from_migration marker and matching payment data" do
     it "updates the card details on the payment method" do

--- a/spec/jobs/database_migrations/backfill_stripe_payment_methods_job_spec.rb
+++ b/spec/jobs/database_migrations/backfill_stripe_payment_methods_job_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe DatabaseMigrations::BackfillStripePaymentMethodsJob do
   subject(:perform_job) { described_class.perform_now }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:stripe_provider) { create(:stripe_provider, organization:) }
   let(:stripe_customer) do
     create(:stripe_customer, customer:, payment_provider: stripe_provider).tap do |sc|

--- a/spec/jobs/database_migrations/backfill_wallet_transactions_billing_entity_job_spec.rb
+++ b/spec/jobs/database_migrations/backfill_wallet_transactions_billing_entity_job_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe DatabaseMigrations::BackfillWalletTransactionsBillingEntityJob do
   subject(:perform_job) { described_class.perform_now }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:wallet) { create(:wallet, customer:, organization:) }
 
   context "when a wallet transaction has no billing entity" do

--- a/spec/jobs/database_migrations/fix_invoices_organization_sequential_id_job_spec.rb
+++ b/spec/jobs/database_migrations/fix_invoices_organization_sequential_id_job_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe DatabaseMigrations::FixInvoicesOrganizationSequentialIdJob do
   subject(:perform_job) { described_class.perform_now }
 
-  let(:organization) { create(:organization, document_numbering: :per_organization) }
+  let_it_be(:organization) { create(:organization, document_numbering: :per_organization) }
 
   context "when maximum sequential_id matches invoice count" do
     it "does not change the last invoice" do

--- a/spec/jobs/events/stores/clickhouse/enriched_store_migration/wait_for_enrichment_job_spec.rb
+++ b/spec/jobs/events/stores/clickhouse/enriched_store_migration/wait_for_enrichment_job_spec.rb
@@ -3,7 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::WaitForEnrichmentJob, type: :job do
-  let(:organization) { create(:organization) }
+  before_all do
+    create_default(:customer)
+    create_default(:plan)
+  end
+
+  let_it_be(:organization) { create_default(:organization) }
   let(:migration) { create(:enriched_store_migration, :processing, organization:) }
   let(:subscription) { create(:subscription, organization:) }
   let(:subscription_migration) do

--- a/spec/jobs/fees/create_pay_in_advance_job_spec.rb
+++ b/spec/jobs/fees/create_pay_in_advance_job_spec.rb
@@ -3,6 +3,13 @@
 require "rails_helper"
 
 RSpec.describe Fees::CreatePayInAdvanceJob do
+  before_all do
+    create_default(:organization)
+    create_default(:billable_metric)
+    create_default(:plan)
+    create_default(:customer)
+  end
+
   let(:charge) { create(:standard_charge, :pay_in_advance) }
   let(:event) { create(:event) }
 

--- a/spec/jobs/fixed_charges/cascade_plan_update_job_spec.rb
+++ b/spec/jobs/fixed_charges/cascade_plan_update_job_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe FixedCharges::CascadePlanUpdateJob do
     )
   end
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:timestamp) { Time.current.to_i }
   let(:cascade_fixed_charges_payload) do
     [

--- a/spec/jobs/inbound_webhooks/process_job_spec.rb
+++ b/spec/jobs/inbound_webhooks/process_job_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe InboundWebhooks::ProcessJob do
+  before_all do
+    create_default(:organization)
+  end
+
   subject(:process_job) { described_class }
 
   let(:inbound_webhook) { create :inbound_webhook }

--- a/spec/jobs/integration_customers/create_job_spec.rb
+++ b/spec/jobs/integration_customers/create_job_spec.rb
@@ -3,13 +3,18 @@
 require "rails_helper"
 
 RSpec.describe IntegrationCustomers::CreateJob do
+  before_all do
+    create_default(:organization)
+  end
+
   let(:integration) { create(:netsuite_integration) }
-  let(:customer) { create(:customer) }
   let(:integration_customer_params) do
     {
       sync_with_provider: true
     }
   end
+
+  let_it_be(:customer) { create(:customer) }
 
   describe "#perform" do
     subject(:create_job) { described_class }

--- a/spec/jobs/integrations/aggregator/invoices/create_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/invoices/create_job_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Integrations::Aggregator::Invoices::CreateJob do
   subject(:create_job) { described_class }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-  let(:invoice) { create(:invoice, customer:, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:invoice) { create(:invoice, customer:, organization:) }
   let(:result) { Integrations::Aggregator::Invoices::CreateService::Result.new }
   let(:reconcile_result) { Integrations::Aggregator::Invoices::ReconcileService::Result.new }
 

--- a/spec/jobs/integrations/aggregator/invoices/hubspot/create_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/invoices/hubspot/create_job_spec.rb
@@ -3,9 +3,14 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateJob do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
+
   subject(:create_job) { described_class }
 
-  let(:invoice) { create(:invoice) }
+  let_it_be(:invoice) { create(:invoice) }
   let(:result) { Integrations::Aggregator::Invoices::Hubspot::CreateService::Result.new }
 
   before do

--- a/spec/jobs/integrations/aggregator/perform_sync_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/perform_sync_job_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::PerformSyncJob do
+  before_all do
+    create_default(:organization)
+  end
+
   subject(:perform_sync_job) { described_class.perform_now(integration:, sync_items:) }
 
   let(:integration) { create(:netsuite_integration) }

--- a/spec/jobs/integrations/aggregator/subscriptions/hubspot/create_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/subscriptions/hubspot/create_job_spec.rb
@@ -3,6 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::CreateJob do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+  end
+
   subject(:create_job) { described_class }
 
   let(:subscription) { create(:subscription) }

--- a/spec/jobs/invoices/create_all_pay_in_advance_fixed_charges_job_spec.rb
+++ b/spec/jobs/invoices/create_all_pay_in_advance_fixed_charges_job_spec.rb
@@ -3,10 +3,14 @@
 require "rails_helper"
 
 RSpec.describe Invoices::CreateAllPayInAdvanceFixedChargesJob do
+  before_all do
+    create_default(:customer)
+  end
+
   subject(:perform_now) { described_class.perform_now(plan, timestamp, fixed_charge) }
 
-  let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:timestamp) { Time.current.to_i }
   let(:fixed_charge) { nil }
 

--- a/spec/jobs/invoices/create_pay_in_advance_charge_job_spec.rb
+++ b/spec/jobs/invoices/create_pay_in_advance_charge_job_spec.rb
@@ -3,6 +3,13 @@
 require "rails_helper"
 
 RSpec.describe Invoices::CreatePayInAdvanceChargeJob do
+  before_all do
+    create_default(:organization)
+    create_default(:billable_metric)
+    create_default(:plan)
+    create_default(:customer)
+  end
+
   describe "#perform" do
     let(:charge) { create(:standard_charge, :pay_in_advance, invoiceable: true) }
     let(:event) { create(:event) }

--- a/spec/jobs/invoices/create_pay_in_advance_fixed_charges_job_spec.rb
+++ b/spec/jobs/invoices/create_pay_in_advance_fixed_charges_job_spec.rb
@@ -3,6 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Invoices::CreatePayInAdvanceFixedChargesJob do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+  end
+
   subject(:perform_now) { described_class.perform_now(subscription, timestamp) }
 
   let(:subscription) { create(:subscription) }

--- a/spec/jobs/invoices/finalize_all_job_spec.rb
+++ b/spec/jobs/invoices/finalize_all_job_spec.rb
@@ -3,12 +3,17 @@
 require "rails_helper"
 
 RSpec.describe Invoices::FinalizeAllJob do
+  before_all do
+    create_default(:customer)
+  end
+
   subject(:finalize_all_job) { described_class }
 
   let(:finalize_batch_service) { instance_double(Invoices::FinalizeBatchService) }
   let(:result) { Invoices::FinalizeBatchService::Result.new }
-  let(:organization) { create(:organization) }
-  let(:invoice) { create(:invoice, :draft, organization:) }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:invoice) { create(:invoice, :draft, organization:) }
 
   context "when succesfully fetching taxes" do
     before do

--- a/spec/jobs/invoices/finalize_job_spec.rb
+++ b/spec/jobs/invoices/finalize_job_spec.rb
@@ -3,7 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Invoices::FinalizeJob do
-  let(:invoice) { create(:invoice) }
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
+
+  let_it_be(:invoice) { create(:invoice) }
 
   let(:result) { Invoices::RefreshDraftAndFinalizeService::Result.new }
 

--- a/spec/jobs/invoices/finalize_pending_vies_invoice_job_spec.rb
+++ b/spec/jobs/invoices/finalize_pending_vies_invoice_job_spec.rb
@@ -3,7 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Invoices::FinalizePendingViesInvoiceJob do
-  let(:invoice) { create(:invoice, :pending, tax_status: "pending") }
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
+
+  let_it_be(:invoice) { create(:invoice, :pending, tax_status: "pending") }
   let(:result) { Invoices::FinalizePendingViesInvoiceService::Result.new }
 
   describe "#perform" do

--- a/spec/jobs/invoices/generate_documents_job_spec.rb
+++ b/spec/jobs/invoices/generate_documents_job_spec.rb
@@ -3,9 +3,14 @@
 require "rails_helper"
 
 RSpec.describe Invoices::GenerateDocumentsJob do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
+
   subject { described_class.perform_now(invoice:, notify:) }
 
-  let(:invoice) { create(:invoice) }
+  let_it_be(:invoice) { create(:invoice) }
   let(:result) { Invoices::GeneratePdfService::Result.new }
   let(:notify) { false }
 

--- a/spec/jobs/invoices/payments/mark_overdue_job_spec.rb
+++ b/spec/jobs/invoices/payments/mark_overdue_job_spec.rb
@@ -3,10 +3,15 @@
 require "rails_helper"
 
 describe Invoices::Payments::MarkOverdueJob, job: true do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
+
   subject { described_class.new }
 
   describe ".perform" do
-    let(:overdue_invoice) { create(:invoice, payment_due_date: 1.day.ago) }
+    let_it_be(:overdue_invoice) { create(:invoice, payment_due_date: 1.day.ago) }
 
     before do
       overdue_invoice

--- a/spec/jobs/invoices/prepaid_credit_job_spec.rb
+++ b/spec/jobs/invoices/prepaid_credit_job_spec.rb
@@ -3,9 +3,13 @@
 require "rails_helper"
 
 RSpec.describe Invoices::PrepaidCreditJob do
+  before_all do
+    create_default(:organization)
+    create_default(:plan)
+  end
+
+  let_it_be(:customer) { create_default(:customer) }
   let(:invoice) { create(:invoice, customer:, organization: customer.organization) }
-  let(:customer) { create(:customer) }
-  let(:subscription) { create(:subscription, customer:) }
   let(:wallet) { create(:wallet, customer:, balance_cents: 1000, credits_balance: 10.0) }
   let(:wallet_transaction) do
     create(:wallet_transaction, wallet:, amount: 15.0, credit_amount: 15.0, status: "pending")
@@ -19,6 +23,8 @@ RSpec.describe Invoices::PrepaidCreditJob do
       invoice:
     )
   end
+
+  let_it_be(:subscription) { create(:subscription, customer:) }
 
   before do
     wallet_transaction

--- a/spec/jobs/invoices/provider_taxes/pull_taxes_and_apply_job_spec.rb
+++ b/spec/jobs/invoices/provider_taxes/pull_taxes_and_apply_job_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyJob do
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, customer:) }
-  let(:customer) { create(:customer, organization:) }
 
   let(:result) { Invoices::ProviderTaxes::PullTaxesAndApplyService::Result.new }
 

--- a/spec/jobs/invoices/provider_taxes/void_job_spec.rb
+++ b/spec/jobs/invoices/provider_taxes/void_job_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Invoices::ProviderTaxes::VoidJob do
-  let(:organization) { create(:organization) }
-  let(:invoice) { create(:invoice, customer:) }
+  let_it_be(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
+  let(:invoice) { create(:invoice, customer:) }
 
   let(:result) { Invoices::ProviderTaxes::VoidService::Result.new }
 

--- a/spec/jobs/invoices/refresh_draft_job_spec.rb
+++ b/spec/jobs/invoices/refresh_draft_job_spec.rb
@@ -3,7 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Invoices::RefreshDraftJob do
-  let(:invoice) { create(:invoice, ready_to_be_refreshed: true) }
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
+
+  let_it_be(:invoice) { create(:invoice, ready_to_be_refreshed: true) }
   let(:result) { Invoices::RefreshDraftService::Result.new }
 
   it "delegates to the RefreshDraft service" do

--- a/spec/jobs/invoices/search_index_job_spec.rb
+++ b/spec/jobs/invoices/search_index_job_spec.rb
@@ -3,9 +3,14 @@
 require "rails_helper"
 
 RSpec.describe Invoices::SearchIndexJob do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
+
   subject(:perform) { described_class.perform_now(invoice_id) }
 
-  let(:invoice) { create(:invoice) }
+  let_it_be(:invoice) { create(:invoice) }
 
   before do
     allow(Invoices::Search::IndexService).to receive(:call!)

--- a/spec/jobs/lifetime_usages/recalculate_and_check_job_spec.rb
+++ b/spec/jobs/lifetime_usages/recalculate_and_check_job_spec.rb
@@ -3,10 +3,15 @@
 require "rails_helper"
 
 RSpec.describe LifetimeUsages::RecalculateAndCheckJob do
-  let(:organization) { create(:organization, :premium, premium_integrations:) }
-  let(:lifetime_usage) { create(:lifetime_usage, organization:) }
+  before_all do
+    create_default(:customer)
+    create_default(:plan)
+  end
 
-  let(:premium_integrations) { ["progressive_billing"] }
+  let(:lifetime_usage) { create(:lifetime_usage, organization:) }
+  let(:organization) { create(:organization, :premium, premium_integrations:) }
+
+  let_it_be(:premium_integrations) { ["progressive_billing"] }
 
   it_behaves_like "a configurable queue", "billing_low_priority", "SIDEKIQ_BILLING" do
     let(:arguments) { lifetime_usage }
@@ -30,7 +35,8 @@ RSpec.describe LifetimeUsages::RecalculateAndCheckJob do
     end
 
     context "when progressive billing is disabled" do
-      let(:premium_integrations) { [] }
+      let_it_be(:premium_integrations) { [] }
+      let(:organization) { create(:organization, :premium, premium_integrations:) }
 
       it "delegates to the RecalculateAndCheck service" do
         allow(LifetimeUsages::CalculateService).to receive(:call!)

--- a/spec/jobs/payment_providers/flutterwave/handle_event_job_spec.rb
+++ b/spec/jobs/payment_providers/flutterwave/handle_event_job_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Flutterwave::HandleEventJob do
   subject(:handle_event_job) { described_class.new }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:event_json) { {event: "charge.completed", data: {}}.to_json }
 
   describe "#perform" do

--- a/spec/jobs/payment_providers/gocardless/handle_event_job_spec.rb
+++ b/spec/jobs/payment_providers/gocardless/handle_event_job_spec.rb
@@ -6,16 +6,15 @@ RSpec.describe PaymentProviders::Gocardless::HandleEventJob do
   subject(:handle_event_job) { described_class }
 
   let(:gocardless_service) { instance_double(PaymentProviders::GocardlessService) }
-  let(:result) { BaseService::Result.new }
-  let(:organization) { create(:organization) }
   let(:payment_provider) { create(:gocardless_provider, organization:) }
-
   let(:event_json) do
     path = Rails.root.join("spec/fixtures/gocardless/events.json")
     JSON.parse(File.read(path))["events"].first.to_json
   end
-
   let(:service_result) { PaymentProviders::Gocardless::HandleEventService::Result.new }
+  let(:result) { BaseService::Result.new }
+
+  let_it_be(:organization) { create(:organization) }
 
   it_behaves_like "a unique job" do
     let(:job_args) { [{payment_provider:, event_json:}] }

--- a/spec/jobs/payment_providers/stripe/customers/fetch_default_payment_method_job_spec.rb
+++ b/spec/jobs/payment_providers/stripe/customers/fetch_default_payment_method_job_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe PaymentProviders::Stripe::Customers::FetchDefaultPaymentMethodJob, type: :job do
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:stripe_provider) { create(:stripe_provider, organization:) }
   let(:provider_customer) do
     create(:stripe_customer, customer:, provider_customer_id: "cus_123", payment_provider: stripe_provider)

--- a/spec/jobs/payment_providers/stripe/handle_event_job_spec.rb
+++ b/spec/jobs/payment_providers/stripe/handle_event_job_spec.rb
@@ -4,11 +4,11 @@ require "rails_helper"
 
 RSpec.describe PaymentProviders::Stripe::HandleEventJob do
   let(:result) { PaymentProviders::Stripe::HandleEventService::Result.new }
-  let(:organization) { create(:organization) }
-
   let(:stripe_event) do
     {}
   end
+
+  let_it_be(:organization) { create(:organization) }
 
   before do
     allow(PaymentProviders::Stripe::HandleEventService)

--- a/spec/jobs/payment_receipts/generate_documents_job_spec.rb
+++ b/spec/jobs/payment_receipts/generate_documents_job_spec.rb
@@ -3,6 +3,12 @@
 require "rails_helper"
 
 RSpec.describe PaymentReceipts::GenerateDocumentsJob do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:invoice)
+  end
+
   subject { described_class.perform_now(payment_receipt:, notify:) }
 
   let(:payment_receipt) { create(:payment_receipt) }

--- a/spec/jobs/payments/set_payment_method_and_create_receipt_job_spec.rb
+++ b/spec/jobs/payments/set_payment_method_and_create_receipt_job_spec.rb
@@ -3,6 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Payments::SetPaymentMethodAndCreateReceiptJob do
+  before_all do
+    create_default(:organization)
+    create_default(:invoice)
+  end
+
   let(:payment) { create(:payment) }
   let(:provider_payment_method_id) { "pm_001" }
 

--- a/spec/jobs/plans/destroy_job_spec.rb
+++ b/spec/jobs/plans/destroy_job_spec.rb
@@ -3,10 +3,14 @@
 require "rails_helper"
 
 RSpec.describe Plans::DestroyJob do
+  before_all do
+    create_default(:organization)
+  end
+
   include ActiveJob::TestHelper
 
-  let(:plan) { create(:plan) }
-  let(:child_plan) { create(:plan, parent: plan) }
+  let_it_be(:plan) { create(:plan) }
+  let_it_be(:child_plan) { create(:plan, parent: plan) }
   let(:service_result) { Plans::DestroyService::Result.new }
 
   before do

--- a/spec/jobs/segment_identify_job_spec.rb
+++ b/spec/jobs/segment_identify_job_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 describe SegmentIdentifyJob, job: true do
+  before_all do
+    create_default(:organization)
+  end
+
   subject { described_class }
 
   describe ".perform" do

--- a/spec/jobs/send_email_job_spec.rb
+++ b/spec/jobs/send_email_job_spec.rb
@@ -4,12 +4,18 @@ require "rails_helper"
 
 # rubocop:disable RSpec/AnyInstance
 RSpec.describe SendEmailJob do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
+
   subject(:perform_job) { job.perform_now }
 
   let(:job) { described_class.new("InvoiceMailer", "created", "deliver_now", args: [], params:) }
-  let(:invoice) { create(:invoice, fees_amount_cents: 100) }
   let(:params) { {invoice:} }
   let(:error) { Net::SMTPServerBusy.new("busy") }
+
+  let_it_be(:invoice) { create(:invoice, fees_amount_cents: 100) }
 
   before do
     allow(Utils::EmailActivityLog).to receive(:produce)
@@ -62,7 +68,7 @@ RSpec.describe SendEmailJob do
   end
 
   context "when email is not sent" do
-    let(:invoice) { create(:invoice, fees_amount_cents: 0) }
+    let_it_be(:invoice) { create(:invoice, fees_amount_cents: 0) }
 
     it "does not deliver email" do
       expect { perform_job }.not_to change { ActionMailer::Base.deliveries.count }

--- a/spec/jobs/send_http_webhook_job_spec.rb
+++ b/spec/jobs/send_http_webhook_job_spec.rb
@@ -4,6 +4,12 @@ require "rails_helper"
 require "aws-sdk-s3"
 
 RSpec.describe SendHttpWebhookJob do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:invoice)
+  end
+
   subject(:send_http_webhook_job) { described_class }
 
   let(:webhook) { create(:webhook) }

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -3,14 +3,19 @@
 require "rails_helper"
 
 RSpec.describe SendWebhookJob do
+  before_all do
+    create_default(:customer)
+  end
+
   subject(:send_webhook_job) { described_class }
 
-  let(:organization) { create(:organization, webhook_url: "http://foo.bar") }
-  let(:invoice) { create(:invoice, organization:) }
+  let_it_be(:organization) { create_default(:organization, webhook_url: "http://foo.bar") }
+  let_it_be(:invoice) { create(:invoice, organization:) }
 
   describe ".perform_later" do
     context "when no webhook endpoints is present" do
-      let(:organization) { create(:organization, webhook_url: nil) }
+      let_it_be(:organization) { create_default(:organization, webhook_url: nil) }
+      let_it_be(:invoice) { create(:invoice, organization:) }
 
       it "does not enqueue a job" do
         expect do

--- a/spec/jobs/subscriptions/terminate_ended_subscription_job_spec.rb
+++ b/spec/jobs/subscriptions/terminate_ended_subscription_job_spec.rb
@@ -3,6 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Subscriptions::TerminateEndedSubscriptionJob do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+  end
+
   let(:subscription) { create(:subscription) }
   let(:result) { Subscriptions::TerminateService::Result.new }
 

--- a/spec/jobs/subscriptions/terminate_job_spec.rb
+++ b/spec/jobs/subscriptions/terminate_job_spec.rb
@@ -3,6 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Subscriptions::TerminateJob do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+  end
+
   let(:subscription) { create(:subscription) }
   let(:timestamp) { Time.zone.now.to_i }
 

--- a/spec/jobs/usage_monitoring/process_lifetime_usage_alert_job_spec.rb
+++ b/spec/jobs/usage_monitoring/process_lifetime_usage_alert_job_spec.rb
@@ -3,8 +3,13 @@
 require "rails_helper"
 
 RSpec.describe UsageMonitoring::ProcessLifetimeUsageAlertJob do
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  before_all do
+    create_default(:plan)
+    create_default(:billable_metric)
+  end
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:, organization:) }
   let(:alert) { create(:billable_metric_lifetime_usage_units_alert, organization:, subscription_external_id: subscription.external_id) }
 

--- a/spec/jobs/usage_monitoring/process_organization_subscription_activities_job_spec.rb
+++ b/spec/jobs/usage_monitoring/process_organization_subscription_activities_job_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe UsageMonitoring::ProcessOrganizationSubscriptionActivitiesJob do
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
 
   it_behaves_like "a configurable queue", "alerts", "SIDEKIQ_ALERTS" do
     let(:arguments) { create(:organization).id }

--- a/spec/jobs/usage_monitoring/process_subscription_activity_job_spec.rb
+++ b/spec/jobs/usage_monitoring/process_subscription_activity_job_spec.rb
@@ -3,6 +3,12 @@
 require "rails_helper"
 
 RSpec.describe UsageMonitoring::ProcessSubscriptionActivityJob do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+    create_default(:plan)
+  end
+
   it_behaves_like "a configurable queue", "alerts", "SIDEKIQ_ALERTS" do
     let(:arguments) { create(:subscription_activity).id }
   end

--- a/spec/jobs/usage_monitoring/process_wallet_alerts_job_spec.rb
+++ b/spec/jobs/usage_monitoring/process_wallet_alerts_job_spec.rb
@@ -3,6 +3,11 @@
 require "rails_helper"
 
 RSpec.describe UsageMonitoring::ProcessWalletAlertsJob do
+  before_all do
+    create_default(:organization)
+    create_default(:customer)
+  end
+
   it_behaves_like "a configurable queue", "alerts_high_priority", "SIDEKIQ_ALERTS" do
     let(:arguments) { create(:wallet) }
   end

--- a/spec/jobs/wallet_transactions/create_job_spec.rb
+++ b/spec/jobs/wallet_transactions/create_job_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe WalletTransactions::CreateJob do
   subject(:create_job) { described_class }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:wallet) { create(:wallet, customer:) }
   let(:wallet_transaction_create_service) { instance_double(WalletTransactions::CreateFromParamsService) }
   let(:params) do

--- a/spec/jobs/wallet_transactions/recredit_job_spec.rb
+++ b/spec/jobs/wallet_transactions/recredit_job_spec.rb
@@ -5,13 +5,14 @@ require "rails_helper"
 describe WalletTransactions::RecreditJob do
   subject(:perform_job) { described_class.perform_now(wallet_transaction) }
 
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:wallet) { create(:wallet, customer:, organization:) }
-  let(:invoice) { create(:invoice, organization:, customer:) }
   let(:wallet_transaction) do
     create(:wallet_transaction, wallet:, organization:, transaction_type: :outbound, invoice:)
   end
+
+  let_it_be(:invoice) { create(:invoice, organization:, customer:) }
 
   before { allow(WalletTransactions::RecreditService).to receive(:call!) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,6 +76,10 @@ Sentry.init do |config|
   config.transport.transport_class = Sentry::DummyTransport
 end
 
+require "test_prof/recipes/rspec/sample"
+require "test_prof/recipes/rspec/let_it_be"
+require "test_prof/recipes/rspec/factory_default"
+
 RSpec.configure do |config|
   config.include ActiveJob::TestHelper
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
## Context

Currently, around **50% of the spec runtime** is spent preparing data and creating factories. A lot of this data is either duplicated or recreates the same objects multiple times, so we can get rid of a good chunk of it and significantly speed up the specs.

To avoid creating unnecessary factories, we can use `let_it_be`, `before_all`, and `create_default` from `test-prof`. More info [here](https://test-prof.evilmartians.io/guide/recipes/let_it_be).

## Description

This PR cleans up the jobs specs and removes unnecessary factory usage.

Here are the numbers before and after the cleanup. The times below are for running the specs in a single process:

| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 3,835 | 2276 |
| Time spent creating factories |  00:30.172 | 00:20.405 |
| Total time | 00:45.852 | 00:34.658 |

## Overall results

This PR is part of a series of PRs focused on cleaning up factory usage across different specs.

Once all the changes are merged, we expect to:

- Reduce the number of factories by **~50k**
- Cut spec runtime by around **20%**
- Shave off roughly **1:15 min** from the CI runtime


| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 157,949 | 103,761 |
| Total time spent creating factories | 17:59.851  | 11:14.739 |
| Total time | 34:41.482 | 27:03.658 |

Here is [the CI run](https://github.com/getlago/lago-api/actions/runs/33399605547/job/99512391170?pr=6255) with all the changes merged together: