### PR TITLE
perf(events): produce raw events without a key

### DIFF
--- a/app/services/events/kafka_producer_service.rb
+++ b/app/services/events/kafka_producer_service.rb
@@ -29,7 +29,6 @@ module Events
     def build_message(event)
       {
         topic: ENV["LAGO_KAFKA_RAW_EVENTS_TOPIC"],
-        key: "#{organization.id}-#{event.external_subscription_id}",
         payload: build_payload(event).to_json
       }
     end

--- a/app/services/events/stores/clickhouse/re_enrich_subscription_events_service.rb
+++ b/app/services/events/stores/clickhouse/re_enrich_subscription_events_service.rb
@@ -66,7 +66,6 @@ module Events
         def build_message(event)
           {
             topic:,
-            key: "#{event.organization_id}-#{event.external_subscription_id}",
             payload: build_payload(event).to_json
           }
         end

--- a/spec/services/events/create_batch_service_spec.rb
+++ b/spec/services/events/create_batch_service_spec.rb
@@ -339,7 +339,7 @@ RSpec.describe Events::CreateBatchService do
               expected_params = events_params[:events][index]
 
               expect(message[:topic]).to eq("raw_events")
-              expect(message[:key]).to eq("#{organization.id}-#{external_subscription_id}")
+              expect(message).not_to have_key(:key)
 
               payload = JSON.parse(message[:payload])
               expect(payload["organization_id"]).to eq(organization.id)

--- a/spec/services/events/kafka_producer_service_spec.rb
+++ b/spec/services/events/kafka_producer_service_spec.rb
@@ -21,9 +21,10 @@ RSpec.describe Events::KafkaProducerService, :capture_kafka_messages do
             expect(messages.size).to eq(2)
 
             events.each_with_index do |event, index|
+              expect(messages[index]).not_to have_key(:key)
+
               expect(messages[index]).to eq(
                 topic: "raw_events",
-                key: "#{organization.id}-#{event.external_subscription_id}",
                 payload: {
                   organization_id: organization.id,
                   external_customer_id: event.external_customer_id,

--- a/spec/services/events/stores/clickhouse/re_enrich_subscription_events_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/re_enrich_subscription_events_service_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Events::Stores::Clickhouse::ReEnrichSubscriptionEventsService, :c
 
         message = messages.first
         expect(message[:topic]).to eq("test-topic")
-        expect(message[:key]).to eq("#{organization.id}-#{subscription.external_id}")
+        expect(message).not_to have_key(:key)
 
         payload = JSON.parse(message[:payload])
         expect(payload).to include(
@@ -253,7 +253,7 @@ RSpec.describe Events::Stores::Clickhouse::ReEnrichSubscriptionEventsService, :c
 
           message = messages.first
           expect(message[:topic]).to eq("test-topic")
-          expect(message[:key]).to eq("#{organization.id}-#{subscription.external_id}")
+          expect(message).not_to have_key(:key)
 
           payload = JSON.parse(message[:payload])
           expect(payload).to include(


### PR DESCRIPTION
## Context

Raw events are produced to Kafka with a `organization_id-external_subscription_id` message key. That key pins every event of a subscription to a single partition, so the ingestion throughput of a high-volume subscription is bounded by one partition and one consumer slot while the other partitions stay idle. Adding partitions does not fix the skew, it only reshuffles the hash — and any partition count change breaks the ordering the key was supposedly buying anyway.

Nothing downstream relies on the key or on per-subscription ordering:

- `events-processor` handles all records of a fetched batch concurrently (one goroutine per record), so same-subscription ordering is already not preserved today.
- Its own output producers (enriched, enriched expanded, charged in advance) already key on `organization_id-transaction_id`, unique per event, so subscription affinity already ends at the first stage.
- The ClickHouse `events_raw_queue` table is `Kafka()` + `JSONEachRow` and the materialized view reads payload columns only, no `_key` virtual column.
- The RisingWave `events_raw` source is declared `FORMAT PLAIN ENCODE JSON` without `INCLUDE key`, and deduplicates on its primary key, which is order-independent.
- `findMaxCommitableRecord` builds its map keys as `key-offset`, and the offset is already unique within a partition, so an empty key is harmless.
- The topic is retention-based, not compacted, so a null key has no effect on compaction.

## Description

Produce raw events without a message key, from both the ingestion path (`Events::KafkaProducerService`) and the re-enrichment path (`Events::Stores::Clickhouse::ReEnrichSubscriptionEventsService`, which produces to the same topic). Keyless messages are spread over every partition by librdkafka's default `consistent_random` partitioner, so ingestion scales with the partition count instead of with the throughput of the hottest subscription's partition.

Batching is not affected: librdkafka groups keyless messages through `sticky.partitioning.linger.ms` (default: twice `linger.ms`), which keeps batches full while still rotating across partitions.

The only thing given up is the option of a future stage that needs per-subscription co-location. Events are immutable and every deduplication in the pipeline is key-based rather than order-based, so such a stage would need to re-key explicitly regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
