### PR TITLE
perf(specs): Clean up factories usage in spec/queries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -167,6 +167,8 @@ group :test do
   # HTML testing (invoice rendering)
   gem "rspec-snapshot", "~> 2.0"
   gem "htmlbeautifier", "~> 1.4"
+
+  gem "test-prof", "~> 1.0"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1004,6 +1004,8 @@ GEM
     temple (0.10.4)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
+    test-prof (1.6.3)
+      logger
     thor (1.5.0)
     throttling (0.4.1)
       logger
@@ -1181,6 +1183,7 @@ DEPENDENCIES
   stripe
   strong_migrations
   super_diff (~> 0.19.0)
+  test-prof (~> 1.0)
   throttling
   timecop
   tzinfo-data

--- a/spec/queries/add_ons_query_spec.rb
+++ b/spec/queries/add_ons_query_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AddOnsQuery do
 
   let(:returned_ids) { result.add_ons.pluck(:id) }
   let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let(:organization) { create_default(:organization) }
   let(:add_on_first) { create(:add_on, organization:, name: "defgh", code: "11") }
   let(:add_on_second) { create(:add_on, organization:, name: "abcde", code: "22") }
   let(:add_on_third) { create(:add_on, organization:, name: "presuv", code: "33") }

--- a/spec/queries/applied_coupons_query_spec.rb
+++ b/spec/queries/applied_coupons_query_spec.rb
@@ -7,17 +7,16 @@ RSpec.describe AppliedCouponsQuery do
     described_class.call(organization:, pagination:, filters:)
   end
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:pagination) { nil }
-  let(:filters) { {} }
-
-  let(:customer_1) { create(:customer, organization:) }
   let(:coupon_1) { create(:coupon, organization:) }
-  let(:customer_2) { create(:customer, organization:) }
   let(:coupon_2) { create(:coupon, organization:) }
-
   let!(:applied_coupon_1) { create(:applied_coupon, coupon: coupon_1, customer: customer_1) }
   let!(:applied_coupon_2) { create(:applied_coupon, coupon: coupon_2, customer: customer_2) }
+  let(:filters) { {} }
+
+  let_it_be(:customer_1) { create(:customer, organization:) }
+  let_it_be(:customer_2) { create(:customer, organization:) }
 
   it "returns a list of applied_coupons" do
     expect(result).to be_success

--- a/spec/queries/billable_metrics_query_spec.rb
+++ b/spec/queries/billable_metrics_query_spec.rb
@@ -11,8 +11,9 @@ RSpec.describe BillableMetricsQuery do
   let(:pagination) { nil }
   let(:search_term) { nil }
   let(:filters) { {} }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:billable_metric_first) { create(:billable_metric, organization:, name: "defgh", code: "11") }
   let(:billable_metric_second) { create(:billable_metric, organization:, name: "abcde", code: "22") }
   let(:billable_metric_third) { create(:billable_metric, organization:, name: "presuv", code: "33") }

--- a/spec/queries/billable_metrics_query_spec.rb
+++ b/spec/queries/billable_metrics_query_spec.rb
@@ -8,16 +8,16 @@ RSpec.describe BillableMetricsQuery do
   end
 
   let(:returned_ids) { result.billable_metrics.map(&:id) }
+  let(:billable_metric_first) { create(:billable_metric, organization:, name: "defgh", code: "11") }
+  let(:billable_metric_second) { create(:billable_metric, organization:, name: "abcde", code: "22") }
+  let(:billable_metric_third) { create(:billable_metric, organization:, name: "presuv", code: "33") }
+  let(:billable_metric_fourth) { create(:unique_count_billable_metric, organization:, name: "qwerty", code: "44") }
   let(:pagination) { nil }
   let(:search_term) { nil }
   let(:filters) { {} }
 
   let_it_be(:membership) { create(:membership) }
   let_it_be(:organization) { create_default(:organization) }
-  let(:billable_metric_first) { create(:billable_metric, organization:, name: "defgh", code: "11") }
-  let(:billable_metric_second) { create(:billable_metric, organization:, name: "abcde", code: "22") }
-  let(:billable_metric_third) { create(:billable_metric, organization:, name: "presuv", code: "33") }
-  let(:billable_metric_fourth) { create(:unique_count_billable_metric, organization:, name: "qwerty", code: "44") }
 
   before do
     billable_metric_first

--- a/spec/queries/coupons_query_spec.rb
+++ b/spec/queries/coupons_query_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CouponsQuery do
   let(:search_term) { nil }
   let(:filters) { {} }
   let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let(:organization) { create_default(:organization) }
   let(:coupon_first) { create(:coupon, organization:, status: "active", name: "defgh", code: "11") }
   let(:coupon_second) { create(:coupon, organization:, status: "terminated", name: "abcde", code: "22") }
   let(:coupon_third) { create(:coupon, organization:, status: "active", name: "presuv", code: "33") }

--- a/spec/queries/credit_notes_query_spec.rb
+++ b/spec/queries/credit_notes_query_spec.rb
@@ -3,18 +3,21 @@
 require "rails_helper"
 
 RSpec.describe CreditNotesQuery do
+  before_all do
+    create_default(:invoice)
+  end
+
   subject(:result) do
     described_class.call(organization:, search_term:, pagination:, filters:)
   end
 
   let(:returned_ids) { result.credit_notes.pluck(:id) }
-
-  let(:organization) { customer.organization }
-  let(:customer) { create(:customer) }
-
   let(:pagination) { nil }
   let(:search_term) { nil }
   let(:filters) { {} }
