### PR TITLE
feat: resolve taxes for product fees

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -60,6 +60,7 @@ class Fee < ApplicationRecord
   validates :events_count, numericality: {greater_than_or_equal_to: 0}, allow_nil: true
   validates :true_up_fee_id, presence: false, unless: :charge?
   validates :total_aggregated_units, presence: true, if: :charge?
+  validates :rate_card_rate, presence: true, if: :product?
 
   scope :positive_units, -> { where("fees.units > ?", 0) }
 

--- a/app/services/fees/apply_taxes_service.rb
+++ b/app/services/fees/apply_taxes_service.rb
@@ -64,6 +64,7 @@ module Fees
     def applicable_taxes
       # organization.taxes - are all taxes created on the organization
       return customer.organization.taxes.where(code: tax_codes) if tax_codes
+      return product_taxes if fee.product?
       return fee.add_on.taxes if fee.add_on? && fee.add_on.taxes.any?
       return fee.charge.taxes if fee.charge? && fee.charge.taxes.any?
       return fee.fixed_charge.taxes if fee.fixed_charge? && fee.fixed_charge.taxes.any?
@@ -74,7 +75,20 @@ module Fees
       return customer.taxes if customer.taxes.any?
 
       # billing_entity.taxes - are the default taxes applied on the billing entity
-      Tax.joins(:billing_entities_taxes).where(billing_entities_taxes: {billing_entity_id: customer.billing_entity_id})
+      billing_entity_taxes(customer.billing_entity_id)
+    end
+
+    def product_taxes
+      rate_card_taxes = fee.rate_card_rate.rate_card.taxes
+      return rate_card_taxes if rate_card_taxes.any?
+      return plan.taxes if plan.taxes.any?
+      return customer.taxes if customer.taxes.any?
+
+      billing_entity_taxes(fee.billing_entity_id)
+    end
+
+    def billing_entity_taxes(billing_entity_id)
+      Tax.joins(:billing_entities_taxes).where(billing_entities_taxes: {billing_entity_id:})
     end
   end
 end

--- a/app/services/rate_cards/apply_taxes_service.rb
+++ b/app/services/rate_cards/apply_taxes_service.rb
@@ -15,7 +15,10 @@ module RateCards
       return result.not_found_failure!(resource: "tax") if (tax_codes - taxes_by_code.keys).present?
 
       rate_card.with_lock do
-        rate_card.applied_taxes.where.not(tax_id: taxes_by_code.values.map(&:id)).destroy_all
+        current_tax_ids = rate_card.applied_taxes.pluck(:tax_id)
+        requested_tax_ids = taxes_by_code.values.map(&:id)
+
+        rate_card.applied_taxes.where.not(tax_id: requested_tax_ids).destroy_all
 
         result.applied_taxes = tax_codes.map do |tax_code|
           rate_card.applied_taxes
@@ -25,6 +28,8 @@ module RateCards
 
         rate_card.applied_taxes.reset
         rate_card.taxes.reset
+
+        refresh_draft_invoices if current_tax_ids.sort != requested_tax_ids.sort
       end
 
       result
@@ -38,6 +43,14 @@ module RateCards
 
     def taxes_by_code
       @taxes_by_code ||= rate_card.organization.taxes.where(code: tax_codes).index_by(&:code)
