### PR TITLE
feat(streaming): Kinesis streaming destinations (POC)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,6 +105,9 @@ gem "google-cloud-storage", require: false
 # stdlib json, so multi_json is no longer pulled in transitively and must be pinned.
 gem "multi_json", require: false
 
+# Streaming
+gem "aws-sdk-kinesis", require: false
+
 # Templating
 gem "slim"
 gem "slim-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
     awesome_print (1.9.2)
     aws-eventstream (1.4.0)
     aws-partitions (1.1208.0)
-    aws-sdk-core (3.241.4)
+    aws-sdk-core (3.254.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -130,6 +130,9 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
+    aws-sdk-kinesis (1.104.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
     aws-sdk-kms (1.121.0)
       aws-sdk-core (~> 3, >= 3.241.4)
       aws-sigv4 (~> 1.5)
@@ -1079,6 +1082,7 @@ DEPENDENCIES
   analytics-ruby
   annotaterb
   awesome_print
+  aws-sdk-kinesis
   aws-sdk-s3
   bcrypt
   bigdecimal

--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -98,11 +98,16 @@ class SendWebhookJob < ApplicationJob
   UNDEFINED = Object.new.freeze
   private_constant :UNDEFINED
 
-  # Override the default perform_later to avoid creating webhooks if no webhook endpoints are present.
+  # Override the default perform_later to avoid creating webhooks if the organization
+  # has nowhere to deliver them.
   #
   # This will prevent enqueueing jobs only to return early from the jobs.
+  #
+  # NOTE: shares Organization#webhook_destinations? with Webhooks::BaseService#call
+  #       on purpose. If the two guards drift, one of the transports goes silent
+  #       with no error raised anywhere.
   def self.perform_later(webhook_type, object, options = UNDEFINED, webhook_id = UNDEFINED)
-    return if (webhook_id.nil? || webhook_id == UNDEFINED) && object.organization.webhook_endpoints.none?
+    return if (webhook_id.nil? || webhook_id == UNDEFINED) && !object.organization.webhook_destinations?
 
     args = [webhook_type, object, options, webhook_id].filter { |arg| arg != UNDEFINED }
     super(*args)

--- a/app/jobs/streaming_destinations/deliver_job.rb
+++ b/app/jobs/streaming_destinations/deliver_job.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module StreamingDestinations
+  class DeliverJob < ApplicationJob
+    # TODO: Move to a dedicated :streaming queue so a backed-up stream cannot
+    #       starve HTTP webhook delivery. That needs a new process config under
+    #       config/sidekiq/ plus a deployment change in lago-infrastructure,
+    #       both out of scope for this POC.
+    queue_as :webhook
+
+    # Kinesis throttles per shard. Named as a string because aws-sdk-kinesis is
+    # `require: false`, so the constant is not loaded when this class is.
+    retry_on "Aws::Kinesis::Errors::ProvisionedThroughputExceededException", wait: :polynomially_longer
+
+    # Stays provider-blind: the destination names its own delivery service. The
+    # result is deliberately not raised on, so a permanently undeliverable record
+    # (see the size cap in the Kinesis service) does not start a retry storm.
+    # Transport errors reach us as exceptions and are retried above.
+    def perform(destination:, payload:, partition_key:)
+      destination.deliver_service_class.call(destination:, payload:, partition_key:)
+    end
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -75,6 +75,7 @@ class Organization < ApplicationRecord
   has_many :wallet_transactions
   has_many :webhook_endpoints
   has_many :webhooks
+  has_many :streaming_destinations, class_name: "StreamingDestinations::BaseDestination", dependent: :destroy
   has_many :cached_aggregations
   has_many :data_exports
   has_many :error_details
@@ -203,6 +204,14 @@ class Organization < ApplicationRecord
     define_method("#{premium_integration}_enabled?") do
       License.premium? && premium_integrations.include?(premium_integration)
     end
+  end
+
+  # Single source of truth for "is there anywhere for a webhook payload to go?".
+  # Webhooks::BaseService#call and SendWebhookJob.perform_later both guard on
+  # this. They must not drift: a guard that only counts webhook_endpoints makes
+  # streaming destinations fail silently, with no error anywhere.
+  def webhook_destinations?
+    webhook_endpoints.any? || streaming_destinations.any?
   end
 
   # Product catalog (billing v2) is a rollout feature flag, not a license-gated

--- a/app/models/streaming_destinations/base_destination.rb
+++ b/app/models/streaming_destinations/base_destination.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module StreamingDestinations
+  # NOTE: Abstract STI parent, should not be instantiated directly
+  class BaseDestination < ApplicationRecord
+    include PaperTrailTraceable
+    include SecretsStorable
+    include SettingsStorable
+    include Discard::Model
+
+    self.discard_column = :deleted_at
+    default_scope -> { kept }
+
+    self.table_name = "streaming_destinations"
+
+    belongs_to :organization
+
+    validates :code, uniqueness: {conditions: -> { kept }, scope: :organization_id}
+    validates :name, presence: true
+
+    # A nil event_types subscribes the destination to every event type, matching
+    # WebhookEndpoint's behaviour.
+    def subscribed?(event_type)
+      return true if event_types.nil?
+
+      event_types.include?(event_type)
+    end
+
+    def deliver_service_class
+      raise NotImplementedError
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: streaming_destinations
+# Database name: primary
+#
+#  id              :uuid             not null, primary key
+#  code            :string           not null
+#  deleted_at      :datetime
+#  event_types     :string           is an Array
+#  name            :string           not null
+#  secrets         :string
+#  settings        :jsonb            not null
+#  type            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_streaming_destinations_on_deleted_at                (deleted_at)
+#  index_streaming_destinations_on_organization_id           (organization_id)
+#  index_unique_streaming_destinations_on_organization_code  (organization_id,code) UNIQUE WHERE (deleted_at IS NULL)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/models/streaming_destinations/kinesis_destination.rb
+++ b/app/models/streaming_destinations/kinesis_destination.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module StreamingDestinations
+  class KinesisDestination < BaseDestination
+    # external_id lives in settings rather than secrets on purpose: AWS treats it
+    # as a confused-deputy guard on the AssumeRole call, not as a credential.
+    settings_accessors :stream_arn, :region, :role_arn, :external_id
+
+    validates :stream_arn, presence: true
+    validates :region, presence: true
+    validates :role_arn, presence: true
+
+    def deliver_service_class
+      StreamingDestinations::Kinesis::DeliverService
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: streaming_destinations
+# Database name: primary
+#
+#  id              :uuid             not null, primary key
+#  code            :string           not null
+#  deleted_at      :datetime
+#  event_types     :string           is an Array
+#  name            :string           not null
+#  secrets         :string
+#  settings        :jsonb            not null
+#  type            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_streaming_destinations_on_deleted_at                (deleted_at)
+#  index_streaming_destinations_on_organization_id           (organization_id)
+#  index_unique_streaming_destinations_on_organization_code  (organization_id,code) UNIQUE WHERE (deleted_at IS NULL)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/services/streaming_destinations/kinesis/deliver_service.rb
+++ b/app/services/streaming_destinations/kinesis/deliver_service.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "aws-sdk-kinesis"
+
+module StreamingDestinations
+  module Kinesis
+    class DeliverService < BaseService
+      # Kinesis hard-rejects a record whose data blob exceeds 1 MiB.
+      MAX_RECORD_SIZE = 1.megabyte
+
+      # One STS AssumeRole per destination rather than per record. A fresh
+      # Aws::AssumeRoleCredentials for every job would mean one STS call per
+      # record, which hits STS throttling long before Kinesis notices any load.
+      # The credentials object refreshes itself before expiry, so caching it is
+      # safe; memoizing inside a service instance would not help, as each job
+      # builds a new one.
+      #
+      # Keyed on the settings that shape the AssumeRole call, not on the id
+      # alone, so editing a destination's role stops serving the old identity.
+      CREDENTIALS = Concurrent::Map.new
+
+      class << self
+        def credentials_for(destination)
+          key = [
+            destination.id,
+            destination.role_arn,
+            destination.external_id,
+            destination.region
+          ].join("|")
+
+          CREDENTIALS.compute_if_absent(key) { build_credentials(destination) }
+        end
+
+        private
+
+        def build_credentials(destination)
+          params = {
+            role_arn: destination.role_arn,
+            # AWS caps this at 64 characters: 15 + a 36 character uuid fits.
+            role_session_name: "lago-streaming-#{destination.id}",
+            client: ::Aws::STS::Client.new(region: destination.region)
+          }
+          # Absent unless the customer asked for one; AWS rejects a nil.
+          params[:external_id] = destination.external_id if destination.external_id.present?
+
+          ::Aws::AssumeRoleCredentials.new(**params)
+        end
+      end
+
+      def initialize(destination:, payload:, partition_key:)
+        @destination = destination
+        @payload = payload
+        @partition_key = partition_key
+
+        super
+      end
+
+      def call
+        data = payload.to_json
+        return oversized_record_failure(data.bytesize) if data.bytesize > MAX_RECORD_SIZE
+
+        client.put_record(
+          stream_arn: destination.stream_arn,
+          partition_key: partition_key.to_s,
+          data:
+        )
+
+        result
+      end
+
+      private
+
+      attr_reader :destination, :payload, :partition_key
+
+      def client
+        ::Aws::Kinesis::Client.new(
+          region: destination.region,
+          credentials: self.class.credentials_for(destination)
+        )
+      end
+
+      # Kinesis rejects the record outright, so retrying cannot help and raising
+      # would only burn the queue. Report it and fail the result instead.
+      def oversized_record_failure(size)
+        message = "Kinesis record of #{size} bytes exceeds the #{MAX_RECORD_SIZE} byte limit"
+
+        Sentry.capture_message(
+          message,
+          level: :error,
+          extra: {
+            streaming_destination_id: destination.id,
+            webhook_type: payload[:webhook_type],
+            size:
+          }
+        )
+
+        result.service_failure!(code: "record_too_large", message:)
+      end
+    end
+  end
+end

--- a/app/services/webhooks/base_service.rb
+++ b/app/services/webhooks/base_service.rb
@@ -11,7 +11,7 @@ module Webhooks
     end
 
     def call
-      return if current_organization.webhook_endpoints.none?
+      return unless current_organization.webhook_destinations?
 
       payload = {
         :webhook_type => webhook_type,
@@ -32,11 +32,41 @@ module Webhooks
         Rails.logger.error("SendWebhookJob failed for deleted webhook endpoint #{webhook_endpoint.id}")
         next
       end
+
+      deliver_to_streaming_destinations(payload)
     end
 
     private
 
     attr_reader :object, :options
+
+    # A second delivery transport hanging off the same fan-out point as the HTTP
+    # webhooks above, deliberately reusing the payload built for them: one
+    # serialization of an entity change, not one per transport.
+    def deliver_to_streaming_destinations(payload)
+      # Stamped once, so every destination sees the same emission instant. This
+      # is the field consumers must use for last-write-wins: concurrent Sidekiq
+      # workers can PutRecord two updates to the same object out of order, and
+      # Kinesis preserves receive order rather than commit order.
+      streaming_payload = payload.merge(emitted_at: Time.current.iso8601(3))
+
+      current_organization.streaming_destinations.each do |streaming_destination|
+        next unless streaming_destination.subscribed?(webhook_type)
+
+        StreamingDestinations::DeliverJob.perform_later(
+          destination: streaming_destination,
+          payload: streaming_payload,
+          partition_key: partition_key.to_s
+        )
+      end
+    end
+
+    # Groups related records onto one shard. It does NOT order them, see the
+    # emitted_at note above. Overridden by the handful of services whose stream
+    # consumers need per-customer grouping.
+    def partition_key
+      current_organization.id
+    end
 
     def subscribed?(webhook_endpoint)
       return true if webhook_endpoint.event_types.nil?

--- a/app/services/webhooks/customers/updated_service.rb
+++ b/app/services/webhooks/customers/updated_service.rb
@@ -20,6 +20,12 @@ module Webhooks
       def object_type
         "customer"
       end
+
+      # Groups every change to one customer onto a single Kinesis shard, so a
+      # consumer can process that customer's records on one worker.
+      def partition_key
+        object.external_id
+      end
     end
   end
 end

--- a/app/services/webhooks/subscriptions/updated_service.rb
+++ b/app/services/webhooks/subscriptions/updated_service.rb
@@ -20,6 +20,12 @@ module Webhooks
       def object_type
         "subscription"
       end
+
+      # Groups every change to one customer onto a single Kinesis shard, so a
+      # consumer can process that customer's records on one worker.
+      def partition_key
+        object.customer.external_id
+      end
     end
   end
 end

--- a/app/services/webhooks/wallets/updated_service.rb
+++ b/app/services/webhooks/wallets/updated_service.rb
@@ -16,6 +16,12 @@ module Webhooks
       def object_type
         "wallet"
       end
+
+      # Groups every change to one customer onto a single Kinesis shard, so a
+      # consumer can process that customer's records on one worker.
+      def partition_key
+        object.customer.external_id
+      end
     end
   end
 end

--- a/db/migrate/20260831120000_create_streaming_destinations.rb
+++ b/db/migrate/20260831120000_create_streaming_destinations.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class CreateStreamingDestinations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :streaming_destinations, id: :uuid do |t|
+      t.references :organization, null: false, foreign_key: true, type: :uuid
+
+      t.string :type, null: false
+      t.string :code, null: false
+      t.string :name, null: false
+
+      # null subscribes the destination to every webhook event type.
+      t.string :event_types, array: true
+
+      t.jsonb :settings, null: false, default: {}
+      t.string :secrets
+
+      t.datetime :deleted_at
+
+      t.timestamps
+
+      # Partial, so a discarded destination frees its code for reuse. It cannot
+      # stand in for the organization_id index above, which stays for lookups
+      # that must also see discarded rows.
+      t.index [:organization_id, :code],
+        unique: true,
+        where: "deleted_at IS NULL",
+        name: "index_unique_streaming_destinations_on_organization_code"
+      t.index :deleted_at
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -61,6 +61,7 @@ ALTER TABLE IF EXISTS ONLY public.enriched_store_subscription_migrations DROP CO
 ALTER TABLE IF EXISTS ONLY public.customers_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_db9140d0fd;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_d9ffb8b4a1;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alerts DROP CONSTRAINT IF EXISTS fk_rails_d9ea200904;
+ALTER TABLE IF EXISTS ONLY public.streaming_destinations DROP CONSTRAINT IF EXISTS fk_rails_d94733afa1;
 ALTER TABLE IF EXISTS ONLY public.integration_resources DROP CONSTRAINT IF EXISTS fk_rails_d9448a540b;
 ALTER TABLE IF EXISTS ONLY public.wallets DROP CONSTRAINT IF EXISTS fk_rails_d9342a8ca7;
 ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP CONSTRAINT IF EXISTS fk_rails_d72a9877be;
@@ -422,6 +423,7 @@ DROP INDEX IF EXISTS public.index_usage_monitoring_alerts_on_billable_metric_id;
 DROP INDEX IF EXISTS public.index_usage_monitoring_alert_thresholds_on_organization_id;
 DROP INDEX IF EXISTS public.index_unique_transaction_id;
 DROP INDEX IF EXISTS public.index_unique_terminating_invoice_subscription;
+DROP INDEX IF EXISTS public.index_unique_streaming_destinations_on_organization_code;
 DROP INDEX IF EXISTS public.index_unique_starting_invoice_subscription;
 DROP INDEX IF EXISTS public.index_unique_quotes_on_organization_sequential_id;
 DROP INDEX IF EXISTS public.index_unique_quotes_on_organization_number;
@@ -462,6 +464,8 @@ DROP INDEX IF EXISTS public.index_subscription_rate_cards_on_deleted_at;
 DROP INDEX IF EXISTS public.index_subscription_fixed_charge_units_overrides_on_deleted_at;
 DROP INDEX IF EXISTS public.index_subscription_activation_rules_on_organization_id;
 DROP INDEX IF EXISTS public.index_sub_fc_units_overrides_on_sub_id_and_fc_id;
+DROP INDEX IF EXISTS public.index_streaming_destinations_on_organization_id;
+DROP INDEX IF EXISTS public.index_streaming_destinations_on_deleted_at;
 DROP INDEX IF EXISTS public.index_search_quantified_events;
 DROP INDEX IF EXISTS public.index_rtr_invoice_custom_sections_unique;
 DROP INDEX IF EXISTS public.index_roles_on_organization_id;
@@ -1019,6 +1023,7 @@ ALTER TABLE IF EXISTS ONLY public.subscriptions_invoice_custom_sections DROP CON
 ALTER TABLE IF EXISTS ONLY public.subscription_rate_cards DROP CONSTRAINT IF EXISTS subscription_rate_cards_pkey;
 ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP CONSTRAINT IF EXISTS subscription_fixed_charge_units_overrides_pkey;
 ALTER TABLE IF EXISTS ONLY public.subscription_activation_rules DROP CONSTRAINT IF EXISTS subscription_activation_rules_pkey;
+ALTER TABLE IF EXISTS ONLY public.streaming_destinations DROP CONSTRAINT IF EXISTS streaming_destinations_pkey;
 ALTER TABLE IF EXISTS ONLY public.schema_migrations DROP CONSTRAINT IF EXISTS schema_migrations_pkey;
 ALTER TABLE IF EXISTS ONLY public.roles DROP CONSTRAINT IF EXISTS roles_pkey;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS refunds_pkey;
@@ -1152,6 +1157,7 @@ DROP TABLE IF EXISTS public.subscriptions_invoice_custom_sections;
 DROP TABLE IF EXISTS public.subscription_rate_cards;
 DROP TABLE IF EXISTS public.subscription_fixed_charge_units_overrides;
 DROP TABLE IF EXISTS public.subscription_activation_rules;
+DROP TABLE IF EXISTS public.streaming_destinations;
 DROP TABLE IF EXISTS public.schema_migrations;
 DROP TABLE IF EXISTS public.roles;
 DROP TABLE IF EXISTS public.refunds;
@@ -5622,6 +5628,25 @@ CREATE TABLE public.schema_migrations (
 
 
 --
+-- Name: streaming_destinations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.streaming_destinations (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    type character varying NOT NULL,
+    code character varying NOT NULL,
+    name character varying NOT NULL,
+    event_types character varying[],
+    settings jsonb DEFAULT '{}'::jsonb NOT NULL,
+    secrets character varying,
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: subscription_activation_rules; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6834,6 +6859,14 @@ ALTER TABLE ONLY public.roles
 
 ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: streaming_destinations streaming_destinations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.streaming_destinations
+    ADD CONSTRAINT streaming_destinations_pkey PRIMARY KEY (id);
 
 
 --
@@ -10790,6 +10823,20 @@ CREATE INDEX index_search_quantified_events ON public.quantified_events USING bt
 
 
 --
+-- Name: index_streaming_destinations_on_deleted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_streaming_destinations_on_deleted_at ON public.streaming_destinations USING btree (deleted_at);
+
+
+--
+-- Name: index_streaming_destinations_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_streaming_destinations_on_organization_id ON public.streaming_destinations USING btree (organization_id);
+
+
+--
 -- Name: index_sub_fc_units_overrides_on_sub_id_and_fc_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -11067,6 +11114,13 @@ CREATE UNIQUE INDEX index_unique_quotes_on_organization_sequential_id ON public.
 --
 
 CREATE UNIQUE INDEX index_unique_starting_invoice_subscription ON public.invoice_subscriptions USING btree (subscription_id, invoicing_reason) WHERE ((invoicing_reason = 'subscription_starting'::public.subscription_invoicing_reason) AND (regenerated_invoice_id IS NULL));
+
+
+--
+-- Name: index_unique_streaming_destinations_on_organization_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_streaming_destinations_on_organization_code ON public.streaming_destinations USING btree (organization_id, code) WHERE (deleted_at IS NULL);
 
 
 --
@@ -13793,6 +13847,14 @@ ALTER TABLE ONLY public.integration_resources
 
 
 --
+-- Name: streaming_destinations fk_rails_d94733afa1; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.streaming_destinations
+    ADD CONSTRAINT fk_rails_d94733afa1 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: usage_monitoring_alerts fk_rails_d9ea200904; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -14215,6 +14277,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260831120000'),
 ('20260819111435'),
 ('20260819111434'),
 ('20260819000710'),

--- a/lib/tasks/streaming_destinations.rake
+++ b/lib/tasks/streaming_destinations.rake
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+namespace :streaming_destinations do
+  # Stands in for the CRUD API during the POC: streaming destinations are seeded
+  # by an operator, not managed by the customer.
+  #
+  # Every value can come from a task argument or the matching ENV variable, the
+  # argument winning. Idempotent on (organization_id, code), so re-running with
+  # new settings updates the existing destination in place.
+  #
+  #   bundle exec rake "streaming_destinations:upsert_kinesis[<org_id>,<code>]" \
+  #     STREAM_ARN=arn:aws:kinesis:eu-west-1:111122223333:stream/lago \
+  #     REGION=eu-west-1 \
+  #     ROLE_ARN=arn:aws:iam::111122223333:role/LagoStreamingWriter \
+  #     EXTERNAL_ID=some-shared-secret \
+  #     EVENT_TYPES=subscription.updated,wallet.updated
+  #
+  # EVENT_TYPES is optional; omit it to subscribe the destination to every event
+  # type. Pass EVENT_TYPES="*" to reset an existing destination back to all.
+  desc "Create or update a Kinesis streaming destination for an organization"
+  task :upsert_kinesis, [:organization_id, :code] => :environment do |_task, args|
+    organization_id = args[:organization_id].presence || ENV["ORGANIZATION_ID"].presence
+    code = args[:code].presence || ENV["CODE"].presence || "kinesis"
+
+    raise "organization_id is required" if organization_id.nil?
+
+    organization = Organization.find(organization_id)
+
+    stream_arn = ENV["STREAM_ARN"].presence
+    region = ENV["REGION"].presence
+    role_arn = ENV["ROLE_ARN"].presence
+    external_id = ENV["EXTERNAL_ID"].presence
+
+    event_types =
+      if ENV["EVENT_TYPES"].blank?
+        nil
+      elsif ENV["EVENT_TYPES"] == "*"
+        :all
+      else
+        ENV["EVENT_TYPES"].split(",").map(&:strip).reject(&:blank?)
+      end
+
+    destination = StreamingDestinations::KinesisDestination.find_or_initialize_by(
+      organization: organization,
+      code: code
+    )
+    created = destination.new_record?
+
+    destination.name = ENV["NAME"].presence || destination.name || "Kinesis (#{code})"
+
+    # Only overwrite what was actually supplied, so a partial re-run does not
+    # blank out settings that are already correct.
+    destination.stream_arn = stream_arn if stream_arn
+    destination.region = region if region
+    destination.role_arn = role_arn if role_arn
+    destination.external_id = external_id if external_id
+    unless event_types.nil?
+      destination.event_types = (event_types == :all) ? nil : event_types
+    end
+
+    destination.save!
+
+    puts "#{created ? "Created" : "Updated"} #{destination.type} #{destination.id}"
+    puts "  organization: #{organization.name} (#{organization.id})"
+    puts "  code:         #{destination.code}"
+    puts "  stream_arn:   #{destination.stream_arn}"
+    puts "  region:       #{destination.region}"
+    puts "  role_arn:     #{destination.role_arn}"
+    puts "  external_id:  #{destination.external_id.present? ? "(set)" : "(none)"}"
+    puts "  event_types:  #{destination.event_types || "(all)"}"
+  end
+end

--- a/spec/factories/streaming_destinations.rb
+++ b/spec/factories/streaming_destinations.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :kinesis_destination, class: "StreamingDestinations::KinesisDestination" do
+    organization
+    type { "StreamingDestinations::KinesisDestination" }
+    code { "kinesis_#{SecureRandom.uuid}" }
+    name { "Kinesis destination 1" }
+
+    transient do
+      stream_arn { "arn:aws:kinesis:eu-west-1:111122223333:stream/lago" }
+      region { "eu-west-1" }
+      role_arn { "arn:aws:iam::111122223333:role/LagoStreamingWriter" }
+      external_id { SecureRandom.uuid }
+    end
+
+    # String keys on purpose: SettingsStorable reads settings["stream_arn"], so
+    # symbol keys would make every accessor nil until the record round-trips
+    # through the database, and presence validation would fail on build.
+    settings do
+      {
+        "stream_arn" => stream_arn,
+        "region" => region,
+        "role_arn" => role_arn,
+        "external_id" => external_id
+      }
+    end
+  end
+end

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe SendWebhookJob do
           end.not_to have_enqueued_job(described_class)
         end
       end
+
+      # Companion guard to Webhooks::BaseService#call. Both must consider
+      # streaming destinations or the transport goes silent with no error.
+      context "when the organization has a streaming destination" do
+        before { create(:kinesis_destination, organization:) }
+
+        it "enqueues a job" do
+          expect do
+            described_class.perform_later("invoice.created", invoice)
+          end.to have_enqueued_job(described_class)
+        end
+      end
     end
 
     context "when webhook_id is present" do

--- a/spec/jobs/streaming_destinations/deliver_job_spec.rb
+++ b/spec/jobs/streaming_destinations/deliver_job_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StreamingDestinations::DeliverJob do
+  let(:destination) { create(:kinesis_destination) }
+  let(:payload) { {webhook_type: "subscription.updated", emitted_at: "2026-08-31T12:00:00.000Z"} }
+  let(:partition_key) { "cust_external_id" }
+
+  it "delegates to the service the destination names, staying provider-blind" do
+    allow(StreamingDestinations::Kinesis::DeliverService)
+      .to receive(:call).and_return(BaseService::Result.new)
+
+    described_class.perform_now(destination:, payload:, partition_key:)
+
+    expect(StreamingDestinations::Kinesis::DeliverService).to have_received(:call).with(
+      destination:, payload:, partition_key:
+    )
+  end
+
+  it "does not raise when the delivery fails permanently, to avoid a retry storm" do
+    failed = BaseService::Result.new.service_failure!(code: "record_too_large", message: "too big")
+    allow(StreamingDestinations::Kinesis::DeliverService).to receive(:call).and_return(failed)
+
+    expect { described_class.perform_now(destination:, payload:, partition_key:) }.not_to raise_error
+  end
+
+  it "runs on the webhook queue" do
+    expect(described_class.new.queue_name).to eq("webhook")
+  end
+end

--- a/spec/models/streaming_destinations/base_destination_spec.rb
+++ b/spec/models/streaming_destinations/base_destination_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StreamingDestinations::BaseDestination do
+  describe "single table inheritance" do
+    it "shares one table with its subclasses" do
+      expect(described_class.table_name).to eq("streaming_destinations")
+      expect(StreamingDestinations::KinesisDestination.table_name).to eq("streaming_destinations")
+    end
+
+    it "loads a persisted record as its concrete subclass" do
+      destination = create(:kinesis_destination)
+
+      expect(described_class.find(destination.id)).to be_a(StreamingDestinations::KinesisDestination)
+    end
+
+    it "exposes the destination through the organization association" do
+      destination = create(:kinesis_destination)
+
+      expect(destination.organization.streaming_destinations).to contain_exactly(destination)
+    end
+  end
+
+  describe "#subscribed?" do
+    subject { destination.subscribed?("subscription.updated") }
+
+    context "when event_types is nil" do
+      let(:destination) { build(:kinesis_destination, event_types: nil) }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when event_types includes the type" do
+      let(:destination) { build(:kinesis_destination, event_types: ["subscription.updated", "wallet.updated"]) }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when event_types excludes the type" do
+      let(:destination) { build(:kinesis_destination, event_types: ["wallet.updated"]) }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when event_types is empty" do
+      let(:destination) { build(:kinesis_destination, event_types: []) }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe "#deliver_service_class" do
+    it "raises on the abstract parent" do
+      expect { described_class.new.deliver_service_class }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "validations" do
+    it "requires a name" do
+      destination = build(:kinesis_destination, name: nil)
+
+      expect(destination).not_to be_valid
+      expect(destination.errors.where(:name, :blank)).to be_present
+    end
+
+    it "rejects a code already used in the same organization" do
+      existing = create(:kinesis_destination)
+      duplicate = build(:kinesis_destination, organization: existing.organization, code: existing.code)
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors.where(:code, :taken)).to be_present
+    end
+
+    it "allows the same code in another organization" do
+      existing = create(:kinesis_destination)
+
+      expect(build(:kinesis_destination, code: existing.code)).to be_valid
+    end
+
+    it "ignores discarded records, so a discarded code can be reused" do
+      existing = create(:kinesis_destination)
+      existing.discard!
+
+      expect(build(:kinesis_destination, organization: existing.organization, code: existing.code)).to be_valid
+    end
+  end
+
+  describe "discarding" do
+    it { expect(described_class).to be_soft_deletable }
+
+    it "hides discarded destinations from the default scope" do
+      destination = create(:kinesis_destination)
+      destination.discard!
+
+      expect(described_class.find_by(id: destination.id)).to be_nil
+      expect(described_class.with_discarded.find_by(id: destination.id)).to eq(destination)
+    end
+  end
+end

--- a/spec/models/streaming_destinations/kinesis_destination_spec.rb
+++ b/spec/models/streaming_destinations/kinesis_destination_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StreamingDestinations::KinesisDestination do
+  describe "#deliver_service_class" do
+    it "names the kinesis delivery service" do
+      expect(build(:kinesis_destination).deliver_service_class)
+        .to eq(StreamingDestinations::Kinesis::DeliverService)
+    end
+  end
+
+  describe "validations" do
+    %i[stream_arn region role_arn].each do |setting|
+      it "requires #{setting}" do
+        destination = build(:kinesis_destination, setting => nil)
+
+        expect(destination).not_to be_valid
+        expect(destination.errors.where(setting, :blank)).to be_present
+      end
+    end
+
+    it "does not require an external_id" do
+      expect(build(:kinesis_destination, external_id: nil)).to be_valid
+    end
+  end
+
+  describe "settings accessors" do
+    it "round-trips through the settings column" do
+      destination = create(
+        :kinesis_destination,
+        stream_arn: "arn:aws:kinesis:us-east-1:111122223333:stream/other",
+        region: "us-east-1",
+        role_arn: "arn:aws:iam::111122223333:role/Other",
+        external_id: "confused-deputy-guard"
+      )
+
+      reloaded = described_class.find(destination.id)
+
+      expect(reloaded.stream_arn).to eq("arn:aws:kinesis:us-east-1:111122223333:stream/other")
+      expect(reloaded.region).to eq("us-east-1")
+      expect(reloaded.role_arn).to eq("arn:aws:iam::111122223333:role/Other")
+      expect(reloaded.external_id).to eq("confused-deputy-guard")
+    end
+
+    it "writes through the accessor into settings" do
+      destination = build(:kinesis_destination)
+
+      destination.region = "ap-south-1"
+
+      expect(destination.settings["region"]).to eq("ap-south-1")
+      expect(destination.region).to eq("ap-south-1")
+    end
+
+    it "keeps external_id in settings rather than secrets" do
+      destination = create(:kinesis_destination, external_id: "guard")
+
+      expect(described_class.find(destination.id).settings["external_id"]).to eq("guard")
+      expect(destination.secrets).to be_nil
+    end
+  end
+end

--- a/spec/services/streaming_destinations/kinesis/deliver_service_spec.rb
+++ b/spec/services/streaming_destinations/kinesis/deliver_service_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StreamingDestinations::Kinesis::DeliverService do
+  subject(:deliver_service) { described_class.new(destination:, payload:, partition_key:) }
+
+  let(:destination) { create(:kinesis_destination) }
+  let(:partition_key) { "cust_external_id" }
+  let(:payload) do
+    {
+      :webhook_type => "subscription.updated",
+      :object_type => "subscription",
+      :organization_id => destination.organization_id,
+      :emitted_at => "2026-08-31T12:00:00.000Z",
+      "subscription" => {lago_id: "sub_1", external_id: "cust_external_id"}
+    }
+  end
+
+  let(:credentials) { instance_double(Aws::AssumeRoleCredentials) }
+  let(:sts_client) { instance_double(Aws::STS::Client) }
+  let(:kinesis_client) do
+    Aws::Kinesis::Client.new(
+      stub_responses: true,
+      region: "eu-west-1",
+      credentials: Aws::Credentials.new("stub", "stub")
+    )
+  end
+
+  before do
+    # Class-level cache, so it has to be reset or counts leak between examples.
+    described_class::CREDENTIALS.clear
+
+    # Built before the stub is installed, otherwise .new would recurse into it.
+    client = kinesis_client
+
+    allow(Aws::Kinesis::Client).to receive(:new).and_return(client)
+    allow(Aws::STS::Client).to receive(:new).and_return(sts_client)
+    allow(Aws::AssumeRoleCredentials).to receive(:new).and_return(credentials)
+  end
+
+  describe "#call" do
+    it "puts the payload on the destination's stream" do
+      result = deliver_service.call
+
+      expect(result).to be_success
+
+      request = kinesis_client.api_requests.first
+      expect(request[:operation_name]).to eq(:put_record)
+      expect(request[:params][:stream_arn]).to eq(destination.stream_arn)
+      expect(request[:params][:partition_key]).to eq("cust_external_id")
+      expect(JSON.parse(request[:params][:data])).to eq(
+        "webhook_type" => "subscription.updated",
+        "object_type" => "subscription",
+        "organization_id" => destination.organization_id,
+        "emitted_at" => "2026-08-31T12:00:00.000Z",
+        "subscription" => {"lago_id" => "sub_1", "external_id" => "cust_external_id"}
+      )
+    end
+
+    it "stringifies a non-string partition key" do
+      result = described_class.new(destination:, payload:, partition_key: 42).call
+
+      expect(result).to be_success
+      expect(kinesis_client.api_requests.first[:params][:partition_key]).to eq("42")
+    end
+
+    it "builds the client for the destination's region with the assumed-role credentials" do
+      deliver_service.call
+
+      expect(Aws::Kinesis::Client).to have_received(:new).with(
+        region: destination.region,
+        credentials: credentials
+      )
+    end
+
+    it "assumes the role with the external id as a confused-deputy guard" do
+      deliver_service.call
+
+      expect(Aws::AssumeRoleCredentials).to have_received(:new).with(
+        role_arn: destination.role_arn,
+        role_session_name: "lago-streaming-#{destination.id}",
+        client: sts_client,
+        external_id: destination.external_id
+      )
+    end
+
+    context "when the destination has no external_id" do
+      let(:destination) { create(:kinesis_destination, external_id: nil) }
+
+      it "omits it rather than passing nil, which AWS rejects" do
+        deliver_service.call
+
+        expect(Aws::AssumeRoleCredentials).to have_received(:new).with(
+          role_arn: destination.role_arn,
+          role_session_name: "lago-streaming-#{destination.id}",
+          client: sts_client
+        )
+      end
+    end
+
+    describe "credential caching" do
+      it "does not rebuild the credentials on a second call for the same destination" do
+        deliver_service.call
+        described_class.new(destination:, payload:, partition_key:).call
+
+        expect(Aws::AssumeRoleCredentials).to have_received(:new).once
+      end
+
+      it "rebuilds them for a different destination" do
+        other = create(:kinesis_destination, organization: destination.organization)
+
+        deliver_service.call
+        described_class.new(destination: other, payload:, partition_key:).call
+
+        expect(Aws::AssumeRoleCredentials).to have_received(:new).twice
+      end
+
+      it "rebuilds them when the destination's role changes" do
+        deliver_service.call
+
+        destination.role_arn = "arn:aws:iam::111122223333:role/Rotated"
+        destination.save!
+        described_class.new(destination:, payload:, partition_key:).call
+
+        expect(Aws::AssumeRoleCredentials).to have_received(:new).twice
+      end
+    end
+
+    context "when the serialized payload exceeds the kinesis record limit" do
+      let(:payload) do
+        {
+          :webhook_type => "subscription.updated",
+          "subscription" => {blob: "x" * (1.megabyte + 1)}
+        }
+      end
+
+      before { allow(Sentry).to receive(:capture_message) }
+
+      it "fails the result without raising and without calling kinesis" do
+        result = nil
+
+        expect { result = deliver_service.call }.not_to raise_error
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ServiceFailure)
+        expect(result.error.code).to eq("record_too_large")
+        expect(kinesis_client.api_requests).to be_empty
+      end
+
+      it "reports the oversized record to Sentry" do
+        deliver_service.call
+
+        expect(Sentry).to have_received(:capture_message).with(
+          /exceeds the #{described_class::MAX_RECORD_SIZE} byte limit/o,
+          hash_including(level: :error)
+        )
+      end
+    end
+  end
+end

--- a/spec/services/webhooks/base_service_spec.rb
+++ b/spec/services/webhooks/base_service_spec.rb
@@ -154,6 +154,93 @@ RSpec.describe Webhooks::BaseService do
         end
       end
     end
+
+    context "with a streaming destination" do
+      let(:streaming_destination) { create(:kinesis_destination, organization:) }
+
+      before do
+        streaming_destination
+        object.reload
+      end
+
+      it "delivers over both transports" do
+        webhook_service.call
+
+        expect(SendHttpWebhookJob).to have_been_enqueued.once
+        expect(StreamingDestinations::DeliverJob).to have_been_enqueued.once
+      end
+
+      it "hands the job the payload the http path got, plus emitted_at" do
+        webhook_service.call
+
+        webhook = Webhook.order(created_at: :desc).first
+
+        expect(StreamingDestinations::DeliverJob).to have_been_enqueued.with(
+          destination: streaming_destination,
+          payload: satisfy { |payload|
+            JSON.parse(payload.except(:emitted_at).to_json) == webhook.payload &&
+              payload[:emitted_at].present?
+          },
+          partition_key: organization.id
+        )
+      end
+
+      context "when the destination is not subscribed to the event type" do
+        let(:streaming_destination) do
+          create(:kinesis_destination, organization:, event_types: ["other.type"])
+        end
+
+        it "skips the destination but still delivers over http" do
+          webhook_service.call
+
+          expect(SendHttpWebhookJob).to have_been_enqueued.once
+          expect(StreamingDestinations::DeliverJob).not_to have_been_enqueued
+        end
+      end
+
+      context "when the destination is subscribed to the event type" do
+        let(:streaming_destination) do
+          create(:kinesis_destination, organization:, event_types: ["dummy.test"])
+        end
+
+        it "enqueues the deliver job" do
+          webhook_service.call
+
+          expect(StreamingDestinations::DeliverJob).to have_been_enqueued.once
+        end
+      end
+
+      context "when the destination is discarded" do
+        before { streaming_destination.discard! }
+
+        it "does not enqueue the deliver job" do
+          webhook_service.call
+
+          expect(StreamingDestinations::DeliverJob).not_to have_been_enqueued
+        end
+      end
+    end
+
+    # Regression guard for the two widened guard conditions. Both this service
+    # and SendWebhookJob.perform_later used to return early on
+    # `webhook_endpoints.none?`; if either reverts, streaming destinations go
+    # silent with no error raised anywhere.
+    context "with a streaming destination and no webhook endpoint" do
+      let(:organization) { create(:organization, webhook_url: nil) }
+
+      before do
+        create(:kinesis_destination, organization:)
+        object.reload
+      end
+
+      it "still enqueues the deliver job" do
+        webhook_service.call
+
+        expect(StreamingDestinations::DeliverJob).to have_been_enqueued.once
+        expect(SendHttpWebhookJob).not_to have_been_enqueued
+        expect(Webhook.where(object: invoice)).not_to exist
+      end
+    end
   end
 end
 

--- a/spec/services/webhooks/customers/updated_service_spec.rb
+++ b/spec/services/webhooks/customers/updated_service_spec.rb
@@ -10,5 +10,22 @@ RSpec.describe Webhooks::Customers::UpdatedService do
 
   describe ".call" do
     it_behaves_like "creates webhook", "customer.updated", "customer"
+
+    context "with a streaming destination" do
+      before do
+        create(:kinesis_destination, organization: customer.organization)
+        customer.reload
+      end
+
+      it "partitions the stream by the customer external id" do
+        webhook_service.call
+
+        expect(StreamingDestinations::DeliverJob).to have_been_enqueued.with(
+          destination: anything,
+          payload: anything,
+          partition_key: customer.external_id
+        )
+      end
+    end
   end
 end

--- a/spec/services/webhooks/subscriptions/updated_service_spec.rb
+++ b/spec/services/webhooks/subscriptions/updated_service_spec.rb
@@ -10,5 +10,22 @@ RSpec.describe Webhooks::Subscriptions::UpdatedService do
 
   describe ".call" do
     it_behaves_like "creates webhook", "subscription.updated", "subscription"
+
+    context "with a streaming destination" do
+      before do
+        create(:kinesis_destination, organization: subscription.organization)
+        subscription.reload
+      end
+
+      it "partitions the stream by the customer external id" do
+        webhook_service.call
+
+        expect(StreamingDestinations::DeliverJob).to have_been_enqueued.with(
+          destination: anything,
+          payload: anything,
+          partition_key: subscription.customer.external_id
+        )
+      end
+    end
   end
 end

--- a/spec/services/webhooks/wallets/updated_service_spec.rb
+++ b/spec/services/webhooks/wallets/updated_service_spec.rb
@@ -12,5 +12,22 @@ RSpec.describe Webhooks::Wallets::UpdatedService do
       "purchase_order_number" => "PO-123",
       "recurring_transaction_rules" => []
     }
+
+    context "with a streaming destination" do
+      before do
+        create(:kinesis_destination, organization: wallet.organization)
+        wallet.reload
+      end
+
+      it "partitions the stream by the customer external id" do
+        webhook_service.call
+
+        expect(StreamingDestinations::DeliverJob).to have_been_enqueued.with(
+          destination: anything,
+          payload: anything,
+          partition_key: wallet.customer.external_id
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

POC for the "Streaming Kinesis for Synthesia" project (P1 + P2): let a single organization receive entity change events, the same payloads Lago already sends over HTTP webhooks, on an AWS Kinesis data stream in a customer-owned AWS account via cross-account `sts:AssumeRole`.

P0 (usage consumption records) is deliberately out of scope: those are materialized in the Go events processor, not here.

There is no API, no GraphQL and no UI. Destinations are seeded by an operator with a rake task.

## Description

A new `streaming_destinations` table follows the existing house pattern for provider-shaped records (`Integrations::BaseIntegration`, `PaymentProviders::BaseProvider`): one table, STI `type`, org-scoped `code`, `settings` jsonb via `SettingsStorable`, encrypted `secrets` via `SecretsStorable`, `Discard::Model`. No AWS-shaped columns, so a second transport would need no migration.

Delivery hangs off the existing webhook fan-out point rather than duplicating it. `Webhooks::BaseService#call` already builds a fully serialized payload and already filters per destination by event type, so the Kinesis path reuses that exact payload: one serialization of an entity change, not one per transport. No new serializers.

`webhook_endpoints` was intentionally not reused: it has `webhook_url NOT NULL`, a unique index on `(webhook_url, organization_id)`, a non-optional `Webhook belongs_to :webhook_endpoint`, and a documented `LIMIT` of 10.

### The two guard conditions that changed, and why

This is the part to review most carefully. Two guards previously short-circuited on "this organization has no webhook endpoints", and **both** had to widen. Changing only one makes the feature fail silently, with no error raised anywhere.

1. `Webhooks::BaseService#call` — was `return if current_organization.webhook_endpoints.none?`
2. `SendWebhookJob.perform_later` (the class-method override) — was `return if (webhook_id.nil? || webhook_id == UNDEFINED) && object.organization.webhook_endpoints.none?`

Both now consult a single predicate, `Organization#webhook_destinations?`, so they cannot drift. The predicate lives on `Organization` rather than in the service because the two call sites reach the organization by different paths (`current_organization` vs `object.organization`), so that is the only placement where one definition genuinely serves both.

`spec/services/webhooks/base_service_spec.rb` and `spec/jobs/send_webhook_job_spec.rb` each carry an explicit regression guard for the zero-endpoints-one-destination case.

Nothing else about the existing HTTP delivery path changed.

### Ordering: read this before writing a consumer

**Lago does not guarantee stream order for concurrent updates to the same object.** Concurrent Sidekiq workers can `PutRecord` two updates to the same object in either order, and Kinesis preserves *receive* order, not *commit* order. The partition key groups related records onto one shard; it does not order them.

Every streamed payload therefore carries an added **`emitted_at`** (ISO 8601, millisecond precision), stamped once per emission. **Consumers must use `emitted_at` for last-write-wins** and must not assume stream position implies recency.

One honest caveat: `emitted_at` is stamped when the webhook service runs, not when the database transaction committed. For two racing updates to the same object it is a much better ordering key than stream position, but it is not a true monotonic version, and neither is the object's own `updated_at`. This is most acute for wallets, whose balances mutate continuously server-side. A real version column is the correct fix and is out of scope for a POC.

Partition key defaults to the organization id. Three services override it to the customer's `external_id`, so a consumer can process one customer's records on one worker:

- `Webhooks::Subscriptions::UpdatedService`
- `Webhooks::Wallets::UpdatedService`
- `Webhooks::Customers::UpdatedService`

### Entitlements

Worth flagging, with a correction to how this was originally scoped: `subscription.updated` **does** carry entitlements, because `Webhooks::Subscriptions::UpdatedService` serializes `includes: %i[plan customer entitlements]`.

The real gap is narrower but still real: **no webhook event type fires when entitlements change on their own.** A consumer sees entitlement state only when something else touches the subscription, so it cannot reliably reconstruct per-subscription entitlements from this stream. Adding subscription-level entitlement events was explicitly out of scope here and is tracked separately.

### Delivery

`StreamingDestinations::DeliverJob#perform` stays provider-blind: it asks the destination for its `deliver_service_class` and calls it. No `case` on type.

`StreamingDestinations::Kinesis::DeliverService`:

- Rejects a record whose serialized payload exceeds 1 MB by failing the result with `record_too_large` and reporting to Sentry, rather than raising. Kinesis hard-rejects oversized records, so a retry storm helps nobody. The job deliberately does not raise on a failed result for the same reason; genuine transport errors arrive as exceptions and are retried.
- Caches the `Aws::AssumeRoleCredentials` object per destination across jobs, letting the SDK auto-refresh handle expiry. This is required, not an optimization: a fresh credentials object per job means one STS call per record, which hits STS throttling long before Kinesis notices any load.

## Deliberate deviations from the plan

Three, all small, flagged for review rather than buried:

1. **One migration, not the two-migration `validate_foreign_key` pair.** That convention exists for adding an FK to an existing populated table (as in the recent `quote_versions` pair). For a brand-new empty table the repo consistently uses inline `foreign_key: true` inside `create_table` (`create_rate_overrides`, `create_orders`, `create_billing_object_connections`, `create_invoice_connections`), and strong_migrations does not object. Following the pair here would have been cargo-culting.

2. **The credential cache key is `(id, role_arn, external_id, region)`, not the destination id alone.** Keying on the id alone would keep serving credentials for a role that had since been edited, a stale-credential bug needing a redeploy to clear. Still one STS call per destination.

3. **`standardrb --fix` was not run repo-wide.** All files in this branch are clean, but `origin/main` currently has 24 pre-existing offenses in unrelated files (`Performance/BigDecimalWithNumericArgument` and friends). Fixing them here would have dragged 24 unrelated files into this PR.

## Follow-ups deliberately deferred

- **Dedicated Sidekiq queue.** `DeliverJob` uses `queue_as :webhook` for now. A dedicated queue is the right end state for blast-radius isolation, so a backed-up stream cannot starve HTTP webhook delivery, but it needs a new process config under `config/sidekiq/` plus a deployment change in `lago-infrastructure`. Marked with a `TODO` in the job.
- **CRUD API / UI** for managing destinations. Seeded by rake task for the POC.
- **Delivery-history persistence.** No `Webhook`-equivalent rows for stream deliveries.

## Seeding

```
bundle exec rake "streaming_destinations:upsert_kinesis[<org_id>,<code>]" \
  STREAM_ARN=arn:aws:kinesis:eu-west-1:111122223333:stream/lago \
  REGION=eu-west-1 \
  ROLE_ARN=arn:aws:iam::111122223333:role/LagoStreamingWriter \
  EXTERNAL_ID=some-shared-secret \
  EVENT_TYPES=subscription.updated,wallet.updated
```

Idempotent on `(organization_id, code)`. Re-running updates only what is supplied, so a partial re-run does not blank correct settings. Omit `EVENT_TYPES` to subscribe to everything; pass `EVENT_TYPES="*"` to reset an existing destination back to all.

Verified by hand against the test database: create, then a region-only update preserving the other settings, then an `EVENT_TYPES="*"` reset.

## Testing

New: model specs (STI resolution, `subscribed?` across nil/matching/non-matching/empty, code uniqueness scoped to org and ignoring discarded records, settings round-tripping, `external_id` staying out of `secrets`), delivery service specs (`stub_responses: true`, asserting partition key and decoded record body, the oversized path failing without raising, and credentials not rebuilt on a second call for the same destination), job specs, fan-out specs, and one partition-key spec per overriding service.

`spec/services/webhooks` runs **119 examples, 0 failures**, confirming no existing webhook behaviour regressed.

Across `spec/models/streaming_destinations spec/services/streaming_destinations spec/services/webhooks spec/jobs`: 863 examples, 7 failures, all pre-existing and environmental on a local machine, none in webhook or streaming code:

- 4 × `SendEmailJob` — `SMTP From address may not be blank: nil`, missing local mail configuration; fails identically in isolation.
- 1 × `Clock::InboundWebhooksCleanupJob` — a stale `activejob_uniqueness` lock in the shared dev Redis (23 such stale locks present).
- 2 × `Clock::EventsValidationJob` — pass in isolation (3 examples, 0 failures); cross-spec lock pollution in that same Redis.