+
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer) }
 
   context "when no filters applied" do
     let!(:credit_notes) { create_pair(:credit_note, customer:) }
@@ -423,13 +426,13 @@ RSpec.describe CreditNotesQuery do
   end
 
   context "when filtering by self_billed" do
-    let(:credit_note_first) do
+    let_it_be(:credit_note_first) do
       invoice = create(:invoice, :self_billed, organization:, customer:)
 
       create(:credit_note, customer:, invoice:)
     end
 
-    let(:credit_note_second) do
+    let_it_be(:credit_note_second) do
       invoice = create(:invoice, organization:, customer:)
 
       create(:credit_note, customer:, invoice:)
@@ -469,11 +472,11 @@ RSpec.describe CreditNotesQuery do
   end
 
   context "when billing entity ids filter applied" do
-    let(:billing_entity) { create(:billing_entity, organization:) }
+    let_it_be(:billing_entity) { create(:billing_entity, organization:) }
     let(:filters) { {billing_entity_ids: [billing_entity.id]} }
 
-    let(:matching_credit_note) { create(:credit_note, customer:, invoice: create(:invoice, billing_entity:)) }
-    let(:other_credit_note) { create(:credit_note, customer:, invoice: create(:invoice, organization:)) }
+    let_it_be(:matching_credit_note) { create(:credit_note, customer:, invoice: create(:invoice, billing_entity:)) }
+    let_it_be(:other_credit_note) { create(:credit_note, customer:, invoice: create(:invoice, organization:)) }
 
     before do
       matching_credit_note

--- a/spec/queries/customers_query_spec.rb
+++ b/spec/queries/customers_query_spec.rb
@@ -8,14 +8,6 @@ RSpec.describe CustomersQuery do
   end
 
   let(:returned_ids) { result.customers.pluck(:id) }
-  let(:pagination) { nil }
-  let(:search_term) { nil }
-  let(:filters) { {} }
-
-  let_it_be(:organization) { create(:organization) }
-  let_it_be(:billing_entity1) { organization.default_billing_entity }
-  let_it_be(:billing_entity2) { create(:billing_entity, organization:) }
-
   let(:customer_first) do
     create(
       :customer,
@@ -72,6 +64,13 @@ RSpec.describe CustomersQuery do
       customer_type: nil
     )
   end
+  let(:pagination) { nil }
+  let(:search_term) { nil }
+  let(:filters) { {} }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:billing_entity1) { organization.default_billing_entity }
+  let_it_be(:billing_entity2) { create(:billing_entity, organization:) }
 
   before do
     customer_first

--- a/spec/queries/customers_query_spec.rb
+++ b/spec/queries/customers_query_spec.rb
@@ -11,9 +11,10 @@ RSpec.describe CustomersQuery do
   let(:pagination) { nil }
   let(:search_term) { nil }
   let(:filters) { {} }
-  let(:organization) { create(:organization) }
-  let(:billing_entity1) { organization.default_billing_entity }
-  let(:billing_entity2) { create(:billing_entity, organization:) }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:billing_entity1) { organization.default_billing_entity }
+  let_it_be(:billing_entity2) { create(:billing_entity, organization:) }
 
   let(:customer_first) do
     create(
@@ -366,6 +367,7 @@ RSpec.describe CustomersQuery do
     let(:filters) do
       {active_subscriptions_count_from: from, active_subscriptions_count_to: to}
     end
+
     let(:subscriptionless_customer) do
       create(:customer, organization:, billing_entity: billing_entity1)
     end

--- a/spec/queries/dunning_campaigns_query_spec.rb
+++ b/spec/queries/dunning_campaigns_query_spec.rb
@@ -8,21 +8,13 @@ RSpec.describe DunningCampaignsQuery do
   end
 
   let(:returned_ids) { result.dunning_campaigns.pluck(:id) }
-  let(:pagination) { nil }
-  let(:search_term) { nil }
-  let(:filters) { nil }
-  let(:order) { nil }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
   let(:default_billing_entity) { organization.default_billing_entity }
-  let(:billing_entity) { create(:billing_entity, organization:) }
   let(:dunning_campaign_first) do
     create(:dunning_campaign, organization:, name: "defgh", code: "11")
   end
   let(:dunning_campaign_second) do
     create(:dunning_campaign, organization:, name: "abcde", code: "22")
   end
-
   let(:dunning_campaign_third) do
     create(
       :dunning_campaign,
@@ -34,6 +26,14 @@ RSpec.describe DunningCampaignsQuery do
   let(:dunning_campaign_fourth) do
     create(:dunning_campaign, organization:, name: "qwerty", code: "44")
   end
+  let(:pagination) { nil }
+  let(:search_term) { nil }
+  let(:filters) { nil }
+  let(:order) { nil }
+
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:billing_entity) { create(:billing_entity, organization:) }
 
   before do
     default_billing_entity.update!(applied_dunning_campaign: dunning_campaign_first)

--- a/spec/queries/entitlement/features_query_spec.rb
+++ b/spec/queries/entitlement/features_query_spec.rb
@@ -3,11 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Entitlement::FeaturesQuery do
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let!(:feature1) { create(:feature, organization:, code: "seats", name: "Number of seats") }
   let!(:feature2) { create(:feature, organization:, code: "storage", name: "Storage") }
   let!(:feature3) { create(:feature, organization:, code: "api_calls", name: "API Calls") }
-  let!(:other_organization_feature) { create(:feature, organization: create(:organization), code: "other") }
+
+  let_it_be(:other_organization_feature) { create(:feature, organization: create(:organization), code: "other") }
 
   describe "#call" do
     subject { described_class.call(organization:, pagination:, search_term:, filters:) }

--- a/spec/queries/entitlement/subscription_entitlement_query_spec.rb
+++ b/spec/queries/entitlement/subscription_entitlement_query_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Entitlement::SubscriptionEntitlementQuery do
+  before_all do
+    create_default(:customer)
+  end
+
   subject do
     described_class.call(
       organization:,
@@ -13,25 +17,22 @@ RSpec.describe Entitlement::SubscriptionEntitlementQuery do
     )
   end
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
 
   let(:subscription_id) { subscription.id }
-  let(:plan_id) { subscription.plan.parent_id || subscription.plan.id }
-
-  let(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, organization:, plan:) }
-
   let(:seats) { create(:feature, organization:, code: "seats", name: "Nb users") }
   let(:seats_max) { create(:privilege, feature: seats, code: "max", name: "Max", value_type: "integer") }
   let(:seats_reset) { create(:privilege, feature: seats, code: "reset", name: "Password Reset", value_type: "boolean") }
