### PR TITLE
feat(billing): Billing engine v2 date services

### DIFF
--- a/app/models/billing_segment.rb
+++ b/app/models/billing_segment.rb
@@ -5,6 +5,13 @@
 class BillingSegment < ApplicationRecord
   include Currencies
 
+  MICROSECOND = Rational(1, 1_000_000)
+
+  # Schedule windows have exclusive ends; the database overlap constraint uses inclusive ends.
+  def self.inclusive_end(instant) = instant - MICROSECOND
+
+  def self.exclusive_end(instant) = instant + MICROSECOND
+
   STATUSES = {
     pending: "pending",
     processing: "processing",

--- a/app/models/billing_segment.rb
+++ b/app/models/billing_segment.rb
@@ -124,8 +124,6 @@ end
 #  index_billing_segments_on_customer_id            (customer_id)
 #  index_billing_segments_on_invoice_id             (invoice_id)
 #  index_billing_segments_on_organization_id        (organization_id)
-#  index_billing_segments_on_pricing_unit_id        (pricing_unit_id)
-#  index_billing_segments_on_rate_card_rate_id      (rate_card_rate_id)
 #  index_billing_segments_on_rate_override_id       (rate_override_id)
 #
 # Foreign Keys

--- a/app/models/rate_card.rb
+++ b/app/models/rate_card.rb
@@ -97,6 +97,10 @@ class RateCard < ApplicationRecord
       Contract.where(catalog_plan_id: plan_applied_rate_cards.select(:catalog_plan_id)).exists?
   end
 
+  def ordered_rates
+    rates.order(:effective_from)
+  end
+
   # The active rate is the latest effective rate; later rates are pending and
   # earlier ones have been superseded (terminated).
   def active_rate

--- a/app/services/billing/billable_segment.rb
+++ b/app/services/billing/billable_segment.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Billing
+  # One slice of one cycle — everything a writer needs for one `billing_segments` row.
+  #
+  # @example a monthly cycle cut by a rate change on Feb 15, in arrears
+  #   [Segment(Feb 1 -> Feb 15, billing_at Feb 15), Segment(Feb 15 -> Mar 1, billing_at Mar 1)]
+  BillableSegment = Data.define(
+    :cycle_index,
+    :cycle_started_at,
+    :started_at,
+    :ended_at,
+    :billing_at,
+    :rate,
+    :rate_override,
+    :proration_ratio,
+    :rate_phase_code
+  )
+end

--- a/app/services/billing/calendar.rb
+++ b/app/services/billing/calendar.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Billing
+  # A ruler: boundaries every `interval` from the start of the anchor day, in the customer's
+  # timezone. Anchored Feb 1 in "America/New_York", boundary 0 is Feb 1 05:00 UTC.
+  class Calendar
+    attr_reader :anchor_date, :interval
+
+    def initialize(anchor_date:, interval:, timezone:)
+      @anchor_date = anchor_date
+      @anchor = anchor_date.in_time_zone(timezone).beginning_of_day
+      @interval = interval
+      @timezone = timezone
+    end
+
+    # The half-open interval `timestamp` falls in, as [boundary, next boundary).
+    def interval_containing(timestamp)
+      index = index_of_interval(timestamp)
+
+      interval_with_index_starts_at(index)...interval_with_index_starts_at(index + 1)
+    end
+
+    # How many intervals separate two instants on this ruler.
+    #
+    # @example a monthly ruler anchored Jan 31, whose boundaries clamp to Feb 28
+    #   intervals_between(Feb 28, Mar 31)  # => 1
+    #   intervals_between(Feb 28, Mar 28)  # => 0   still inside the interval that opened Feb 28
+    def intervals_between(from, to)
+      index_of_interval(to) - index_of_interval(from)
+    end
+
+    # The boundary `steps` intervals after the one containing an instant.
+    #
+    # @example a monthly ruler anchored Jan 31
+    #   boundary_after(Feb 10, 2)  # => Mar 31
+    def boundary_after(timestamp, steps)
+      interval_with_index_starts_at(index_of_interval(timestamp) + steps)
+    end
+
+    # The first boundary at or after an instant — when a change landing mid-interval takes hold.
+    #
+    # @example a monthly ruler anchored Jan 1
+    #   boundary_at_or_after(Feb 1)   # => Feb 1   already a boundary
+    #   boundary_at_or_after(Feb 10)  # => Mar 1
+    def boundary_at_or_after(timestamp)
+      window = interval_containing(timestamp)
+
+      (window.begin == timestamp) ? window.begin : window.end
+    end
+
+    # The share of its containing interval that the half-open window [from, to) covers.
+    #
+    # @return [Float] denominator is the CONTAINING interval, never a fixed 30 days (decision #55)
+    #
+    # @example a 30-day interval anchored Jun 1
+    #   proration_ratio(Jun  1, Jul 1)  # => 1.0
+    #   proration_ratio(Jun 16, Jul 1)  # => 0.5
+    def proration_ratio(from, to)
+      raise ArgumentError, "window end #{to} precedes its start #{from}" if to < from
+
+      window = interval_containing(from)
+      raise ArgumentError, "window [#{from}, #{to}) crosses the boundary at #{window.end}" if to > window.end
+
+      Days.between(from, to, timezone:).fdiv(Days.between(window.begin, window.end, timezone:))
+    end
+
+    private
+
+    attr_reader :anchor, :timezone
+
+    # Which interval `timestamp` falls in — a position on this ruler, not a cycle number. The
+    # anchor is a reference day, not a start date, so instants before it have negative indices.
+    def index_of_interval(timestamp)
+      interval.steps_between(anchor, timestamp.in_time_zone(timezone))
+    end
+
+    def interval_with_index_starts_at(index)
+      @boundaries ||= {}
+      @boundaries[index] ||= interval.advance(anchor, index)
+    end
+  end
+end

--- a/app/services/billing/cycle.rb
+++ b/app/services/billing/cycle.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Billing
+  # One billing period of one rate card.
+  #
+  # @param ended_at [Time] EXCLUSIVE, unlike the column of the same name
+  # @param calendar [Calendar] the ruler this cycle was measured on; it varies per cycle,
+  #   because a cadence change re-anchors mid-walk
+  #
+  # @example a monthly card anchored Jan 1, cut short by a weekly intro phase
+  #   Cycle(index: 0, started_at: Jan 15, ended_at: Jan 22, phase: "intro", calendar: ...)
+  Cycle = Data.define(:index, :started_at, :ended_at, :phase, :calendar)
+end

--- a/app/services/billing/days.rb
+++ b/app/services/billing/days.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Billing
+  module Days
+    # Whole billable days in the half-open window [from, to).
+    # A day belongs to the window holding its LOCAL midnight
+    #
+    # @example in "Europe/Paris"
+    #   between(Jun  1 00:00, Jun  1 09:30)  # =>  1   a day begun counts whole
+    #   between(Jun 16 09:30, Jul  1 00:00)  # => 14   the two sides sum to 30
+    #   between(Mar  1 00:00, Apr  1 00:00)  # => 31   Mar 29 2026 loses an hour to DST (23h),
+    #                                        #          but days are counted midnight-to-midnight,
+    #                                        #          so the short day still counts as one
+    def self.between(from, to, timezone:)
+      (opening_date(to, timezone:) - opening_date(from, timezone:)).to_i
+    end
+
+    # The first local date whose midnight is at or after `timestamp`.
+    #
+    # @return [Date] tomorrow when part-way through a day — the day in progress was already
+    #   given to whatever window opened it, so the next one to hand out is the next
+    #
+    # @example in "Europe/Paris"
+    #   opening_date(Jun 16 00:00:00 Paris)  # => Jun 16   already a local midnight
+    #   opening_date(Jun 16 00:00:01 Paris)  # => Jun 17   one second in, the day is spoken for
+    #   opening_date(Jun 16 09:30    Paris)  # => Jun 17
+    #   opening_date(Jun 16 00:00    UTC)    # => Jun 17   02:00 in Paris, so the 16th is gone
+    #
+    # Compares against midnight rather than adding a day, so a DST transition cannot shift it.
+    def self.opening_date(timestamp, timezone:)
+      local = timestamp.in_time_zone(timezone)
+
+      (local == local.beginning_of_day) ? local.to_date : local.to_date + 1
+    end
+    private_class_method :opening_date
+  end
+end

--- a/app/services/billing/interval.rb
+++ b/app/services/billing/interval.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Billing
+  # A cadence: how far one billing period runs.
+  class Interval < Data.define(:count, :unit)
+    UNITS = %i[day week month year].freeze
+
+    # The cadence a rate bills on, with an override laid over it field by field.
+    #
+    # @param override [RateOverride, nil] either column alone wins
+    # @return [Interval]
+    #
+    # @example a `3 month` rate
+    #   from(rate)                                   # => 3 month
+    #   from(rate, override: unit week)              # => 3 week
+    #   from(rate, override: count 2)                # => 2 month
+    def self.from(rate, override: nil)
+      new(
+        count: override&.billing_interval_count || rate.billing_interval_count,
+        unit: override&.billing_interval_unit || rate.billing_interval_unit
+      )
+    end
+
+    def initialize(count:, unit:)
+      unit = unit.to_sym if unit.respond_to?(:to_sym)
+
+      raise ArgumentError, "unknown interval unit #{unit.inspect}, expected one of #{UNITS.join(", ")}" unless UNITS.include?(unit)
+      raise ArgumentError, "interval count must be a positive integer, got #{count.inspect}" unless count.is_a?(Integer) && count.positive?
+
+      super
+    end
+
+    # Move an instant by whole intervals.
+    #
+    # @param steps [Integer] may be negative
+    # @return [Time] month-end clamped
+    #
+    # @example monthly
+    #   advance(Jan 31, 1)   # => Feb 28   clamped, not Mar 3
+    #   advance(Jan 15, -2)  # => Nov 15 of the year before
+    def advance(timestamp, steps)
+      units = count * steps
+
+      case unit
+      when :day then timestamp + units.days
+      when :week then timestamp + units.weeks
+      when :month then timestamp + units.months
+      when :year then timestamp + units.years
+      end
+    end
+
+    # Whole intervals between two instants.
+    #
+    # @return [Integer] may be negative
+    #
+    # @example monthly, and the correction that earns this method
+    #   steps_between(Jan 31, Feb 15)  # => 0   the calendar changed month; a month has not passed
+    #   steps_between(Jan 31, Feb 28)  # => 1   here it has
+    #
+    # @example every 3 months, and weekly
+    #   steps_between(Jan 1, Aug 1)    # => 2   7 months hold two whole 3-month intervals
+    #   steps_between(Jun 1, Jun 20)   # => 2   weekly
+    def steps_between(from, to)
+      estimate = calendar_steps_between(from, to)
+
+      if advance(from, estimate) > to
+        estimate - 1
+      else
+        estimate
+      end
+    end
+
+    private
+
+    # Whole units by the calendar, then how many intervals of `count` fit in them.
+    #
+    # @return [Integer] over by at most one, which #steps_between corrects
+    #
+    # @example monthly
+    #   calendar_steps_between(Jan 31, Feb 15)  # => 1   the month number changed
+    def calendar_steps_between(from, to)
+      whole_units = case unit
+      when :day then (to.to_date - from.to_date).to_i
+      when :week then (to.to_date - from.to_date).to_i / 7
+      when :month then ((to.year - from.year) * 12) + (to.month - from.month)
+      when :year then to.year - from.year
+      end
+
+      whole_units / count
+    end
+  end
+end

--- a/app/services/billing/phase.rb
+++ b/app/services/billing/phase.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Billing
+  # A stretch of consecutive cycles priced under one override.
+  #
+  # @param billing_interval_cycle_count [Integer, nil] nil runs to the end of the card
+  # @param code [String, nil] carried onto every segment the phase prices, so the consumer
+  #   reads the attribution off the row instead of resolving the phases again
+  #
+  # Carries no dates: a phase starts where the previous one ended, so its place in the queue
+  # is its date.
+  #
+  # @example a 3-cycle weekly intro, then the card's own cadence
+  #   [Phase(code: "intro", count: 3, rate_override: weekly), Phase.default]
+  Phase = Data.define(:code, :billing_interval_cycle_count, :rate_override) do
+    # The card's own rate and cadence, with no cycle limit.
+    #
+    # @return [Phase] no code, because nothing persisted it — being last is what defines it
+    def self.default = new(code: nil, billing_interval_cycle_count: nil, rate_override: nil)
+
+    def initialize(code:, billing_interval_cycle_count:, rate_override:)
+      if invalid_length?(billing_interval_cycle_count)
+        raise ArgumentError, "a phase lasts a positive whole number of cycles, or nil to run " \
+          "to the end, got #{billing_interval_cycle_count.inspect}"
+      end
+
+      super
+    end
+
+    # @return [Boolean] whether this phase runs to the end of the card. Only the last one may.
+    def unbounded? = billing_interval_cycle_count.nil?
+
+    private
+
+    def invalid_length?(count)
+      return false if count.nil?
+
+      !count.is_a?(Integer) || !count.positive?
+    end
+  end
+end

--- a/app/services/billing/rate_cards/build_schedule_service.rb
+++ b/app/services/billing/rate_cards/build_schedule_service.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Billing
+  module RateCards
+    class BuildScheduleService < BaseService
+      class MismatchedPlanRateCard < StandardError; end
+
+      Result = BaseResult[:schedule]
+
+      def initialize(contract_rate_card:, plan_rate_card: nil, ends_at: nil)
+        @contract_rate_card = contract_rate_card
+        @plan_rate_card = plan_rate_card
+        @ends_at = ends_at
+        super
+      end
+
+      def call
+        rate_card = contract_rate_card.rate_card
+        rates = rate_card.ordered_rates.to_a
+
+        if rates.empty?
+          result.not_found_failure!(resource: "rate")
+        else
+          terms = Terms.new(timing: rate_card.billing_timing, prorated: rate_card.proration?)
+
+          result.schedule = Schedule.new(
+            rates:,
+            terms:,
+            phases:,
+            resume_at: contract_rate_card.billing_segments.maximum(:cycle_started_at),
+            starts_at: contract_rate_card.effective_date.in_time_zone(timezone),
+            ends_at: schedule_ends_at,
+            anchor_date: contract_rate_card.billing_anchor_date,
+            timezone:
+          )
+        end
+
+        result
+      rescue ArgumentError => error
+        result.service_failure!(code: "invalid_billing_schedule", message: error.message)
+      end
+
+      private
+
+      attr_reader :contract_rate_card, :plan_rate_card, :ends_at
+
+      def timezone
+        contract_rate_card.contract.customer.applicable_timezone
+      end
+
+      def schedule_ends_at
+        # Contract card dates are inclusive; the walker expects an exclusive instant.
+        card_end = contract_rate_card.ended_date&.next_day&.in_time_zone(timezone)
+
+        [ends_at, card_end, contract_rate_card.contract.ended_at].compact.min
+      end
+
+      def phases
+        rate_phases = ::ContractRateCards::ResolveRatePhasesService.call!(
+          contract_rate_card:,
+          plan_rate_card: resolved_plan_rate_card
+        ).rate_phases
+
+        configured = rate_phases.map do |rate_phase|
+          Phase.new(
+            code: rate_phase.code,
+            billing_interval_cycle_count: rate_phase.billing_interval_cycle_count,
+            rate_override: rate_phase.rate_override
+          )
+        end
+
+        if configured.last&.unbounded?
+          configured
+        else
+          configured + [Phase.default]
+        end
+      end
+
+      def resolved_plan_rate_card
+        if plan_rate_card.nil?
+          contract_rate_card.contract.catalog_plan&.applied_rate_cards
+            &.find { it.rate_card_id == contract_rate_card.rate_card_id }
+        elsif plan_rate_card.rate_card_id != contract_rate_card.rate_card_id
+          raise MismatchedPlanRateCard, "plan_rate_card #{plan_rate_card.id} prices rate card " \
+            "#{plan_rate_card.rate_card_id}, not #{contract_rate_card.rate_card_id}"
+        else
+          plan_rate_card
+        end
+      end
+    end
+  end
+end

--- a/app/services/billing/rate_cards/cycle_walker.rb
+++ b/app/services/billing/rate_cards/cycle_walker.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+module Billing
+  module RateCards
+    class CycleWalker
+      attr_reader :current_cycle
+
+      def initialize(rates:, phases:, starts_at:, anchor_date:, timezone:, ends_at: nil)
+        @rates = rates.sort_by(&:effective_from)
+        @phases = phases
+        @starts_at = starts_at.in_time_zone(timezone).beginning_of_day
+        @ends_at = ends_at
+        @anchor_date = anchor_date
+        @timezone = timezone
+
+        validate!(raw_starts_at: starts_at)
+      end
+
+      def start
+        @current_cycle = build_cycle(index: 0, started_at: starts_at)
+      end
+
+      def advance
+        return nil unless current_cycle
+
+        @current_cycle = build_cycle(
+          index: current_cycle.index + 1,
+          started_at: current_cycle.ended_at,
+          previous_calendar: current_cycle.calendar
+        )
+      end
+
+      def resume(timestamp)
+        start
+        return current_cycle if timestamp.nil?
+
+        @current_cycle = nil if ends_at && timestamp >= ends_at
+
+        while current_cycle && current_cycle.ended_at <= timestamp
+          steps = steps_to_advance(timestamp)
+          calendar = current_cycle.calendar
+
+          @current_cycle = build_cycle(
+            index: current_cycle.index + steps,
+            started_at: calendar.boundary_after(current_cycle.started_at, steps),
+            previous_calendar: calendar
+          )
+        end
+
+        current_cycle
+      end
+
+      # Include the cycle containing timestamp; nil starts from the beginning.
+      def walk_to(timestamp, from: nil)
+        cycles = []
+        resume(from)
+
+        while current_cycle && current_cycle.started_at <= timestamp
+          cycles << current_cycle
+          break if current_cycle.ended_at > timestamp
+
+          advance
+        end
+
+        cycles
+      end
+
+      private
+
+      attr_reader :rates, :phases, :starts_at, :ends_at, :anchor_date, :timezone
+
+      def validate!(raw_starts_at:)
+        raise ArgumentError, "at least one rate is required to determine the billing interval" if rates.empty?
+        raise ArgumentError, "ends_at #{ends_at} precedes starts_at #{raw_starts_at}" if ends_at && ends_at < raw_starts_at
+        raise ArgumentError, "at least one phase is required" if phases.empty?
+        raise ArgumentError, "the last phase must run to the end of the card" unless phases.last.unbounded?
+        raise ArgumentError, "only the last phase may run to the end of the card" if phases[0...-1].any?(&:unbounded?)
+
+        rates.each { |rate| Interval.from(rate) }
+        phases.each do |phase|
+          if phase.rate_override
+            # The base rate supplies any interval fields the override leaves unchanged.
+            Interval.from(rates.first, override: phase.rate_override)
+          end
+        end
+      end
+
+      # Example with current_cycle.index = 3, using the current calendar:
+      # - steps_to_timestamp = 6: the requested time falls in cycle 9.
+      # - phase_start_index = 4: the next phase starts at cycle 4.
+      # - steps_to_phase_change = 4 - 3 = 1.
+      # - steps_to_rate_change = 3: the first boundary at/after the next rate is cycle 6.
+      # [6, 1, 3].min = 1: advance from index 3 to 4, apply the new phase, then
+      # recalculate the steps to the requested time using the resulting calendar.
+      # An unbounded phase or no later rate gives nil, which compact removes.
+      def steps_to_advance(timestamp)
+        calendar = current_cycle.calendar
+        started_at = current_cycle.started_at
+        steps_to_timestamp = calendar.intervals_between(started_at, timestamp)
+
+        phase_start_index = next_phase_start_index
+        steps_to_phase_change = if phase_start_index
+          phase_start_index - current_cycle.index
+        end
+
+        next_rate = rates.find { |rate| rate.effective_from > started_at }
+        steps_to_rate_change = if next_rate
+          boundary = calendar.boundary_at_or_after(next_rate.effective_from)
+          calendar.intervals_between(started_at, boundary)
+        end
+
+        # Each limit is a number of steps from current_cycle.index.
+        [steps_to_timestamp, steps_to_phase_change, steps_to_rate_change].compact.min
+      end
+
+      def next_phase_start_index
+        phase_boundary_index = 0
+
+        phases.each do |phase|
+          return nil if phase.unbounded?
+
+          phase_boundary_index += phase.billing_interval_cycle_count
+          if phase_boundary_index > current_cycle.index
+            return phase_boundary_index
+          end
+        end
+
+        raise ArgumentError, "phases must end with an unbounded phase"
+      end
+
+      def build_cycle(index:, started_at:, previous_calendar: nil)
+        return nil if ends_at && started_at >= ends_at
+
+        phase = phase_by_index(index)
+        rate = rate_for_cycle(started_at)
+        interval = Interval.from(rate, override: phase.rate_override)
+
+        calendar = if previous_calendar && interval == previous_calendar.interval
+          previous_calendar
+        else
+          anchor = previous_calendar ? started_at.in_time_zone(timezone).to_date : anchor_date
+          # Keep calculated boundaries when another resume or walk uses this calendar.
+          @calendars ||= {}
+          @calendars[[anchor, interval]] ||= Calendar.new(anchor_date: anchor, interval:, timezone:)
+        end
+
+        window = calendar.interval_containing(started_at)
+
+        Cycle.new(
+          index:,
+          started_at:,
+          ended_at: ends_at ? [window.end, ends_at].min : window.end,
+          phase:,
+          calendar:
+        )
+      end
+
+      def phase_by_index(index)
+        phases.each do |phase|
+          return phase if phase.unbounded? || index < phase.billing_interval_cycle_count
+
+          index -= phase.billing_interval_cycle_count
+        end
+
+        raise ArgumentError, "phases must end with an unbounded phase"
+      end
+
+      def rate_for_cycle(timestamp)
+        # Before the first rate takes effect, use its interval to build the cycle.
+        # This does not price the period before its effective date.
+        rates.rfind { |candidate| candidate.effective_from <= timestamp } || rates.first
+      end
+    end
+  end
+end

--- a/app/services/billing/rate_cards/schedule.rb
+++ b/app/services/billing/rate_cards/schedule.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+module Billing
+  module RateCards
+    class Schedule
+      def initialize(rates:, terms:, phases:, starts_at:, anchor_date:, timezone:, ends_at: nil, resume_at: nil)
+        if resume_at && resume_at < starts_at.in_time_zone(timezone).beginning_of_day
+          raise ArgumentError, "resume_at #{resume_at} precedes the card's start"
+        end
+
+        @rates = rates
+        @terms = terms
+        @timezone = timezone
+        @resume_at = resume_at
+        @walker = CycleWalker.new(rates:, phases:, starts_at:, anchor_date:, timezone:, ends_at:)
+      end
+
+      # A rate change can make a segment due before its cycle ends.
+      def segments_due_by(timestamp)
+        cycles = walker.walk_to(timestamp, from: resume_at)
+
+        billable_segments_of(cycles).select do |segment|
+          segment.billing_at <= timestamp
+        end
+      end
+
+      # Next billing instant strictly after the given time, or nil when billing has ended.
+      def next_billing_at(after:)
+        cycle = walker.resume(after)
+
+        while cycle
+          segment = billable_segments_of([cycle]).find do |candidate|
+            candidate.billing_at > after
+          end
+
+          if segment
+            return segment.billing_at
+          end
+
+          cycle = walker.advance
+        end
+
+        nil
+      end
+
+      # Bill the segment being served, or the first future one if pricing has not started.
+      def billing_at_covering(timestamp)
+        segment = segment_at(timestamp)
+
+        segment&.billing_at || next_billing_at(after: timestamp)
+      end
+
+      # Measure consumption against the original billed segment, whose end is exclusive.
+      def consumed_ratio(segment:, at:)
+        segment_days = Days.between(segment.started_at, segment.ended_at, timezone:)
+
+        if segment_days.zero?
+          1.0
+        else
+          consumed_until = at.clamp(segment.started_at, segment.ended_at)
+          consumed_days = Days.between(segment.started_at, consumed_until, timezone:)
+
+          consumed_days.fdiv(segment_days)
+        end
+      end
+
+      private
+
+      attr_reader :rates, :terms, :timezone, :resume_at, :walker
+
+      def segment_at(timestamp)
+        cycle = walker.resume(timestamp)
+
+        if cycle
+          billable_segments_of([cycle]).find do |segment|
+            (segment.started_at...segment.ended_at).cover?(timestamp)
+          end
+        end
+      end
+
+      def billable_segments_of(cycles)
+        cycles.flat_map do |cycle|
+          Segments.within(cycle, rates:).filter_map do |segment|
+            if segment.rate
+              build_billable_segment(cycle:, segment:)
+            end
+          end
+        end
+      end
+
+      def build_billable_segment(cycle:, segment:)
+        proration_ratio = if terms.prorated
+          cycle.calendar.proration_ratio(segment.started_at, segment.ended_at)
+        else
+          1.0
+        end
+
+        BillableSegment.new(
+          cycle_index: cycle.index,
+          cycle_started_at: cycle.started_at,
+          started_at: segment.started_at,
+          ended_at: segment.ended_at,
+          billing_at: terms.billing_at_for(segment),
+          rate: segment.rate,
+          rate_override: cycle.phase.rate_override,
+          proration_ratio:,
+          rate_phase_code: cycle.phase.code
+        )
+      end
+    end
+  end
+end

--- a/app/services/billing/segments.rb
+++ b/app/services/billing/segments.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Billing
+  module Segments
+    Segment = Data.define(:started_at, :ended_at, :rate)
+
+    # Split the half-open window at each rate change, keeping unpriced periods with rate: nil.
+    def self.within(window, rates:)
+      boundaries = [window.started_at] + rate_changes_inside(window, rates) + [window.ended_at]
+
+      boundaries.each_cons(2).map do |started_at, ended_at|
+        Segment.new(started_at:, ended_at:, rate: rate_at(rates, started_at))
+      end
+    end
+
+    def self.rate_changes_inside(window, rates)
+      rates.map(&:effective_from)
+        .select { |at| at > window.started_at && at < window.ended_at }
+        .uniq
+        .sort
+    end
+
+    def self.rate_at(rates, timestamp)
+      rates.select { |rate| rate.effective_from <= timestamp }.max_by(&:effective_from)
+    end
+
+    private_class_method :rate_changes_inside, :rate_at
+  end
+end

--- a/app/services/billing/terms.rb
+++ b/app/services/billing/terms.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Billing
+  class Terms < Data.define(:timing, :prorated)
+    TIMINGS = %i[advance arrears].freeze
+
+    def initialize(timing:, prorated:)
+      timing = timing.to_sym if timing.respond_to?(:to_sym)
+
+      raise ArgumentError, "unknown billing timing #{timing.inspect}, expected one of #{TIMINGS.join(", ")}" unless TIMINGS.include?(timing)
+      raise ArgumentError, "prorated must be true or false, got #{prorated.inspect}" unless [true, false].include?(prorated)
+
+      super
+    end
+
+    # Which end of a window falls due.
+    #
+    # @param window [#started_at, #ended_at] a cycle, or a slice of one
+    # @return [Time] the start in advance, the end in arrears
+    def billing_at_for(window)
+      if timing == :advance
+        window.started_at
+      else
+        window.ended_at
+      end
+    end
+  end
+end

--- a/app/services/contract_rate_cards/resolve_rate_phases_service.rb
+++ b/app/services/contract_rate_cards/resolve_rate_phases_service.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module ContractRateCards
+  # Which rate phases apply to one card, in the order they are billed in. Phases live on the
+  # card once it has its own, and on the plan entry it was materialized from until then —
+  # never both at once, so the card's set wins whole rather than merging.
+  class ResolveRatePhasesService < BaseService
+    Result = BaseResult[:rate_phases]
+
+    # `plan_rate_card` is the plan entry this card was materialized from, or nil when the
+    # card is not on a plan. A caller holding many of them picks the matching one itself:
+    # batching is its concern, not this service's.
+    def initialize(contract_rate_card:, plan_rate_card: nil)
+      @contract_rate_card = contract_rate_card
+      @plan_rate_card = plan_rate_card
+      super
+    end
+
+    def call
+      result.rate_phases = phases
+      result
+    end
+
+    private
+
+    attr_reader :contract_rate_card, :plan_rate_card
+
+    def phases
+      contract_phases = contract_rate_card.rate_phases.to_a
+      if contract_phases.any?
+        contract_phases
+      else
+        plan_rate_card&.rate_phases.to_a
+      end
+    end
+  end
+end

--- a/app/services/contracts/materialize_rate_cards_service.rb
+++ b/app/services/contracts/materialize_rate_cards_service.rb
@@ -20,12 +20,15 @@ module Contracts
       materialized = []
       ActiveRecord::Base.transaction do
         contract.catalog_plan.applied_rate_cards.find_each do |plan_rate_card|
-          materialized << contract.applied_rate_cards.create!(
+          card = contract.applied_rate_cards.new(
             organization: contract.organization,
             rate_card: plan_rate_card.rate_card,
             units: plan_rate_card.units,
             **contract.default_rate_card_lifecycle
           )
+          card.next_billing_at = initial_next_billing_at(card, plan_rate_card)
+          card.save!
+          materialized << card
         end
       end
 
@@ -36,5 +39,16 @@ module Contracts
     private
 
     attr_reader :contract
+
+    def initial_next_billing_at(card, plan_rate_card)
+      build = Billing::RateCards::BuildScheduleService.call(contract_rate_card: card, plan_rate_card:)
+
+      if build.success?
+        # Backdated contracts join the current period; an ended schedule has no next date.
+        build.schedule.billing_at_covering(Time.current) || card.next_billing_at
+      else
+        card.next_billing_at
+      end
+    end
   end
 end

--- a/db/migrate/20260908180522_remove_unused_billing_segment_indexes.rb
+++ b/db/migrate/20260908180522_remove_unused_billing_segment_indexes.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class RemoveUnusedBillingSegmentIndexes < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :billing_segments, :pricing_unit_id, algorithm: :concurrently, if_exists: true
+    remove_index :billing_segments, :rate_card_rate_id, algorithm: :concurrently, if_exists: true
+  end
+
+  def down
+    add_index :billing_segments, :pricing_unit_id, algorithm: :concurrently, if_not_exists: true
+    add_index :billing_segments, :rate_card_rate_id, algorithm: :concurrently, if_not_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -905,8 +905,6 @@ DROP INDEX IF EXISTS public.index_cached_aggregations_on_external_subscription_i
 DROP INDEX IF EXISTS public.index_cached_aggregations_on_event_transaction_id;
 DROP INDEX IF EXISTS public.index_cached_aggregations_on_charge_id;
 DROP INDEX IF EXISTS public.index_billing_segments_on_rate_override_id;
-DROP INDEX IF EXISTS public.index_billing_segments_on_rate_card_rate_id;
-DROP INDEX IF EXISTS public.index_billing_segments_on_pricing_unit_id;
 DROP INDEX IF EXISTS public.index_billing_segments_on_organization_id;
 DROP INDEX IF EXISTS public.index_billing_segments_on_invoice_id;
 DROP INDEX IF EXISTS public.index_billing_segments_on_customer_id;
@@ -8357,20 +8355,6 @@ CREATE INDEX index_billing_segments_on_organization_id ON public.billing_segment
 
 
 --
--- Name: index_billing_segments_on_pricing_unit_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_billing_segments_on_pricing_unit_id ON public.billing_segments USING btree (pricing_unit_id);
-
-
---
--- Name: index_billing_segments_on_rate_card_rate_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_billing_segments_on_rate_card_rate_id ON public.billing_segments USING btree (rate_card_rate_id);
-
-
---
 -- Name: index_billing_segments_on_rate_override_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -14920,6 +14904,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260908180522'),
 ('20260905223042'),
 ('20260905223041'),
 ('20260904173416'),

--- a/spec/factories/billing_segments.rb
+++ b/spec/factories/billing_segments.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     billing_at { Time.current }
     cycle_started_at { Time.current.beginning_of_day }
     started_at { cycle_started_at }
-    ended_at { cycle_started_at + 1.month - Rational(1, 1_000_000) }
+    ended_at { BillingSegment.inclusive_end(cycle_started_at + 1.month) }
     status { :pending }
   end
 end

--- a/spec/models/billing_segment_spec.rb
+++ b/spec/models/billing_segment_spec.rb
@@ -174,8 +174,8 @@ RSpec.describe BillingSegment do
         rate_card_rate: create(:rate_card_rate, organization: contract_rate_card.organization, rate_card: contract_rate_card.rate_card),
         cycle_started_at:
       }
-      first = create(:billing_segment, **attributes, started_at: cycle_started_at, ended_at: cut - Rational(1, 1_000_000))
-      second = create(:billing_segment, **attributes, started_at: cut, ended_at: Time.zone.parse("2026-10-01") - Rational(1, 1_000_000))
+      first = create(:billing_segment, **attributes, started_at: cycle_started_at, ended_at: described_class.inclusive_end(cut))
+      second = create(:billing_segment, **attributes, started_at: cut, ended_at: described_class.inclusive_end(Time.zone.parse("2026-10-01")))
 
       expect(described_class.where(contract_rate_card:, cycle_started_at:)).to match_array([first, second])
     end

--- a/spec/services/billing/calendar_spec.rb
+++ b/spec/services/billing/calendar_spec.rb
@@ -1,0 +1,556 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Billing::Calendar do
+  subject(:calendar) { described_class.new(anchor_date:, interval:, timezone:) }
+
+  let(:anchor_date) { Date.new(2022, 2, 1) }
+  let(:interval) { Billing::Interval.new(count: 1, unit: :month) }
+  let(:timezone) { "UTC" }
+
+  def calendar_for(anchor, count, unit, timezone = "UTC")
+    described_class.new(
+      anchor_date: anchor,
+      interval: Billing::Interval.new(count:, unit:),
+      timezone:
+    )
+  end
+
+  # Where the ruler begins. The anchor is a date, so it lands at the start of that day where
+  # the customer is rather than in UTC — visible through the interval it opens.
+  describe "the anchor boundary" do
+    it "opens the interval at the start of the anchor day" do
+      expect(calendar.interval_containing(Time.utc(2022, 2, 15)).begin).to eq(Time.utc(2022, 2, 1))
+    end
+
+    context "with a customer timezone" do
+      let(:timezone) { "America/New_York" }
+
+      it "opens it at the start of the anchor day there" do
+        expect(calendar.interval_containing(Time.utc(2022, 2, 15)).begin).to eq(Time.utc(2022, 2, 1, 5))
+      end
+    end
+  end
+
+  # The step function, asserted through the window it opens: constant inside an interval,
+  # turning exactly on the boundary. Anchored on the 31st so month-end clamping is in play,
+  # which puts the boundaries on Dec 31, Jan 31, Feb 28, Mar 31.
+  describe "stepping from the anchor" do
+    [
+      {timestamp: Time.utc(2022, 1, 30), opens: Time.utc(2021, 12, 31)},
+      {timestamp: Time.utc(2022, 1, 31), opens: Time.utc(2022, 1, 31)},
+      {timestamp: Time.utc(2022, 2, 15), opens: Time.utc(2022, 1, 31)},
+      {timestamp: Time.utc(2022, 2, 27), opens: Time.utc(2022, 1, 31)},
+      {timestamp: Time.utc(2022, 2, 28), opens: Time.utc(2022, 2, 28)},
+      {timestamp: Time.utc(2022, 3, 31), opens: Time.utc(2022, 3, 31)}
+    ].each do |test_case|
+      it "opens #{test_case[:timestamp].to_date}'s interval on #{test_case[:opens].to_date}" do
+        subject = calendar_for(Date.new(2022, 1, 31), 1, :month)
+
+        expect(subject.interval_containing(test_case[:timestamp]).begin).to eq(test_case[:opens])
+      end
+    end
+
+    # Same timestamp, two timezones, two answers. Mar 1 02:00 UTC is still Feb 28 in
+    # New York, so the March boundary has not been reached there yet.
+    context "when the timestamp straddles a boundary in the customer timezone" do
+      let(:timestamp) { Time.utc(2022, 3, 1, 2) }
+
+      it "counts the boundary as reached in UTC" do
+        window = calendar_for(Date.new(2022, 2, 1), 1, :month).interval_containing(timestamp)
+
+        expect(window.begin).to eq(Time.utc(2022, 3, 1))
+      end
+
+      it "does not count it as reached in New York" do
+        window = calendar_for(Date.new(2022, 2, 1), 1, :month, "America/New_York").interval_containing(timestamp)
+
+        expect(window.begin).to eq(Time.utc(2022, 2, 1, 5))
+      end
+    end
+  end
+
+  describe "#interval_containing" do
+    [
+      {anchor: Date.new(2022, 2, 1), count: 1, unit: :month, timestamp: Time.utc(2022, 2, 10),
+       expected: Time.utc(2022, 2, 1)...Time.utc(2022, 3, 1)},
+      # Before the anchor: the anchor is a reference day, not a start date.
+      {anchor: Date.new(2022, 2, 1), count: 1, unit: :month, timestamp: Time.utc(2022, 1, 10),
+       expected: Time.utc(2022, 1, 1)...Time.utc(2022, 2, 1)},
+      # Anchored on the 31st: February clamps to the 28th...
+      {anchor: Date.new(2022, 1, 31), count: 1, unit: :month, timestamp: Time.utc(2022, 2, 15),
+       expected: Time.utc(2022, 1, 31)...Time.utc(2022, 2, 28)},
+      # ...and March goes back to the 31st instead of dragging along at the 28th.
+      {anchor: Date.new(2022, 1, 31), count: 1, unit: :month, timestamp: Time.utc(2022, 3, 1),
+       expected: Time.utc(2022, 2, 28)...Time.utc(2022, 3, 31)},
+      {anchor: Date.new(2022, 1, 1), count: 3, unit: :month, timestamp: Time.utc(2022, 8, 1),
+       expected: Time.utc(2022, 7, 1)...Time.utc(2022, 10, 1)},
+      {anchor: Date.new(2022, 1, 1), count: 1, unit: :week, timestamp: Time.utc(2022, 1, 25),
+       expected: Time.utc(2022, 1, 22)...Time.utc(2022, 1, 29)},
+      {anchor: Date.new(2022, 1, 1), count: 1, unit: :day, timestamp: Time.utc(2022, 2, 15, 12),
+       expected: Time.utc(2022, 2, 15)...Time.utc(2022, 2, 16)},
+      {anchor: Date.new(2024, 2, 29), count: 1, unit: :year, timestamp: Time.utc(2025, 3, 1),
+       expected: Time.utc(2025, 2, 28)...Time.utc(2026, 2, 28)}
+    ].each do |test_case|
+      it "puts #{test_case[:timestamp].to_date} in #{test_case[:expected].begin.to_date}..." \
+         "#{test_case[:expected].end.to_date} at #{test_case[:count]} #{test_case[:unit]} " \
+         "anchored on #{test_case[:anchor]}" do
+        subject = calendar_for(test_case[:anchor], test_case[:count], test_case[:unit])
+
+        expect(subject.interval_containing(test_case[:timestamp])).to eq(test_case[:expected])
+      end
+    end
+
+    it "excludes its end, so the boundary belongs to the next interval" do
+      window = calendar.interval_containing(Time.utc(2022, 2, 10))
+
+      expect(window.exclude_end?).to be(true)
+    end
+
+    it "covers the last moment before the boundary but not the boundary" do
+      window = calendar.interval_containing(Time.utc(2022, 2, 10))
+
+      expect(window.cover?(Time.utc(2022, 2, 28, 23, 59, 59))).to be(true)
+      expect(window.cover?(Time.utc(2022, 3, 1))).to be(false)
+    end
+  end
+
+  # The three questions the jump is built on. They are asked once per cadence change instead of
+  # once per cycle, which is the whole reason a resumed walk can skip — so they are pinned here
+  # directly rather than only through Schedule.
+  describe "positions on the ruler" do
+    # The case that makes a boundary useless as an anchor: anchored Jan 31 the ruler clamps to
+    # Feb 28, but Mar 28 is still INSIDE the interval that opened Feb 28.
+    let(:month_end) { calendar_for(Date.new(2026, 1, 31), 1, :month) }
+
+    describe "#intervals_between" do
+      it "counts whole intervals, not calendar months" do
+        expect(month_end.intervals_between(Time.utc(2026, 2, 28), Time.utc(2026, 3, 31))).to eq(1)
+        expect(month_end.intervals_between(Time.utc(2026, 2, 28), Time.utc(2026, 3, 28))).to eq(0)
+      end
+
+      it "is the difference of two positions, so it is signed and additive" do
+        a = Time.utc(2026, 2, 28)
+        b = Time.utc(2026, 5, 31)
+
+        expect(month_end.intervals_between(a, b)).to eq(3)
+        expect(month_end.intervals_between(b, a)).to eq(-3)
+        expect(month_end.intervals_between(a, Time.utc(2026, 3, 31)) +
+          month_end.intervals_between(Time.utc(2026, 3, 31), b)).to eq(3)
+      end
+
+      it "counts a day-long interval across a spring-forward day as one" do
+        daily = calendar_for(Date.new(2026, 3, 1), 1, :day, "America/New_York")
+
+        expect(daily.intervals_between(Time.utc(2026, 3, 8, 5), Time.utc(2026, 3, 9, 4))).to eq(1)
+      end
+    end
+
+    describe "#boundary_after" do
+      it "re-derives from the anchor rather than from the clamped boundary" do
+        expect(month_end.boundary_after(Time.utc(2026, 2, 10), 1)).to eq(Time.utc(2026, 2, 28))
+        expect(month_end.boundary_after(Time.utc(2026, 2, 10), 2)).to eq(Time.utc(2026, 3, 31))
+      end
+
+      it "counts from the interval CONTAINING the instant, not from the instant" do
+        expect(month_end.boundary_after(Time.utc(2026, 3, 1), 1))
+          .to eq(month_end.boundary_after(Time.utc(2026, 3, 30), 1))
+      end
+    end
+
+    describe "#boundary_at_or_after" do
+      it "answers with the instant itself when it is already a boundary" do
+        expect(month_end.boundary_at_or_after(Time.utc(2026, 2, 28))).to eq(Time.utc(2026, 2, 28))
+      end
+
+      it "answers with the next boundary from anywhere inside an interval" do
+        expect(month_end.boundary_at_or_after(Time.utc(2026, 2, 28, 0, 0, 1))).to eq(Time.utc(2026, 3, 31))
+        expect(month_end.boundary_at_or_after(Time.utc(2026, 3, 30))).to eq(Time.utc(2026, 3, 31))
+      end
+
+      # A rate takes effect at an instant; the cadence it brings takes hold at the next cycle
+      # start. One microsecond past a boundary must not resolve back to that boundary.
+      it "never answers with a boundary before the instant" do
+        [Time.utc(2026, 2, 28), Time.utc(2026, 3, 15), Time.utc(2026, 3, 31),
+          Time.utc(2026, 4, 30, 23, 59, 59)].each do |at|
+          expect(month_end.boundary_at_or_after(at)).to be >= at
+        end
+      end
+    end
+  end
+
+  describe "#proration_ratio" do
+    subject(:calendar) { calendar_for(Date.new(2022, 6, 1), 1, :month) }
+
+    it "is 1.0 for a whole interval" do
+      expect(calendar.proration_ratio(Time.utc(2022, 6, 1), Time.utc(2022, 7, 1))).to eq(1.0)
+    end
+
+    it "prorates a window clamped at the start" do
+      expect(calendar.proration_ratio(Time.utc(2022, 6, 1), Time.utc(2022, 6, 16))).to eq(0.5)
+    end
+
+    it "prorates a window clamped at both ends" do
+      expect(calendar.proration_ratio(Time.utc(2022, 6, 28), Time.utc(2022, 7, 1))).to eq(0.1)
+    end
+
+    # The denominator is the interval containing `from`, so a window reaching past the
+    # boundary would be measured against the wrong length. A short straddling window
+    # returns a plausible number, which is why this is rejected rather than capped.
+    it "rejects a window crossing the boundary" do
+      expect { calendar.proration_ratio(Time.utc(2022, 6, 29), Time.utc(2022, 7, 2)) }
+        .to raise_error(ArgumentError, /crosses the boundary/)
+    end
+
+    it "rejects a window spanning several intervals" do
+      expect { calendar.proration_ratio(Time.utc(2022, 6, 1), Time.utc(2022, 8, 1)) }
+        .to raise_error(ArgumentError, /crosses the boundary/)
+    end
+
+    it "rejects a window ending before it starts" do
+      expect { calendar.proration_ratio(Time.utc(2022, 6, 20), Time.utc(2022, 6, 10)) }
+        .to raise_error(ArgumentError, /precedes its start/)
+    end
+
+    it "is 0.0 for an empty window" do
+      expect(calendar.proration_ratio(Time.utc(2022, 6, 1), Time.utc(2022, 6, 1))).to eq(0.0)
+    end
+
+    # The denominator is the interval's own length, so one day of it pins that length. Short
+    # and long months, a leap February, a quarter and a fortnight.
+    [
+      {anchor: Date.new(2022, 2, 1), count: 1, unit: :month, timestamp: Time.utc(2022, 2, 10), days: 28},
+      {anchor: Date.new(2024, 2, 1), count: 1, unit: :month, timestamp: Time.utc(2024, 2, 10), days: 29},
+      {anchor: Date.new(2022, 6, 1), count: 1, unit: :month, timestamp: Time.utc(2022, 6, 10), days: 30},
+      {anchor: Date.new(2022, 7, 1), count: 1, unit: :month, timestamp: Time.utc(2022, 7, 10), days: 31},
+      {anchor: Date.new(2022, 1, 1), count: 3, unit: :month, timestamp: Time.utc(2022, 2, 10), days: 90},
+      {anchor: Date.new(2022, 1, 1), count: 2, unit: :week, timestamp: Time.utc(2022, 1, 10), days: 14}
+    ].each do |test_case|
+      it "prorates one day of the #{test_case[:count]} #{test_case[:unit]} interval covering " \
+         "#{test_case[:timestamp].to_date} as 1/#{test_case[:days]}" do
+        subject = calendar_for(test_case[:anchor], test_case[:count], test_case[:unit])
+        window = subject.interval_containing(test_case[:timestamp])
+
+        expect(subject.proration_ratio(window.begin, window.begin + 1.day)).to eq(1.fdiv(test_case[:days]))
+        expect(subject.proration_ratio(window.begin, window.end)).to eq(1.0)
+      end
+    end
+
+    # A day begun counts as a whole day at the end of service. This is the v1 billing
+    # rule — a policy, not an implementation detail, so it is pinned here rather than
+    # left to emerge. It holds because a terminal window opens on the interval's own
+    # boundary, so that midnight is inside it.
+    context "when the window ends part-way through a day" do
+      it "counts a full day for a termination a few hours in" do
+        expect(calendar.proration_ratio(Time.utc(2022, 6, 1), Time.utc(2022, 6, 1, 9))).to eq(1.fdiv(30))
+      end
+
+      it "counts the started day in full" do
+        expect(calendar.proration_ratio(Time.utc(2022, 6, 1), Time.utc(2022, 6, 15, 14, 30))).to eq(15.fdiv(30))
+      end
+
+      it "counts one day less when the window ends exactly on midnight" do
+        expect(calendar.proration_ratio(Time.utc(2022, 6, 1), Time.utc(2022, 6, 15))).to eq(14.fdiv(30))
+      end
+    end
+
+    # A DST transition makes one day 23 or 25 hours long. Without the timezone-aware
+    # day count these intervals would come out as 30.96 and 30.04 days, and a full
+    # interval would silently prorate.
+    context "when a daylight saving transition falls inside the interval" do
+      let(:new_york) { Time.find_zone!("America/New_York") }
+
+      it "is 1.0 over a spring forward" do
+        subject = calendar_for(Date.new(2026, 3, 1), 1, :month, "America/New_York")
+
+        expect(subject.proration_ratio(new_york.local(2026, 3, 1), new_york.local(2026, 4, 1))).to eq(1.0)
+      end
+
+      it "is 1.0 over a fall back" do
+        subject = calendar_for(Date.new(2026, 11, 1), 1, :month, "America/New_York")
+
+        expect(subject.proration_ratio(new_york.local(2026, 11, 1), new_york.local(2026, 12, 1))).to eq(1.0)
+      end
+    end
+  end
+
+  # Scenarios lifted from the Plan v2 QA plan (2026-08-10). These are the boundaries QA
+  # signs off against, so they are pinned here against the pure calendar rather than only
+  # through a billing run.
+  describe "QA plan v2 scenarios" do
+    def walk(subject, from, count)
+      cursor = from
+
+      Array.new(count) do
+        window = subject.interval_containing(cursor)
+        cursor = window.end
+        window
+      end
+    end
+
+    # BC — the cycle matrix: every billing_interval_unit x count, anchored on the signing
+    # day. Bounds are shown inclusive in the plan, so the exclusive end is the day after.
+    [
+      {label: "day x 1", count: 1, unit: :day, bounds: ["2026-08-10", "2026-08-10", "2026-08-11", "2026-08-11"]},
+      {label: "day x 45", count: 45, unit: :day, bounds: ["2026-08-10", "2026-09-23", "2026-09-24", "2026-11-07"]},
+      {label: "week x 1", count: 1, unit: :week, bounds: ["2026-08-10", "2026-08-16", "2026-08-17", "2026-08-23"]},
+      {label: "week x 4", count: 4, unit: :week, bounds: ["2026-08-10", "2026-09-06", "2026-09-07", "2026-10-04"]},
+      {label: "month x 3", count: 3, unit: :month, bounds: ["2026-08-10", "2026-11-09", "2026-11-10", "2027-02-09"]},
+      {label: "month x 6", count: 6, unit: :month, bounds: ["2026-08-10", "2027-02-09", "2027-02-10", "2027-08-09"]},
+      {label: "year x 1", count: 1, unit: :year, bounds: ["2026-08-10", "2027-08-09", "2027-08-10", "2028-08-09"]},
+      {label: "year x 2", count: 2, unit: :year, bounds: ["2026-08-10", "2028-08-09", "2028-08-10", "2030-08-09"]}
+    ].each do |test_case|
+      it "BC: bounds the first two #{test_case[:label]} cycles" do
+        subject = calendar_for(Date.new(2026, 8, 10), test_case[:count], test_case[:unit])
+        inclusive = walk(subject, Time.utc(2026, 8, 10), 2)
+          .flat_map { |window| [window.begin.to_date.to_s, (window.end - 1.day).to_date.to_s] }
+
+        expect(inclusive).to eq(test_case[:bounds])
+      end
+    end
+
+    # X5 — "A subscription anchored on the 31st clamps to shorter month-ends but must
+    # RETURN to the 31st — no permanent drift."
+    it "X5: returns to the 31st after clamping to shorter months" do
+      subject = calendar_for(Date.new(2026, 8, 31), 1, :month)
+
+      expect(walk(subject, Time.utc(2026, 8, 31), 4).map { |window| window.begin.to_date }).to eq(
+        [Date.new(2026, 8, 31), Date.new(2026, 9, 30), Date.new(2026, 10, 31), Date.new(2026, 11, 30)]
+      )
+    end
+
+    # X6a — monthly across a leap February: the clamped boundary lands on Feb 29.
+    it "X6a: clamps into a leap February and out again" do
+      subject = calendar_for(Date.new(2028, 1, 31), 1, :month)
+
+      expect(walk(subject, Time.utc(2028, 1, 31), 2).map { |window| window.begin.to_date })
+        .to eq([Date.new(2028, 1, 31), Date.new(2028, 2, 29)])
+    end
+
+    # X6b — "Boundary 2029 = Feb 28 (clamped); the 2032 boundary returns to Feb 29."
+    it "X6b: a yearly anchor on Feb 29 returns to Feb 29 in the next leap year" do
+      subject = calendar_for(Date.new(2028, 2, 29), 1, :year)
+
+      expect(walk(subject, Time.utc(2028, 2, 29), 5).map { |window| window.begin.to_date }).to eq(
+        [
+          Date.new(2028, 2, 29),
+          Date.new(2029, 2, 28),
+          Date.new(2030, 2, 28),
+          Date.new(2031, 2, 28),
+          Date.new(2032, 2, 29)
+        ]
+      )
+    end
+
+    # AN1/AN2 — signing on Aug 20 with the anchor on Sep 1 yields the stub Aug 20 -> Aug 31
+    # and then the anchored month. CS1a pins the stub's denominator as the containing
+    # anchored interval (Aug 1 -> Sep 1, 31 days), not the following one.
+    it "AN1: an anchor ahead of the signing date opens a stub cycle" do
+      subject = calendar_for(Date.new(2026, 9, 1), 1, :month)
+      signed_at = Time.utc(2026, 8, 20)
+      stub = subject.interval_containing(signed_at)
+
+      expect(stub).to eq(Time.utc(2026, 8, 1)...Time.utc(2026, 9, 1))
+      expect(subject.proration_ratio(signed_at, stub.end)).to eq(12.fdiv(31))
+      expect(subject.interval_containing(stub.end)).to eq(Time.utc(2026, 9, 1)...Time.utc(2026, 10, 1))
+    end
+  end
+
+  describe "timezone handling" do
+    # Boundaries are calendar positions, not fixed offsets from UTC. If `advance` ever
+    # did UTC arithmetic instead, every boundary after a transition would shift by an
+    # hour — and containment and contiguity would both still hold, so the invariants
+    # below would not catch it.
+    it "keeps every boundary at local midnight through a daylight saving transition" do
+      subject = calendar_for(Date.new(2026, 1, 1), 1, :month, "America/New_York")
+      starts = (1..12).map { |month| subject.interval_containing(Time.utc(2026, month, 15, 12)).begin }
+
+      expect(starts.map { |start| [start.hour, start.min] }.uniq).to eq([[0, 0]])
+      expect(starts.map(&:utc_offset).uniq).to match_array([-5 * 3600, -4 * 3600])
+    end
+
+    it "anchors intervals at local midnight in a half-hour offset timezone" do
+      subject = calendar_for(Date.new(2022, 6, 1), 1, :month, "Asia/Kolkata")
+      window = subject.interval_containing(Time.utc(2022, 6, 15))
+
+      expect([window.begin.hour, window.begin.min]).to eq([0, 0])
+      expect(window.begin.utc_offset).to eq((5 * 3600) + 1800)
+      expect(window.end - window.begin).to eq(30.days)
+    end
+  end
+
+  # Where this engine parts company with v1, deliberately. v1 counts each side of a cut
+  # independently and both with a ceil, so the day the cut falls on is billed twice: an
+  # upgrade at 14:00 charges 16 + 15 days of a 30-day month, 103.33% of the interval, and one
+  # at midnight charges 16 + 16. Here a day belongs to the window that opens it.
+  describe "a cycle cut part-way through a day" do
+    subject(:calendar) { calendar_for(Date.new(2022, 6, 1), 1, :month) }
+
+    let(:window) { calendar.interval_containing(Time.utc(2022, 6, 15)) }
+
+    it "gives the day holding the cut to the window that opens it" do
+      cut = Time.utc(2022, 6, 16, 14)
+
+      expect(calendar.proration_ratio(window.begin, cut)).to eq(16.fdiv(30))
+      expect(calendar.proration_ratio(cut, window.end)).to eq(14.fdiv(30))
+    end
+
+    it "bills one interval and no more, wherever the cut lands" do
+      cuts = [
+        Time.utc(2022, 6, 16),
+        Time.utc(2022, 6, 16, 0, 0, 1),
+        Time.utc(2022, 6, 16, 14),
+        Time.utc(2022, 6, 30, 23, 59, 59)
+      ]
+
+      totals = cuts.map do |cut|
+        calendar.proration_ratio(window.begin, cut) + calendar.proration_ratio(cut, window.end)
+      end
+
+      expect(totals).to eq([1.0, 1.0, 1.0, 1.0])
+    end
+
+    it "holds for two rate changes inside one cycle" do
+      first = Time.utc(2022, 6, 6, 7)
+      second = Time.utc(2022, 6, 20, 22)
+
+      total = calendar.proration_ratio(window.begin, first) +
+        calendar.proration_ratio(first, second) +
+        calendar.proration_ratio(second, window.end)
+
+      expect(total).to eq(1.0)
+    end
+
+    # An arrears rate is floored to UTC midnight, which is 02:00 the same day in Paris and
+    # 20:00 the day before in New York — mid-day either way, so the timezone alone is
+    # enough to put a cut inside a day.
+    it "bills one interval in a timezone where UTC midnight is not local midnight" do
+      totals = ["Europe/Paris", "America/New_York", "Asia/Kolkata", "Australia/Lord_Howe"].map do |timezone|
+        subject = calendar_for(Date.new(2022, 6, 1), 1, :month, timezone)
+        window = subject.interval_containing(Time.utc(2022, 6, 15))
+        cut = Time.utc(2022, 6, 16)
+
+        subject.proration_ratio(window.begin, cut) + subject.proration_ratio(cut, window.end)
+      end
+
+      expect(totals).to eq([1.0, 1.0, 1.0, 1.0])
+    end
+
+    # The cut lands in the hour the clocks move, where a day is 23 or 25 hours long.
+    it "bills one interval when the cut falls on a daylight saving transition" do
+      new_york = Time.find_zone!("America/New_York")
+
+      totals = [[Date.new(2026, 3, 1), new_york.local(2026, 3, 8, 3, 30)],
+        [Date.new(2026, 11, 1), new_york.local(2026, 11, 1, 1, 30)]].map do |anchor, cut|
+        subject = calendar_for(anchor, 1, :month, "America/New_York")
+        window = subject.interval_containing(cut)
+
+        subject.proration_ratio(window.begin, cut) + subject.proration_ratio(cut, window.end)
+      end
+
+      expect(totals).to eq([1.0, 1.0])
+    end
+  end
+
+  # The two invariants everything downstream assumes, stated only through the public
+  # API and checked across a matrix rather than a few chosen rows.
+  describe "invariants" do
+    let(:anchors) do
+      [Date.new(2022, 1, 31), Date.new(2024, 2, 29), Date.new(2022, 7, 15), Date.new(2021, 12, 1)]
+    end
+    let(:timezones) { ["UTC", "America/New_York", "Asia/Tokyo"] }
+    let(:offsets) { [-400, -95, -31, -30, -1, 0, 1, 27, 28, 30, 31, 59, 90, 365, 366] }
+    # Real timestamps are rarely midnight, and the ones just inside a boundary are where
+    # an off-by-one would show.
+    let(:times_of_day) { [0.seconds, 7.hours + 31.minutes, 23.hours + 59.minutes] }
+
+    it "always returns a window containing the timestamp" do
+      violations = each_case do |subject, timestamp, label|
+        window = subject.interval_containing(timestamp)
+        next if window.cover?(timestamp)
+
+        "#{label} at #{timestamp}: got #{window}"
+      end
+
+      expect(violations).to be_empty
+    end
+
+    # A rate change cuts a window into separately-billed windows, so their shares have to
+    # add up to exactly one window — never 103% because both sides claimed the day the cut
+    # fell on. Checked at every anchor, cadence, timezone and timestamp of day above, since a
+    # cut lands wherever a rate happens to take effect.
+    it "never bills more or less than the whole window when a window is cut in two" do
+      violations = each_case do |subject, timestamp, label|
+        window = subject.interval_containing(timestamp)
+        total = subject.proration_ratio(window.begin, timestamp) + subject.proration_ratio(timestamp, window.end)
+        next if (total - 1.0).abs < 1e-9
+
+        "#{label} cut at #{timestamp}: bills #{total} of the window"
+      end
+
+      expect(violations).to be_empty
+    end
+
+    # A cycle can be cut more than once, and a pay-in-advance rate takes effect at an
+    # arbitrary moment rather than at midnight (RateCardRate#normalize_effective_from
+    # floors only arrears rates, and to UTC midnight at that). Billing::Days is a
+    # difference of its two endpoints, so any partition telescopes — this pins it instead
+    # of trusting it, across every cadence and timezone above.
+    it "bills exactly the whole window however many times it is cut" do
+      fractions = [0.11, 0.37, 0.5, 0.5001, 0.83, 0.9999]
+
+      violations = timezones.flat_map do |timezone|
+        [[1, :month], [3, :month], [1, :week], [1, :year]].flat_map do |count, unit|
+          anchors.filter_map do |anchor|
+            subject = calendar_for(anchor, count, unit, timezone)
+            window = subject.interval_containing(anchor.in_time_zone(timezone) + 2.days)
+            span = window.end - window.begin
+            cuts = fractions.map { |fraction| window.begin + (span * fraction) }
+            total = [window.begin, *cuts, window.end].each_cons(2).sum do |from, to|
+              subject.proration_ratio(from, to)
+            end
+            next if (total - 1.0).abs < 1e-9
+
+            "#{count} #{unit} on #{anchor} in #{timezone}: bills #{total} of the window"
+          end
+        end
+      end
+
+      expect(violations).to be_empty
+    end
+
+    # A boundary is the exclusive end of one window, so the window containing it must
+    # start exactly there. Anything else is a gap or an overlap.
+    it "never leaves a gap or an overlap between consecutive windows" do
+      violations = each_case do |subject, timestamp, label|
+        boundary = subject.interval_containing(timestamp).end
+        next if subject.interval_containing(boundary).begin == boundary
+
+        "#{label} at #{timestamp}: the window after #{boundary} does not start there"
+      end
+
+      expect(violations).to be_empty
+    end
+
+    def each_case
+      Billing::Interval::UNITS.flat_map do |unit|
+        [1, 3].flat_map do |count|
+          timezones.flat_map do |timezone|
+            anchors.flat_map do |anchor|
+              subject = calendar_for(anchor, count, unit, timezone)
+
+              offsets.flat_map do |offset|
+                times_of_day.filter_map do |time_of_day|
+                  timestamp = anchor.in_time_zone(timezone) + offset.days + time_of_day
+
+                  yield(subject, timestamp, "#{count} #{unit} on #{anchor} in #{timezone}")
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/billing/days_spec.rb
+++ b/spec/services/billing/days_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Day ownership: a day belongs to the window holding its LOCAL midnight. Two places decide
+# whose a day is — the proration denominator and the credit numerator — and when they used
+# different rules a cut month billed 103.33%.
+RSpec.describe Billing::Days do
+  describe ".between" do
+    it "counts the days a whole interval opens" do
+      expect(described_class.between(Time.utc(2026, 6, 1), Time.utc(2026, 7, 1), timezone: "UTC")).to eq(30)
+    end
+
+    it "counts nothing for a window that opens and closes inside one day" do
+      expect(described_class.between(Time.utc(2026, 6, 1, 9), Time.utc(2026, 6, 1, 17), timezone: "UTC")).to eq(0)
+    end
+
+    # The half-open window [from, to) owns the day at `from` only when it holds its opening.
+    # Starting mid-morning, the 16th already belongs to whatever ran before.
+    it "gives a day that has already opened to the window before it" do
+      expect(described_class.between(Time.utc(2026, 6, 16, 9, 30), Time.utc(2026, 7, 1), timezone: "UTC")).to eq(14)
+    end
+
+    it "keeps the day when the window opens exactly on its midnight" do
+      expect(described_class.between(Time.utc(2026, 6, 16), Time.utc(2026, 7, 1), timezone: "UTC")).to eq(15)
+    end
+
+    # The one shape that catches a timezone being ignored, and it has to be a CUT.
+    #
+    # Move both ends of a window by the same offset and a UTC-only reading lands on the right
+    # answer by luck — the offsets cancel and the total is still 30. A cut does not cancel: the
+    # window opens on a local midnight and the cut falls mid-day, so only one end shifts.
+    # Dropping the timezone from #opening_date passes every other example in this file and
+    # misprices both slices of a cut period for every customer outside UTC.
+    it "shares a cut interval by local days, not by UTC days" do
+      window = [Time.utc(2026, 6, 1, 4), Time.utc(2026, 7, 1, 4)] # Jun 1 -> Jul 1 in New York
+      cut = Time.utc(2026, 6, 15, 12)                             # 08:00 on the 15th there
+
+      before = described_class.between(window.first, cut, timezone: "America/New_York")
+      after = described_class.between(cut, window.last, timezone: "America/New_York")
+
+      expect([before, after]).to eq([15, 15])
+    end
+
+    # The two sides of a cut always add back up to the whole, whatever hour the cut lands
+    # at. This is the invariant the 103% bug broke.
+    it "splits an interval into shares that sum to it" do
+      window = [Time.utc(2026, 3, 1), Time.utc(2026, 4, 1)]
+      whole = described_class.between(*window, timezone: "UTC")
+
+      [0, 9, 14, 23].each do |hour|
+        cut = Time.utc(2026, 3, 15, hour)
+        before = described_class.between(window.first, cut, timezone: "UTC")
+        after = described_class.between(cut, window.last, timezone: "UTC")
+
+        expect(before + after).to eq(whole)
+      end
+    end
+
+    # New York loses an hour on 2026-03-08 and gains one on 2026-11-01, so March holds a
+    # 23-hour day and November a 25-hour one. Neither is worth a different share: the day is
+    # the unit, not the elapsed hours. Counting hours would make every month with a transition
+    # total slightly wrong, and in opposite directions.
+    it "counts a DST day as one day like any other" do
+      march = described_class.between(Time.utc(2026, 3, 1, 5), Time.utc(2026, 4, 1, 4), timezone: "America/New_York")
+      november = described_class.between(Time.utc(2026, 11, 1, 4), Time.utc(2026, 12, 1, 5), timezone: "America/New_York")
+
+      expect([march, november]).to eq([31, 30])
+    end
+  end
+end

--- a/spec/services/billing/interval_spec.rb
+++ b/spec/services/billing/interval_spec.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Billing::Interval do
+  it "covers exactly the billing interval units the catalog allows" do
+    expect(described_class::UNITS).to match_array(RateCardRate::BILLING_INTERVAL_UNITS.keys)
+  end
+
+  describe "validation" do
+    it "rejects an unknown unit" do
+      expect { described_class.new(count: 1, unit: :fortnight) }
+        .to raise_error(ArgumentError, /unknown interval unit/)
+    end
+
+    it "rejects a zero count" do
+      expect { described_class.new(count: 0, unit: :month) }
+        .to raise_error(ArgumentError, /must be a positive integer/)
+    end
+
+    it "rejects a negative count" do
+      expect { described_class.new(count: -1, unit: :month) }
+        .to raise_error(ArgumentError, /must be a positive integer/)
+    end
+
+    it "still takes the unit as a string, which is how the enum column reads" do
+      expect(described_class.new(count: 3, unit: "month")).to eq(described_class.new(count: 3, unit: :month))
+    end
+
+    # The count used to be coerced with `to_i`. That turned "3" into 3 quietly, and 1.5 into
+    # 1 — a cadence silently halved, which is the worst answer this class can give. The
+    # column is an integer, so nothing legitimate arrives as anything else.
+    it "rejects a count that is not an integer rather than coercing it" do
+      expect { described_class.new(count: "3", unit: :month) }
+        .to raise_error(ArgumentError, /must be a positive integer/)
+      expect { described_class.new(count: 1.5, unit: :month) }
+        .to raise_error(ArgumentError, /must be a positive integer/)
+    end
+
+    it "rejects a nil unit without blowing up on it" do
+      expect { described_class.new(count: 1, unit: nil) }
+        .to raise_error(ArgumentError, /unknown interval unit/)
+    end
+  end
+
+  # The two override columns are nullable independently of each other, which is why this
+  # reads four columns rather than composing two Intervals: a phase that only changes the
+  # unit keeps the rate's count.
+  describe ".from" do
+    let(:rate) { build_stubbed(:rate_card_rate, billing_interval_count: 3, billing_interval_unit: "month") }
+
+    it "reads the rate when there is no override" do
+      expect(described_class.from(rate)).to eq(described_class.new(count: 3, unit: :month))
+    end
+
+    it "reads the override when it sets both columns" do
+      override = build_stubbed(:rate_override, billing_interval_count: 2, billing_interval_unit: "week")
+
+      expect(described_class.from(rate, override:)).to eq(described_class.new(count: 2, unit: :week))
+    end
+
+    it "keeps the rate's count when the override sets only the unit" do
+      override = build_stubbed(:rate_override, billing_interval_count: nil, billing_interval_unit: "week")
+
+      expect(described_class.from(rate, override:)).to eq(described_class.new(count: 3, unit: :week))
+    end
+
+    it "keeps the rate's unit when the override sets only the count" do
+      override = build_stubbed(:rate_override, billing_interval_count: 2, billing_interval_unit: nil)
+
+      expect(described_class.from(rate, override:)).to eq(described_class.new(count: 2, unit: :month))
+    end
+
+    it "falls back to the rate entirely when the override sets neither" do
+      override = build_stubbed(:rate_override, billing_interval_count: nil, billing_interval_unit: nil)
+
+      expect(described_class.from(rate, override:)).to eq(described_class.new(count: 3, unit: :month))
+    end
+  end
+
+  describe "#advance" do
+    [
+      {count: 1, unit: :month, from: Time.utc(2022, 1, 31), steps: 1, expected: Time.utc(2022, 2, 28)},
+      {count: 1, unit: :month, from: Time.utc(2022, 1, 31), steps: 2, expected: Time.utc(2022, 3, 31)},
+      {count: 1, unit: :month, from: Time.utc(2022, 1, 31), steps: -1, expected: Time.utc(2021, 12, 31)},
+      {count: 1, unit: :month, from: Time.utc(2022, 1, 31), steps: 0, expected: Time.utc(2022, 1, 31)},
+      {count: 3, unit: :month, from: Time.utc(2022, 1, 31), steps: 1, expected: Time.utc(2022, 4, 30)},
+      {count: 3, unit: :month, from: Time.utc(2022, 1, 1), steps: 2, expected: Time.utc(2022, 7, 1)},
+      {count: 1, unit: :day, from: Time.utc(2022, 1, 31), steps: 10, expected: Time.utc(2022, 2, 10)},
+      {count: 2, unit: :week, from: Time.utc(2022, 1, 31), steps: 1, expected: Time.utc(2022, 2, 14)},
+      {count: 1, unit: :year, from: Time.utc(2024, 2, 29), steps: 1, expected: Time.utc(2025, 2, 28)}
+    ].each do |test_case|
+      it "moves #{test_case[:from].to_date} by #{test_case[:steps]} x #{test_case[:count]} #{test_case[:unit]}" do
+        interval = described_class.new(count: test_case[:count], unit: test_case[:unit])
+
+        expect(interval.advance(test_case[:from], test_case[:steps])).to eq(test_case[:expected])
+      end
+    end
+
+    # Calendar passes a zone-aware timestamp, never a UTC one, and these are the two ways
+    # that matters. Paris springs forward on Mar 29 2026, and Mar 1 00:00 there is Feb 28
+    # 23:00 UTC — a different month.
+    context "with a zone-aware timestamp" do
+      let(:paris) { Time.find_zone("Europe/Paris") }
+      let(:local_midnight) { paris.local(2026, 3, 1) }
+
+      it "steps a month by the local date rather than the UTC one" do
+        interval = described_class.new(count: 1, unit: :month)
+
+        expect(interval.advance(local_midnight, 1)).to eq(paris.local(2026, 4, 1))
+        expect(interval.advance(local_midnight.utc, 1)).to eq(Time.utc(2026, 3, 28, 23))
+      end
+
+      it "keeps the wall-clock time when a week crosses the transition" do
+        interval = described_class.new(count: 1, unit: :week)
+        result = interval.advance(local_midnight, 5)
+
+        expect(result).to eq(paris.local(2026, 4, 5))
+        expect(result.in_time_zone(paris)).to eq(result.in_time_zone(paris).beginning_of_day)
+      end
+    end
+
+    # Month-ends only stay put because every step is derived from the same origin.
+    # Accumulating one step at a time would collapse to Feb 28.
+    it "does not drift when month-ends are re-derived from the same origin" do
+      interval = described_class.new(count: 1, unit: :month)
+      origin = Time.utc(2022, 1, 31)
+
+      expect((0..3).map { interval.advance(origin, it) })
+        .to eq([Time.utc(2022, 1, 31), Time.utc(2022, 2, 28), Time.utc(2022, 3, 31), Time.utc(2022, 4, 30)])
+    end
+  end
+
+  describe "#steps_between" do
+    [
+      {count: 1, unit: :month, from: Time.utc(2022, 1, 31), to: Time.utc(2022, 1, 31), expected: 0},
+      # Feb 15 has not reached the Feb 28 step, so no whole interval has closed.
+      # The calendar grid would say 1 here; the correction brings it back to 0.
+      {count: 1, unit: :month, from: Time.utc(2022, 1, 31), to: Time.utc(2022, 2, 15), expected: 0},
+      {count: 1, unit: :month, from: Time.utc(2022, 1, 31), to: Time.utc(2022, 2, 28), expected: 1},
+      {count: 1, unit: :month, from: Time.utc(2022, 1, 31), to: Time.utc(2021, 12, 15), expected: -2},
+      {count: 3, unit: :month, from: Time.utc(2022, 1, 1), to: Time.utc(2022, 8, 1), expected: 2},
+      {count: 3, unit: :month, from: Time.utc(2022, 1, 31), to: Time.utc(2022, 4, 15), expected: 0},
+      {count: 3, unit: :month, from: Time.utc(2022, 1, 1), to: Time.utc(2021, 11, 1), expected: -1},
+      {count: 1, unit: :day, from: Time.utc(2022, 1, 1), to: Time.utc(2022, 1, 10), expected: 9},
+      {count: 3, unit: :day, from: Time.utc(2022, 1, 11), to: Time.utc(2022, 1, 1), expected: -4},
+      {count: 1, unit: :week, from: Time.utc(2022, 1, 1), to: Time.utc(2022, 1, 15), expected: 2},
+      {count: 1, unit: :week, from: Time.utc(2022, 1, 15), to: Time.utc(2022, 1, 1), expected: -2},
+      {count: 1, unit: :year, from: Time.utc(2022, 6, 1), to: Time.utc(2025, 1, 1), expected: 2}
+    ].each do |test_case|
+      it "fits #{test_case[:expected]} x #{test_case[:count]} #{test_case[:unit]} " \
+         "from #{test_case[:from].to_date} to #{test_case[:to].to_date}" do
+        interval = described_class.new(count: test_case[:count], unit: test_case[:unit])
+
+        expect(interval.steps_between(test_case[:from], test_case[:to])).to eq(test_case[:expected])
+      end
+    end
+
+    # The defining property: `from` advanced by the answer never passes `to`, and one
+    # more step always does.
+    #
+    # Checked across a matrix rather than a few chosen rows, because this is what
+    # pins calendar_steps_between to overshooting by at most one. steps_between takes
+    # a single step back; if a change ever made the bracket overshoot by two it would
+    # silently return a wrong index, and this is what catches that.
+    it "always lands on the last step at or before the target" do
+      # The last two are zone-aware and sit on Paris's DST transition days, because that is
+      # the type Calendar passes and a UTC-only matrix would never exercise it.
+      froms = [
+        Time.utc(2022, 1, 31),
+        Time.utc(2024, 2, 29),
+        Time.utc(2022, 7, 15),
+        Time.utc(2021, 12, 1),
+        Time.utc(2022, 6, 30),
+        Time.find_zone("Europe/Paris").local(2026, 3, 29),
+        Time.find_zone("Europe/Paris").local(2026, 10, 25)
+      ]
+      offsets = [-400, -95, -31, -30, -29, -1, 0, 1, 27, 28, 29, 30, 31, 32, 59, 90, 365, 366, 730]
+
+      violations = described_class::UNITS.flat_map do |unit|
+        [1, 3].flat_map do |count|
+          interval = described_class.new(count:, unit:)
+
+          froms.flat_map do |from|
+            offsets.filter_map do |offset|
+              to = from + offset.days
+              steps = interval.steps_between(from, to)
+              next if interval.advance(from, steps) <= to && interval.advance(from, steps + 1) > to
+
+              "#{count} #{unit} from #{from.to_date} to #{to.to_date} gave #{steps}"
+            end
+          end
+        end
+      end
+
+      expect(violations).to be_empty
+    end
+  end
+end

--- a/spec/services/billing/phase_spec.rb
+++ b/spec/services/billing/phase_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Billing::Phase do
+  describe ".default" do
+    subject(:phase) { described_class.default }
+
+    # A card with no configured phases is a card with exactly one: its own cadence, its own
+    # price, for as long as it runs. The walk needs a phase that never ends or it stops
+    # producing cycles.
+    it "runs for as long as the card does" do
+      expect(phase).to be_unbounded
+    end
+
+    it "prices at the card's own rate" do
+      expect(phase.rate_override).to be_nil
+    end
+
+    it "has no code, because nothing persisted it" do
+      expect(phase.code).to be_nil
+    end
+  end
+
+  describe "#unbounded?" do
+    it "is unbounded when no cycle count was given" do
+      expect(described_class.new(code: "tail", billing_interval_cycle_count: nil, rate_override: nil))
+        .to be_unbounded
+    end
+
+    it "is bounded by a cycle count, however large" do
+      expect(described_class.new(code: "intro", billing_interval_cycle_count: 1, rate_override: nil))
+        .not_to be_unbounded
+    end
+  end
+
+  # A phase of zero cycles produced nothing and left the cursor where it was, so the walk
+  # skipped it in silence. It is not a length the domain has a meaning for.
+  describe "validation" do
+    it "rejects a phase that lasts no cycles" do
+      expect { described_class.new(code: "empty", billing_interval_cycle_count: 0, rate_override: nil) }
+        .to raise_error(ArgumentError, /positive whole number of cycles/)
+    end
+
+    it "rejects a length that is not a whole number" do
+      [1.5, "3"].each do |count|
+        expect { described_class.new(code: "fractional", billing_interval_cycle_count: count, rate_override: nil) }
+          .to raise_error(ArgumentError, /positive whole number of cycles/)
+      end
+    end
+
+    it "still allows nil, which is what running to the end means" do
+      expect { described_class.new(code: "tail", billing_interval_cycle_count: nil, rate_override: nil) }
+        .not_to raise_error
+    end
+  end
+end

--- a/spec/services/billing/rate_cards/build_schedule_service_cadence_spec.rb
+++ b/spec/services/billing/rate_cards/build_schedule_service_cadence_spec.rb
@@ -1,0 +1,323 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Ported from the previous engine, where these behaviours were covered and passing:
+#
+#   spec/services/billing_periods/dates/advance_service_spec.rb
+#     "with three rates using different billing intervals"
+#     "uses the interval active at the cycle start while splitting on effective dates"
+#
+# The contract has three parts, and the previous engine honoured all three:
+#
+#   1. the cadence is resolved at the START of each cycle, from the rate in force there
+#   2. a rate taking effect INSIDE a cycle splits it into segments — it does not
+#      change the cadence of the cycle it lands in
+#   3. when the cadence changes, billing re-anchors on the day it changes — LAGO-1766
+#      settled this as the ONLY behaviour ("reading B, everything is glued"), which is
+#      why the walk re-anchors unconditionally and there is no mode to turn it off
+#
+# The previous engine stored `period_to` inclusively; this one is half-open, so every
+# expectation below is the old one with the end moved to the next instant.
+RSpec.describe Billing::RateCards::BuildScheduleService do
+  describe "cadence from the rates in force" do
+    subject(:schedule) do
+      described_class.call(contract_rate_card:).schedule
+    end
+
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:, timezone: "UTC") }
+    let(:catalog_plan) { create(:catalog_plan, organization:) }
+    let(:contract) { create(:contract, organization:, customer:, catalog_plan:, started_at: Time.utc(2026, 1, 1)) }
+    let(:rate_card) { create(:rate_card, :advance, organization:) }
+
+    let(:rates) { rate_card.rates.order(:effective_from) }
+
+    let(:contract_rate_card) do
+      create(
+        :contract_rate_card,
+        organization:, contract:, rate_card:,
+        billing_anchor_date: Date.new(2026, 1, 1),
+        effective_date: Date.new(2026, 1, 1),
+        next_billing_at: Time.utc(2026, 1, 1)
+      )
+    end
+
+    # Monthly, then weekly from Mar 15, then monthly again from May 1. Named by their code,
+    # which is what the expectations below read back.
+    before do
+      create(:rate_card_rate, organization:, rate_card:, code: "monthly",
+        effective_from: Time.utc(2026, 1, 1), billing_interval_count: 1, billing_interval_unit: "month")
+      create(:rate_card_rate, organization:, rate_card:, code: "weekly",
+        effective_from: Time.utc(2026, 3, 15), billing_interval_count: 1, billing_interval_unit: "week")
+      create(:rate_card_rate, organization:, rate_card:, code: "monthly_again",
+        effective_from: Time.utc(2026, 5, 1), billing_interval_count: 1, billing_interval_unit: "month")
+    end
+
+    # Advance segments bill at their start, so keep those opening in the requested window.
+    def t(*parts) = Time.utc(*parts).to_fs(:db)
+
+    def billed_windows(from, to)
+      schedule.segments_due_by(to)
+        .select { |segment| segment.started_at >= from && segment.started_at < to }
+        .map { |segment| [segment.started_at.to_fs(:db), segment.ended_at.to_fs(:db), segment.rate.code] }
+    end
+
+    it "uses the interval active at the cycle start while splitting on effective dates" do
+      expect(billed_windows(Time.utc(2026, 1, 1), Time.utc(2026, 6, 1))).to eq(
+        [
+          # Monthly, from the only rate in force.
+          [t(2026, 1, 1), t(2026, 2, 1), "monthly"],
+          [t(2026, 2, 1), t(2026, 3, 1), "monthly"],
+          # The weekly rate lands inside the March cycle: it splits it, and March stays monthly.
+          [t(2026, 3, 1), t(2026, 3, 15), "monthly"],
+          [t(2026, 3, 15), t(2026, 4, 1), "weekly"],
+          # April opens with the weekly rate in force, so the cadence turns weekly — and
+          # re-anchors on the day it turns, which puts the weeks on the 1st, 8th, 15th...
+          [t(2026, 4, 1), t(2026, 4, 8), "weekly"],
+          [t(2026, 4, 8), t(2026, 4, 15), "weekly"],
+          [t(2026, 4, 15), t(2026, 4, 22), "weekly"],
+          [t(2026, 4, 22), t(2026, 4, 29), "weekly"],
+          # The monthly rate lands inside the Apr 29 week and splits it, without moving it.
+          [t(2026, 4, 29), t(2026, 5, 1), "weekly"],
+          [t(2026, 5, 1), t(2026, 5, 6), "monthly_again"],
+          # The cadence turns monthly at the next boundary and re-anchors there.
+          [t(2026, 5, 6), t(2026, 6, 6), "monthly_again"]
+        ]
+      )
+    end
+
+    # UNRULED, PINNED HERE SO IT IS NOT A SILENT TRAP.
+    #
+    # Parts 1 and 2 of the contract above mean a slice can be priced by one cadence and
+    # measured against another: the cycle's length comes from the rate in force at its start,
+    # while the slice after a cut is priced by a rate that may declare a different interval.
+    # `proration_ratio` is a share of the CYCLE, so a consumer computing
+    # `amount x units x proration_ratio` uses one rate's amount against the other rate's
+    # period.
+    #
+    # The numbers below are what the engine answers today. They are not a decision:
+    #
+    #   [Mar 15, Apr 1) is 17 days of the 31-day MONTHLY cycle -> 17/31 = 0.548,
+    #   and it is priced by the WEEKLY rate. 17 days is 2.43 weeks, so a consumer
+    #   charges 0.548 of a week for 2.43 weeks of service - 4.4x too little.
+    #
+    #   [May 1, May 6) is 5 days of the 7-day WEEKLY cycle -> 5/7 = 0.714, and it is
+    #   priced by the MONTHLY rate. 5 days is 5/31 = 0.161 of a month, so a consumer
+    #   charges 0.714 of a month - 4.4x too much.
+    #
+    # AND THERE IS A WRITTEN POLICY THAT SAYS THIS SHOULD NOT BE POSSIBLE.
+    #
+    # [BE] [Dive-In] 1 - Product, Plan and Rates system (last edited 2026-08-03), "Billing
+    # cadence":
+    #
+    #   "any rate change with a different billing_interval closes the current period at the
+    #    effective_from boundary and starts a new period. Mid-period interval mixing is
+    #    disallowed, so period length is always derivable from the currently-active rate."
+    #
+    # and, under the lifecycle of next_billing_at: "Rate change with new interval - close the
+    # current period at effective_from, recompute next_billing_at from the new rate's
+    # interval starting at that boundary."
+    #
+    # That is option (D), and its second sentence forbids exactly what the examples below
+    # produce. This engine implements neither: the cadence is resolved at the cycle's start
+    # (part 1 of the contract at the top of this file) and a mid-cycle rate change splits
+    # without moving the boundary (part 2) - both ported from the previous engine, "where
+    # these behaviours were covered and passing", so the divergence is inherited, not new.
+    #
+    # It has not simply been overlooked either. Three later documents reopen it:
+    #   - Dive-In 3, open question "Default-phase interval drift": freeze the interval for
+    #     the phase, or re-scale the remaining window?
+    #   - Dive-In 4, §7 "Interval mismatch": how do cycles map when the sub's billing period
+    #     differs from the rate interval?
+    #   - [Spec] Plan v2 - Current usage/fees, §7 OQ 1 (2026-08-26, the most recent of the
+    #     set): re-anchoring after a cadence-changing phase, "Must be settled before the
+    #     window algorithm is implemented."
+    # And BIL-464, "Preview across a pending rate or phase transition inside the period",
+    # which would have forced the answer, was CANCELED on 2026-08-20.
+    #
+    # What IS settled, and does not decide this: a SAME-cadence mid-period rate change splits
+    # the window and preserves the anchor ([SPEC] Rate cards and Rates, 2026-08-24, scenario
+    # 3 and worked ATTEMPT 3; next_billing_at returns to the original boundary) - not (D);
+    # and the proration denominator is the period CONTAINING the window (decision #55,
+    # measured and confirmed on LAGO-1796), which points at (A). Every application of #55
+    # pairs that denominator with the amount charged for that same window, never with a
+    # differently-cadenced rate's amount. (B) has no support in Notion, Slack or Linear.
+    #
+    # So: do not "fix" these numbers to match Dive-In 1 without a ruling, and do not wire a
+    # fee computation onto them without reading this. The mixing is latent today - nothing
+    # outside app/services/billing reads proration_ratio.
+    describe "a cut whose slices are priced on different cadences" do
+      # The card above does not prorate, so every slice of a cut cycle reads 1.0 and the
+      # question cannot arise on it. It needs a PRORATING card, which is what makes the
+      # denominator observable at all.
+      let(:rate_card) do
+        create(:rate_card, :advance, organization:, proration: true,
+          product: create(:product, :fixed, organization:))
+      end
+
+      def ratios_by_slice(from, to)
+        schedule.segments_due_by(to)
+          .select { |segment| segment.started_at >= from && segment.started_at < to }
+          .map { |segment| [segment.rate.code, segment.proration_ratio] }
+      end
+
+      it "measures the slice against the cycle it sits in, not against its own rate's interval" do
+        expect(ratios_by_slice(Time.utc(2026, 3, 1), Time.utc(2026, 4, 1)))
+          .to eq([["monthly", 14.fdiv(31)], ["weekly", 17.fdiv(31)]])
+      end
+
+      it "does the same in the mirror case, a monthly rate inside a weekly cycle" do
+        expect(ratios_by_slice(Time.utc(2026, 4, 29), Time.utc(2026, 5, 6)))
+          .to eq([["weekly", 2.fdiv(7)], ["monthly_again", 5.fdiv(7)]])
+      end
+
+      # The property that makes it coherent as far as it goes, and the reason B is not a free
+      # swap: whatever the slices are priced by, they still add back up to their cycle.
+      it "keeps the slices summing to the cycle either way" do
+        [[Time.utc(2026, 3, 1), Time.utc(2026, 4, 1)], [Time.utc(2026, 4, 29), Time.utc(2026, 5, 6)]].each do |from, to|
+          expect(ratios_by_slice(from, to).sum { |_code, ratio| ratio }).to eq(1.0)
+        end
+      end
+    end
+
+    # The advance segment is already due and still carries the re-anchored end of its cycle.
+    it "runs the cadence in force through to the re-anchored boundary" do
+      at = Time.utc(2026, 5, 20)
+      in_force = schedule.segments_due_by(at).find { |cycle| cycle.ended_at > at }
+
+      expect(in_force.ended_at).to eq(Time.utc(2026, 6, 6))
+    end
+  end
+
+  # Ported from the previous engine:
+  #
+  #   spec/services/billing_periods/dates/advance_service_spec.rb
+  #     "splits periods at billing boundaries and rate effective dates"
+  #   spec/services/billing_periods/dates/arrears_service_spec.rb
+  #     "splits shifted periods at billing boundaries and rate effective dates"
+  #
+  # Both used the same grid — a card starting a month before its anchor, on a weekly cadence,
+  # with a second rate of the same cadence taking effect mid-cycle. The two specs differed only in
+  # which cycles their range selected, so the grid and the splits are asserted here once.
+  describe "a second rate on the same cadence" do
+    subject(:schedule) { described_class.call(contract_rate_card:).schedule }
+
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:, timezone: "UTC") }
+    let(:catalog_plan) { create(:catalog_plan, organization:) }
+    let(:contract) { create(:contract, organization:, customer:, catalog_plan:, started_at: Time.utc(2026, 1, 1)) }
+    let(:rate_card) { create(:rate_card, organization:) }
+    let(:rates) { rate_card.rates.order(:effective_from) }
+
+    let(:contract_rate_card) do
+      create(
+        :contract_rate_card,
+        organization:, contract:, rate_card:,
+        billing_anchor_date: Date.new(2026, 8, 3),
+        effective_date: Date.new(2026, 7, 1),
+        next_billing_at: Time.utc(2026, 7, 1)
+      )
+    end
+
+    before do
+      create(:rate_card_rate, organization:, rate_card:, code: "first",
+        effective_from: Time.utc(2026, 7, 1), billing_interval_count: 1, billing_interval_unit: "week")
+      create(:rate_card_rate, organization:, rate_card:, code: "second",
+        effective_from: Time.utc(2026, 8, 6), billing_interval_count: 1, billing_interval_unit: "week")
+    end
+
+    # The anchor is a reference day, not a start date: the weekly grid runs backwards from
+    # Aug 3 through Jul 27, Jul 20, Jul 13 and Jul 6, and the card's own start opens the first
+    # cycle on Jul 1 rather than on the boundary before it.
+    it "puts the cycles on the anchor's grid and clamps the first to the card start" do
+      windows = schedule.segments_due_by(Time.utc(2026, 8, 20)).group_by(&:cycle_started_at)
+        .map { |started_at, group| [started_at.to_fs(:db), group.last.ended_at.to_fs(:db)] }
+
+      expect(windows).to eq(
+        [
+          ["2026-07-01 00:00:00", "2026-07-06 00:00:00"],
+          ["2026-07-06 00:00:00", "2026-07-13 00:00:00"],
+          ["2026-07-13 00:00:00", "2026-07-20 00:00:00"],
+          ["2026-07-20 00:00:00", "2026-07-27 00:00:00"],
+          ["2026-07-27 00:00:00", "2026-08-03 00:00:00"],
+          ["2026-08-03 00:00:00", "2026-08-10 00:00:00"],
+          ["2026-08-10 00:00:00", "2026-08-17 00:00:00"]
+        ]
+      )
+    end
+
+    # The second rate carries the same cadence, so it moves nothing: it only cuts the cycle it
+    # lands in. This is the case that separates a rate change from a cadence change.
+    it "splits the cycle the second rate lands in without moving any boundary" do
+      segments = schedule.segments_due_by(Time.utc(2026, 8, 17))
+        .select { |segment| segment.started_at >= Time.utc(2026, 8, 3) }
+        .map { |segment| [segment.started_at.to_fs(:db), segment.ended_at.to_fs(:db), segment.rate.code] }
+
+      expect(segments).to eq(
+        [
+          ["2026-08-03 00:00:00", "2026-08-06 00:00:00", "first"],
+          ["2026-08-06 00:00:00", "2026-08-10 00:00:00", "second"],
+          ["2026-08-10 00:00:00", "2026-08-17 00:00:00", "second"]
+        ]
+      )
+    end
+  end
+
+  # Ported from the previous engine:
+  #
+  #   spec/services/billing_periods/dates_service_spec.rb
+  #     "returns periods overlapping the range regardless of billing timing and clamps the
+  #      final period"
+  #
+  # Termination is not a mode here — it is a schedule with an end — so the same walk has to
+  # produce the final, clamped cycle and the segments inside it.
+  describe "a termination cutting the last cycle short" do
+    subject(:schedule) do
+      described_class.call(contract_rate_card:, ends_at: terminated_at).schedule
+    end
+
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:, timezone: "UTC") }
+    let(:catalog_plan) { create(:catalog_plan, organization:) }
+    let(:contract) { create(:contract, organization:, customer:, catalog_plan:, started_at: Time.utc(2026, 1, 1)) }
+    let(:rate_card) { create(:rate_card, organization:) }
+    let(:rates) { rate_card.rates.order(:effective_from) }
+    let(:terminated_at) { Time.utc(2026, 8, 17, 12, 34, 56) }
+
+    let(:contract_rate_card) do
+      create(
+        :contract_rate_card,
+        organization:, contract:, rate_card:,
+        billing_anchor_date: Date.new(2026, 8, 3),
+        effective_date: Date.new(2026, 8, 3),
+        next_billing_at: Time.utc(2026, 8, 3)
+      )
+    end
+
+    before do
+      create(:rate_card_rate, organization:, rate_card:, code: "first",
+        effective_from: Time.utc(2026, 8, 1), billing_interval_count: 1, billing_interval_unit: "week")
+      create(:rate_card_rate, organization:, rate_card:, code: "second",
+        effective_from: Time.utc(2026, 8, 6), billing_interval_count: 1, billing_interval_unit: "week")
+    end
+
+    it "clamps the final cycle to the termination instant, not to the boundary" do
+      segments = schedule.segments_due_by(Time.utc(2026, 9, 1))
+        .map { |segment| [segment.started_at.to_fs(:db), segment.ended_at.to_fs(:db), segment.rate.code] }
+
+      expect(segments).to eq(
+        [
+          ["2026-08-03 00:00:00", "2026-08-06 00:00:00", "first"],
+          ["2026-08-06 00:00:00", "2026-08-10 00:00:00", "second"],
+          ["2026-08-10 00:00:00", "2026-08-17 00:00:00", "second"],
+          ["2026-08-17 00:00:00", "2026-08-17 12:34:56", "second"]
+        ]
+      )
+    end
+
+    it "stops producing cycles after the termination" do
+      expect(schedule.next_billing_at(after: Time.utc(2027, 1, 1))).to be_nil
+    end
+  end
+end

