### PR TITLE
fix(subscriptions): validate invoice consolidation

### DIFF
--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -29,7 +29,9 @@ module Subscriptions
         ending_at: params[:ending_at],
         payment_method: params[:payment_method],
         activation_rules: params[:activation_rules],
-        subscription_type:
+        subscription_type:,
+        consolidate_invoice: params[:consolidate_invoice],
+        consolidate_invoice_provided: params.key?(:consolidate_invoice)
       )
       return result.forbidden_failure! if !License.premium? && params.key?(:plan_overrides)
 
@@ -145,7 +147,7 @@ module Subscriptions
         ending_at: params[:ending_at],
         purchase_order_number: params[:purchase_order_number],
         progressive_billing_disabled: params[:progressive_billing_disabled] || false,
-        consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : true,
+        consolidate_invoice: consolidate_invoice,
         billing_entity: resolve_billing_entity(organization: customer.organization, params:)
       )
 
@@ -296,6 +298,12 @@ module Subscriptions
           units: entry[:units]
         )
       end
+    end
+
+    def consolidate_invoice
+      return true unless params.key?(:consolidate_invoice)
+
+      ActiveModel::Type::Boolean.new.cast(params[:consolidate_invoice])
     end
 
     def payment_method

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -39,7 +39,9 @@ module Subscriptions
         payment_method: params[:payment_method],
         activation_rules: params[:activation_rules],
         subscription_type: "update",
-        subscription:
+        subscription:,
+        consolidate_invoice: params[:consolidate_invoice],
+        consolidate_invoice_provided: params.key?(:consolidate_invoice)
       )
         return result
       end
@@ -63,7 +65,9 @@ module Subscriptions
         subscription.ending_at = params[:ending_at] if params.key?(:ending_at)
         subscription.purchase_order_number = params[:purchase_order_number] if params.key?(:purchase_order_number)
         subscription.progressive_billing_disabled = params[:progressive_billing_disabled] if params.key?(:progressive_billing_disabled)
-        subscription.consolidate_invoice = params[:consolidate_invoice] if params.key?(:consolidate_invoice)
+        if params.key?(:consolidate_invoice)
+          subscription.consolidate_invoice = ActiveModel::Type::Boolean.new.cast(params[:consolidate_invoice])
+        end
 
         if pay_in_advance? && params.key?(:on_termination_credit_note)
           subscription.on_termination_credit_note = params[:on_termination_credit_note]

--- a/app/services/subscriptions/validate_service.rb
+++ b/app/services/subscriptions/validate_service.rb
@@ -12,6 +12,7 @@ module Subscriptions
       valid_on_termination_invoice?
       valid_payment_method?
       valid_activation_rules?
+      valid_consolidate_invoice?
 
       if errors?
         result.validation_failure!(errors:)
@@ -117,6 +118,14 @@ module Subscriptions
         codes.each { |code| add_error(field:, error_code: code) }
       end
 
+      false
+    end
+
+    def valid_consolidate_invoice?
+      return true unless args[:consolidate_invoice_provided]
+      return true if [true, false, "true", "false"].include?(args[:consolidate_invoice])
+
+      add_error(field: :consolidate_invoice, error_code: "invalid_value")
       false
     end
   end

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -712,6 +712,24 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
       end
     end
 
+    context "when consolidate_invoice is null" do
+      let(:params) do
+        {
+          external_customer_id: customer.external_id,
+          plan_code:,
+          external_id: SecureRandom.uuid,
+          consolidate_invoice: "null"
+        }
+      end
+
+      it "returns a validation failure" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json[:error_details]).to eq({consolidate_invoice: ["invalid_value"]})
+      end
+    end
+
     context "with applied_invoice_custom_sections in response" do
       it "includes applied_invoice_custom_sections in the serialized response" do
         subject

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -238,6 +238,28 @@ RSpec.describe Subscriptions::CreateService do
       end
     end
 
+    context "when consolidate_invoice is passed as null" do
+      let(:params) do
+        {
+          external_customer_id:,
+          plan_code:,
+          name:,
+          external_id:,
+          billing_time:,
+          subscription_at:,
+          subscription_id:,
+          consolidate_invoice: "null"
+        }
+      end
+
+      it "returns a validation failure" do
+        result = create_service.call
+
+        expect(result).not_to be_success
+        expect(result.error.messages).to eq({consolidate_invoice: ["invalid_value"]})
+      end
+    end
+
     context "when customer is invalid in an api context" do
       let(:customer) do
         build(:customer, organization:, currency: "EUR", external_id: nil)

--- a/spec/services/subscriptions/validate_service_spec.rb
+++ b/spec/services/subscriptions/validate_service_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe Subscriptions::ValidateService do
       on_termination_credit_note:,
       on_termination_invoice:,
       subscription:,
-      subscription_type:
+      subscription_type:,
+      consolidate_invoice:,
+      consolidate_invoice_provided:
     }
   end
 
@@ -30,6 +32,8 @@ RSpec.describe Subscriptions::ValidateService do
   let(:on_termination_invoice) { nil }
   let(:subscription) { nil }
   let(:subscription_type) { "create" }
+  let(:consolidate_invoice) { nil }
+  let(:consolidate_invoice_provided) { false }
 
   describe "#ending_at" do
     subject(:method_call) { validate_service.__send__(:ending_at) }
@@ -248,6 +252,25 @@ RSpec.describe Subscriptions::ValidateService do
 
     context "with valid on_termination_invoice skip" do
       let(:on_termination_invoice) { "skip" }
+
+      it "returns true" do
+        expect(validate_service).to be_valid
+      end
+    end
+
+    context "with invalid consolidate_invoice" do
+      let(:consolidate_invoice) { "null" }
+      let(:consolidate_invoice_provided) { true }
+
+      it "returns false and result has errors" do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:consolidate_invoice]).to eq(["invalid_value"])
+      end
+    end
+
+    context "with valid consolidate_invoice" do
+      let(:consolidate_invoice) { "false" }
+      let(:consolidate_invoice_provided) { true }
 
       it "returns true" do
         expect(validate_service).to be_valid


### PR DESCRIPTION
## Context

Passing a non-boolean consolidate_invoice value could reach persistence and produce an internal error instead of a validation response.

## Description

Validate consolidate_invoice when it is provided and only allow boolean true or false inputs. Cast accepted values during create and update so string boolean payloads keep working while invalid values return field-level validation errors.

Fixes LAGO-1858