-
   let(:storage) { create(:feature, organization:, code: "storage", name: "Storage") }
   let(:storage_limit) { create(:privilege, feature: storage, code: "limit", name: "Limit", value_type: "string") }
   let(:storage_type) { create(:privilege, feature: storage, code: "type", name: "Type", value_type: "select", config: {select_options: ["rom", "ram"]}) }
-
   let(:support) { create(:feature, organization:, code: "support", name: "Premium Support") }
+  let(:plan_id) { subscription.plan.parent_id || subscription.plan.id }
 
-  let(:other_organization_feature) { create(:feature, organization: create(:organization), code: "other") }
+  let_it_be(:plan) { create(:plan, organization:) }
+
+  let_it_be(:other_organization_feature) { create(:feature, organization: create(:organization), code: "other") }
 
   before do
     storage_type

--- a/spec/queries/events_query_spec.rb
+++ b/spec/queries/events_query_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe EventsQuery do
   subject(:events_query) { described_class.new(organization:, pagination:, filters:) }
 
-  let(:organization) { create(:organization) }
+  let(:organization) { create_default(:organization) }
   let(:pagination) { nil }
   let(:filters) { {} }
 

--- a/spec/queries/fees_query_spec.rb
+++ b/spec/queries/fees_query_spec.rb
@@ -3,14 +3,18 @@
 require "rails_helper"
 
 RSpec.describe FeesQuery do
+  before_all do
+    create_default(:invoice)
+  end
+
   subject(:fees_query) { described_class.new(organization:, pagination:, filters:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:pagination) { nil }
   let(:filters) { {} }
 
   describe "call" do
-    let(:customer) { create(:customer, organization:) }
+    let_it_be(:customer) { create_default(:customer, organization:) }
     let(:subscription) { create(:subscription, customer:) }
     let(:fee) { create(:fee, subscription:, invoice: nil) }
 
@@ -104,7 +108,7 @@ RSpec.describe FeesQuery do
 
     context "with billable metric code filter" do
       let(:billable_metric) { create(:billable_metric, organization:) }
-      let(:plan) { create(:plan, organization:) }
+      let(:plan) { create_default(:plan) }
       let(:charge) { create(:standard_charge, billable_metric:, plan:) }
 
       let(:fee) { create(:charge_fee, charge:, subscription:, invoice: nil) }

--- a/spec/queries/integration_items_query_spec.rb
+++ b/spec/queries/integration_items_query_spec.rb
@@ -8,20 +8,19 @@ RSpec.describe IntegrationItemsQuery do
   end
 
   let(:returned_ids) { result.integration_items.pluck(:id) }
-  let(:pagination) { nil }
-  let(:search_term) { nil }
-  let(:filters) { {} }
-  let_it_be(:membership) { create(:membership) }
-  let_it_be(:organization) { membership.organization }
-
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:integration_second) { create(:netsuite_integration, organization:) }
   let(:integration_third) { create(:netsuite_integration) }
-
   let(:integration_item_first) { create(:integration_item, item_type: "tax", integration:) }
   let(:integration_item_second) { create(:integration_item, integration: integration_second) }
   let(:integration_item_third) { create(:integration_item, integration: integration_third) }
   let(:integration_item_fourth) { create(:integration_item, external_name: "Findme", integration:) }
+  let(:pagination) { nil }
+  let(:search_term) { nil }
+  let(:filters) { {} }
+
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:organization) { membership.organization }
 
   before do
     integration_item_first

--- a/spec/queries/integration_items_query_spec.rb
+++ b/spec/queries/integration_items_query_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe IntegrationItemsQuery do
   let(:pagination) { nil }
   let(:search_term) { nil }
   let(:filters) { {} }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:organization) { membership.organization }
 
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:integration_second) { create(:netsuite_integration, organization:) }

--- a/spec/queries/order_forms_query_spec.rb
+++ b/spec/queries/order_forms_query_spec.rb
@@ -8,16 +8,17 @@ RSpec.describe OrderFormsQuery do
   end
 
   let(:returned_ids) { result.order_forms.pluck(:id) }
-  let(:pagination) { nil }
-  let(:filters) { nil }
-  let(:search_term) { nil }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:quote_version) { create(:quote_version, quote:, organization:) }
   let(:order_form_one) { create(:order_form, organization:, customer:, quote_version:) }
   let(:order_form_two) { create(:order_form, organization:, customer:) }
+  let(:pagination) { nil }
+  let(:filters) { nil }
+  let(:search_term) { nil }
+
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   before do
     order_form_one