--- a/spec/services/billing/rate_cards/build_schedule_service_spec.rb
+++ b/spec/services/billing/rate_cards/build_schedule_service_spec.rb
@@ -1,0 +1,500 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Billing::RateCards::BuildScheduleService do
+  subject(:result) { described_class.call(contract_rate_card:, plan_rate_card:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:, timezone:) }
+  let(:timezone) { "UTC" }
+  let(:catalog_plan) { create(:catalog_plan, organization:) }
+  let(:contract) { create(:contract, organization:, customer:, catalog_plan:, started_at: Time.utc(2026, 1, 1), ended_at:) }
+  let(:rate_card) { create(:rate_card, organization:) }
+  let(:plan_rate_card) { nil }
+  let(:ended_at) { nil }
+
+  let(:contract_rate_card) do
+    create(
+      :contract_rate_card,
+      organization:, contract:, rate_card:,
+      billing_anchor_date: Date.new(2026, 1, 1),
+      effective_date: Date.new(2026, 1, 15),
+      next_billing_at: Time.utc(2026, 2, 1)
+    )
+  end
+
+  before do
+    create(
+      :rate_card_rate,
+      organization:, rate_card:,
+      effective_from: Time.utc(2025, 1, 1),
+      billing_interval_count: 1,
+      billing_interval_unit: "month"
+    )
+  end
+
+  it "builds a schedule when rates are available" do
+    expect(result).to be_success
+    expect(result.schedule).to be_a(Billing::RateCards::Schedule)
+  end
+
+  it "carries the card's anchor, timing and end onto the schedule" do
+    segment = result.schedule.segments_due_by(Time.utc(2026, 3, 1)).first
+
+    expect(result).to be_success
+    expect(segment.started_at...segment.ended_at).to eq(Time.utc(2026, 1, 15)...Time.utc(2026, 2, 1))
+    expect(segment.billing_at).to eq(Time.utc(2026, 2, 1))
+  end
+
+  # The service is what knows a card has been billed before, so the walk it hands back starts at
+  # the last billed cycle rather than replaying the card.
+  context "when the card has already been billed for some cycles" do
+    # The card's own first three cycles: anchored Jan 1 and attached Jan 15, the first is a stub
+    # running to the anchor's next boundary rather than a whole month.
+    before do
+      [[Time.utc(2026, 1, 15), Time.utc(2026, 2, 1)],
+        [Time.utc(2026, 2, 1), Time.utc(2026, 3, 1)],
+        [Time.utc(2026, 3, 1), Time.utc(2026, 4, 1)]].each do |opens_at, closes_at|
+        create(
+          :billing_segment,
+          organization:, contract:, customer:, contract_rate_card:,
+          rate_card_rate: rate_card.rates.sole,
+          cycle_started_at: opens_at, started_at: opens_at, billing_at: closes_at,
+          ended_at: BillingSegment.inclusive_end(closes_at)
+        )
+      end
+    end
+
+    it "resumes at the last billed cycle instead of walking from the card's start" do
+      cycles = result.schedule.segments_due_by(Time.utc(2026, 6, 1))
+
+      expect(cycles.map(&:cycle_index)).to eq([2, 3, 4])
+      expect(cycles.first.started_at).to eq(Time.utc(2026, 3, 1))
+    end
+
+    it "answers the same cycles the full walk would have" do
+      resumed = result.schedule.segments_due_by(Time.utc(2026, 6, 1))
+      contract_rate_card.billing_segments.destroy_all
+      full = described_class.call(contract_rate_card:).schedule.segments_due_by(Time.utc(2026, 6, 1))
+
+      expect(full.size).to be > resumed.size
+      expect(full.map { [it.cycle_index, it.started_at, it.ended_at] })
+        .to end_with(*resumed.map { [it.cycle_index, it.started_at, it.ended_at] })
+    end
+
+    it "does not carry billing history into a separate attachment of the same rate card" do
+      contract_rate_card.update!(ended_date: Date.new(2026, 6, 30))
+      successor = create(:contract_rate_card, organization:, contract:, rate_card:,
+        effective_date: Date.new(2026, 7, 1), billing_anchor_date: Date.new(2026, 1, 1))
+      schedule = described_class.call!(contract_rate_card: successor).schedule
+
+      expect(schedule.segments_due_by(Time.utc(2026, 8, 1)).map(&:cycle_index)).to eq([0])
+    end
+  end
+
+  context "when resuming the first cycle of an attachment" do
+    before do
+      create(:billing_segment, organization:, contract:, customer:, contract_rate_card:,
+        rate_card_rate: rate_card.rates.sole,
+        cycle_started_at: Time.utc(2026, 1, 15), started_at: Time.utc(2026, 1, 15),
+        ended_at: BillingSegment.inclusive_end(Time.utc(2026, 2, 1)), billing_at: Time.utc(2026, 2, 1))
+    end
+
+    it "resumes at midnight of the card's effective date" do
+      expect(result).to be_success
+      expect(result.schedule.segments_due_by(Time.utc(2026, 2, 1)).sole.cycle_started_at)
+        .to eq(Time.utc(2026, 1, 15))
+    end
+  end
+
+  context "with persisted advance segments" do
+    let(:product) { create(:product, :fixed, organization:) }
+    let(:rate_card) { create(:rate_card, organization:, product:, billing_timing: "advance", proration: true) }
+    let(:billed_segment) do
+      create(:billing_segment, organization:, contract:, customer:, contract_rate_card:,
+        rate_card_rate: rate_card.rates.sole, status: :done,
+        cycle_started_at: Time.utc(2026, 1, 15), started_at: Time.utc(2026, 1, 15),
+        ended_at: BillingSegment.inclusive_end(Time.utc(2026, 2, 1)), billing_at: Time.utc(2026, 1, 15))
+    end
+
+    it "resumes from the cycle start when the persisted segment is only its last slice" do
+      applied = create(:plan_rate_card, organization:, catalog_plan:, rate_card:)
+      create(:rate_phase, organization:, plan_rate_card: applied, code: "intro", billing_interval_cycle_count: 1)
+      new_rate = create(:rate_card_rate, organization:, rate_card:, effective_from: Time.utc(2026, 1, 20))
+      create(:billing_segment, organization:, contract:, customer:, contract_rate_card:,
+        rate_card_rate: new_rate, cycle_started_at: Time.utc(2026, 1, 15), started_at: Time.utc(2026, 1, 20),
+        ended_at: BillingSegment.inclusive_end(Time.utc(2026, 2, 1)), billing_at: Time.utc(2026, 1, 20))
+
+      segments = result.schedule.segments_due_by(Time.utc(2026, 2, 1))
+
+      expect(segments.map { |segment| [segment.cycle_index, segment.cycle_started_at, segment.rate_phase_code] })
+        .to eq([[0, Time.utc(2026, 1, 15), "intro"], [0, Time.utc(2026, 1, 15), "intro"], [1, Time.utc(2026, 2, 1), nil]])
+    end
+
+    it "measures consumption against the saved segment after the card terminates" do
+      persisted = billed_segment
+      contract.update!(ended_at: Time.utc(2026, 1, 20, 12))
+      segment = Billing::Segments::Segment.new(
+        started_at: persisted.started_at, ended_at: BillingSegment.exclusive_end(persisted.ended_at),
+        rate: persisted.rate_card_rate
+      )
+      schedule = described_class.call!(contract_rate_card:).schedule
+
+      consumed = [Time.utc(2026, 1, 20), Time.utc(2026, 1, 20, 12), Time.utc(2026, 2, 1)]
+        .map { |at| schedule.consumed_ratio(segment:, at:) }
+
+      # The original segment covers 17 days, even though the card has now ended inside it.
+      expect(consumed).to eq([5.fdiv(17), 6.fdiv(17), 1.0])
+      expect(schedule.next_billing_at(after: contract.ended_at)).to be_nil
+    end
+  end
+
+  # Effective dates are local calendar days, not UTC midnights.
+  context "with a customer timezone" do
+    let(:timezone) { "Europe/Paris" }
+
+    it "opens the first cycle at the start of the signing day there" do
+      cycle = result.schedule.segments_due_by(Time.utc(2026, 3, 1)).first
+
+      expect(cycle.started_at).to eq(Time.utc(2026, 1, 14, 23))
+    end
+  end
+
+  # The card's effective date and inherited anchor must use the same customer-local day.
+  context "when the signing instant falls on a different date where the customer is" do
+    let(:timezone) { "America/New_York" }
+
+    let(:contract_rate_card) do
+      create(
+        :contract_rate_card,
+        organization:, contract:, rate_card:,
+        billing_anchor_date: contract.effective_billing_anchor_date,
+        effective_date: contract.started_at.in_time_zone(timezone).to_date,
+        next_billing_at: Time.utc(2026, 2, 15)
+      )
+    end
+
+    let(:contract) do
+      create(:contract, organization:, customer:, catalog_plan:, started_at: Time.utc(2026, 1, 15, 2))
+    end
+
+    it "derives the anchor in the customer's calendar, not in UTC" do
+      expect(contract.effective_billing_anchor_date).to eq(Date.new(2026, 1, 14))
+    end
+
+    it "opens a single first cycle, not a one-day stub before the anchor" do
+      first = result.schedule.segments_due_by(Time.utc(2026, 4, 1)).first
+
+      expect(first.cycle_index).to eq(0)
+      expect(first.started_at).to eq(Time.utc(2026, 1, 14, 5))
+      expect(first.ended_at).to eq(Time.utc(2026, 2, 14, 5))
+    end
+  end
+
+  # The hint is a shortcut, not the only route. The termination and credit paths build a
+  # schedule from the card alone, and passing nil straight through made the resolver fall
+  # back to `nil&.rate_phases.to_a` — so every phase and every override the plan configured
+  # disappeared, with no error and no clue on the invoice.
+  describe "resolving the plan entry when the caller has no hint" do
+    let(:plan_rate_card) { create(:plan_rate_card, organization:, catalog_plan:, rate_card:, units: 5) }
+    let(:rate_override) { create(:rate_override, organization:, rate_properties: {"amount" => "1.00"}) }
+
+    before do
+      plan_rate_card
+      create(:rate_phase, organization:, plan_rate_card:, code: "intro",
+        billing_interval_cycle_count: 1, position: 1, rate_override_id: rate_override.id)
+    end
+
+    it "finds the plan entry itself when none is handed in" do
+      schedule = described_class.call(contract_rate_card:).schedule
+      first = schedule.segments_due_by(Time.utc(2026, 4, 1)).first
+
+      expect(first.rate_phase_code).to eq("intro")
+      expect(first.rate_override).to eq(rate_override)
+    end
+
+    it "answers the same whether the hint is handed in or looked up" do
+      with_hint = described_class.call(contract_rate_card:, plan_rate_card:).schedule
+      without = described_class.call(contract_rate_card:).schedule
+      codes = ->(s) { s.segments_due_by(Time.utc(2026, 4, 1)).map { |cycle| cycle.rate_phase_code } }
+
+      expect(codes.call(without)).to eq(codes.call(with_hint))
+    end
+
+    # A hint for a different card is a caller bug, and silently ignoring it prices the card
+    # at the base rate — the same invisible failure, arrived at from the other side.
+    it "refuses a hint that prices a different rate card" do
+      other = create(:plan_rate_card, organization:, catalog_plan:, rate_card: create(:rate_card, organization:))
+
+      expect { described_class.call(contract_rate_card:, plan_rate_card: other) }
+        .to raise_error(described_class::MismatchedPlanRateCard, /prices rate card/)
+    end
+  end
+
+  # The window is a fact about SERVICE; the price is a decision about BILLING. The schedule
+  # closes where service stopped, and the termination day is still paid in full — but by the
+  # day-ownership rule, not by stretching the boundary. Stretching it would record a window
+  # service never covered, and usage metering reads these boundaries to pick its events.
+  context "when the contract has ended" do
+    # Prorating, so the day count is visible in the ratio rather than flattened to 1.0. A fixed
+    # product, because proration on a usage product needs a recurring metric behind it.
+    let(:rate_card) do
+      create(:rate_card, organization:, proration: true, product: create(:product, :fixed, organization:))
+    end
+    let(:ended_at) { Time.utc(2026, 1, 20, 14, 30) }
+
+    def final_slice = result.schedule.segments_due_by(Time.utc(2026, 6, 1)).last
+
+    # The card opened Jan 15 and closed part-way through the 20th: six days begun, out of the
+    # 31 in the January interval the slice sits in.
+    it "closes where service stopped, and still bills that day whole" do
+      expect(final_slice.ended_at).to eq(ended_at)
+      expect(final_slice.proration_ratio).to eq(6.fdiv(31))
+    end
+
+    # The one instant where the two readings differ. Service ran for none of the 20th, so the
+    # 20th is not billed — 19 days, not 20. Rounding the boundary up to the 21st would charge
+    # a day the customer never entered.
+    context "when it ended on the first instant of a day" do
+      let(:ended_at) { Time.utc(2026, 1, 20) }
+
+      it "bills nothing for the day it ended on" do
+        expect(final_slice.ended_at).to eq(ended_at)
+        expect(final_slice.proration_ratio).to eq(5.fdiv(31))
+      end
+    end
+
+    # 2026-01-21 02:00 UTC is still the 20th in New York. The boundary is the raw instant
+    # either way; what the timezone decides is the day COUNT, and reading it in UTC would
+    # bill a day the customer never entered.
+    context "when the customer is west of UTC" do
+      let(:timezone) { "America/New_York" }
+      let(:ended_at) { Time.utc(2026, 1, 21, 2) }
+
+      it "counts the days where the customer is" do
+        expect(final_slice.ended_at).to eq(ended_at)
+        expect(final_slice.proration_ratio).to eq(6.fdiv(31))
+      end
+    end
+  end
+
+  context "when the card has an inclusive end date" do
+    let(:rate_card) { create(:rate_card, organization:, proration: true, product: create(:product, :fixed, organization:)) }
+
+    before { contract_rate_card.update!(ended_date: Date.new(2026, 1, 20)) }
+
+    it "covers the whole final day and stops at the next local midnight" do
+      segment = result.schedule.segments_due_by(Time.utc(2026, 2, 1)).sole
+
+      expect(segment.ended_at).to eq(Time.utc(2026, 1, 21))
+      expect(segment.proration_ratio).to eq(6.fdiv(31))
+      expect(result.schedule.next_billing_at(after: segment.ended_at)).to be_nil
+    end
+
+    context "with a customer timezone" do
+      let(:timezone) { "America/New_York" }
+
+      it "converts the end date in the customer's timezone" do
+        expect(result.schedule.segments_due_by(Time.utc(2026, 2, 1)).sole.ended_at)
+          .to eq(Time.utc(2026, 1, 21, 5))
+      end
+    end
+
+    context "when the contract ends earlier" do
+      let(:ended_at) { Time.utc(2026, 1, 18, 12) }
+
+      it "stops at the contract end" do
+        expect(result.schedule.segments_due_by(Time.utc(2026, 2, 1)).sole.ended_at).to eq(ended_at)
+      end
+    end
+
+    it "does not extend the card when the caller supplies a later termination" do
+      schedule = described_class.call!(contract_rate_card:, ends_at: Time.utc(2026, 1, 25)).schedule
+
+      expect(schedule.segments_due_by(Time.utc(2026, 2, 1)).sole.ended_at).to eq(Time.utc(2026, 1, 21))
+    end
+  end
+
+  context "without a catalog plan" do
+    let(:catalog_plan) { nil }
+
+    it "builds a schedule from the card's rates" do
+      expect(result).to be_success
+      expect(result.schedule.segments_due_by(Time.utc(2026, 2, 1)).sole.rate).to eq(rate_card.rates.sole)
+    end
+  end
+
+  describe "phases" do
+    # No phases at all: the card bills on its own cadence forever, which is one open phase.
+    it "gives a card without phases a single open phase" do
+      cycles = result.schedule.segments_due_by(Time.utc(2026, 3, 1))
+
+      expect(cycles.map(&:rate_override)).to eq([nil, nil])
+      expect(cycles.map { |cycle| cycle.rate_phase_code }).to eq([nil, nil])
+    end
+
+    context "with a bounded phase carrying an interval override" do
+      let(:rate_override) do
+        create(:rate_override, organization:, billing_interval_count: 1, billing_interval_unit: "week")
+      end
+
+      before do
+        create(
+          :rate_phase,
+          organization:,
+          plan_rate_card: nil,
+          contract_rate_card:,
+          position: 1,
+          code: "weekly_intro",
+          billing_interval_cycle_count: 2,
+          rate_override:
+        )
+      end
+
+      # Two weekly cycles, then the card's own monthly cadence takes over: the default phase
+      # is appended because every configured phase is bounded.
+      it "uses the override cadence and then falls back to the card's" do
+        cycles = result.schedule.segments_due_by(Time.utc(2026, 4, 1))
+
+        expect(cycles.first(2).map { |cycle| [cycle.started_at.to_date.to_s, cycle.rate_phase_code] }).to eq(
+          [["2026-01-15", "weekly_intro"], ["2026-01-22", "weekly_intro"]]
+        )
+        expect(cycles[2].started_at.to_date.to_s).to eq("2026-01-29")
+        expect(cycles[2].rate_phase_code).to be_nil
+      end
+
+      it "carries the override so the caller can price the cycle with it" do
+        expect(result.schedule.segments_due_by(Time.utc(2026, 2, 1)).first.rate_override).to eq(rate_override)
+      end
+    end
+
+    # Phases live on the plan entry until the contract overrides them.
+    context "with phases on the plan entry" do
+      let(:plan_rate_card) { create(:plan_rate_card, organization:, catalog_plan:, rate_card:, units: 1) }
+
+      before do
+        create(
+          :rate_phase,
+          organization:, plan_rate_card:, position: 1, code: "intro",
+          billing_interval_cycle_count: 2
+        )
+      end
+
+      it "reads them through the plan" do
+        expect(result.schedule.segments_due_by(Time.utc(2026, 2, 1)).first.rate_phase_code).to eq("intro")
+      end
+    end
+  end
+
+  # RateCardRate#normalize_effective_from floors an arrears rate to midnight, so only an
+  # advance rate can take effect part-way through the day the card is attached. The cadence
+  # has to come from the rate that also prices the first window — Billing::Segments picks
+  # that one at the window's start, 00:00 — or the card bills weekly windows at the monthly
+  # rate's price.
+  context "when a rate takes effect later on the day the card is attached" do
+    let(:rate_card) { create(:rate_card, :advance, organization:) }
+
+    before do
+      create(
+        :rate_card_rate,
+        organization:, rate_card:,
+        effective_from: Time.utc(2026, 1, 15, 8),
+        billing_interval_count: 1,
+        billing_interval_unit: "week"
+      )
+    end
+
+    it "takes the cadence from the rate in force when the window opens" do
+      segments = result.schedule.segments_due_by(Time.utc(2026, 3, 1))
+        .select { |segment| segment.cycle_started_at == Time.utc(2026, 1, 15) }
+
+      expect(segments.first.started_at...segments.last.ended_at)
+        .to eq(Time.utc(2026, 1, 15)...Time.utc(2026, 2, 1))
+    end
+
+    # The later rate is not ignored — it cuts the cycle into two priced windows instead.
+    it "bills the change as a segment rather than as a new cadence" do
+      segments = result.schedule.segments_due_by(Time.utc(2026, 3, 1))
+        .select { it.cycle_started_at == Time.utc(2026, 1, 15) }
+
+      expect(segments.map { |segment| [segment.started_at, segment.ended_at] }).to eq(
+        [[Time.utc(2026, 1, 15), Time.utc(2026, 1, 15, 8)],
+          [Time.utc(2026, 1, 15, 8), Time.utc(2026, 2, 1)]]
+      )
+    end
+  end
+
+  # QA plan R2: "No rate = no fee is expected behavior, not an error."
+  #
+  # A card can start before its first rate without anyone doing anything odd: a rate made
+  # effective "Jan 1" is stored at 00:00 UTC, and a customer west of Greenwich signing at
+  # that instant is still on Dec 31 where they are. The card is not broken — it just has
+  # nothing to bill yet.
+  context "when the card starts before its first rate" do
+    before do
+      rate_card.rates.update_all(effective_from: Time.utc(2026, 3, 1)) # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    it "still schedules the card, on the cadence the coming rate asks for" do
+      segments = result.schedule.segments_due_by(Time.utc(2026, 5, 1))
+
+      expect(result).to be_success
+      expect(segments.map(&:cycle_index)).to eq([2, 3])
+      expect(segments.map { |segment| segment.started_at.to_date.to_s }).to eq(%w[2026-03-01 2026-04-01])
+    end
+
+    it "bills nothing until the rate lands, then bills normally" do
+      expect(result.schedule.segments_due_by(Time.utc(2026, 3, 1))).to be_empty
+      segments = result.schedule.segments_due_by(Time.utc(2026, 5, 1))
+
+      expect(segments.map { |segment| [segment.cycle_index, segment.started_at.to_date.to_s] })
+        .to eq([[2, "2026-03-01"], [3, "2026-04-01"]])
+    end
+  end
+
+  # The walk is lazy, so a phase carrying a bad cadence used to build a schedule that looked
+  # fine and raised on the first question asked of it — past this service's own `success?`,
+  # from inside a method that only asks about dates. Contract materialization is the live caller
+  # and it guards with `success?`, so the raise escaped it.
+  context "when a rate phase overrides the cadence with an impossible one" do
+    before do
+      # billing_interval_count is nullable with no CHECK behind it, so a legacy row or an
+      # update_all reaches the engine with a count no cadence can be built from.
+      override = create(:rate_override, organization:, billing_interval_unit: "week")
+      override.update_columns(billing_interval_count: 0) # rubocop:disable Rails/SkipsModelValidations
+      create(:rate_phase, organization:, plan_rate_card: nil, contract_rate_card:,
+        position: 1, code: "broken", billing_interval_cycle_count: 2, rate_override: override)
+    end
+
+    it "fails the result rather than raising when the schedule is walked" do
+      expect(result).not_to be_success
+      expect(result.error.code).to eq("invalid_billing_schedule")
+      expect(result.error.error_message).to eq("interval count must be a positive integer, got 0")
+      expect(result.schedule).to be_nil
+    end
+
+    context "when the invalid override belongs to a later phase" do
+      before do
+        contract_rate_card.rate_phases.sole.update!(position: 2)
+        create(:rate_phase, organization:, plan_rate_card: nil, contract_rate_card:,
+          position: 1, code: "valid_intro", billing_interval_cycle_count: 2)
+      end
+
+      it "fails the build before the walker reaches that phase" do
+        expect(result).not_to be_success
+        expect(result.error.code).to eq("invalid_billing_schedule")
+        expect(result.error.error_message).to eq("interval count must be a positive integer, got 0")
+      end
+    end
+  end
+
+  context "when the card has no rates at all" do
+    before { rate_card.rates.destroy_all }
+
+    it "cannot be scheduled" do
+      expect(result).not_to be_success
+      expect(result.error.error_code).to eq("rate_not_found")
+    end
+  end
+end