+    end
+
+    def refresh_draft_invoices
+      invoice_ids = Fee.where(rate_card_rate_id: rate_card.rates.select(:id)).select(:invoice_id)
+
+      rate_card.organization.invoices.draft
+        .where(id: invoice_ids)
+        .update_all(ready_to_be_refreshed: true, updated_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
     end
   end
 end

--- a/app/services/taxes/destroy_service.rb
+++ b/app/services/taxes/destroy_service.rb
@@ -51,10 +51,12 @@ module Taxes
     attr_reader :tax
 
     def draft_invoice_ids
-      @draft_invoice_ids ||= tax.organization.invoices
+      @draft_invoice_ids ||= (
+        tax.organization.invoices
         .where(customer_id: tax.applicable_customers.select(:id))
         .draft
-        .pluck(:id)
+        .pluck(:id) + tax.draft_fee_taxes.distinct.pluck("fees.invoice_id")
+      ).uniq
     end
   end
 end

--- a/app/services/taxes/update_service.rb
+++ b/app/services/taxes/update_service.rb
@@ -15,6 +15,7 @@ module Taxes
       return result.not_found_failure!(resource: "tax") unless tax
 
       customer_ids = tax.applicable_customers.select(:id).to_a
+      draft_invoice_ids = tax.draft_fee_taxes.distinct.pluck("fees.invoice_id")
 
       tax.name = params[:name] if params.key?(:name)
       tax.code = params[:code] if params.key?(:code)
@@ -26,8 +27,9 @@ module Taxes
       manage_taxes_on_billing_entity if params.key?(:applied_to_organization)
 
       customer_ids = (customer_ids + tax.reload.applicable_customers.select(:id)).uniq
-      draft_invoices = tax.organization.invoices.where(customer_id: customer_ids).draft
-      draft_invoices.update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
+      draft_invoice_ids |= tax.organization.invoices.where(customer_id: customer_ids).draft.pluck(:id)
+      tax.organization.invoices.where(id: draft_invoice_ids)
+        .update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
 
       result.tax = tax
       result

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -158,6 +158,29 @@ FactoryBot.define do
     end
   end
 
+  factory :product_fee, parent: :fee do
+    fee_type { "product" }
+    subscription do
+      association(
+        :subscription,
+        organization: invoice.organization,
+        customer: invoice.customer,
+        plan: association(:plan, organization: invoice.organization)
+      )
+    end
+    rate_card_rate do
+      association(
+        :rate_card_rate,
+        organization: invoice.organization,
+        rate_card: association(:rate_card, organization: invoice.organization)
+      )
+    end
+    invoiceable { rate_card_rate.rate_card.product }
+    billing_entity { invoice.billing_entity }
+    taxes_amount_cents { 0 }
+    taxes_precise_amount_cents { 0 }
+  end
+
   factory :credit_fee, parent: :fee do
     transient do
       wallet_transaction { association(:wallet_transaction, organization:) }

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe Fee do
   it { is_expected.to have_one(:true_up_fee).with_foreign_key(:true_up_parent_fee_id).class_name("Fee").dependent(:destroy) }
   it { is_expected.to belong_to(:original_fee).class_name("Fee").optional }
 
+  describe "validations" do
+    it "requires a Rate Card Rate for Product fees" do
+      fee = build(:fee, fee_type: :product, rate_card_rate: nil)
+
+      fee.validate
+
+      expect(fee.errors.of_kind?(:rate_card_rate, :blank)).to be(true)
+    end
+  end
+
   describe "#ordered_by_period" do
     let(:fee1) do
       create(:fee, properties: {

--- a/spec/services/fees/apply_taxes_service_spec.rb
+++ b/spec/services/fees/apply_taxes_service_spec.rb
@@ -327,6 +327,166 @@ RSpec.describe Fees::ApplyTaxesService do
       end
     end
 
+    context "when fee is a product type" do
+      let(:plan) { create(:plan, organization:) }
+      let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+      let(:product) { create(:product, organization:) }
+      let(:rate_card) { create(:rate_card, organization:, product:) }
+      let(:rate_card_rate) { create(:rate_card_rate, organization:, rate_card:) }
+      let(:rate_card_tax) { create(:tax, organization:, rate: 8) }
+      let(:fee) do
+        create(
+          :product_fee,
+          invoice:,
+          subscription:,
+          rate_card_rate:,
+          amount_cents: 1000,
+          precise_amount_cents: 1000.0
+        )
+      end
+
+      it "uses the rate card taxes before the other levels" do
+        create(:rate_card_applied_tax, rate_card:, tax: rate_card_tax, organization:)
+        create(:plan_applied_tax, plan:, tax: tax2)
+        create(:customer_applied_tax, customer:, tax: tax1)
+
+        result = apply_service.call
+
+        expect(result).to be_success
+        expect(result.applied_taxes).to contain_exactly(
+          have_attributes(
+            fee:,
+            tax: rate_card_tax,
+            tax_description: rate_card_tax.description,
+            tax_code: rate_card_tax.code,
+            tax_name: rate_card_tax.name,
+            tax_rate: 8,
+            amount_currency: fee.currency,
+            amount_cents: 80,
+            precise_amount_cents: 80.0
+          )
+        )
+        expect(fee).to have_attributes(taxes_amount_cents: 80, taxes_precise_amount_cents: 80.0, taxes_rate: 8)
+      end
+
+      it "falls back to the plan taxes" do
+        create(:plan_applied_tax, plan:, tax: tax2)
+        create(:customer_applied_tax, customer:, tax: tax1)
+
+        result = apply_service.call
+
+        expect(result).to be_success
+        expect(result.applied_taxes.map(&:tax_code)).to contain_exactly(tax2.code)
+      end
+
+      it "falls back to the customer taxes" do
+        create(:customer_applied_tax, customer:, tax: tax1)
+
+        result = apply_service.call
+
+        expect(result).to be_success
+        expect(result.applied_taxes.map(&:tax_code)).to contain_exactly(tax1.code)
+      end
+
+      it "falls back to the billing entity taxes" do
+        result = apply_service.call
+
+        expect(result).to be_success
+        expect(result.applied_taxes.map(&:tax_code)).to contain_exactly(tax3.code)
+      end
+
+      context "when the subscription uses another billing entity" do
+        let(:subscription_billing_entity) { create(:billing_entity, organization:) }
+        let(:subscription_tax) { create(:tax, organization:, rate: 20) }
+        let(:invoice) { create(:invoice, organization:, customer:, billing_entity: subscription_billing_entity) }
+        let(:subscription) do
+          create(:subscription, organization:, customer:, plan:, billing_entity: subscription_billing_entity)
+        end
+
+        before do
+          create(
+            :billing_entity_applied_tax,
+            billing_entity: subscription_billing_entity,
+            tax: subscription_tax
+          )
+        end
+
+        it "falls back to the subscription billing entity taxes" do
+          result = apply_service.call
+
+          expect(result).to be_success
+          expect(result.applied_taxes.map(&:tax_code)).to contain_exactly(subscription_tax.code)
+        end
+      end
+
+      it "applies no taxes when every level is empty" do
+        billing_entity.applied_taxes.destroy_all
+
+        result = apply_service.call
+
+        expect(result).to be_success
+        expect(result.applied_taxes).to be_empty
+        expect(fee).to have_attributes(taxes_amount_cents: 0, taxes_precise_amount_cents: 0, taxes_rate: 0)
+      end
+
+      it "uses every assigned rate card tax" do
+        create(:rate_card_applied_tax, rate_card:, tax: rate_card_tax, organization:)
+        create(:rate_card_applied_tax, rate_card:, tax: tax1, organization:)
+        create(:plan_applied_tax, plan:, tax: tax2)
+
+        result = apply_service.call
+
+        expect(result).to be_success
+        expect(result.applied_taxes.map(&:tax_code)).to contain_exactly(rate_card_tax.code, tax1.code)
+        expect(fee).to have_attributes(taxes_amount_cents: 180, taxes_precise_amount_cents: 180.0, taxes_rate: 18)
+      end
+
+      it "treats a zero-percent rate card tax as an override" do
+        zero_tax = create(:tax, organization:, rate: 0)
+        create(:rate_card_applied_tax, rate_card:, tax: zero_tax, organization:)
+        create(:plan_applied_tax, plan:, tax: tax2)
+
+        result = apply_service.call
+
+        expect(result).to be_success
+        expect(result.applied_taxes.map(&:tax_code)).to contain_exactly(zero_tax.code)
+        expect(fee).to have_attributes(taxes_amount_cents: 0, taxes_precise_amount_cents: 0.0, taxes_rate: 0)
+      end
+
+      it "uses the next configured level for a replacement fee after removing the rate card override" do
+        create(:rate_card_applied_tax, rate_card:, tax: rate_card_tax, organization:)
+        create(:plan_applied_tax, plan:, tax: tax2)
+
+        first_result = apply_service.call
+        RateCards::ApplyTaxesService.call!(rate_card:, tax_codes: [])
+
+        replacement_fee = create(:product_fee, invoice:, subscription:, rate_card_rate:, amount_cents: 1000)
+        replacement_result = described_class.call(fee: replacement_fee)
+
+        expect(first_result.applied_taxes.map(&:tax_code)).to contain_exactly(rate_card_tax.code)
+        expect(replacement_result.applied_taxes.map(&:tax_code)).to contain_exactly(tax2.code)
+      end
+
+      it "keeps the stored tax snapshot after the invoice is finalized" do
+        create(:rate_card_applied_tax, rate_card:, tax: rate_card_tax, organization:)
+        apply_service.call
+        invoice.update!(status: :finalized)
+
+        RateCards::ApplyTaxesService.call!(rate_card:, tax_codes: [])
+
+        expect(fee.reload.applied_taxes).to contain_exactly(
+          have_attributes(
+            tax_id: rate_card_tax.id,
+            tax_code: rate_card_tax.code,
+            tax_name: rate_card_tax.name,
+            tax_rate: 8,
+            amount_cents: 80,
+            precise_amount_cents: 80.0
+          )
+        )
+      end
+    end
+
     context "when fee is a fixed charge type with taxes" do
       let(:fixed_charge) { create(:fixed_charge, organization:) }
       let(:fee) { create(:fixed_charge_fee, invoice:, amount_cents: 1000, precise_amount_cents: 1000.0, fixed_charge:) }

--- a/spec/services/invoices/compute_amounts_from_fees_spec.rb
+++ b/spec/services/invoices/compute_amounts_from_fees_spec.rb
@@ -37,6 +37,34 @@ RSpec.describe Invoices::ComputeAmountsFromFees do
     expect(fee2.taxes_amount_cents).to eq(84) # (379 - 100) * (10 + 20) / 100
   end
 
+  context "when the invoice contains a product fee" do
+    let(:plan) { create(:plan, organization:) }
+    let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+    let(:rate_card) { create(:rate_card, organization:) }
+    let(:rate_card_rate) { create(:rate_card_rate, organization:, rate_card:) }
+    let(:fee1) do
+      create(
+        :product_fee,
+        invoice:,
+        subscription:,
+        rate_card_rate:,
+        amount_cents: 151,
+        precise_amount_cents: 151
+      )
+    end
+
+    before do
+      create(:rate_card_applied_tax, rate_card:, tax: tax1, organization:)
+    end
+
+    it "applies the rate card taxes through the invoice calculation entry point" do
+      compute_amounts.call
+
+      expect(fee1.reload.applied_taxes.map(&:tax_code)).to contain_exactly(tax1.code)
+      expect(fee1).to have_attributes(taxes_rate: 10, taxes_amount_cents: 15)
+    end
+  end
+
   it "sets fees_amount_cents from the list of fees" do
     expect { compute_amounts.call }.to change(invoice, :fees_amount_cents).from(0).to(530)
   end

--- a/spec/services/invoices/compute_amounts_from_fees_spec.rb
+++ b/spec/services/invoices/compute_amounts_from_fees_spec.rb
@@ -52,6 +52,17 @@ RSpec.describe Invoices::ComputeAmountsFromFees do
         precise_amount_cents: 151
       )
     end
+    let(:fee2) do
+      create(
+        :product_fee,
+        invoice:,
+        subscription:,
+        rate_card_rate:,
+        amount_cents: 379,
+        precise_amount_cents: 379,
+        precise_coupons_amount_cents: 100
+      )
+    end
 
     before do
       create(:rate_card_applied_tax, rate_card:, tax: tax1, organization:)
@@ -62,6 +73,92 @@ RSpec.describe Invoices::ComputeAmountsFromFees do
 
       expect(fee1.reload.applied_taxes.map(&:tax_code)).to contain_exactly(tax1.code)
       expect(fee1).to have_attributes(taxes_rate: 10, taxes_amount_cents: 15)
+      expect(invoice.applied_taxes.sole).to have_attributes(
+        tax: tax1,
+        tax_code: tax1.code,
+        tax_rate: 10,
+        amount_cents: 43,
+        fees_amount_cents: 430
+      )
+      expect(invoice).to have_attributes(
+        taxes_rate: 10,
+        taxes_amount_cents: 43,
+        sub_total_including_taxes_amount_cents: 473,
+        total_amount_cents: 473
+      )
+    end
+
+    context "with different taxes that have the same rate" do
+      let(:same_rate_tax) { create(:tax, organization:, rate: tax1.rate, code: "same-rate-tax") }
+
+      before do
+        create(:rate_card_applied_tax, rate_card:, tax: same_rate_tax, organization:)
+      end
+
+      it "keeps separate invoice tax groups" do
+        compute_amounts.call
+
+        expect(invoice.applied_taxes.order(:tax_code).pluck(:tax_code, :tax_rate, :amount_cents)).to eq(
+          [
+            [same_rate_tax.code, 10, 43],
+            [tax1.code, 10, 43]
+          ]
+        )
+      end
+    end
+
+    context "with a zero-rate tax" do
+      let(:zero_rate_tax) { create(:tax, organization:, rate: 0, code: "zero-rate-tax") }
+
+      before do
+        create(:rate_card_applied_tax, rate_card:, tax: zero_rate_tax, organization:)
+      end
+
+      it "keeps the zero-rate tax on the invoice" do
+        compute_amounts.call
+
+        expect(invoice.applied_taxes.find_by!(tax: zero_rate_tax)).to have_attributes(
+          tax_code: zero_rate_tax.code,
+          tax_rate: 0,
+          amount_cents: 0,
+          fees_amount_cents: 430
+        )
+      end
+    end
+
+    context "when fee tax amounts require rounding" do
+      let(:fee1) do
+        create(
+          :product_fee,
+          invoice:,
+          subscription:,
+          rate_card_rate:,
+          amount_cents: 55,
+          precise_amount_cents: 55
+        )
+      end
+      let(:fee2) do
+        create(
+          :product_fee,
+          invoice:,
+          subscription:,
+          rate_card_rate:,
+          amount_cents: 55,
+          precise_amount_cents: 55
+        )
+      end
+
+      before do
+        invoice.credits.destroy_all
+      end
+
+      it "rounds the combined invoice tax amount" do
+        compute_amounts.call
+
+        expect(invoice.fees.sum(&:taxes_amount_cents)).to eq(12)
+        expect(invoice.applied_taxes.sole.amount_cents).to eq(11)
+        expect(invoice.taxes_amount_cents).to eq(11)
+      end
     end
   end
 
@@ -186,6 +283,42 @@ RSpec.describe Invoices::ComputeAmountsFromFees do
       expect(invoice.sub_total_including_taxes_amount_cents).to eq(272)
       expect(invoice.taxes_rate).to eq(80)
       expect(invoice.total_amount_cents).to eq(272)
+    end
+
+    context "when the invoice contains a product fee" do
+      let(:plan) { create(:plan, organization:) }
+      let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+      let(:rate_card) { create(:rate_card, organization:) }
+      let(:rate_card_rate) { create(:rate_card_rate, organization:, rate_card:) }
+      let(:fee1) do
+        create(
+          :product_fee,
+          invoice:,
+          subscription:,
+          rate_card_rate:,
+          amount_cents: 151,
+          precise_amount_cents: 151
+        )
+      end
+
+      it "preserves provider tax metadata on the invoice" do
+        described_class.new(invoice:, provider_taxes: [fee_taxes]).call
+
+        expect(invoice.applied_taxes.order(:tax_code).pluck(
+          :tax_description,
+          :tax_code,
+          :tax_name,
+          :tax_rate,
+          :amount_cents,
+          :taxable_base_amount_cents
+        )).to eq(
+          [
+            ["type1", "tax_1", "tax 1", 50, 76, 151],
+            ["type2", "tax_2", "tax 2", 30, 45, 151]
+          ]
+        )
+        expect(invoice).to have_attributes(taxes_amount_cents: 121, taxes_rate: 80)
+      end
     end
 
     context "when provider taxes are not provided" do

--- a/spec/services/rate_cards/apply_taxes_service_spec.rb
+++ b/spec/services/rate_cards/apply_taxes_service_spec.rb
@@ -28,6 +28,56 @@ RSpec.describe RateCards::ApplyTaxesService do
     expect(rate_card).to have_received(:with_lock)
   end
 
+  context "when the rate card is used by an invoice fee" do
+    let(:customer) { create(:customer, organization:) }
+    let(:plan) { create(:plan, organization:) }
+    let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+    let(:invoice) { create(:invoice, organization:, customer:, status: invoice_status) }
+    let(:invoice_status) { :draft }
+    let(:rate_card_rate) { create(:rate_card_rate, organization:, rate_card:) }
+
+    before do
+      create(:product_fee, invoice:, subscription:, rate_card_rate:)
+    end
+
+    it "marks a draft invoice for refresh and updates its timestamp when the assignments change" do
+      invoice.update!(updated_at: 1.day.ago)
+      previous_updated_at = invoice.updated_at
+
+      result
+
+      expect(invoice.reload.ready_to_be_refreshed).to be(true)
+      expect(invoice.updated_at).to be > previous_updated_at
+    end
+
+    it "does not mark a draft invoice when the assignments do not change" do
+      create(:rate_card_applied_tax, rate_card:, tax: tax1, organization:)
+      create(:rate_card_applied_tax, rate_card:, tax: tax2, organization:)
+
+      expect { result }.not_to change { invoice.reload.ready_to_be_refreshed }
+    end
+
+    context "when every assignment is removed" do
+      let(:tax_codes) { [] }
+
+      before do
+        create(:rate_card_applied_tax, rate_card:, tax: tax1, organization:)
+      end
+
+      it "marks a draft invoice for refresh" do
+        expect { result }.to change { invoice.reload.ready_to_be_refreshed }.from(false).to(true)
+      end
+    end
+
+    context "when the invoice is finalized" do
+      let(:invoice_status) { :finalized }
+
+      it "does not mark the invoice for refresh" do
+        expect { result }.not_to change { invoice.reload.ready_to_be_refreshed }
+      end
+    end
+  end
+
   context "when tax codes contain duplicates" do
     let(:tax_codes) { [tax1.code, tax1.code] }
 

--- a/spec/services/taxes/destroy_service_spec.rb
+++ b/spec/services/taxes/destroy_service_spec.rb
@@ -23,6 +23,23 @@ RSpec.describe Taxes::DestroyService do
       expect { destroy_service.call }.to change { draft_invoice.reload.ready_to_be_refreshed }.to(true)
     end
 
+    context "when the tax is applied only to a Rate Card" do
+      let(:tax) { create(:tax, organization:) }
+      let(:rate_card) { create(:rate_card, organization:) }
+      let(:rate_card_rate) { create(:rate_card_rate, organization:, rate_card:) }
+      let(:draft_invoice) { create(:invoice, :draft, organization:, customer:) }
+
+      before do
+        create(:rate_card_applied_tax, rate_card:, tax:, organization:)
+        fee = create(:product_fee, invoice: draft_invoice, rate_card_rate:)
+        create(:fee_applied_tax, fee:, tax:)
+      end
+
+      it "marks the draft invoice as ready to be refreshed" do
+        expect { destroy_service.call }.to change { draft_invoice.reload.ready_to_be_refreshed }.to(true)
+      end
+    end
+
     it "does not remove the other tax from the default billing entity" do
       expect { destroy_service.call }.to change { billing_entity.applied_taxes.count }.by(-1)
     end

--- a/spec/services/taxes/update_service_spec.rb
+++ b/spec/services/taxes/update_service_spec.rb
@@ -113,6 +113,23 @@ RSpec.describe Taxes::UpdateService do
       expect { update_service.call }.to change { draft_invoice.reload.ready_to_be_refreshed }.to(true)
     end
 
+    context "when the tax is applied only to a Rate Card" do
+      let(:tax) { create(:tax, organization:) }
+      let(:rate_card) { create(:rate_card, organization:) }
+      let(:rate_card_rate) { create(:rate_card_rate, organization:, rate_card:) }
+      let(:draft_invoice) { create(:invoice, :draft, organization:, customer:) }
+
+      before do
+        create(:rate_card_applied_tax, rate_card:, tax:, organization:)
+        fee = create(:product_fee, invoice: draft_invoice, rate_card_rate:)
+        create(:fee_applied_tax, fee:, tax:)
+      end
+
+      it "marks the draft invoice as ready to be refreshed" do
+        expect { update_service.call }.to change { draft_invoice.reload.ready_to_be_refreshed }.to(true)
+      end
+    end
+
     context "when tax is not found" do
       let(:tax) { nil }
 


### PR DESCRIPTION
## Context

_Part of the "products and plans" project._

Product fees did not resolve taxes from rate cards.

## Description

- Resolve taxes using Rate Card -> Plan -> Customer -> Billing Entity.
- Use the fee's billing entity for Product fees.
- Mark affected draft invoices for refresh when rate rard taxes change.
- Keep taxes on finalized invoice unchanged.