--- a/spec/queries/orders_query_spec.rb
+++ b/spec/queries/orders_query_spec.rb
@@ -8,18 +8,19 @@ RSpec.describe OrdersQuery do
   end
 
   let(:returned_ids) { result.orders.pluck(:id) }
-  let(:pagination) { nil }
-  let(:filters) { nil }
-  let(:search_term) { nil }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:order_form) { create(:order_form, :signed, organization:, customer:, quote:) }
   let(:order_one) { create(:order, organization:, customer:, order_form:) }
   let(:quote_two) { create(:quote, organization:, customer:) }
   let(:order_form_two) { create(:order_form, :signed, organization:, customer:, quote: quote_two) }
   let(:order_two) { create(:order, organization:, customer:, order_form: order_form_two) }
+  let(:pagination) { nil }
+  let(:filters) { nil }
+  let(:search_term) { nil }
+
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   before do
     order_one

--- a/spec/queries/past_usage_query_spec.rb
+++ b/spec/queries/past_usage_query_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PastUsageQuery do
   subject(:result) { described_class.call(organization:, pagination:, filters:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:pagination) { nil }
   let(:filters) do
     {
@@ -14,8 +14,8 @@ RSpec.describe PastUsageQuery do
     }
   end
 
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:) }
   let(:subscription2) { create(:subscription, customer:, plan:) }
 
@@ -158,10 +158,10 @@ RSpec.describe PastUsageQuery do
   end
 
   context "with billable_metric_code" do
-    let(:billable_metric1) { create(:billable_metric, organization:) }
+    let_it_be(:billable_metric1) { create(:billable_metric, organization:) }
     let(:billable_metric_code) { billable_metric1&.code }
 
-    let(:billable_metric2) { create(:billable_metric, organization:) }
+    let_it_be(:billable_metric2) { create(:billable_metric, organization:) }
 
     let(:charge1) { create(:standard_charge, plan:, billable_metric: billable_metric1) }
     let(:charge2) { create(:standard_charge, plan:, billable_metric: billable_metric2) }

--- a/spec/queries/past_usage_query_spec.rb
+++ b/spec/queries/past_usage_query_spec.rb
@@ -7,6 +7,32 @@ RSpec.describe PastUsageQuery do
 
   let_it_be(:organization) { create(:organization) }
   let(:pagination) { nil }
+  let(:subscription) { create(:subscription, customer:, plan:) }
+  let(:subscription2) { create(:subscription, customer:, plan:) }
+  let(:invoice_subscription1) do
+    create(
+      :invoice_subscription,
+      charges_from_datetime: DateTime.parse("2023-08-17T00:00:00"),
+      charges_to_datetime: DateTime.parse("2023-09-16T23:59:59"),
+      subscription:
+    )
+  end
+  let(:invoice_subscription2) do
+    create(
+      :invoice_subscription,
+      charges_from_datetime: DateTime.parse("2023-07-17T00:00:00"),
+      charges_to_datetime: DateTime.parse("2023-08-16T23:59:59"),
+      subscription:
+    )
+  end
+  let(:invoice_subscription3) do
+    create(
+      :invoice_subscription,
+      charges_from_datetime: DateTime.parse("2023-07-17T00:00:00"),
+      charges_to_datetime: DateTime.parse("2023-08-16T23:59:59"),
+      subscription: subscription2
+    )
+  end
   let(:filters) do
     {
       external_customer_id: customer.external_id,
@@ -16,35 +42,6 @@ RSpec.describe PastUsageQuery do
 
   let_it_be(:customer) { create_default(:customer, organization:) }
   let_it_be(:plan) { create(:plan, organization:) }
-  let(:subscription) { create(:subscription, customer:, plan:) }
-  let(:subscription2) { create(:subscription, customer:, plan:) }
-
-  let(:invoice_subscription1) do
-    create(
-      :invoice_subscription,
-      charges_from_datetime: DateTime.parse("2023-08-17T00:00:00"),
-      charges_to_datetime: DateTime.parse("2023-09-16T23:59:59"),
-      subscription:
-    )
-  end
-
-  let(:invoice_subscription2) do
-    create(
-      :invoice_subscription,
-      charges_from_datetime: DateTime.parse("2023-07-17T00:00:00"),
-      charges_to_datetime: DateTime.parse("2023-08-16T23:59:59"),
-      subscription:
-    )
-  end
-
-  let(:invoice_subscription3) do
-    create(
-      :invoice_subscription,
-      charges_from_datetime: DateTime.parse("2023-07-17T00:00:00"),
-      charges_to_datetime: DateTime.parse("2023-08-16T23:59:59"),
-      subscription: subscription2
-    )
-  end
 
   before do
     invoice_subscription1
@@ -160,15 +157,10 @@ RSpec.describe PastUsageQuery do
   context "with billable_metric_code" do
     let_it_be(:billable_metric1) { create(:billable_metric, organization:) }
     let(:billable_metric_code) { billable_metric1&.code }
-
-    let_it_be(:billable_metric2) { create(:billable_metric, organization:) }
-
     let(:charge1) { create(:standard_charge, plan:, billable_metric: billable_metric1) }
     let(:charge2) { create(:standard_charge, plan:, billable_metric: billable_metric2) }
-
     let(:fee1) { create(:charge_fee, charge: charge1, subscription:, invoice: invoice_subscription1.invoice) }
     let(:fee2) { create(:charge_fee, charge: charge2, subscription:, invoice: invoice_subscription1.invoice) }
-
     let(:filters) do
       {
         external_customer_id: customer.external_id,
@@ -176,6 +168,8 @@ RSpec.describe PastUsageQuery do
         billable_metric_code:
       }
     end
+
+    let_it_be(:billable_metric2) { create(:billable_metric, organization:) }
 
     before do
       fee1

--- a/spec/queries/payment_methods_query_spec.rb
+++ b/spec/queries/payment_methods_query_spec.rb
@@ -8,16 +8,16 @@ RSpec.describe PaymentMethodsQuery do
   end
 
   let(:returned_ids) { result.payment_methods.pluck(:id) }
+  let(:payment_method_first) { create(:payment_method, organization:) }
+  let(:payment_method_second) { create(:payment_method, organization:, customer:) }
+  let(:payment_method_third) { create(:payment_method, organization:, deleted_at: Time.current) }
 
   let(:pagination) { nil }
   let(:filters) { {} }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:payment_method_first) { create(:payment_method, organization:) }