--- a/spec/services/billing/rate_cards/cycle_walker_spec.rb
+++ b/spec/services/billing/rate_cards/cycle_walker_spec.rb
@@ -1,0 +1,479 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Billing::RateCards::CycleWalker do
+  subject(:walker) do
+    described_class.new(
+      anchor_date: Date.new(2026, 1, 31), starts_at:,
+      phases:, rates:, timezone:, ends_at:
+    )
+  end
+
+  let(:ends_at) { nil }
+  let(:starts_at) { Time.utc(2026, 1, 31) }
+  let(:timezone) { "UTC" }
+  let(:phases) { [Billing::Phase.default] }
+  let(:rates) { [rate] }
+  let(:rate) do
+    Struct.new(:effective_from, :billing_interval_count, :billing_interval_unit)
+      .new(Time.utc(2026, 1, 1), 1, :month)
+  end
+
+  context "when several rates are scheduled after the card starts" do
+    subject(:walker) do
+      described_class.new(
+        anchor_date: Date.new(2026, 1, 1), starts_at: Time.utc(2026, 1, 1),
+        phases:, rates:, timezone:
+      )
+    end
+
+    let(:rates) do
+      [rate.class.new(Time.utc(2026, 6, 1), 1, :week),
+        rate.class.new(Time.utc(2026, 9, 1), 1, :month)]
+    end
+
+    it "uses the earliest rate's cadence before pricing starts" do
+      cycles = walker.walk_to(Time.utc(2026, 3, 1))
+
+      expect(cycles.first(3).map { |cycle| [cycle.started_at, cycle.ended_at] }).to eq(
+        [[Time.utc(2026, 1, 1), Time.utc(2026, 1, 8)],
+          [Time.utc(2026, 1, 8), Time.utc(2026, 1, 15)],
+          [Time.utc(2026, 1, 15), Time.utc(2026, 1, 22)]]
+      )
+      expect(cycles.map(&:index)).to eq((0..8).to_a)
+    end
+  end
+
+  describe "#start" do
+    it "opens cycle zero on the anchor's month-end grid" do
+      cycle = walker.start
+
+      expect([cycle.index, cycle.started_at, cycle.ended_at])
+        .to eq([0, Time.utc(2026, 1, 31), Time.utc(2026, 2, 28)])
+      expect(walker.current_cycle).to eq(cycle)
+    end
+
+    context "when the card starts inside a calendar interval" do
+      let(:starts_at) { Time.utc(2026, 2, 10, 14, 30) }
+
+      it "starts on the card's first billing day and keeps the next anchor boundary" do
+        cycle = walker.start
+
+        expect([cycle.started_at, cycle.ended_at]).to eq([Time.utc(2026, 2, 10), Time.utc(2026, 2, 28)])
+      end
+    end
+
+    context "when the card ends during its first cycle" do
+      let(:ends_at) { Time.utc(2026, 2, 15, 12) }
+
+      it "clips the cycle to the actual end of service" do
+        expect(walker.start.ended_at).to eq(ends_at)
+      end
+    end
+
+    context "when the customer is west of UTC" do
+      let(:starts_at) { Time.utc(2026, 2, 1, 2) }
+      let(:timezone) { "America/New_York" }
+
+      it "uses the local signing day and local calendar boundaries" do
+        cycle = walker.start
+
+        expect([cycle.started_at, cycle.ended_at]).to eq([Time.utc(2026, 1, 31, 5), Time.utc(2026, 2, 28, 5)])
+      end
+    end
+
+    context "when the first phase overrides the interval unit" do
+      let(:phases) do
+        override = Struct.new(:billing_interval_count, :billing_interval_unit).new(nil, :week)
+        [Billing::Phase.new(code: "intro", billing_interval_cycle_count: 2, rate_override: override), Billing::Phase.default]
+      end
+
+      it "uses the phase's unit and the rate's interval count" do
+        expect(walker.start.ended_at).to eq(Time.utc(2026, 2, 7))
+      end
+    end
+
+    context "when the card has rates before and after the one in force" do
+      let(:rates) do
+        previous = rate.class.new(Time.utc(2025, 12, 1), 1, :week)
+        upcoming = rate.class.new(Time.utc(2026, 2, 1), 1, :year)
+        [upcoming, previous, rate]
+      end
+
+      it "uses the interval of the rate effective on the first billing day" do
+        expect(walker.start.ended_at).to eq(Time.utc(2026, 2, 28))
+      end
+    end
+  end
+
+  describe "#advance" do
+    it "returns nil before the walker has started" do
+      expect(walker.advance).to be_nil
+    end
+
+    it "continues from the previous cycle's end and preserves the month-end anchor" do
+      walker.start
+      cycle = walker.advance
+
+      expect([cycle.index, cycle.started_at, cycle.ended_at])
+        .to eq([1, Time.utc(2026, 2, 28), Time.utc(2026, 3, 31)])
+      expect(walker.current_cycle).to eq(cycle)
+      expect(walker.advance.ended_at).to eq(Time.utc(2026, 4, 30))
+    end
+
+    context "when the rate changes inside a cycle" do
+      let(:rates) { [rate, rate.class.new(Time.utc(2026, 2, 15), 1, :week)] }
+
+      it "applies the new interval from the next cycle's start" do
+        expect(walker.start.ended_at).to eq(Time.utc(2026, 2, 28))
+
+        cycle = walker.advance
+
+        expect([cycle.started_at, cycle.ended_at]).to eq([Time.utc(2026, 2, 28), Time.utc(2026, 3, 7)])
+      end
+    end
+
+    context "when the rate changes on a cycle boundary without changing the interval" do
+      let(:rates) { [rate, rate.class.new(Time.utc(2026, 2, 28), 1, :month)] }
+
+      it "keeps the original month-end anchor" do
+        walker.start
+
+        expect(walker.advance.ended_at).to eq(Time.utc(2026, 3, 31))
+      end
+    end
+
+    context "when a weekly intro phase ends" do
+      let(:phases) do
+        override = Struct.new(:billing_interval_count, :billing_interval_unit).new(nil, :week)
+        [Billing::Phase.new(code: "intro", billing_interval_cycle_count: 2, rate_override: override), Billing::Phase.default]
+      end
+
+      it "counts the intro cycles and starts the monthly calendar where the intro ends" do
+        walker.start
+        second_cycle = walker.advance
+        monthly_cycle = walker.advance
+
+        expect([second_cycle.index, second_cycle.ended_at, second_cycle.phase.code])
+          .to eq([1, Time.utc(2026, 2, 14), "intro"])
+        expect([monthly_cycle.index, monthly_cycle.started_at, monthly_cycle.ended_at, monthly_cycle.phase])
+          .to eq([2, Time.utc(2026, 2, 14), Time.utc(2026, 3, 14), phases.last])
+        expect(walker.advance.ended_at).to eq(Time.utc(2026, 4, 14))
+      end
+    end
+
+    context "when the phase changes without changing the interval" do
+      let(:phases) do
+        [Billing::Phase.new(code: "intro", billing_interval_cycle_count: 1, rate_override: nil), Billing::Phase.default]
+      end
+
+      it "changes the phase and keeps the original month-end anchor" do
+        walker.start
+        cycle = walker.advance
+
+        expect([cycle.phase, cycle.ended_at]).to eq([phases.last, Time.utc(2026, 3, 31)])
+      end
+    end
+
+    context "when the card ends inside the next cycle" do
+      let(:ends_at) { Time.utc(2026, 3, 15, 12) }
+
+      it "clips the last cycle and stays exhausted until explicitly restarted" do
+        walker.start
+
+        expect(walker.advance.ended_at).to eq(ends_at)
+        expect(walker.advance).to be_nil
+        expect(walker.current_cycle).to be_nil
+        expect(walker.advance).to be_nil
+        expect(walker.start.index).to eq(0)
+      end
+    end
+
+    context "when the card ends on a cycle boundary" do
+      let(:ends_at) { Time.utc(2026, 2, 28) }
+
+      it "stops without creating an empty cycle" do
+        walker.start
+
+        expect(walker.advance).to be_nil
+        expect(walker.current_cycle).to be_nil
+      end
+    end
+
+    context "when daylight saving time starts" do
+      let(:timezone) { "America/New_York" }
+      let(:starts_at) { Time.utc(2026, 1, 31, 5) }
+
+      it "keeps the boundaries at local midnight" do
+        walker.start
+        cycle = walker.advance
+
+        expect([cycle.started_at, cycle.ended_at]).to eq([Time.utc(2026, 2, 28, 5), Time.utc(2026, 3, 31, 4)])
+      end
+    end
+  end
+
+  describe "#resume" do
+    it "reuses calculated boundaries when resuming again on the same calendar" do
+      allow(Billing::Calendar).to receive(:new).and_call_original
+
+      first = walker.resume(Time.utc(2026, 3, 15))
+      repeated = walker.resume(Time.utc(2026, 3, 15))
+
+      expect(repeated.calendar).to equal(first.calendar)
+      expect([repeated.index, repeated.started_at, repeated.ended_at])
+        .to eq([first.index, first.started_at, first.ended_at])
+      expect(Billing::Calendar).to have_received(:new).once
+    end
+
+    it "jumps across a long history without building the intermediate cycles" do
+      allow(Billing::Cycle).to receive(:new).and_call_original
+
+      cycle = walker.resume(Time.utc(2126, 3, 15))
+
+      expect([cycle.index, cycle.started_at, cycle.ended_at])
+        .to eq([1201, Time.utc(2126, 2, 28), Time.utc(2126, 3, 31)])
+      expect(Billing::Cycle).to have_received(:new).twice
+    end
+
+    it "selects the cycle opening exactly at the requested time" do
+      cycle = walker.resume(Time.utc(2026, 3, 31))
+
+      expect([cycle.index, cycle.started_at]).to eq([2, Time.utc(2026, 3, 31)])
+    end
+
+    it "starts at the first cycle when the requested time precedes the card" do
+      cycle = walker.resume(Time.utc(2025, 1, 1))
+
+      expect([cycle.index, cycle.started_at]).to eq([0, starts_at])
+    end
+
+    context "when the first cycle starts inside a calendar interval" do
+      let(:starts_at) { Time.utc(2026, 2, 10) }
+
+      it "counts the partial first cycle once and preserves the original anchor" do
+        cycle = walker.resume(Time.utc(2026, 4, 10))
+
+        expect([cycle.index, cycle.started_at, cycle.ended_at])
+          .to eq([2, Time.utc(2026, 3, 31), Time.utc(2026, 4, 30)])
+      end
+    end
+
+    context "when a rate changes the interval during the skipped history" do
+      let(:rates) { [rate, rate.class.new(Time.utc(2026, 7, 15), 1, :week)] }
+
+      it "jumps straight to the change without building the preceding cycle" do
+        allow(Billing::Cycle).to receive(:new).and_call_original
+
+        cycle = walker.resume(Time.utc(2026, 7, 31))
+
+        expect([cycle.index, cycle.started_at, cycle.ended_at])
+          .to eq([6, Time.utc(2026, 7, 31), Time.utc(2026, 8, 7)])
+        expect(Billing::Cycle).to have_received(:new).twice
+      end
+    end
+
+    context "when a phase overrides only the interval unit" do
+      let(:rates) { [rate, rate.class.new(Time.utc(2026, 2, 5), 2, :month)] }
+      let(:phases) do
+        override = Struct.new(:billing_interval_count, :billing_interval_unit).new(nil, :week)
+        [Billing::Phase.new(code: "intro", billing_interval_cycle_count: 3, rate_override: override), Billing::Phase.default]
+      end
+
+      it "combines the override with the new rate and removes it when the phase ends" do
+        intro_cycle = walker.resume(Time.utc(2026, 2, 10))
+        regular_cycle = walker.resume(Time.utc(2026, 3, 10))
+
+        expect([intro_cycle.index, intro_cycle.started_at, intro_cycle.ended_at, intro_cycle.phase.code])
+          .to eq([1, Time.utc(2026, 2, 7), Time.utc(2026, 2, 21), "intro"])
+        expect([regular_cycle.index, regular_cycle.started_at, regular_cycle.ended_at, regular_cycle.phase])
+          .to eq([3, Time.utc(2026, 3, 7), Time.utc(2026, 5, 7), phases.last])
+      end
+    end
+
+    context "when phases and rates change during the skipped history" do
+      let(:rates) do
+        [rate,
+          rate.class.new(Time.utc(2026, 2, 15), 2, :month),
+          rate.class.new(Time.utc(2026, 2, 20), 3, :month),
+          rate.class.new(Time.utc(2026, 5, 28), 1, :week),
+          rate.class.new(Time.utc(2026, 7, 1), 1, :month)]
+      end
+      let(:phases) do
+        override = Struct.new(:billing_interval_count, :billing_interval_unit).new(1, :month)
+        [Billing::Phase.new(code: "intro", billing_interval_cycle_count: 3, rate_override: override),
+          Billing::Phase.new(code: "discount", billing_interval_cycle_count: 2, rate_override: nil),
+          Billing::Phase.default]
+      end
+
+      it "matches a full walk inside cycles and on every cycle boundary" do
+        cycles = walker.walk_to(Time.utc(2027, 1, 1))
+
+        cycles.each do |expected|
+          [expected.started_at, expected.started_at + 1.hour].each do |timestamp|
+            actual = walker.resume(timestamp)
+
+            expect([actual.index, actual.started_at, actual.ended_at, actual.phase])
+              .to eq([expected.index, expected.started_at, expected.ended_at, expected.phase])
+            expect([actual.calendar.anchor_date, actual.calendar.interval])
+              .to eq([expected.calendar.anchor_date, expected.calendar.interval])
+          end
+        end
+      end
+
+      it "reuses each calendar without mixing intervals or realigned anchors" do
+        first_walk = walker.walk_to(Time.utc(2027, 1, 1))
+        calendars = first_walk.map(&:calendar).uniq
+        allow(Billing::Calendar).to receive(:new).and_call_original
+
+        repeated_walk = walker.walk_to(Time.utc(2027, 1, 1))
+
+        expect(repeated_walk.map(&:calendar)).to eq(first_walk.map(&:calendar))
+        expect(calendars.select { |calendar| calendar.interval == calendars.first.interval }.map(&:anchor_date).uniq.size)
+          .to be > 1
+        expect(Billing::Calendar).not_to have_received(:new)
+      end
+    end
+
+    context "when the first rate takes effect after the card starts" do
+      let(:rates) do
+        [rate.class.new(Time.utc(2026, 3, 15), 1, :month),
+          rate.class.new(Time.utc(2026, 5, 15), 1, :week)]
+      end
+
+      it "counts the unpriced cycles and matches a full walk across the interval change" do
+        expected = walker.walk_to(Time.utc(2026, 6, 10)).last
+        actual = walker.resume(Time.utc(2026, 6, 10))
+
+        expect([actual.index, actual.started_at, actual.ended_at])
+          .to eq([expected.index, expected.started_at, expected.ended_at])
+      end
+    end
+
+    context "when a daily calendar crosses daylight saving time" do
+      let(:timezone) { "America/New_York" }
+      let(:starts_at) { Time.utc(2026, 1, 31, 5) }
+      let(:rates) { [rate.class.new(Time.utc(2026, 1, 1), 1, :day)] }
+
+      it "skips local days and keeps midnight boundaries" do
+        cycle = walker.resume(Time.utc(2026, 3, 10, 12))
+
+        expect([cycle.index, cycle.started_at, cycle.ended_at])
+          .to eq([38, Time.utc(2026, 3, 10, 4), Time.utc(2026, 3, 11, 4)])
+      end
+    end
+
+    context "when the requested time is after termination" do
+      let(:ends_at) { Time.utc(2026, 3, 15) }
+
+      it "leaves the walker exhausted" do
+        expect(walker.resume(Time.utc(2026, 4, 1))).to be_nil
+        expect(walker.current_cycle).to be_nil
+      end
+    end
+  end
+
+  describe "#walk_to" do
+    it "returns the completed cycles and the cycle containing the requested time" do
+      cycles = walker.walk_to(Time.utc(2026, 4, 10))
+
+      expect(cycles.map { |cycle| [cycle.index, cycle.started_at, cycle.ended_at] }).to eq([
+        [0, Time.utc(2026, 1, 31), Time.utc(2026, 2, 28)],
+        [1, Time.utc(2026, 2, 28), Time.utc(2026, 3, 31)],
+        [2, Time.utc(2026, 3, 31), Time.utc(2026, 4, 30)]
+      ])
+      expect(walker.current_cycle).to eq(cycles.last)
+      expect(walker.advance.started_at).to eq(Time.utc(2026, 4, 30))
+    end
+
+    it "includes the cycle opening exactly at the requested time" do
+      cycles = walker.walk_to(Time.utc(2026, 2, 28))
+
+      expect(cycles.map(&:index)).to eq([0, 1])
+      expect(cycles.last.started_at).to eq(Time.utc(2026, 2, 28))
+    end
+
+    it "returns no cycles before the card starts" do
+      expect(walker.walk_to(Time.utc(2026, 1, 30))).to be_empty
+    end
+
+    it "includes the first cycle at the card's start" do
+      expect(walker.walk_to(starts_at).map(&:index)).to eq([0])
+    end
+
+    it "starts a fresh walk regardless of the previous position" do
+      walker.walk_to(Time.utc(2026, 4, 10))
+
+      expect(walker.walk_to(Time.utc(2026, 3, 10)).map(&:index)).to eq([0, 1])
+      expect(walker.walk_to(Time.utc(2026, 4, 10)).map(&:index)).to eq([0, 1, 2])
+    end
+
+    context "when the card ends before the requested time" do
+      let(:ends_at) { Time.utc(2026, 3, 15, 12) }
+
+      it "returns all cycles through termination and stops" do
+        cycles = walker.walk_to(Time.utc(2026, 4, 10))
+
+        expect(cycles.map(&:index)).to eq([0, 1])
+        expect(cycles.last.ended_at).to eq(ends_at)
+        expect(walker.current_cycle).to be_nil
+      end
+    end
+
+    context "when the card ends at its start" do
+      let(:ends_at) { starts_at }
+
+      it "returns no cycles" do
+        expect(walker.walk_to(starts_at)).to be_empty
+      end
+    end
+  end
+
+  it "resumes inside a cycle and preserves the month-end anchor when advancing" do
+    expect(walker.resume(Time.utc(2026, 2, 10)).started_at).to eq(Time.utc(2026, 1, 31))
+    expect(walker.advance.ended_at).to eq(Time.utc(2026, 3, 31))
+    expect(walker.current_cycle.index).to eq(1)
+  end
+
+  it "can resume backwards after advancing" do
+    walker.resume(Time.utc(2026, 4, 1))
+    walker.advance
+
+    cycle = walker.resume(Time.utc(2026, 2, 10))
+
+    expect([cycle.index, cycle.started_at, cycle.ended_at])
+      .to eq([0, Time.utc(2026, 1, 31), Time.utc(2026, 2, 28)])
+  end
+
+  it "starts each walk at its explicit from date regardless of the current position" do
+    timestamp = Time.utc(2026, 4, 30)
+    walker.resume(Time.utc(2026, 4, 1))
+    walker.advance
+
+    expect(walker.walk_to(timestamp, from: nil).map(&:index)).to eq([0, 1, 2, 3])
+    expect(walker.walk_to(timestamp, from: Time.utc(2026, 3, 31)).map(&:index)).to eq([2, 3])
+    expect(walker.advance.index).to eq(4)
+  end
+
+  it "can explicitly return to the beginning after advancing" do
+    walker.resume(Time.utc(2026, 4, 1))
+    walker.advance
+
+    expect(walker.resume(nil).index).to eq(0)
+    expect(walker.advance.index).to eq(1)
+  end
+
+  context "when the card ends inside a cycle" do
+    let(:ends_at) { Time.utc(2026, 4, 15) }
+
+    it "stops at termination and can subsequently resume an earlier cycle" do
+      expect(walker.resume(Time.utc(2026, 4, 1)).ended_at).to eq(ends_at)
+      expect(walker.advance).to be_nil
+      expect(walker.advance).to be_nil
+      expect(walker.resume(ends_at)).to be_nil
+      expect(walker.current_cycle).to be_nil
+      expect(walker.resume(Time.utc(2026, 2, 1)).index).to eq(0)
+    end
+  end
+end