-  let(:payment_method_second) { create(:payment_method, organization:, customer:) }
-  let(:payment_method_third) { create(:payment_method, organization:, deleted_at: Time.current) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   before do
     payment_method_first

--- a/spec/queries/payment_receipts_query_spec.rb
+++ b/spec/queries/payment_receipts_query_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe PaymentReceiptsQuery do
   let(:returned_ids) { result.payment_receipts.pluck(:id) }
   let(:pagination) { nil }
   let(:filters) { nil }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:organization) { membership.organization }
   let(:invoice) { create(:invoice, organization:) }
   let(:invoice2) { create(:invoice, organization:) }
   let(:payment_request) { create(:payment_request, organization:) }

--- a/spec/queries/payment_receipts_query_spec.rb
+++ b/spec/queries/payment_receipts_query_spec.rb
@@ -8,20 +8,20 @@ RSpec.describe PaymentReceiptsQuery do
   end
 
   let(:returned_ids) { result.payment_receipts.pluck(:id) }
-  let(:pagination) { nil }
-  let(:filters) { nil }
-  let_it_be(:membership) { create(:membership) }
-  let_it_be(:organization) { membership.organization }
   let(:invoice) { create(:invoice, organization:) }
   let(:invoice2) { create(:invoice, organization:) }
   let(:payment_request) { create(:payment_request, organization:) }
   let(:payment_one) { create(:payment, payable: invoice) }
   let(:payment_two) { create(:payment, payable: invoice2) }
   let(:payment_three) { create(:payment, payable: payment_request) }
-
   let!(:payment_receipt_one) { create(:payment_receipt, payment: payment_one, organization:) }
   let!(:payment_receipt_two) { create(:payment_receipt, payment: payment_two, organization:) }
   let!(:payment_receipt_three) { create(:payment_receipt, payment: payment_three, organization:) }
+  let(:pagination) { nil }
+  let(:filters) { nil }
+
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:organization) { membership.organization }
 
   before do
     create(:payment_receipt)

--- a/spec/queries/payment_requests_query_spec.rb
+++ b/spec/queries/payment_requests_query_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe PaymentRequestsQuery do
   end
 
   let(:returned_ids) { result.payment_requests.pluck(:id) }
+  let(:payment_request_first) { create(:payment_request, organization:) }
+  let(:payment_request_second) { create(:payment_request, organization:, customer:) }
 
   let(:pagination) { nil }
   let(:filters) { {} }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
-  let(:payment_request_first) { create(:payment_request, organization:) }
-  let(:payment_request_second) { create(:payment_request, organization:, customer:) }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   before do
     payment_request_first
@@ -97,14 +97,14 @@ RSpec.describe PaymentRequestsQuery do
   end
 
   context "when filtering by billing_entity_ids" do
-    let(:billing_entity_eu) { create(:billing_entity, organization:, code: "EU") }
-    let(:billing_entity_us) { create(:billing_entity, organization:, code: "US") }
+    let_it_be(:billing_entity_eu) { create(:billing_entity, organization:, code: "EU") }
+    let_it_be(:billing_entity_us) { create(:billing_entity, organization:, code: "US") }
 
-    let(:customer_first) { create(:customer, organization:) }
-    let(:customer_second) { create(:customer, organization:) }
+    let_it_be(:customer_first) { create(:customer, organization:) }
+    let_it_be(:customer_second) { create(:customer, organization:) }
 
-    let(:invoice_eu) { create(:invoice, organization:, customer: customer_first, billing_entity: billing_entity_eu) }
-    let(:invoice_us) { create(:invoice, organization:, customer: customer_second, billing_entity: billing_entity_us) }
+    let_it_be(:invoice_eu) { create(:invoice, organization:, customer: customer_first, billing_entity: billing_entity_eu) }
+    let_it_be(:invoice_us) { create(:invoice, organization:, customer: customer_second, billing_entity: billing_entity_us) }
 
     let(:payment_request_first) do
       create(:payment_request, organization:, customer: customer_first, invoices: [invoice_eu])

--- a/spec/queries/payments_query_spec.rb
+++ b/spec/queries/payments_query_spec.rb
@@ -8,17 +8,18 @@ RSpec.describe PaymentsQuery do
   end
 
   let(:returned_ids) { result.payments.pluck(:id) }
-  let(:pagination) { nil }
-  let(:filters) { nil }
-  let(:search_term) { nil }
-  let_it_be(:membership) { create(:membership) }
-  let_it_be(:organization) { create_default(:organization) }
   let(:invoice) { create(:invoice, organization:) }
   let(:invoice2) { create(:invoice, organization:) }
   let(:payment_request) { create(:payment_request, organization:) }
   let(:payment_one) { create(:payment, payable: invoice) }
   let(:payment_two) { create(:payment, payable: invoice2) }
   let(:payment_three) { create(:payment, payable: payment_request) }
+  let(:pagination) { nil }
+  let(:filters) { nil }
+  let(:search_term) { nil }
+
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization) }
 
   before do
     payment_one

--- a/spec/queries/payments_query_spec.rb
+++ b/spec/queries/payments_query_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe PaymentsQuery do
   let(:pagination) { nil }
   let(:filters) { nil }
   let(:search_term) { nil }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization) }
   let(:invoice) { create(:invoice, organization:) }
   let(:invoice2) { create(:invoice, organization:) }
   let(:payment_request) { create(:payment_request, organization:) }
@@ -49,9 +49,9 @@ RSpec.describe PaymentsQuery do
   end
 
   context "with search_term" do
-    let(:customer) { create(:customer, organization:, firstname: "first", lastname: "last", external_id: "external_c_id", email: "email@example.com", name: "The name") }
-    let(:invoice) { create(:invoice, :finalized, organization:, customer:, number: "number-test-123") }
-    let(:invoice3) { create(:invoice, :finalized, organization:, customer:) }
+    let_it_be(:customer) { create(:customer, organization:, firstname: "first", lastname: "last", external_id: "external_c_id", email: "email@example.com", name: "The name") }
+    let_it_be(:invoice) { create(:invoice, :finalized, organization:, customer:, number: "number-test-123") }
+    let_it_be(:invoice3) { create(:invoice, :finalized, organization:, customer:) }
     let(:payment_one) { create(:payment, payable: invoice) }
     let(:payment_two) { create(:payment, payable: invoice3) }
     let(:payment_three) { create(:payment, payable: invoice2) }
@@ -182,9 +182,11 @@ RSpec.describe PaymentsQuery do
 
   context "when filtering by external_customer_id" do
     let(:filters) { {external_customer_id: customer.external_id} }
-    let(:customer) { create(:customer) }
-    let(:new_invoice) { create(:invoice, organization:, customer:) }
     let(:new_payment) { create(:payment, payable: new_invoice) }
+    let(:customer) { create_default(:customer) }
+    let(:invoice) { create(:invoice, organization:) }
+
+    let(:new_invoice) { create(:invoice, organization:, customer:) }
 
     before do
       new_payment