--- a/spec/services/billing/rate_cards/schedule_resume_spec.rb
+++ b/spec/services/billing/rate_cards/schedule_resume_spec.rb
@@ -1,0 +1,382 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Resuming exists so a two-year-old weekly card does not walk a hundred cycles to answer a
+# question about next week. It is only worth having if it is INDISTINGUISHABLE from the full
+# walk, so nothing here asserts a value of its own: every example resumes at every cycle of
+# every shape and compares the tail against walking from the start.
+RSpec.describe Billing::RateCards::Schedule do
+  def rate(effective_from, count, unit)
+    Struct.new(:effective_from, :billing_interval_count, :billing_interval_unit).new(effective_from, count, unit)
+  end
+
+  def override(count, unit)
+    Struct.new(:billing_interval_count, :billing_interval_unit).new(count, unit)
+  end
+
+  def phase(cycle_count, count, unit, code = nil)
+    Billing::Phase.new(code:, billing_interval_cycle_count: cycle_count,
+      rate_override: count && override(count, unit))
+  end
+
+  def build(shape, resume_at: nil)
+    described_class.new(
+      anchor_date: shape[:anchor], starts_at: shape[:starts_at], timezone: shape[:timezone],
+      phases: shape[:phase_args].map { |args| phase(*args) },
+      rates: shape[:rate_args].map { |args| rate(*args) },
+      ends_at: shape[:ends_at], resume_at:,
+      terms: Billing::Terms.new(timing: shape[:timing], prorated: shape.fetch(:prorated, true))
+    )
+  end
+
+  def build_walker(shape)
+    Billing::RateCards::CycleWalker.new(
+      anchor_date: shape[:anchor], starts_at: shape[:starts_at], timezone: shape[:timezone],
+      phases: shape[:phase_args].map { |args| phase(*args) },
+      rates: shape[:rate_args].map { |args| rate(*args) }, ends_at: shape[:ends_at]
+    )
+  end
+
+  def walk(shape, to: asked_at, from: nil)
+    build_walker(shape).walk_to(to, from:)
+  end
+
+  # Far enough out that every shape has billed a run of cycles by then, including the yearly
+  # override and the card whose first rate lands in May 2026.
+  let(:asked_at) { Time.utc(2027, 6, 1) }
+
+  # Everything the walk carries at a cycle, read off a cycle the full walk produced — the oracle
+  # the jump is measured against. The ruler is compared by what it IS rather than by identity,
+  # because an anchor that clamps and an anchor that does not are two different rulers.
+  def state_of(cycle)
+    [cycle.started_at, cycle.calendar.anchor_date, cycle.calendar.interval, cycle.index]
+  end
+
+  def fingerprint(cycles)
+    cycles.map do |cycle|
+      [cycle.index, cycle.started_at, cycle.ended_at,
+        cycle.phase.code, cycle.phase.billing_interval_cycle_count,
+        cycle.calendar.interval, cycle.calendar.anchor_date]
+    end
+  end
+
+  anchors = {
+    "month-end" => Date.new(2026, 1, 31),
+    "leap day" => Date.new(2024, 2, 29),
+    "mid-month" => Date.new(2026, 3, 15),
+    # Havana springs forward AT MIDNIGHT, so 00:00 does not exist on this date and
+    # `beginning_of_day` answers 01:00. That breaks the identity every other shape relies on —
+    # that a ruler boundary is the local midnight of its anchor day — so a re-anchor lands on a
+    # ruler that opens at a different instant than the cursor which built it.
+    "a day whose midnight does not exist" => Date.new(2026, 3, 8)
+  }
+
+  rate_sets = {
+    "one rate" => [[Time.utc(2025, 1, 1), 1, :month]],
+    "two rates, same cadence" => [[Time.utc(2025, 1, 1), 1, :month], [Time.utc(2026, 4, 10), 1, :month]],
+    "monthly then weekly" => [[Time.utc(2025, 1, 1), 1, :month], [Time.utc(2026, 4, 10), 1, :week]],
+    "monthly, weekly, monthly" => [[Time.utc(2025, 1, 1), 1, :month], [Time.utc(2026, 3, 10), 1, :week],
+      [Time.utc(2026, 6, 20), 1, :month]],
+    "three cadences and a rate change" => [[Time.utc(2025, 1, 1), 2, :week], [Time.utc(2026, 2, 5), 1, :month],
+      [Time.utc(2026, 5, 17), 3, :day], [Time.utc(2026, 6, 2), 3, :day]],
+    "first rate lands after the card opens" => [[Time.utc(2026, 5, 1), 1, :month]]
+  }
+
+  phase_sets = {
+    "one open phase" => [[nil, 1, :month]],
+    "weekly intro then monthly" => [[3, 1, :week, "intro"], [nil, 1, :month]],
+    "two bounded then open" => [[2, 1, :week, "a"], [2, 1, :month, "b"], [nil, 1, :month]],
+    "phase override differs from every rate" => [[4, 2, :week, "odd"], [nil, 1, :year]]
+  }
+
+  shapes = anchors.flat_map do |anchor_name, anchor|
+    rate_sets.flat_map do |rates_name, rate_args|
+      phase_sets.flat_map do |phases_name, phase_args|
+        [["UTC", :arrears], ["America/New_York", :advance], ["Asia/Kolkata", :arrears],
+          ["America/Havana", :arrears]].map do |timezone, timing|
+          {name: "#{anchor_name} / #{rates_name} / #{phases_name} / #{timezone} #{timing}",
+           anchor:, timezone:, timing:, starts_at: anchor.in_time_zone(timezone) + 2.days,
+           rate_args:, phase_args:}
+        end
+      end
+    end
+  end
+
+  # The jump is a shortcut through the walk, so the walk itself is the only honest oracle: for
+  # every cycle of every shape, jumping to it must land on exactly the state the walk carried
+  # there. A wrong index picks the wrong phase; a wrong anchor moves every later boundary.
+  it "lands on the state the walk carries, for every cycle of every shape" do
+    mismatches = shapes.flat_map do |shape|
+      walker = build_walker(shape)
+
+      walk(shape).filter_map do |cycle|
+        jumped = state_of(walker.resume(cycle.started_at))
+        next if jumped == state_of(cycle)
+
+        "#{shape[:name]}: jumping to #{cycle.started_at} gave #{jumped}, walk had #{state_of(cycle)}"
+      end
+    end
+
+    expect(mismatches).to be_empty
+  end
+
+  # The walker accepts a plain array and sorts rates before finding the next change.
+  # Handing it the same rates backwards must preserve both the full and resumed walks.
+  it "does not care what order the rates were handed in" do
+    shape = {anchor: Date.new(2026, 1, 31), starts_at: Time.utc(2026, 1, 31), timezone: "UTC",
+             timing: :arrears, phase_args: [[nil, nil, nil]],
+             rate_args: [[Time.utc(2025, 1, 1), 1, :month], [Time.utc(2026, 4, 12), 1, :week],
+               [Time.utc(2026, 8, 3), 3, :day]]}
+    backwards = shape.merge(rate_args: shape[:rate_args].reverse)
+    ascending = walk(shape)
+
+    expect(ascending.size).to be > 20
+    expect(fingerprint(walk(backwards))).to eq(fingerprint(ascending))
+
+    ascending.each do |cycle|
+      expect(walk(backwards, from: cycle.started_at).map(&:index))
+        .to eq(ascending.drop(ascending.index(cycle)).map(&:index))
+    end
+  end
+
+  # An instant inside a cycle resumes at that WHOLE cycle, not at the instant — which is what
+  # re-billing a period that was only partly billed asks for. The consumer's own clock can hold
+  # a mid-cycle instant, because a cut cycle's slice bills on its cut.
+  it "resumes at the whole cycle covering a mid-cycle instant" do
+    shape = shapes.first
+    full = walk(shape)
+    inside = full[2].started_at + ((full[2].ended_at - full[2].started_at) / 2)
+
+    expect(fingerprint(walk(shape, from: inside)))
+      .to eq(fingerprint(full.drop(2)))
+  end
+
+  context "when querying explicit dates on a resumed schedule" do
+    let(:shape) { shapes.first }
+    let(:full) { build(shape) }
+    let(:cycles) { walk(shape) }
+    let(:resumed) { build(shape, resume_at: cycles[3].started_at) }
+
+    it "finds the current billing date before, at and after the resume point" do
+      cycles[1..4].each do |cycle|
+        expected = full.billing_at_covering(cycle.started_at)
+
+        expect(expected).not_to be_nil
+        expect(resumed.billing_at_covering(cycle.started_at)).to eq(expected)
+      end
+    end
+
+    it "finds the billing instant of a cycle before the resume point" do
+      at = cycles[1].started_at + 1.day
+
+      expect(resumed.billing_at_covering(at)).to eq(cycles[1].ended_at)
+      expect(resumed.next_billing_at(after: at)).to eq(cycles[1].ended_at)
+    end
+
+    it "keeps the due listing resumed after answering a historical billing date query" do
+      resumed.billing_at_covering(cycles[1].started_at)
+
+      expect(resumed.segments_due_by(cycles[4].ended_at).map(&:cycle_index)).to eq([3, 4])
+    end
+
+    it "finds the first billing date when asked before the card began" do
+      at = shape[:starts_at] - 1.year
+
+      expect(resumed.billing_at_covering(at)).to eq(cycles.first.ended_at)
+    end
+  end
+
+  # Reject invalid inputs during construction, before a caller checks result.success?
+  # and starts querying the schedule.
+  it "refuses an instant before the card's own start when it is built" do
+    shape = shapes.first
+
+    expect { build(shape, resume_at: shape[:starts_at] - 1.year) }
+      .to raise_error(ArgumentError, /precedes the card's start/)
+  end
+
+  # The cross product above varies one dimension at a time and shares one plain shape. These are
+  # the cases the engine's own specs are built on, each resumed at every cycle: if resuming holds
+  # for the matrix but breaks a QA scenario or a terminated card, the matrix was the wrong shape.
+  named_scenarios = {
+    "X5: a month-end anchor clamping and returning to the 31st" =>
+      {anchor: Date.new(2026, 1, 31), timezone: "UTC", timing: :arrears,
+       rate_args: [[Time.utc(2025, 1, 1), 1, :month]], phase_args: [[nil, 1, :month]]},
+
+    "X6b: a yearly anchor on a leap day" =>
+      {anchor: Date.new(2024, 2, 29), timezone: "UTC", timing: :arrears,
+       rate_args: [[Time.utc(2023, 1, 1), 1, :year]], phase_args: [[nil, 1, :year]]},
+
+    "AN1: an anchor ahead of the card's start, opening a stub cycle" =>
+      {anchor: Date.new(2026, 2, 20), starts_at: Time.utc(2026, 2, 3), timezone: "UTC",
+       timing: :arrears, rate_args: [[Time.utc(2025, 1, 1), 1, :month]], phase_args: [[nil, 1, :month]]},
+
+    # Arrears on a two-year cadence: the first cycle only falls due in 2028, so this one is
+    # asked far enough out to have cycles at all.
+    "a cadence longer than a year" =>
+      {anchor: Date.new(2018, 1, 1), timezone: "UTC", timing: :arrears,
+       rate_args: [[Time.utc(2017, 1, 1), 2, :year]], phase_args: [[nil, 2, :year]]},
+
+    "decision #56: the first rate lands after the card opens" =>
+      {anchor: Date.new(2026, 1, 1), starts_at: Time.utc(2026, 1, 15), timezone: "UTC",
+       timing: :arrears, rate_args: [[Time.utc(2026, 4, 1), 1, :month]], phase_args: [[nil, 1, :month]]},
+
+    "a termination cutting the last cycle short" =>
+      {anchor: Date.new(2026, 1, 31), timezone: "UTC", timing: :arrears, ends_at: Time.utc(2026, 6, 17, 14, 30),
+       rate_args: [[Time.utc(2025, 1, 1), 1, :month]], phase_args: [[nil, 1, :month]]},
+
+    "a termination landing exactly on a boundary" =>
+      {anchor: Date.new(2026, 1, 31), timezone: "UTC", timing: :arrears, ends_at: Time.utc(2026, 5, 31),
+       rate_args: [[Time.utc(2025, 1, 1), 1, :month]], phase_args: [[nil, 1, :month]]},
+
+    "a card that does not prorate" =>
+      {anchor: Date.new(2026, 1, 31), timezone: "UTC", timing: :arrears, prorated: false,
+       ends_at: Time.utc(2026, 6, 17), rate_args: [[Time.utc(2025, 1, 1), 1, :month]],
+       phase_args: [[nil, 1, :month]]},
+
+    "a spring-forward day as the anchor" =>
+      {anchor: Date.new(2026, 3, 8), timezone: "America/New_York", timing: :advance,
+       rate_args: [[Time.utc(2025, 1, 1), 1, :day]], phase_args: [[nil, 1, :day]]},
+
+    "a fall-back day as the anchor" =>
+      {anchor: Date.new(2026, 11, 1), timezone: "America/New_York", timing: :arrears,
+       rate_args: [[Time.utc(2025, 1, 1), 1, :day]], phase_args: [[nil, 1, :day]]},
+
+    "a half-hour timezone that also observes DST" =>
+      {anchor: Date.new(2026, 4, 5), timezone: "Australia/Lord_Howe", timing: :arrears,
+       rate_args: [[Time.utc(2025, 1, 1), 1, :week]], phase_args: [[nil, 1, :week]]},
+
+    "a rate change landing mid-cycle, cutting it" =>
+      {anchor: Date.new(2026, 1, 1), timezone: "UTC", timing: :arrears,
+       rate_args: [[Time.utc(2025, 1, 1), 1, :month], [Time.utc(2026, 3, 14, 7, 5), 1, :month]],
+       phase_args: [[nil, 1, :month]]},
+
+    "a cadence change on a month-end card" =>
+      {anchor: Date.new(2026, 1, 31), timezone: "UTC", timing: :arrears,
+       rate_args: [[Time.utc(2025, 1, 1), 1, :month], [Time.utc(2026, 4, 12), 1, :week]],
+       phase_args: [[nil, nil, nil]]}
+  }
+
+  named_scenarios.each do |name, base|
+    it "answers the same tail resuming anywhere in #{name}" do
+      shape = {starts_at: base[:anchor].in_time_zone(base[:timezone])}.merge(base)
+      full = walk(shape)
+      segments = segment_values(build(shape).segments_due_by(asked_at))
+
+      expect(full).not_to be_empty
+
+      mismatches = full.each_index.flat_map do |n|
+        resumed = build(shape, resume_at: full[n].started_at)
+        [
+          ((fingerprint(walk(shape, from: full[n].started_at)) == fingerprint(full.drop(n))) ? nil : "cycles at #{n}"),
+          ((segment_values(resumed.segments_due_by(asked_at)) ==
+            segments.select { |values| values.first >= full[n].index }) ? nil : "segments at #{n}")
+        ].compact
+      end
+
+      expect(mismatches).to be_empty
+    end
+  end
+
+  it "answers the same tail whichever cycle it resumes at, across #{shapes.size} card shapes" do
+    mismatches = shapes.flat_map do |shape|
+      full = walk(shape)
+
+      full.each_index.filter_map do |n|
+        resumed = walk(shape, from: full[n].started_at)
+        next if fingerprint(resumed) == fingerprint(full.drop(n))
+
+        "#{shape[:name]}: resuming at #{n} of #{full.size} gave " \
+          "#{fingerprint(resumed).first(2)}, expected #{fingerprint(full.drop(n)).first(2)}"
+      end
+    end
+
+    expect(mismatches).to be_empty
+  end
+
+  # The segments are what reaches the database, so the equality has to hold there too: a cycle
+  # that matched but sliced differently would bill the same periods at different prices.
+  #
+  # Compared by value rather than by object: each schedule is handed its own rate stubs, and
+  # two stubs of the same shape are never `==` because Struct.new makes a fresh class each time.
+  def segment_values(segments)
+    segments.map do |segment|
+      [segment.cycle_index, segment.cycle_started_at, segment.started_at, segment.ended_at,
+        segment.billing_at, segment.proration_ratio, segment.rate_phase_code,
+        segment.rate.effective_from, segment.rate_override&.billing_interval_unit]
+    end
+  end
+
+  it "produces the same segments whichever cycle it resumes at" do
+    mismatches = shapes.flat_map do |shape|
+      cycles = walk(shape)
+      full = segment_values(build(shape).segments_due_by(asked_at))
+
+      cycles.filter_map do |cycle|
+        resumed = segment_values(build(shape, resume_at: cycle.started_at).segments_due_by(asked_at))
+        tail = full.select { |values| values.first >= cycle.index }
+        next if resumed == tail
+
+        "#{shape[:name]}: resuming at #{cycle.index} gave #{resumed.first(2)}, expected #{tail.first(2)}"
+      end
+    end
+
+    expect(mismatches).to be_empty
+  end
+
+  # The point of resuming: the same answer, less work.
+  it "walks only the cycles it was not given" do
+    shape = {anchor: Date.new(2026, 1, 31), starts_at: Time.utc(2026, 1, 31), timezone: "UTC",
+             timing: :arrears, phase_args: [[nil, 1, :month]], rate_args: [[Time.utc(2025, 1, 1), 1, :month]]}
+    asked = Time.utc(2028, 1, 1)
+    full = walk(shape, to: asked)
+    resumed = walk(shape, to: asked, from: full[-3].started_at)
+
+    expect(full.size).to be > 20
+    expect(resumed.size).to eq(3)
+    expect(resumed.first.index).to eq(full[-3].index)
+  end
+
+  it "skips a century of daily cycles without visiting them" do
+    shape = {anchor: Date.new(1926, 1, 1), starts_at: Time.utc(1926, 1, 1), timezone: "UTC",
+             timing: :arrears, phase_args: [[nil, nil, nil]],
+             rate_args: [[Time.utc(1926, 1, 1), 1, :day]]}
+    walker = build_walker(shape)
+    allow(walker).to receive(:build_cycle).and_call_original
+
+    cycles = walker.walk_to(Time.utc(2026, 1, 3), from: Time.utc(2026, 1, 1))
+
+    expect(cycles.map(&:started_at)).to eq([Time.utc(2026, 1, 1), Time.utc(2026, 1, 2), Time.utc(2026, 1, 3)])
+    expect(cycles.map(&:index)).to eq([36_525, 36_526, 36_527])
+    # Build the initial cycle, jump to January 1, then visit January 2 and 3.
+    expect(walker).to have_received(:build_cycle).at_most(4).times
+  end
+
+  # The measured hazard, kept as an absolute assertion rather than a comparison: a boundary is
+  # NOT an anchor. Anchored Jan 31 the boundaries run Feb 28, Mar 31; re-anchored on the Feb 28
+  # boundary they would run Mar 28, Apr 28, and a month-end card never gets its day back. So the
+  # anchor of a run reaching back past the rows is the ruler #state_at arrived carrying, never
+  # the cursor's own date.
+  it "keeps a month-end card's day when it resumes from the clamped February cycle" do
+    shape = {anchor: Date.new(2026, 1, 31), starts_at: Time.utc(2026, 1, 31), timezone: "UTC",
+             timing: :arrears, phase_args: [[nil, 1, :month]], rate_args: [[Time.utc(2025, 1, 1), 1, :month]]}
+    resumed = walk(shape, from: Time.utc(2026, 2, 28))
+
+    expect(resumed.first.started_at).to eq(Time.utc(2026, 2, 28))
+    expect(resumed.map(&:ended_at).first(3))
+      .to eq([Time.utc(2026, 3, 31), Time.utc(2026, 4, 30), Time.utc(2026, 5, 31)])
+  end
+
+  # Unrelated to resuming: starts_at is floored to the start of its local day and ends_at is not,
+  # so comparing the floored start let a card terminated BEFORE it began through — and it billed
+  # the six hours between.
+  it "refuses a card whose end precedes its raw start" do
+    expect {
+      described_class.new(anchor_date: Date.new(2026, 1, 31), starts_at: Time.utc(2026, 1, 31, 8),
+        ends_at: Time.utc(2026, 1, 31, 6), timezone: "UTC",
+        phases: [phase(nil, 1, :month)], rates: [rate(Time.utc(2025, 1, 1), 1, :month)],
+        terms: Billing::Terms.new(timing: :arrears, prorated: true))
+    }.to raise_error(ArgumentError, /precedes starts_at/)
+  end
+end

--- a/spec/services/billing/rate_cards/schedule_resume_stress_spec.rb
+++ b/spec/services/billing/rate_cards/schedule_resume_stress_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The resume matrix next door varies one thing at a time. This one turns everything on at once:
+# 200 back-to-back effective rates cycling through six cadences, 61 phases alternating between
+# their own cadence override and none at all — so the cadence comes from the RATE half the time
+# and from the PHASE the other half — read off month-end, leap-day and mid-month anchors in
+# three timezones, both advance and arrears.
+#
+# The number that matters is the re-anchor count: over 30 in every shape, up to 122. Each one is
+# a chance for a resumed walk to rebuild the wrong ruler, and a ruler rebuilt one day off
+# reprices every cycle after it.
+RSpec.describe Billing::RateCards::Schedule do
+  cadences = [[1, :day], [2, :day], [1, :week], [2, :week], [1, :month], [3, :day]]
+
+  def rate(effective_from, count, unit)
+    Struct.new(:effective_from, :billing_interval_count, :billing_interval_unit).new(effective_from, count, unit)
+  end
+
+  def override(count, unit)
+    Struct.new(:billing_interval_count, :billing_interval_unit).new(count, unit)
+  end
+
+  # Every four days, so no rate gets a full cycle to itself on the slower cadences and a change
+  # can land anywhere inside a window rather than only on its boundary.
+  let(:rates) do
+    (0...200).map do |i|
+      count, unit = cadences[i % cadences.size]
+      rate(Time.utc(2026, 1, 1) + (i * 4).days, count, unit)
+    end
+  end
+
+  # Alternating: an even phase has NO override, so the rate in force decides the cadence; an odd
+  # one overrides it with a cadence deliberately out of step with the rates. Every phase is 2 to
+  # 4 cycles long, so resuming lands inside an override phase as often as at its first cycle.
+  let(:phases) do
+    (0...60).map { |i|
+      Billing::Phase.new(
+        code: "p#{i}",
+        billing_interval_cycle_count: 2 + (i % 3),
+        rate_override: i.even? ? nil : override(*cadences[(i + 2) % cadences.size])
+      )
+    } + [Billing::Phase.new(code: nil, billing_interval_cycle_count: nil, rate_override: nil)]
+  end
+
+  let(:asked_at) { Time.utc(2027, 7, 1) }
+
+  def build(timezone:, timing:, anchor:, resume_at: nil)
+    described_class.new(
+      anchor_date: anchor, starts_at: anchor.in_time_zone(timezone), timezone:,
+      phases:, rates:, resume_at:, terms: Billing::Terms.new(timing:, prorated: true)
+    )
+  end
+
+  def build_walker(timezone:, anchor:, **)
+    Billing::RateCards::CycleWalker.new(
+      anchor_date: anchor, starts_at: anchor.in_time_zone(timezone), timezone:, phases:, rates:
+    )
+  end
+
+  def walk(from: nil, **shape)
+    build_walker(**shape).walk_to(asked_at, from:)
+  end
+
+  def state_of(cycle)
+    [cycle.started_at, cycle.calendar.anchor_date, cycle.calendar.interval, cycle.index]
+  end
+
+  def cycle_values(cycles)
+    cycles.map do |cycle|
+      [cycle.index, cycle.started_at, cycle.ended_at, cycle.phase.code,
+        cycle.calendar.interval, cycle.calendar.anchor_date]
+    end
+  end
+
+  def segment_values(segments)
+    segments.map do |segment|
+      [segment.cycle_index, segment.cycle_started_at, segment.started_at, segment.ended_at,
+        segment.billing_at, segment.proration_ratio, segment.rate_phase_code,
+        segment.rate.effective_from, segment.rate_override&.billing_interval_unit]
+    end
+  end
+
+  shapes = [
+    {timezone: "America/New_York", timing: :arrears, anchor: Date.new(2026, 1, 31)},
+    {timezone: "America/New_York", timing: :advance, anchor: Date.new(2026, 1, 31)},
+    {timezone: "Asia/Kolkata", timing: :arrears, anchor: Date.new(2024, 2, 29)},
+    {timezone: "Europe/Paris", timing: :advance, anchor: Date.new(2026, 3, 15)}
+  ]
+
+  # A stress test that quietly stops stressing is worthless, so the shape is asserted before the
+  # behaviour is. Thresholds are the measured values less a margin: if a future edit thins the
+  # fixture, this fails instead of the suite passing vacuously.
+  shapes.each do |shape|
+    it "keeps stressing re-anchoring, every cadence and both override modes on #{shape[:anchor]} in #{shape[:timezone]}" do
+      cycles = walk(**shape)
+      inside_an_override = cycles.each_with_index.count do |cycle, n|
+        cycle.phase.rate_override && n.positive? && cycles[n - 1].phase.code == cycle.phase.code
+      end
+
+      expect(cycles.size).to be > 50
+      expect(cycles.map { it.calendar.anchor_date }.uniq.size).to be > 30
+      expect(cycles.map { it.calendar.interval }.uniq.size).to eq(cadences.size)
+      expect(cycles.map { it.phase.rate_override.nil? }.uniq).to match_array([true, false])
+      expect(inside_an_override).to be > 15
+    end
+  end
+
+  shapes.each do |shape|
+    context "with #{shape[:timing]} on #{shape[:anchor]} in #{shape[:timezone]}" do
+      # The jump skips from one cadence change to the next, so a fixture with 122 re-anchors is
+      # where it has the most to get wrong. The walk is the oracle.
+      it "lands on the state the walk carries, at every one of its cycles" do
+        walker = build_walker(**shape)
+
+        mismatches = walk(**shape).filter_map do |cycle|
+          jumped = state_of(walker.resume(cycle.started_at))
+          next if jumped == state_of(cycle)
+
+          "at #{cycle.started_at}: jumped to #{jumped}, walk had #{state_of(cycle)}"
+        end
+
+        expect(mismatches).to be_empty
+      end
+
+      it "answers the same cycles whichever of them it resumes at" do
+        full = walk(**shape)
+
+        mismatches = full.each_index.filter_map do |n|
+          resumed = walk(**shape, from: full[n].started_at)
+          next if cycle_values(resumed) == cycle_values(full.drop(n))
+
+          "resuming at #{n} of #{full.size}: got #{cycle_values(resumed).first}, " \
+            "expected #{cycle_values(full.drop(n)).first}"
+        end
+
+        expect(mismatches).to be_empty
+      end
+
+      it "answers the same segments whichever cycle it resumes at" do
+        cycles = walk(**shape)
+        full = segment_values(build(**shape).segments_due_by(asked_at))
+
+        mismatches = cycles.filter_map do |cycle|
+          resumed = segment_values(build(**shape, resume_at: cycle.started_at).segments_due_by(asked_at))
+          tail = full.select { |values| values.first >= cycle.index }
+          next if resumed == tail
+
+          "resuming at #{cycle.index}: got #{resumed.size} segments, expected #{tail.size}"
+        end
+
+        expect(mismatches).to be_empty
+      end
+    end
+  end
+end

--- a/spec/services/billing/rate_cards/schedule_spec.rb
+++ b/spec/services/billing/rate_cards/schedule_spec.rb
@@ -1,0 +1,873 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Billing::RateCards::Schedule do
+  subject(:schedule) do
+    described_class.new(anchor_date:, phases:, rates:, terms:, timezone:, starts_at:, ends_at:)
+  end
+
+  let(:anchor_date) { Date.new(2022, 1, 1) }
+  let(:phases) { [phase(cycle_count: nil, every: 1, unit: :month)] }
+  let(:rates) { [card_rate(Time.utc(2000, 1, 1))] }
+  let(:prorated) { true }
+  let(:timezone) { "UTC" }
+  let(:starts_at) { Time.utc(2022, 1, 15) }
+  let(:timing) { :arrears }
+  let(:ends_at) { nil }
+  let(:terms) { Billing::Terms.new(timing:, prorated:) }
+
+  # The two shapes the schedule reads. A rate carries the cadence and the date it takes
+  # effect; an override pins the cadence for one phase and wins over the rate, which is how
+  # production configures a phase that bills on its own rhythm.
+  def card_rate(effective_from, count = 1, unit = :month)
+    Struct.new(:effective_from, :billing_interval_count, :billing_interval_unit)
+      .new(effective_from, count, unit)
+  end
+
+  def interval_override(count, unit, label)
+    Struct.new(:billing_interval_count, :billing_interval_unit, :label).new(count, unit, label)
+  end
+
+  # The phases are handed in the order they bill. The schedule does not re-sort them: both
+  # associations that produce them are `order(:position)`, so the order is the producer's
+  # contract and Schedule#validate! asserts it rather than repairing it.
+  def phase(cycle_count:, every:, unit:, code: "standard", override: nil)
+    Billing::Phase.new(
+      code:,
+      billing_interval_cycle_count: cycle_count,
+      rate_override: interval_override(every, unit, override)
+    )
+  end
+
+  # The plan shows bounds inclusive, so the exclusive end reads as the day before.
+  def windows(cycles)
+    cycles.map { |cycle| "#{cycle.started_at.to_date} -> #{(cycle.ended_at - 1.day).to_date}" }
+  end
+
+  describe "validation" do
+    # Without a rate the walk breaks before producing anything and answers "no cycles", which
+    # reads as a card that never bills rather than as a card built wrong. BuildScheduleService
+    # already fails its result on this; a schedule built directly must not stay silent.
+    it "rejects a schedule with no rates" do
+      expect { described_class.new(anchor_date:, phases:, rates: [], terms:, timezone:, starts_at:, ends_at:) }
+        .to raise_error(ArgumentError, /at least one rate/)
+    end
+
+    it "rejects an end before the start" do
+      expect { described_class.new(anchor_date:, phases:, rates:, terms:, timezone:, starts_at:, ends_at: starts_at - 1.day) }
+        .to raise_error(ArgumentError, /precedes starts_at/)
+    end
+
+    it "rejects an empty phase list" do
+      expect { described_class.new(anchor_date:, phases: [], rates:, terms:, timezone:, starts_at:) }
+        .to raise_error(ArgumentError, /at least one phase/)
+    end
+
+    # A bounded last phase stops producing cycles while the card is still live, which
+    # downstream reads as nothing being due rather than as an error.
+    it "rejects a bounded last phase" do
+      broken = [phase(cycle_count: 6, every: 1, unit: :month)]
+
+      expect { described_class.new(anchor_date:, phases: broken, rates:, terms:, timezone:, starts_at:) }
+        .to raise_error(ArgumentError, /last phase must run to the end/)
+    end
+
+    it "rejects an open phase that is not the last" do
+      broken = [phase(cycle_count: nil, every: 1, unit: :week), phase(cycle_count: nil, every: 1, unit: :month)]
+
+      expect { described_class.new(anchor_date:, phases: broken, rates:, terms:, timezone:, starts_at:) }
+        .to raise_error(ArgumentError, /only the last phase/)
+    end
+  end
+
+  describe "cycle information on billable segments" do
+    it "clamps the first cycle to the start rather than to the boundary before it" do
+      expect(windows(schedule.segments_due_by(Time.utc(2022, 3, 1))))
+        .to eq(["2022-01-15 -> 2022-01-31", "2022-02-01 -> 2022-02-28"])
+    end
+
+    # A cycle running over the timestamp but closing after it has not fallen due yet.
+    it "leaves out a cycle that has not closed by the timestamp" do
+      expect(windows(schedule.segments_due_by(Time.utc(2022, 2, 10)))).to eq(["2022-01-15 -> 2022-01-31"])
+    end
+
+    # The last one closes exactly on the timestamp asked about, so it has fallen due.
+    it "numbers cycles from zero, counting from the card start" do
+      expect(schedule.segments_due_by(Time.utc(2022, 5, 1)).map(&:cycle_index)).to eq([0, 1, 2, 3])
+    end
+
+    it "returns nothing when nothing has fallen due" do
+      expect(schedule.segments_due_by(starts_at)).to be_empty
+    end
+
+    context "when the card bills in advance" do
+      let(:timing) { :advance }
+
+      it "includes the first cycle as soon as it starts" do
+        expect(schedule.segments_due_by(starts_at).map(&:cycle_index)).to eq([0])
+      end
+
+      it "includes the cycle opening exactly at the requested time" do
+        expect(schedule.segments_due_by(Time.utc(2022, 2, 1)).map(&:cycle_index)).to eq([0, 1])
+      end
+    end
+
+    context "when the card starts before the anchor" do
+      let(:starts_at) { Time.utc(2021, 12, 20) }
+
+      it "still opens at cycle 0, clamped to the start" do
+        cycle = schedule.segments_due_by(Time.utc(2022, 1, 1)).sole
+
+        expect(cycle.cycle_index).to eq(0)
+        expect(cycle.started_at...cycle.ended_at).to eq(Time.utc(2021, 12, 20)...Time.utc(2022, 1, 1))
+      end
+    end
+
+    context "when the schedule ends" do
+      let(:ends_at) { Time.utc(2022, 3, 20) }
+
+      it "clamps the final cycle to the end and stops there" do
+        expect(windows(schedule.segments_due_by(Time.utc(2023, 1, 1))))
+          .to eq(["2022-01-15 -> 2022-01-31", "2022-02-01 -> 2022-02-28", "2022-03-01 -> 2022-03-19"])
+      end
+
+      context "when the end falls exactly on a boundary" do
+        let(:ends_at) { Time.utc(2022, 3, 1) }
+
+        it "stops without emitting an empty cycle" do
+          expect(windows(schedule.segments_due_by(Time.utc(2023, 1, 1))))
+            .to eq(["2022-01-15 -> 2022-01-31", "2022-02-01 -> 2022-02-28"])
+        end
+      end
+    end
+  end
+
+  describe "when a window falls due" do
+    it "bills at the end of the cycle in arrears" do
+      expect(schedule.segments_due_by(Time.utc(2022, 4, 1)).map(&:billing_at))
+        .to eq([Time.utc(2022, 2, 1), Time.utc(2022, 3, 1), Time.utc(2022, 4, 1)])
+    end
+
+    context "when the card bills in advance" do
+      let(:timing) { :advance }
+
+      it "bills at the start of the cycle" do
+        expect(schedule.segments_due_by(Time.utc(2022, 4, 1)).map(&:billing_at))
+          .to eq([Time.utc(2022, 1, 15), Time.utc(2022, 2, 1), Time.utc(2022, 3, 1), Time.utc(2022, 4, 1)])
+      end
+    end
+
+    context "when a termination cuts the cycle short" do
+      let(:ends_at) { Time.utc(2022, 3, 20) }
+
+      it "bills the final cycle at the termination, not at the boundary" do
+        expect(schedule.segments_due_by(Time.utc(2023, 1, 1)).last.billing_at).to eq(Time.utc(2022, 3, 20))
+      end
+    end
+  end
+
+  # The flat shape the consumer lane writes rows from: one entry per slice, cycle facts
+  # already joined, so a writer never has to hold two objects to fill one row.
+  describe "the flat segment surface" do
+    let(:cut) { Time.utc(2022, 2, 15) }
+    let(:rates) { [card_rate(Time.utc(2021, 1, 1)), card_rate(cut)] }
+
+    describe "#segments_due_by" do
+      # The bug this fixes, and the reason the release gate cannot live on the cycle: the
+      # February cycle is cut on the 15th, so its first slice falls due THAT DAY. Gating on
+      # the cycle's own due instant (Mar 1) withheld it, and for an arrears card whose clock
+      # had already moved past the 15th, withheld it for good. QA plan R3b, decision #60 —
+      # one document per transition.
+      it "releases the slice before a cut as soon as the cut passes, not when the cycle closes" do
+        due = schedule.segments_due_by(Time.utc(2022, 2, 20))
+
+        expect(due.map { |segment| [segment.started_at.to_date.to_s, segment.billing_at.to_date.to_s] }).to eq(
+          [["2022-01-15", "2022-02-01"],
+            ["2022-02-01", "2022-02-15"]]
+        )
+      end
+
+      it "still withholds the slice after the cut until its own boundary" do
+        expect(schedule.segments_due_by(Time.utc(2022, 2, 20)).map(&:ended_at))
+          .not_to include(Time.utc(2022, 3, 1))
+      end
+
+      it "joins the cycle's facts onto every slice" do
+        first, second = schedule.segments_due_by(Time.utc(2022, 2, 20)).last(2)
+
+        expect([first.cycle_index, second.cycle_index]).to eq([0, 1])
+        expect(second.cycle_started_at).to eq(Time.utc(2022, 2, 1))
+      end
+
+      # The two slices of one cut cycle are shares of that cycle, so they add back up to it.
+      it "prorates each slice against its own cycle" do
+        ratios = schedule.segments_due_by(Time.utc(2022, 4, 1))
+          .select { |segment| segment.cycle_index == 1 }
+          .map(&:proration_ratio)
+
+        expect(ratios).to eq([14.fdiv(28), 14.fdiv(28)])
+        expect(ratios.sum).to eq(1.0)
+      end
+
+      context "when the card bills in advance" do
+        let(:timing) { :advance }
+
+        it "releases each segment when it starts, including at a rate change" do
+          segments = schedule.segments_due_by(cut)
+
+          expect(segments.map { |segment| [segment.started_at, segment.billing_at] }).to eq([
+            [Time.utc(2022, 1, 15), Time.utc(2022, 1, 15)],
+            [Time.utc(2022, 2, 1), Time.utc(2022, 2, 1)],
+            [cut, cut]
+          ])
+        end
+      end
+
+      context "when the first rate starts inside a cycle" do
+        let(:rates) { [card_rate(cut)] }
+
+        it "does not return the unpriced segments before the first rate" do
+          expect(schedule.segments_due_by(cut)).to be_empty
+        end
+
+        it "returns only the priced part when it falls due" do
+          segment = schedule.segments_due_by(Time.utc(2022, 3, 1)).sole
+
+          expect([segment.cycle_index, segment.started_at, segment.ended_at, segment.billing_at, segment.rate])
+            .to eq([1, cut, Time.utc(2022, 3, 1), Time.utc(2022, 3, 1), rates.sole])
+          expect(segment.proration_ratio).to eq(0.5)
+        end
+      end
+
+      context "when proration is disabled" do
+        let(:prorated) { false }
+
+        it "gives each priced segment a full ratio" do
+          segments = schedule.segments_due_by(Time.utc(2022, 3, 1)).select { |segment| segment.cycle_index == 1 }
+
+          expect(segments.map(&:proration_ratio)).to eq([1.0, 1.0])
+        end
+      end
+    end
+
+    describe "#consumed_ratio" do
+      subject(:segment) do
+        schedule.segments_due_by(Date.new(2022, 3, 1).in_time_zone(timezone))
+          .find { |candidate| candidate.started_at == cut }
+      end
+
+      # A share of the SEGMENT, never of the cycle. Measuring elapsed segment days against
+      # the whole cycle refunds days the slice before the rate change already paid for.
+      it "measures elapsed segment days against billed segment days" do
+        expect(schedule.consumed_ratio(segment:, at: Time.utc(2022, 2, 22))).to eq(7.fdiv(14))
+      end
+
+      it "is nothing consumed at the segment's own start" do
+        expect(schedule.consumed_ratio(segment:, at: segment.started_at)).to eq(0.0)
+      end
+
+      it "is nothing consumed before the segment starts" do
+        expect(schedule.consumed_ratio(segment:, at: segment.started_at - 1.day)).to eq(0.0)
+      end
+
+      it "is fully consumed at its end" do
+        expect(schedule.consumed_ratio(segment:, at: segment.ended_at)).to eq(1.0)
+      end
+
+      it "is fully consumed after its end" do
+        expect(schedule.consumed_ratio(segment:, at: segment.ended_at + 1.day)).to eq(1.0)
+      end
+
+      context "when the customer is west of UTC" do
+        let(:timezone) { "America/New_York" }
+        let(:cut) { Time.utc(2022, 2, 15, 5) }
+
+        it "counts the day in progress in the customer's timezone" do
+          expect(schedule.consumed_ratio(segment:, at: Time.utc(2022, 2, 22, 12))).to eq(8.fdiv(14))
+        end
+      end
+
+      # QA plan X2, through the path production actually takes: the credit for an unused
+      # pay-in-advance interval is `1 - consumed_ratio`, measured to the instant
+      # Days hands back. It was previously asserted against a formula written in
+      # the spec file, which meant neither of the two methods below had to be right.
+      context "with the X2 termination scenario" do
+        subject(:segment) do
+          advance_schedule.segments_due_by(Time.utc(2026, 9, 15)).sole
+        end
+
+        let(:advance_schedule) do
+          described_class.new(
+            anchor_date: Date.new(2026, 9, 10),
+            phases: [phase(cycle_count: nil, every: 1, unit: :month)],
+            rates: [card_rate(Time.utc(2026, 1, 1))],
+            terms: Billing::Terms.new(timing: :advance, prorated: true),
+            timezone: "UTC",
+            starts_at: Time.utc(2026, 9, 10),
+            ends_at: nil
+          )
+        end
+
+        # A 30-day window Sep 10 -> Oct 9 paid at 150.00, terminated on Sep 25. The
+        # termination day is consumed, so 14 unused days are worth 70.00.
+        it "credits the fourteen unused days" do
+          unused = 1 - advance_schedule.consumed_ratio(segment:, at: Time.utc(2026, 9, 25, 16, 30))
+
+          expect(unused).to eq(14.fdiv(30))
+          expect((unused * 150_00).round).to eq(70_00)
+        end
+
+        # QA plan X1: the termination day is inclusive, so the hour it happens at must not
+        # move the credit. Terminating at midnight used to credit a day more than
+        # terminating the same afternoon.
+        it "credits the same whatever hour the termination lands at" do
+          # Any hour AFTER midnight answers alike, because the day-ownership rule gives the
+          # day it lands in whole. Midnight itself is the one instant that differs, and it is
+          # a termination with no service in that day at all.
+          credits = [Time.utc(2026, 9, 25, 0, 0, 1), Time.utc(2026, 9, 25, 12, 34, 56), Time.utc(2026, 9, 25, 23, 59, 59)]
+            .map { |at| 1 - advance_schedule.consumed_ratio(segment:, at:) }
+
+          expect(credits).to eq([14.fdiv(30)] * 3)
+
+          expect(1 - advance_schedule.consumed_ratio(segment:, at: Time.utc(2026, 9, 25)))
+            .to eq(15.fdiv(30))
+        end
+
+        it "credits nothing when the termination lands on the closing boundary" do
+          expect(1 - advance_schedule.consumed_ratio(segment:, at: Time.utc(2026, 10, 9, 23))).to eq(0.0)
+        end
+      end
+
+      # Billing::Days counts day OPENINGS, so a slice that opens and closes inside one local
+      # day covers none — it was charged nothing, and 0/0 would put a NaN into a credit note.
+      # A NaN is worse than a wrong number here: it compares false against every threshold,
+      # so a caller's clamp passes it straight through.
+      context "when a slice opens and closes inside one day" do
+        subject(:segment) do
+          schedule.segments_due_by(Time.utc(2022, 4, 1))
+            .find { |candidate| candidate.started_at == Time.utc(2022, 2, 15, 9) }
+        end
+
+        let(:rates) do
+          [card_rate(Time.utc(2021, 1, 1)),
+            card_rate(Time.utc(2022, 2, 15, 9)),
+            card_rate(Time.utc(2022, 2, 15, 18))]
+        end
+
+        it "is a real number, never NaN" do
+          ratio = schedule.consumed_ratio(segment:, at: Time.utc(2022, 2, 15, 12))
+
+          expect(ratio).to be_a(Float)
+          expect(ratio).not_to be_nan
+        end
+
+        it "has nothing left to credit, because it was charged nothing" do
+          expect(segment.proration_ratio).to eq(0.0)
+          expect(schedule.consumed_ratio(segment:, at: Time.utc(2022, 2, 15, 12))).to eq(1.0)
+        end
+      end
+    end
+  end
+
+  # The cut and the share, read where the consumer reads them. The cycle carries the ruler it
+  # was measured on and nothing else: what a window costs needs the card's terms, so the
+  # schedule answers that, not the cycle.
+  describe "cutting a cycle and sharing it" do
+    subject(:slices) do
+      schedule.segments_due_by(Time.utc(2022, 4, 1))
+        .select { |segment| segment.cycle_started_at == Time.utc(2022, 3, 1) }
+    end
+
+    def bounds = slices.map { |slice| [slice.started_at, slice.ended_at] }
+
+    def ratios = slices.map(&:proration_ratio)
+
+    it "is the whole cycle when no rate changes inside it" do
+      expect(bounds).to eq([[Time.utc(2022, 3, 1), Time.utc(2022, 4, 1)]])
+      expect(ratios).to eq([1.0])
+    end
+
+    context "when a rate change lands part-way through" do
+      let(:change) { Time.utc(2022, 3, 15) }
+      let(:rates) { [card_rate(Time.utc(2021, 1, 1)), card_rate(change)] }
+
+      it "splits at the change" do
+        expect(bounds).to eq([[Time.utc(2022, 3, 1), change], [change, Time.utc(2022, 4, 1)]])
+      end
+    end
+
+    # The two sides of a rate change have to add up to one interval, whatever hour the
+    # change lands at — the day-ownership rule Billing::Days exists to keep.
+    context "when a rate change lands mid-day inside the cycle" do
+      let(:rates) { [card_rate(Time.utc(2021, 1, 1)), card_rate(Time.utc(2022, 3, 15, 14))] }
+
+      it "shares one interval between the segments of a cut cycle" do
+        expect(ratios).to eq([15.fdiv(31), 16.fdiv(31)])
+        expect(ratios.sum).to eq(1.0)
+      end
+    end
+
+    # A termination clamps the cycle, so it bills the share it actually ran.
+    context "when the schedule ends part-way through the cycle" do
+      let(:ends_at) { Time.utc(2022, 3, 20) }
+
+      it "prorates the clamped cycle" do
+        expect(ratios).to eq([19.fdiv(31)])
+      end
+    end
+
+    # An unprorated card pays the full price for whatever it got: the clamp changes what
+    # the cycle covers, never what it costs. Without this the `prorated` flag could be
+    # deleted outright and every other example here would still pass.
+    context "when the card does not prorate" do
+      let(:prorated) { false }
+      let(:ends_at) { Time.utc(2022, 3, 20) }
+
+      it "bills a clamped cycle whole" do
+        expect(ratios).to eq([1.0])
+      end
+
+      context "when a rate change cuts the cycle as well" do
+        let(:rates) { [card_rate(Time.utc(2021, 1, 1)), card_rate(Time.utc(2022, 3, 10))] }
+
+        it "bills each slice whole, so the cut cycle costs twice" do
+          expect(ratios).to eq([1.0, 1.0])
+        end
+      end
+    end
+
+    # Both clamps at once, which no other example combines: the cycle is cut by a rate
+    # change AND closed early by the termination. The slices must add up to the share the
+    # card actually ran, not to a whole interval.
+    context "when the cycle is both cut by a rate change and clamped by the end" do
+      let(:rates) { [card_rate(Time.utc(2021, 1, 1)), card_rate(Time.utc(2022, 3, 10))] }
+      let(:ends_at) { Time.utc(2022, 3, 20) }
+
+      it "shares the clamped run between the slices" do
+        expect(ratios).to eq([9.fdiv(31), 10.fdiv(31)])
+        expect(ratios.sum).to eq(19.fdiv(31))
+      end
+    end
+  end
+
+  # What seeds the clock. It counts a cycle already due but still
+  # running, because nothing has billed it yet.
+  # Two questions, two methods, and the names used to be one. #next_billing_at ADVANCES the
+  # clock — strictly after, per segment; #billing_at_covering SEEDS it — the cycle being
+  # served, even when it already fell due. The consumer lane calls the first from three
+  # places with `after:`, and the second only at materialization.
+  describe "#next_billing_at" do
+    it "answers the first slice falling due strictly after the instant asked about" do
+      expect(schedule.next_billing_at(after: starts_at)).to eq(Time.utc(2022, 2, 1))
+    end
+
+    it "skips the cycles that already closed" do
+      expect(schedule.next_billing_at(after: Time.utc(2022, 3, 10))).to eq(Time.utc(2022, 4, 1))
+    end
+
+    it "skips billing exactly at the requested instant" do
+      expect(schedule.next_billing_at(after: Time.utc(2022, 3, 1))).to eq(Time.utc(2022, 4, 1))
+    end
+
+    context "when asked before the card starts" do
+      it "returns the end of the first priced segment in arrears" do
+        expect(schedule.next_billing_at(after: Time.utc(2022, 1, 1))).to eq(Time.utc(2022, 2, 1))
+      end
+
+      context "when billing in advance" do
+        let(:timing) { :advance }
+
+        it "returns the card's start" do
+          expect(schedule.next_billing_at(after: Time.utc(2022, 1, 1))).to eq(starts_at)
+        end
+      end
+    end
+
+    # A cut cycle owes the piece before the cut ON the cut. Answering with the cycle's own
+    # due instant dragged that piece to the end of the cycle, and for a clock already past
+    # it, lost it — a 15-day arrears segment, never billed.
+    context "when a rate change cuts the cycle" do
+      let(:rates) { [card_rate(Time.utc(2021, 1, 1)), card_rate(Time.utc(2022, 2, 15))] }
+
+      it "owes the cut, not the end of the cycle" do
+        expect(schedule.next_billing_at(after: Time.utc(2022, 2, 1))).to eq(Time.utc(2022, 2, 15))
+      end
+
+      context "when billing in advance" do
+        let(:timing) { :advance }
+
+        it "finds the next segment in a cycle that is already due" do
+          expect(schedule.next_billing_at(after: Time.utc(2022, 2, 10))).to eq(Time.utc(2022, 2, 15))
+        end
+
+        it "skips the segment starting exactly at the requested instant" do
+          expect(schedule.next_billing_at(after: Time.utc(2022, 2, 15))).to eq(Time.utc(2022, 3, 1))
+        end
+      end
+    end
+
+    context "when pricing starts after several unpriced cycles" do
+      let(:rates) { [card_rate(Time.utc(2022, 5, 1))] }
+
+      it "finds the end of the first priced segment in arrears" do
+        expect(schedule.next_billing_at(after: starts_at)).to eq(Time.utc(2022, 6, 1))
+      end
+
+      context "when billing in advance" do
+        let(:timing) { :advance }
+
+        it "finds the start of the first priced segment" do
+          expect(schedule.next_billing_at(after: starts_at)).to eq(Time.utc(2022, 5, 1))
+        end
+      end
+
+      context "when the card ends before pricing starts" do
+        let(:ends_at) { Time.utc(2022, 4, 1) }
+
+        it "reports nothing further" do
+          expect(schedule.next_billing_at(after: starts_at)).to be_nil
+        end
+      end
+    end
+
+    # It used to bound its own walk by `after + 1.year`, which answered "nothing, ever
+    # again" for any cadence longer than a year — and the consumer reads that answer as a
+    # clock that never needs winding, so the card would never bill again.
+    context "with a cadence longer than the bound a guess would have used" do
+      let(:rates) { [card_rate(Time.utc(2021, 1, 1), 2, :year)] }
+      let(:phases) { [phase(cycle_count: nil, every: 2, unit: :year)] }
+      let(:anchor_date) { Date.new(2022, 1, 1) }
+      let(:starts_at) { Time.utc(2022, 1, 1) }
+
+      it "still finds the next slice" do
+        expect(schedule.next_billing_at(after: Time.utc(2022, 1, 1))).to eq(Time.utc(2024, 1, 1))
+      end
+    end
+
+    context "when the schedule has already ended" do
+      let(:ends_at) { Time.utc(2022, 3, 1) }
+
+      it "reports nothing further" do
+        expect(schedule.next_billing_at(after: Time.utc(2023, 1, 1))).to be_nil
+      end
+    end
+  end
+
+  describe "#billing_at_covering" do
+    # Every other example here asks at a NON-boundary instant, where the two readings agree.
+    # Materialization asks exactly on the boundary on every rollover, and there `>=` returns
+    # the cycle that just CLOSED — seeding the clock a whole period in the past and re-billing
+    # a period already invoiced.
+    it "answers the cycle a boundary opens, not the one it closes" do
+      expect(schedule.billing_at_covering(Time.utc(2022, 3, 1))).to eq(Time.utc(2022, 4, 1))
+    end
+
+    it "waits for the first cycle to close in arrears" do
+      expect(schedule.billing_at_covering(starts_at)).to eq(Time.utc(2022, 2, 1))
+    end
+
+    context "when a rate change splits the current cycle" do
+      let(:rates) { [card_rate(Time.utc(2021, 1, 1)), card_rate(Time.utc(2022, 2, 15))] }
+
+      it "returns the current segment's end before the change" do
+        expect(schedule.billing_at_covering(Time.utc(2022, 2, 10))).to eq(Time.utc(2022, 2, 15))
+      end
+
+      it "selects the new segment exactly at the change" do
+        expect(schedule.billing_at_covering(Time.utc(2022, 2, 15))).to eq(Time.utc(2022, 3, 1))
+      end
+
+      context "when billing in advance" do
+        let(:timing) { :advance }
+
+        it "returns the current segment's start before the change" do
+          expect(schedule.billing_at_covering(Time.utc(2022, 2, 10))).to eq(Time.utc(2022, 2, 1))
+        end
+
+        it "returns the new segment's start exactly at the change" do
+          expect(schedule.billing_at_covering(Time.utc(2022, 2, 15))).to eq(Time.utc(2022, 2, 15))
+        end
+
+        it "keeps the current segment's billing date after the change" do
+          expect(schedule.billing_at_covering(Time.utc(2022, 2, 20))).to eq(Time.utc(2022, 2, 15))
+        end
+      end
+    end
+
+    context "when pricing has not started" do
+      let(:rates) { [card_rate(Time.utc(2022, 5, 1))] }
+
+      it "waits for the first priced segment to end" do
+        expect(schedule.billing_at_covering(starts_at)).to eq(Time.utc(2022, 6, 1))
+      end
+
+      context "when billing in advance" do
+        let(:timing) { :advance }
+
+        it "waits for the first priced segment to start" do
+          expect(schedule.billing_at_covering(starts_at)).to eq(Time.utc(2022, 5, 1))
+        end
+      end
+
+      context "when the card ends before pricing starts" do
+        let(:ends_at) { Time.utc(2022, 4, 1) }
+
+        it "has no billing date" do
+          expect(schedule.billing_at_covering(starts_at)).to be_nil
+        end
+      end
+    end
+
+    context "when the card bills in advance" do
+      let(:timing) { :advance }
+
+      it "reports the cycle in force even though it is already due" do
+        expect(schedule.billing_at_covering(starts_at)).to eq(starts_at)
+      end
+
+      # The cycle covering Mar 10 opened on Mar 1 and was never billed, so the clock owes
+      # that rather than the cycle ahead.
+      it "does not skip a due cycle that is still running" do
+        expect(schedule.billing_at_covering(Time.utc(2022, 3, 10))).to eq(Time.utc(2022, 3, 1))
+      end
+
+      # The one case that separates the two methods, and the reason shipping them under one
+      # name was a defect: seeding must answer the period being served, advancing must not.
+      it "differs from #next_billing_at on the very cycle being served" do
+        at = Time.utc(2022, 3, 10)
+
+        expect(schedule.billing_at_covering(at)).to eq(Time.utc(2022, 3, 1))
+        expect(schedule.next_billing_at(after: at)).to eq(Time.utc(2022, 4, 1))
+      end
+    end
+
+    context "when the schedule has already ended" do
+      let(:ends_at) { Time.utc(2022, 3, 1) }
+
+      it "reports nothing further" do
+        expect(schedule.billing_at_covering(Time.utc(2023, 1, 1))).to be_nil
+      end
+
+      it "has no segment covering the exclusive end" do
+        expect(schedule.billing_at_covering(ends_at)).to be_nil
+      end
+    end
+  end
+
+  # The walk builds one ruler per (anchor, interval), not one per cycle. No assertion on the
+  # cycles it returns can see the difference — 240 identical calendars produce the same
+  # answer as one — so the count is asserted here directly.
+  describe "calendar reuse" do
+    let(:asked_at) { Time.utc(2032, 1, 1) }
+
+    before { allow(Billing::Calendar).to receive(:new).and_call_original }
+
+    it "builds one calendar however many cycles it walks" do
+      expect(schedule.segments_due_by(asked_at).size).to eq(120)
+      expect(Billing::Calendar).to have_received(:new).once
+    end
+  end
+
+  # The worked example the PR description is built on, kept executable so the two cannot
+  # drift. A monthly card with a three-cycle weekly intro phase, starting two days after its
+  # anchor, with two rates taking effect inside cycles rather than on a boundary.
+  describe "an intro phase with rate changes landing inside cycles" do
+    subject(:schedule) { described_class.new(**arguments) }
+
+    let(:arguments) do
+      {
+        anchor_date: Date.new(2026, 8, 10),
+        starts_at: Time.utc(2026, 8, 12),
+        rates:,
+        terms: Billing::Terms.new(timing:, prorated: true),
+        timezone: "UTC",
+        phases: [
+          phase(cycle_count: 3, every: 1, unit: :week, code: "weekly_intro", override: "-50%"),
+          phase(cycle_count: nil, every: 1, unit: :month, code: "standard")
+        ]
+      }
+    end
+    let(:rates) { [rate("A", Time.utc(2026, 1, 1)), rate("B", Time.utc(2026, 8, 20)), rate("C", Time.utc(2026, 9, 15))] }
+    # The cadence in this example comes from the phase overrides, so the rates only need to
+    # answer where they take effect and what a phase would fall back to.
+    let(:asked_at) { Time.utc(2026, 12, 1) }
+
+    def rate(label, effective_from)
+      Struct.new(:label, :effective_from, :billing_interval_count, :billing_interval_unit)
+        .new(label, effective_from, 1, :month)
+    end
+
+    # The flat surface carries the cycle it came from, so a per-cycle assertion groups on it
+    # exactly as the billing_segments index does.
+    def slices_by_cycle
+      schedule.segments_due_by(asked_at).group_by(&:cycle_started_at).first(4)
+    end
+
+    it "runs weekly for three cycles, then on the card's own month" do
+      windows = slices_by_cycle.map do |started_at, group|
+        ["#{started_at.to_date} -> #{group.last.ended_at.to_date}", group.first.rate_phase_code]
+      end
+
+      expect(windows).to eq(
+        [["2026-08-12 -> 2026-08-17", "weekly_intro"],
+          ["2026-08-17 -> 2026-08-24", "weekly_intro"],
+          ["2026-08-24 -> 2026-08-31", "weekly_intro"],
+          ["2026-08-31 -> 2026-09-30", "standard"]]
+      )
+    end
+
+    # A cycle is one turn of the interval clamped by the card's life, so the anchor decides
+    # where the boundary falls and the card's start decides where the first cycle opens.
+    it "opens the first cycle where the card starts, not on the anchor" do
+      started_at, segments = slices_by_cycle.first
+
+      expect(started_at).to eq(Time.utc(2026, 8, 12))
+      expect(segments.last.ended_at).to eq(Time.utc(2026, 8, 17))
+    end
+
+    it "prices each segment at its share of a whole interval" do
+      billed = slices_by_cycle.map { |_cycle, group| group.map { [it.rate.label, it.proration_ratio] } }
+
+      expect(billed).to eq(
+        [[["A", 5.fdiv(7)]],
+          [["A", 3.fdiv(7)], ["B", 4.fdiv(7)]],
+          [["B", 1.0]],
+          [["B", 1.fdiv(2)], ["C", 1.fdiv(2)]]]
+      )
+    end
+
+    # Two different facts, and the totals tell them apart. A cycle clamped by the card's
+    # start bills less than a whole interval — 5 of its 7 days. A cycle merely cut by a rate
+    # change bills exactly one, however many segments it ends up with.
+    it "bills a clamped cycle short and a cut cycle whole" do
+      totals = slices_by_cycle.map { |_cycle, group| group.sum(&:proration_ratio) }
+
+      expect(totals).to eq([5.fdiv(7), 1.0, 1.0, 1.0])
+    end
+
+    # The two fields the flat surface carries purely for attribution: which phase priced the
+    # slice, and the override it priced it with. Neither shows up in an amount, so nothing
+    # else in the suite would notice them both returning nil.
+    it "carries the phase that priced each slice onto the flat surface" do
+      attributed = schedule.segments_due_by(asked_at).first(6).map do |segment|
+        [segment.rate.label, segment.rate_phase_code, segment.rate_override&.label]
+      end
+
+      expect(attributed).to eq(
+        [["A", "weekly_intro", "-50%"],
+          ["A", "weekly_intro", "-50%"],
+          ["B", "weekly_intro", "-50%"],
+          ["B", "weekly_intro", "-50%"],
+          ["B", "standard", nil],
+          ["C", "standard", nil]]
+      )
+    end
+
+    it "falls due when each cycle closes in arrears" do
+      expect(slices_by_cycle.map { |_cycle, group| group.last.billing_at.to_date.to_s })
+        .to eq(["2026-08-17", "2026-08-24", "2026-08-31", "2026-09-30"])
+    end
+
+    # The only thing billing timing changes: same cycles, same segments, earlier due dates.
+    context "when the card bills in advance" do
+      let(:timing) { :advance }
+
+      it "falls due when each cycle opens" do
+        expect(slices_by_cycle.map { |_cycle, group| group.first.billing_at.to_date.to_s })
+          .to eq(["2026-08-12", "2026-08-17", "2026-08-24", "2026-08-31"])
+      end
+
+      it "produces the same cycles as arrears" do
+        arrears = described_class.new(**arguments.merge(terms: Billing::Terms.new(timing: :arrears, prorated: true)))
+          .segments_due_by(asked_at).group_by(&:cycle_started_at).first(4)
+
+        expect(slices_by_cycle.map { |started_at, group| [started_at, group.last.ended_at] })
+          .to eq(arrears.map { |started_at, group| [started_at, group.last.ended_at] })
+      end
+    end
+  end
+
+  # Decision #56 says the cadence through an unpriced window comes from the EARLIEST rate — for
+  # its interval only, never for its price. Every existing example of this has a single rate, so
+  # the earliest and the latest are the same row and nothing pins which one is read. Found by
+  # mutating the fallback from `min_by` to `max_by`: no example failed.
+  describe "the cadence before any rate is in force, with more than one rate to choose from" do
+    let(:anchor_date) { Date.new(2026, 1, 1) }
+    let(:starts_at) { Time.utc(2026, 1, 1) }
+    let(:phases) { [phase(cycle_count: nil, every: nil, unit: nil)] }
+    let(:rates) { [card_rate(Time.utc(2026, 6, 1), 1, :week), card_rate(Time.utc(2026, 9, 1), 1, :month)] }
+
+    it "bills nothing before the first rate and preserves the cycle numbering afterwards" do
+      expect(schedule.segments_due_by(Time.utc(2026, 3, 1))).to be_empty
+      first = schedule.segments_due_by(Time.utc(2026, 6, 11)).first
+
+      expect(first.cycle_index).to eq(21)
+      expect(first.started_at).to eq(Time.utc(2026, 6, 1))
+      expect(first.ended_at).to eq(Time.utc(2026, 6, 4))
+    end
+  end
+
+  # LAGO-1766, the cycles Tiago published from staging on 2026-08-10: a monthly card with
+  # a six-cycle weekly intro phase. The tail re-anchors on the day the intro ended, so
+  # billing moves to the 21st for good instead of returning to the 10th.
+  describe "with the LAGO-1766 phase transition" do
+    subject(:schedule) do
+      described_class.new(
+        anchor_date: Date.new(2026, 8, 10),
+        starts_at: Time.utc(2026, 8, 10),
+        rates:,
+        terms: Billing::Terms.new(timing: :arrears, prorated: true),
+        timezone: "UTC",
+        phases: [
+          phase(cycle_count: 6, every: 1, unit: :week, code: "weekly_intro"),
+          phase(cycle_count: nil, every: 1, unit: :month, code: "standard")
+        ]
+      )
+    end
+
+    let(:end_on) { Time.utc(2027, 12, 30) }
+
+    it "reproduces the published cycles" do
+      expect(windows(schedule.segments_due_by(end_on))).to eq(
+        [
+          "2026-08-10 -> 2026-08-16", "2026-08-17 -> 2026-08-23", "2026-08-24 -> 2026-08-30",
+          "2026-08-31 -> 2026-09-06", "2026-09-07 -> 2026-09-13", "2026-09-14 -> 2026-09-20",
+          "2026-09-21 -> 2026-10-20", "2026-10-21 -> 2026-11-20", "2026-11-21 -> 2026-12-20",
+          "2026-12-21 -> 2027-01-20", "2027-01-21 -> 2027-02-20", "2027-02-21 -> 2027-03-20",
+          "2027-03-21 -> 2027-04-20", "2027-04-21 -> 2027-05-20", "2027-05-21 -> 2027-06-20",
+          "2027-06-21 -> 2027-07-20", "2027-07-21 -> 2027-08-20", "2027-08-21 -> 2027-09-20",
+          "2027-09-21 -> 2027-10-20", "2027-10-21 -> 2027-11-20", "2027-11-21 -> 2027-12-20"
+        ]
+      )
+    end
+
+    it "keeps numbering across the phase change" do
+      expect(schedule.segments_due_by(end_on).map(&:cycle_index)).to eq((0..20).to_a)
+    end
+
+    it "reports which phase each cycle was billed under" do
+      codes = schedule.segments_due_by(end_on).map { |cycle| cycle.rate_phase_code }
+
+      expect(codes.first(6).uniq).to eq(["weekly_intro"])
+      expect(codes.drop(6).uniq).to eq(["standard"])
+    end
+
+    # The point of the ticket, and the thing that reads as a regression until you know it is
+    # ruled: the monthly tail bills on the 21st for good, not back on the card's own 10th.
+    # A phase starts where the previous one ended and runs its own cadence from there
+    # (Reading B, chained phases — the `billing_anchor_mode` that would have kept the 10th was
+    # built and reverted on 2026-08-03).
+    it "reports the published next billing date, on the day the intro ended" do
+      asked_at = Time.utc(2026, 9, 25)
+
+      expect(schedule.next_billing_at(after: asked_at)).to eq(Time.utc(2026, 10, 21))
+    end
+
+    it "never returns to the card's own anchor day once the cadence has changed" do
+      billing_days = schedule.segments_due_by(end_on).drop(6).map { |segment| segment.billing_at.day }
+
+      expect(billing_days.uniq).to eq([21])
+    end
+  end
+end

--- a/spec/services/billing/segments_spec.rb
+++ b/spec/services/billing/segments_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Billing::Segments do
+  # Only effective_from is read, so the cases below stay free of the catalog.
+  def rate(code, effective_from)
+    Struct.new(:code, :effective_from).new(code, effective_from)
+  end
+
+  def windows(segments)
+    segments.map { |segment| [segment.started_at.to_date.to_s, segment.ended_at.to_date.to_s, segment.rate&.code] }
+  end
+
+  # The window is anything answering started_at/ended_at — a Cycle in production.
+  def window_of(from, to) = Struct.new(:started_at, :ended_at).new(from, to)
+
+  let(:window) { window_of(Time.utc(2026, 9, 10), Time.utc(2026, 10, 10)) }
+
+  describe ".within" do
+    it "leaves a window whole when no rate changes inside it" do
+      segments = described_class.within(window, rates: [rate("v1", Time.utc(2026, 1, 1))])
+
+      expect(windows(segments)).to eq([["2026-09-10", "2026-10-10", "v1"]])
+    end
+
+    # QA plan R3b — a mid-window change splits the cycle into two priced windows.
+    it "cuts the window where a rate takes effect inside it" do
+      rates = [rate("v1", Time.utc(2026, 1, 1)), rate("v2", Time.utc(2026, 9, 25))]
+
+      expect(windows(described_class.within(window, rates:))).to eq(
+        [
+          ["2026-09-10", "2026-09-25", "v1"],
+          ["2026-09-25", "2026-10-10", "v2"]
+        ]
+      )
+    end
+
+    it "cuts once per change" do
+      rates = [
+        rate("v1", Time.utc(2026, 1, 1)),
+        rate("v2", Time.utc(2026, 9, 20)),
+        rate("v3", Time.utc(2026, 9, 30))
+      ]
+
+      expect(windows(described_class.within(window, rates:))).to eq(
+        [
+          ["2026-09-10", "2026-09-20", "v1"],
+          ["2026-09-20", "2026-09-30", "v2"],
+          ["2026-09-30", "2026-10-10", "v3"]
+        ]
+      )
+    end
+
+    # QA plan R3a — "effective date ON a boundary (no split)". The change is simply the
+    # rate in force from the first instant, so there is nothing to cut.
+    it "does not cut for a change landing on the window's start" do
+      rates = [rate("v1", Time.utc(2026, 1, 1)), rate("v2", Time.utc(2026, 9, 10))]
+
+      expect(windows(described_class.within(window, rates:))).to eq([["2026-09-10", "2026-10-10", "v2"]])
+    end
+
+    it "does not cut for a change landing on the window's end" do
+      rates = [rate("v1", Time.utc(2026, 1, 1)), rate("v2", Time.utc(2026, 10, 10))]
+
+      expect(windows(described_class.within(window, rates:))).to eq([["2026-09-10", "2026-10-10", "v1"]])
+    end
+
+    it "keeps the whole window unpriced while no rate is in force" do
+      segments = described_class.within(window, rates: [rate("v1", Time.utc(2027, 1, 1))])
+
+      expect(windows(segments)).to eq([["2026-09-10", "2026-10-10", nil]])
+    end
+
+    it "keeps the unpriced period before the first rate takes effect" do
+      segments = described_class.within(window, rates: [rate("v1", Time.utc(2026, 9, 25))])
+
+      expect(windows(segments)).to eq([
+        ["2026-09-10", "2026-09-25", nil],
+        ["2026-09-25", "2026-10-10", "v1"]
+      ])
+    end
+
+    it "keeps the window unpriced when the first rate starts at its exclusive end" do
+      segments = described_class.within(window, rates: [rate("v1", window.ended_at)])
+
+      expect(windows(segments)).to eq([["2026-09-10", "2026-10-10", nil]])
+    end
+
+    it "does not require the rates to be ordered" do
+      rates = [rate("v2", Time.utc(2026, 9, 25)), rate("v1", Time.utc(2026, 1, 1))]
+
+      expect(windows(described_class.within(window, rates:)).map(&:last)).to eq(%w[v1 v2])
+    end
+
+    it "keeps the whole window unpriced when there are no rates" do
+      expect(windows(described_class.within(window, rates: []))).to eq([["2026-09-10", "2026-10-10", nil]])
+    end
+
+    it "covers the whole window without gaps or overlap, including the unpriced period" do
+      rates = [
+        rate("v1", Time.utc(2026, 9, 15)),
+        rate("v2", Time.utc(2026, 9, 20)),
+        rate("v3", Time.utc(2026, 9, 30))
+      ]
+      segments = described_class.within(window, rates:)
+
+      expect(segments.first.started_at).to eq(window.started_at)
+      expect(segments.last.ended_at).to eq(window.ended_at)
+      expect(segments.each_cons(2).all? { |before, after| before.ended_at == after.started_at }).to be(true)
+    end
+  end
+end

--- a/spec/services/billing/terms_spec.rb
+++ b/spec/services/billing/terms_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Billing::Terms do
+  subject(:terms) { described_class.new(timing: :arrears, prorated: true) }
+
+  let(:window) { Billing::Segments::Segment.new(started_at: Time.utc(2026, 8, 10), ended_at: Time.utc(2026, 9, 10), rate: nil) }
+
+  it "covers exactly the billing timings the catalog allows" do
+    expect(described_class::TIMINGS).to match_array(RateCard::BILLING_TIMINGS.keys)
+  end
+
+  describe "validation" do
+    it "rejects an unknown timing" do
+      expect { described_class.new(timing: :upfront, prorated: true) }
+        .to raise_error(ArgumentError, /unknown billing timing/)
+    end
+
+    it "rejects a nil timing without blowing up on it" do
+      expect { described_class.new(timing: nil, prorated: true) }
+        .to raise_error(ArgumentError, /unknown billing timing/)
+    end
+
+    it "takes the timing as a string, which is how the enum column reads" do
+      expect(described_class.new(timing: "advance", prorated: false).timing).to eq(:advance)
+    end
+
+    # The flag decides money, so a nil or a truthy string must not slip through as "on".
+    it "rejects a proration flag that is not a boolean" do
+      expect { described_class.new(timing: :arrears, prorated: nil) }
+        .to raise_error(ArgumentError, /must be true or false/)
+      expect { described_class.new(timing: :arrears, prorated: "true") }
+        .to raise_error(ArgumentError, /must be true or false/)
+    end
+  end
+
+  # The one place in the engine that knows what advance and arrears mean.
+  describe "#billing_at_for" do
+    it "falls due when the window closes in arrears" do
+      expect(terms.billing_at_for(window)).to eq(window.ended_at)
+    end
+
+    it "falls due when the window opens in advance" do
+      expect(described_class.new(timing: :advance, prorated: true).billing_at_for(window))
+        .to eq(window.started_at)
+    end
+
+    # It is asked about a whole cycle and about one slice of a cut cycle, and answers each on
+    # its own bounds — which is what lets a slice fall due on the cut rather than at the
+    # cycle's close.
+    it "answers on the bounds it is given, whatever kind of window that is" do
+      slice = Billing::Segments::Segment.new(started_at: window.started_at, ended_at: Time.utc(2026, 8, 25), rate: nil)
+
+      expect(terms.billing_at_for(slice)).to eq(Time.utc(2026, 8, 25))
+    end
+  end
+end

--- a/spec/services/contract_rate_cards/resolve_rate_phases_service_spec.rb
+++ b/spec/services/contract_rate_cards/resolve_rate_phases_service_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ContractRateCards::ResolveRatePhasesService do
+  subject(:result) { described_class.call(contract_rate_card:, plan_rate_card:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:catalog_plan) { create(:catalog_plan, organization:) }
+  let(:contract) { create(:contract, organization:, customer:, catalog_plan:) }
+  let(:rate_card) { create(:rate_card, organization:) }
+  let(:plan_rate_card) { nil }
+  let(:contract_rate_card) do
+    create(:contract_rate_card, organization:, contract:, rate_card:)
+  end
+
+  context "with contract-level phases" do
+    let!(:intro_phase) do
+      create(
+        :rate_phase,
+        :contract_level,
+        organization:,
+        contract_rate_card:,
+        position: 1,
+        billing_interval_cycle_count: 2
+      )
+    end
+    let!(:standard_phase) do
+      create(
+        :rate_phase,
+        :contract_level,
+        organization:,
+        contract_rate_card:,
+        position: 2,
+        billing_interval_cycle_count: nil
+      )
+    end
+
+    it "returns the card's phases in position order" do
+      expect(result.rate_phases).to eq([intro_phase, standard_phase])
+    end
+  end
+
+  context "without contract-level phases" do
+    let(:plan_rate_card) { create(:plan_rate_card, organization:, catalog_plan:, rate_card:) }
+    let!(:plan_phase) do
+      create(
+        :rate_phase,
+        organization:,
+        plan_rate_card:,
+        position: 1,
+        billing_interval_cycle_count: nil
+      )
+    end
+
+    it "falls back to the plan entry's phases" do
+      expect(result.rate_phases).to eq([plan_phase])
+    end
+  end
+
+  # Neither the card nor a plan entry carries phases, and a card off a plan has no entry
+  # to fall back to at all.
+  context "without any phases" do
+    it "returns none" do
+      expect(result.rate_phases).to be_empty
+    end
+  end
+end

--- a/spec/services/contracts/materialize_rate_cards_service_spec.rb
+++ b/spec/services/contracts/materialize_rate_cards_service_spec.rb
@@ -75,4 +75,64 @@ RSpec.describe Contracts::MaterializeRateCardsService do
       expect(result.contract_rate_cards).to be_nil
     end
   end
+
+  describe "next_billing_at" do
+    subject(:next_billing_at) { result.contract_rate_cards.sole.next_billing_at }
+
+    let(:contract) do
+      create(:contract, customer:, catalog_plan:, started_at:, billing_anchor_date: Date.new(2026, 1, 1))
+    end
+    let(:started_at) { Time.utc(2026, 1, 15, 14, 30) }
+    let(:now) { Time.utc(2026, 1, 15, 14, 30) }
+
+    before do
+      create(:rate_card_rate, organization:, rate_card:, effective_from: Time.utc(2025, 1, 1))
+    end
+
+    around { |example| travel_to(now) { example.run } }
+
+    it "waits for the first period to close in arrears" do
+      expect(next_billing_at).to eq(Time.utc(2026, 2, 1))
+    end
+
+    context "when the rate card bills in advance" do
+      let(:rate_card) { create(:rate_card, :advance, organization:) }
+
+      # Billable as soon as the cycle opens, and the cycle opens at the start of the
+      # signing day rather than at 14:30.
+      it "bills from the start of the day the card was signed" do
+        expect(next_billing_at).to eq(Time.utc(2026, 1, 15))
+      end
+    end
+
+    # The contract is backdated by nearly three months. Those periods are not billed:
+    # the card joins the calendar at the period it lands in today.
+    context "when the contract is backdated" do
+      let(:started_at) { Time.utc(2025, 12, 15) }
+      let(:now) { Time.utc(2026, 3, 10, 12, 0) }
+
+      it "starts from the current period rather than back-billing the gap" do
+        expect(next_billing_at).to eq(Time.utc(2026, 4, 1))
+      end
+    end
+
+    # QA plan PH3: the first phase sets the cadence, so seeding the clock on the card's own
+    # monthly interval would put the first look a whole month late.
+    context "when the first rate phase overrides the interval" do
+      before do
+        create(
+          :rate_phase,
+          organization:,
+          plan_rate_card: catalog_plan.applied_rate_cards.sole,
+          position: 1,
+          billing_interval_cycle_count: 2,
+          rate_override: create(:rate_override, organization:, billing_interval_count: 1, billing_interval_unit: "week")
+        )
+      end
+
+      it "seeds the clock on the phase's cadence, not the card's" do
+        expect(next_billing_at).to eq(Time.utc(2026, 1, 22))
+      end
+    end
+  end
 end


### PR DESCRIPTION
Contract billing needs consistent dates across rate changes, phase overrides and long billing histories. This adds a rate-card schedule that produces billable segments and can resume near a requested date without walking every historical cycle.

### Behaviour

- `CycleWalker` owns traversal and resume. It stops at rate and phase transitions, recalculates the calendar when the interval changes, and reuses calendars between calls. Walking the complete history remains supported.
- `Schedule` splits cycles at rate changes and assigns each priced segment its own billing date: start for advance, end for arrears. Unpriced windows still consume cycle indices.
- Proration uses customer-local calendar days and the containing interval. Schedule windows have exclusive ends; `BillingSegment.inclusive_end` and `.exclusive_end` convert stored boundaries.
- `BuildScheduleService` reads `ContractRateCard`, resolves ordered rates and card or plan phases, and resumes from that attachment's latest persisted cycle. The last cycle is intentionally returned again, so the writer must deduplicate persisted segments. Separate attachments do not share billing history.
- Card effective and end dates use the customer's timezone. An inclusive card end date covers the whole final day; an earlier contract end or explicit termination instant takes precedence.
- Contract materialization seeds the initial billing clock from the schedule, including backdated contracts and phase interval overrides.

### Public schedule API

| Method | Purpose |
| --- | --- |
| `segments_due_by(timestamp)` | Return priced segments due by that instant. |
| `next_billing_at(after:)` | Find the next billing instant strictly after the given time. |
| `billing_at_covering(timestamp)` | Find the billing date of the segment being served, or the next priced segment. |
| `consumed_ratio(segment:, at:)` | Measure consumption against the original billed segment. |

### Integration with main

This PR is based directly on `main` and contains only the date engine and its contract integration. It uses the existing contract models and billing-segment table. Existing migrations, Ruby 4.0.6 and dependencies are unchanged.

A separate migration removes the unused `pricing_unit_id` and `rate_card_rate_id` indexes from `billing_segments`, with concurrent operations and a reversible rollback.

The invoice writer and processor are outside this PR.

### Validation

- 422 examples passed with Ruby 4.0.6 in a temporary API container and isolated database: 113 integration/model examples and 309 date/walker/resume examples.
- Coverage includes month ends, leap years, DST, rate and phase transitions, unpriced periods, termination, persisted history, contract materialization and equivalence between full and resumed walks.
- RuboCop: 32 files, no offenses.
- Migration up/down/up verified with an existing billing segment; both indexes were restored on rollback and the row was unchanged.