--- a/spec/queries/pricing_units_query_spec.rb
+++ b/spec/queries/pricing_units_query_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PricingUnitsQuery do
   subject(:result) { described_class.call(organization:, search_term:, pagination:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:pagination) { nil }
   let(:search_term) { nil }
 

--- a/spec/queries/product_categories_query_spec.rb
+++ b/spec/queries/product_categories_query_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe ProductCategoriesQuery do
   subject(:result) { described_class.call(organization:, search_term:, pagination:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:search_term) { nil }
   let(:pagination) { nil }
 

--- a/spec/queries/product_filters_query_spec.rb
+++ b/spec/queries/product_filters_query_spec.rb
@@ -3,9 +3,13 @@
 require "rails_helper"
 
 RSpec.describe ProductFiltersQuery do
+  before_all do
+    create_default(:billable_metric)
+  end
+
   subject(:result) { described_class.call(organization:, search_term:, pagination:, filters:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:search_term) { nil }
   let(:pagination) { nil }
   let(:filters) { {} }

--- a/spec/queries/products_query_spec.rb
+++ b/spec/queries/products_query_spec.rb
@@ -3,9 +3,13 @@
 require "rails_helper"
 
 RSpec.describe ProductsQuery do
+  before_all do
+    create_default(:billable_metric)
+  end
+
   subject(:result) { described_class.call(organization:, search_term:, pagination:, filters:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:search_term) { nil }
   let(:pagination) { nil }
   let(:filters) { {} }

--- a/spec/queries/quotes_query_spec.rb
+++ b/spec/queries/quotes_query_spec.rb
@@ -8,13 +8,14 @@ RSpec.describe QuotesQuery do
   end
 
   let(:returned_ids) { result.quotes.pluck(:id) }
-  let(:pagination) { nil }
-  let(:filters) { {} }
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
   let(:quote_draft) { create(:quote, :with_version, organization:, customer:, created_at: 8.days.ago) }
   let(:quote_approved) { create(:quote, :with_version, version_trait: :approved, organization:, customer:, created_at: 6.days.ago) }
   let(:quote_voided) { create(:quote, :with_version, version_trait: :voided, organization:, customer:, created_at: 4.days.ago) }
+  let(:pagination) { nil }
+  let(:filters) { {} }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
 
   before do
     quote_draft

--- a/spec/queries/rate_card_rates_query_spec.rb
+++ b/spec/queries/rate_card_rates_query_spec.rb
@@ -3,9 +3,13 @@
 require "rails_helper"
 
 RSpec.describe RateCardRatesQuery do
+  before_all do
+    create_default(:billable_metric)
+  end
+
   subject(:result) { described_class.call(organization:, pagination:, filters:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:pagination) { nil }
   let(:filters) { {} }
 

--- a/spec/queries/rate_cards_query_spec.rb
+++ b/spec/queries/rate_cards_query_spec.rb
@@ -3,9 +3,13 @@
 require "rails_helper"
 
 RSpec.describe RateCardsQuery do
+  before_all do
+    create_default(:billable_metric)
+  end
+
   subject(:result) { described_class.call(organization:, search_term:, pagination:, filters:) }
 
-  let(:organization) { create(:organization) }
+  let_it_be(:organization) { create(:organization) }
   let(:search_term) { nil }
   let(:pagination) { nil }
   let(:filters) { {} }

--- a/spec/queries/subscriptions_query_spec.rb
+++ b/spec/queries/subscriptions_query_spec.rb
@@ -6,15 +6,14 @@ RSpec.describe SubscriptionsQuery do
   subject(:result) { described_class.call(organization:, pagination:, filters:, search_term:) }
 
   let(:returned_ids) { result.subscriptions.pluck(:id) }
-
-  let(:organization) { create(:organization) }
   let(:pagination) { nil }
   let(:filters) { {} }
   let(:search_term) { nil }
-
-  let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:) }
+
+  let_it_be(:organization) { create(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
+  let_it_be(:plan) { create(:plan, organization:) }
 
   before { subscription }
 
@@ -76,11 +75,12 @@ RSpec.describe SubscriptionsQuery do
   end
 
   context "with search_term" do
-    let(:plan) { create(:plan, organization:, name: "Test Plan") }
+    let_it_be(:plan) { create(:plan, organization:, name: "Test Plan") }
     let(:subscription) { create(:subscription, customer:, plan:, name: "Test Subscription") }
-    let(:subscription_2) { create(:subscription, customer:, plan:, name: "Test Subscription 2") }
-    let(:other_plan) { create(:plan, organization:, name: "Other Plan") }
     let(:other_subscription) { create(:subscription, customer:, plan: other_plan, name: "Other Subscription") }
+    let(:subscription_2) { create(:subscription, customer:, plan:, name: "Test Subscription 2") }
+
+    let_it_be(:other_plan) { create(:plan, organization:, name: "Other Plan") }
 
     before { subscription_2 }
 
@@ -331,9 +331,10 @@ RSpec.describe SubscriptionsQuery do
   context "with overriden filter" do
     let(:filters) { {} }
     let(:plan) { create(:plan, organization:, parent: parent_plan) }
+    let(:subscription_2) { create(:subscription, customer:, plan: parent_plan) }
+
     let(:parent_plan) { create(:plan, organization:) }
     let(:subscription) { create(:subscription, customer:, plan:) }
-    let(:subscription_2) { create(:subscription, customer:, plan: parent_plan) }
 
     before { [subscription, subscription_2] }
 
@@ -367,8 +368,8 @@ RSpec.describe SubscriptionsQuery do
   end
 
   context "with billing_entity_ids filter" do
-    let(:us_entity) { create(:billing_entity, organization:, code: "us") }
-    let(:eu_entity) { create(:billing_entity, organization:, code: "eu") }
+    let_it_be(:us_entity) { create(:billing_entity, organization:, code: "us") }
+    let_it_be(:eu_entity) { create(:billing_entity, organization:, code: "eu") }
     let(:subscription) { create(:subscription, customer:, plan:, billing_entity: us_entity) }
     let(:us_subscription) { subscription }
     let(:eu_subscription) { create(:subscription, customer:, plan:, billing_entity: eu_entity) }
@@ -406,8 +407,8 @@ RSpec.describe SubscriptionsQuery do
     end
 
     context "when a subscription has NULL billing_entity_id inherits from customer" do
-      let(:us_customer) { create(:customer, organization:, billing_entity: us_entity) }
-      let(:eu_customer) { create(:customer, organization:, billing_entity: eu_entity) }
+      let_it_be(:us_customer) { create(:customer, organization:, billing_entity: us_entity) }
+      let_it_be(:eu_customer) { create(:customer, organization:, billing_entity: eu_entity) }
 
       let!(:inherits_eu) { create(:subscription, customer: eu_customer, plan:, billing_entity: nil) }
       let!(:inherits_us) { create(:subscription, customer: us_customer, plan:, billing_entity: nil) }
@@ -440,8 +441,8 @@ RSpec.describe SubscriptionsQuery do
   end
 
   context "with currency filter" do
-    let(:eur_plan) { create(:plan, organization:, amount_currency: "EUR") }
-    let(:usd_plan) { create(:plan, organization:, amount_currency: "USD") }
+    let_it_be(:eur_plan) { create(:plan, organization:, amount_currency: "EUR") }
+    let_it_be(:usd_plan) { create(:plan, organization:, amount_currency: "USD") }
     let(:eur_subscription) { create(:subscription, customer:, plan: eur_plan) }
     let(:usd_subscription) { create(:subscription, customer:, plan: usd_plan) }
     let(:subscription) { nil }

--- a/spec/queries/taxes_query_spec.rb
+++ b/spec/queries/taxes_query_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe TaxesQuery do
   let(:filters) { nil }
   let(:order) { nil }
   let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let(:organization) { create_default(:organization) }
   let(:tax_first) { create(:tax, :applied_to_billing_entity, organization:, name: "defgh", code: "11", rate: 10) }
   let(:tax_second) { create(:tax, :applied_to_billing_entity, organization:, name: "abcde", code: "22", rate: 5) }
 

--- a/spec/queries/usage_monitoring/alerts_query_spec.rb
+++ b/spec/queries/usage_monitoring/alerts_query_spec.rb
@@ -3,12 +3,18 @@
 require "rails_helper"
 
 RSpec.describe UsageMonitoring::AlertsQuery do
+  before_all do
+    create_default(:customer)
+    create_default(:plan)
+    create_default(:billable_metric)
+  end
+
   subject(:result) do
     described_class.call(organization:, pagination:, filters:)
   end
 
   let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let(:organization) { create_default(:organization) }
   let(:subscription) { create(:subscription, organization:) }
   let(:alert_first) { create(:alert, organization:, subscription_external_id: subscription.external_id) }
   let(:alert_second) { create(:billable_metric_current_usage_amount_alert, organization:, subscription_external_id: subscription.external_id) }

--- a/spec/queries/wallet_transaction_consumptions_query_spec.rb
+++ b/spec/queries/wallet_transaction_consumptions_query_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe WalletTransactionConsumptionsQuery do
     )
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create(:customer, organization:) }
   let(:wallet) { create(:wallet, customer:, traceable: true) }
   let(:pagination) { nil }
 

--- a/spec/queries/wallet_transactions_query_spec.rb
+++ b/spec/queries/wallet_transactions_query_spec.rb
@@ -13,19 +13,19 @@ RSpec.describe WalletTransactionsQuery do
   end
 
   let(:returned_ids) { result.wallet_transactions.pluck(:id) }
-
-  let(:wallet_id) { wallet.id }
-  let(:pagination) { nil }
-  let(:filters) { {} }
-
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:) }
   let(:wallet) { create(:wallet, customer:) }
   let(:wallet_transaction_first) { create(:wallet_transaction, wallet:) }
   let(:wallet_transaction_second) { create(:wallet_transaction, wallet:) }
   let(:wallet_transaction_third) { create(:wallet_transaction, wallet:) }
   let(:wallet_transaction_fourth) { create(:wallet_transaction) }
+
+  let(:wallet_id) { wallet.id }
+  let(:pagination) { nil }
+  let(:filters) { {} }
+
+  let_it_be(:membership) { create(:membership) }
+  let_it_be(:organization) { create_default(:organization) }
+  let_it_be(:customer) { create_default(:customer, organization:) }
 
   before do
     wallet_transaction_first

--- a/spec/queries/wallets_query_spec.rb
+++ b/spec/queries/wallets_query_spec.rb
@@ -3,20 +3,25 @@
 require "rails_helper"
 
 RSpec.describe WalletsQuery do
+  before_all do
+    create_default(:customer)
+  end
+
   subject(:result) do
     described_class.call(organization:, pagination:, filters:)
   end
 
   let(:returned_ids) { result.wallets.pluck(:id) }
-  let(:organization) { create :organization }
-  let(:customer_1) { create :customer, organization:, external_id: "customer_1" }
-  let(:customer_2) { create :customer, organization:, external_id: "customer_2" }
   let(:wallet_1) { create :wallet, customer: customer_1 }
   let(:wallet_2) { create :wallet, customer: customer_1 }
   let(:wallet_3) { create :wallet, customer: customer_2 }
   let(:wallet_4) { create :wallet }
   let(:pagination) { {page: 1, limit: 10} }
   let(:filters) { nil }
+
+  let_it_be(:organization) { create :organization }
+  let_it_be(:customer_1) { create :customer, organization:, external_id: "customer_1" }
+  let_it_be(:customer_2) { create :customer, organization:, external_id: "customer_2" }
 
   before do
     wallet_1
@@ -110,11 +115,11 @@ RSpec.describe WalletsQuery do
   end
 
   context "when filtering by billing_entity_ids" do
-    let(:billing_entity_eu) { create(:billing_entity, organization:, code: "EU") }
-    let(:billing_entity_us) { create(:billing_entity, organization:, code: "US") }
+    let_it_be(:billing_entity_eu) { create(:billing_entity, organization:, code: "EU") }
+    let_it_be(:billing_entity_us) { create(:billing_entity, organization:, code: "US") }
 
-    let(:customer_eu) { create(:customer, organization:, billing_entity: billing_entity_eu) }
-    let(:customer_us) { create(:customer, organization:, billing_entity: billing_entity_us) }
+    let_it_be(:customer_eu) { create(:customer, organization:, billing_entity: billing_entity_eu) }
+    let_it_be(:customer_us) { create(:customer, organization:, billing_entity: billing_entity_us) }
 
     let(:wallet_eu_direct) { create(:wallet, customer: customer_us, billing_entity: billing_entity_eu) }
     let(:wallet_eu_fallback) { create(:wallet, customer: customer_eu, billing_entity: nil) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,6 +76,10 @@ Sentry.init do |config|
   config.transport.transport_class = Sentry::DummyTransport
 end
 
+require "test_prof/recipes/rspec/sample"
+require "test_prof/recipes/rspec/let_it_be"
+require "test_prof/recipes/rspec/factory_default"
+
 RSpec.configure do |config|
   config.include ActiveJob::TestHelper
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
## Context

Currently, around **50% of the spec runtime** is spent preparing data and creating factories. A lot of this data is either duplicated or recreates the same objects multiple times, so we can get rid of a good chunk of it and significantly speed up the specs.

To avoid creating unnecessary factories, we can use `let_it_be`, `before_all`, and `create_default` from `test-prof`. More info [here](https://test-prof.evilmartians.io/guide/recipes/let_it_be).

## Description

This PR cleans up the queries specs and removes unnecessary factory usage.

Here are the numbers before and after the cleanup. The times below are for running the specs in a single process:

| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 7,399 | 5,396 |
| Time spent creating factories |  00:34.787 | 00:20.223 |
| Total time | 00:42.773 | 00:28.628 |

## Overall results

This PR is part of a series of PRs focused on cleaning up factory usage across different specs.

Once all the changes are merged, we expect to:

- Reduce the number of factories by **~50k**
- Cut spec runtime by around **20%**
- Shave off roughly **1:15 min** from the CI runtime


| Metric | Before | After |
| --- | ---: | ---: |
| Total # of factories | 157,949 | 103,761 |
| Total time spent creating factories | 17:59.851  | 11:14.739 |
| Total time | 34:41.482 | 27:03.658 |

Here is [the CI run](https://github.com/getlago/lago-api/actions/runs/33399605547/job/99512391170?pr=6255) with all the changes merged together: