### PR TITLE
feat(event-destinations): deliver usage on refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,10 @@ To create a webhook:
 - `LAGO_FINANCE_ASSISTANT_URL` — base URL of the finance assistant service that answers `askFinanceAssistant`. When blank the feature is unavailable and the mutation returns a forbidden failure. Example: `LAGO_FINANCE_ASSISTANT_URL=http://lago-data-agent:8000`
 - `LAGO_FINANCE_ASSISTANT_OPEN_TIMEOUT` — connection timeout, in seconds, for the finance assistant call. Defaults to 5. Example: `LAGO_FINANCE_ASSISTANT_OPEN_TIMEOUT=5`
 - `LAGO_FINANCE_ASSISTANT_READ_TIMEOUT` — response timeout, in seconds, for the finance assistant call. Defaults to 60. Must stay above the assistant's own run deadline (`ASK_DEADLINE_SECS`, 55s today) so that a slow answer is received instead of being cut off. Example: `LAGO_FINANCE_ASSISTANT_READ_TIMEOUT=60`
+- `LAGO_EVENT_DESTINATION_ORG_ID` (POC only): id of the single organization whose current usage is delivered to an event destination on wallet refresh. When blank the feature is fully off. Example: `LAGO_EVENT_DESTINATION_ORG_ID=11111111-2222-3333-4444-555555555555`
+- `LAGO_EVENT_DESTINATION_TRANSPORT` (POC only): `log`, the default, stubs the Kinesis client so records are only logged; `kinesis` talks to the real stream. Example: `LAGO_EVENT_DESTINATION_TRANSPORT=log`
+- `LAGO_EVENT_DESTINATION_KINESIS_STREAM_ARN`: ARN of the target Kinesis stream. Example: `LAGO_EVENT_DESTINATION_KINESIS_STREAM_ARN=arn:aws:kinesis:eu-west-1:123456789012:stream/lago-current-usage`
+- `LAGO_EVENT_DESTINATION_KINESIS_REGION`: AWS region used to build the Kinesis client. Example: `LAGO_EVENT_DESTINATION_KINESIS_REGION=eu-west-1`
 - Sensitive values (keys, secrets, passwords, tokens, credentials embedded in URLs) must always be masked in examples, e.g. `LAGO_SMTP_PASSWORD=***` or `DATABASE_URL=postgresql://***@db:5432/lago`
 
 # Service

--- a/Gemfile
+++ b/Gemfile
@@ -99,6 +99,7 @@ gem "datadog", require: false
 
 # Storage
 gem "aws-sdk-s3", require: false
+gem "aws-sdk-kinesis"
 gem "google-cloud-storage", require: false
 # google-apis-core < 1.2.1 loads representable/json, which calls `gem "multi_json"`
 # without declaring the dependency. googleauth 1.17 and signet 0.22 both migrated to

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
     awesome_print (1.9.2)
     aws-eventstream (1.4.0)
     aws-partitions (1.1208.0)
-    aws-sdk-core (3.241.4)
+    aws-sdk-core (3.254.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -130,6 +130,9 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
+    aws-sdk-kinesis (1.106.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
     aws-sdk-kms (1.121.0)
       aws-sdk-core (~> 3, >= 3.241.4)
       aws-sigv4 (~> 1.5)
@@ -1079,6 +1082,7 @@ DEPENDENCIES
   analytics-ruby
   annotaterb
   awesome_print
+  aws-sdk-kinesis
   aws-sdk-s3
   bcrypt
   bigdecimal

--- a/app/jobs/deliver_event_job.rb
+++ b/app/jobs/deliver_event_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class DeliverEventJob < ApplicationJob
+  # POC only: a dedicated queue is a post-POC decision.
+  queue_as :default
+
+  # Snapshot payloads carry a read-time `version`, which only orders correctly if no two
+  # jobs read the usage cache for one customer at once: the per-charge fragments interleave
+  # and a later version can then carry staler content.
+  unique :until_and_while_executing, on_conflict: :log, lock_ttl: 10.minutes
+
+  EVENT_SERVICES = {
+    "customer_usage.refreshed" => EventDestinations::CustomerUsage::RefreshedService
+  }.freeze
+
+  def perform(event_type, object)
+    EVENT_SERVICES.fetch(event_type).call(object:)
+  end
+end

--- a/app/services/customers/refresh_wallets_service.rb
+++ b/app/services/customers/refresh_wallets_service.rb
@@ -35,6 +35,10 @@ module Customers
 
       customer.update!(awaiting_wallet_refresh: false)
 
+      if EventDestinations::KinesisStream.for(customer.organization)
+        DeliverEventJob.perform_after_commit("customer_usage.refreshed", customer)
+      end
+
       result.wallets = customer.wallets.active.reload
       result
     rescue BaseService::FailedResult => e

--- a/app/services/event_destinations/customer_usage/refreshed_service.rb
+++ b/app/services/event_destinations/customer_usage/refreshed_service.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module EventDestinations
+  module CustomerUsage
+    class RefreshedService < BaseService
+      Result = BaseResult
+
+      EVENT_TYPE = "customer_usage.refreshed"
+      OBJECT_TYPE = "customer_usage"
+
+      def initialize(object:)
+        @customer = object
+
+        super
+      end
+
+      def call
+        return result if stream.nil?
+
+        customer.active_subscriptions.each do |subscription|
+          deliver(subscription)
+        rescue => e
+          Rails.logger.error(
+            "[event_destinations] #{EVENT_TYPE} failed for subscription #{subscription.id}: #{e.class} #{e.message}"
+          )
+        end
+
+        result
+      end
+
+      private
+
+      attr_reader :customer
+
+      def stream
+        return @stream if defined?(@stream)
+
+        @stream = EventDestinations::KinesisStream.for(customer.organization)
+      end
+
+      def producer
+        @producer ||= EventDestinations::KinesisProducer.new(stream:)
+      end
+
+      def deliver(subscription)
+        usage_result = ::Invoices::CustomerUsageService.call(customer:, subscription:, with_cache: true)
+
+        unless usage_result.success?
+          Rails.logger.warn(
+            "[event_destinations] #{EVENT_TYPE} skipped for subscription #{subscription.id}: #{usage_result.error}"
+          )
+          return
+        end
+
+        producer.produce(data: envelope(subscription, usage_result.usage), partition_key: customer.external_id)
+      end
+
+      # Webhook-shaped envelope, plus the identifiers a consumer needs and that the usage
+      # payload itself does not carry.
+      def envelope(subscription, usage)
+        {
+          webhook_type: EVENT_TYPE,
+          object_type: OBJECT_TYPE,
+          organization_id: customer.organization_id,
+          customer_external_id: customer.external_id,
+          subscription_external_id: subscription.external_id,
+          version:,
+          customer_usage: serialized_usage(usage)
+        }
+      end
+
+      # Monotonic per customer because DeliverEventJob serializes on the customer. Fixed-width
+      # UTC ISO8601 so consumers can compare it as a string. One token per delivery: the two
+      # records of a customer are different dedup keys, so they may share it.
+      def version
+        @version ||= Time.current.iso8601(6)
+      end
+
+      def serialized_usage(usage)
+        ::V1::Customers::UsageSerializer.new(
+          usage,
+          root_name: OBJECT_TYPE,
+          includes: %i[charges_usage]
+        ).serialize
+      end
+    end
+  end
+end

--- a/app/services/event_destinations/kinesis_producer.rb
+++ b/app/services/event_destinations/kinesis_producer.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module EventDestinations
+  # Thin wrapper over the Kinesis SDK. In log mode the client is stubbed, so the SDK still
+  # validates the request parameters but nothing leaves the process: going live is a
+  # constructor change, not a redesign.
+  class KinesisProducer
+    # A dead destination must not hold a Sidekiq thread for minutes. The SDK defaults
+    # (15s connect, 60s read, 3 retries) allow up to 240s per record; these cap it near 14s.
+    # Dropping a snapshot is cheap: the next wallet refresh re-emits it with a newer version.
+    HTTP_OPEN_TIMEOUT = 2
+    HTTP_READ_TIMEOUT = 5
+    RETRY_LIMIT = 1
+
+    def initialize(stream:)
+      @stream = stream
+    end
+
+    def produce(data:, partition_key:)
+      payload = JSON.generate(data)
+
+      response = client.put_record(
+        stream_arn: stream.stream_arn,
+        data: payload,
+        partition_key:
+      )
+
+      Rails.logger.info(log_line(payload, partition_key, response))
+
+      response
+    end
+
+    private
+
+    attr_reader :stream
+
+    def log_line(payload, partition_key, response)
+      line = "[event_destinations] put_record stream=#{stream.stream_arn} " \
+             "partition_key=#{partition_key} bytes=#{payload.bytesize}"
+
+      if stream.log_only?
+        # Stubbed responses carry placeholder ids, so the payload is the useful evidence here.
+        "#{line} data=#{payload}"
+      else
+        # With no read access to a customer's stream, these are the only proof a record landed.
+        "#{line} shard=#{response.shard_id} sequence=#{response.sequence_number}"
+      end
+    end
+
+    def client
+      @client ||= Aws::Kinesis::Client.new(
+        region: stream.region,
+        stub_responses: stream.log_only?,
+        http_open_timeout: HTTP_OPEN_TIMEOUT,
+        http_read_timeout: HTTP_READ_TIMEOUT,
+        retry_limit: RETRY_LIMIT
+      ).tap do |kinesis|
+        # The SDK does not check this itself: with unresolvable credentials it fails deep in
+        # endpoint construction with `undefined method 'credentials' for nil`, which says
+        # nothing about the actual problem.
+        raise Aws::Errors::MissingCredentialsError if kinesis.config.credentials.nil?
+      end
+    end
+  end
+end

--- a/app/services/event_destinations/kinesis_stream.rb
+++ b/app/services/event_destinations/kinesis_stream.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module EventDestinations
+  # POC stand-in for the future per-organization destination record: the target stream is
+  # described by ENV instead of a persisted row.
+  class KinesisStream
+    LIVE_TRANSPORT = "kinesis"
+
+    def self.for(organization)
+      return nil if ENV["LAGO_EVENT_DESTINATION_ORG_ID"].blank?
+      return nil unless organization&.id == ENV["LAGO_EVENT_DESTINATION_ORG_ID"]
+
+      new
+    end
+
+    def stream_arn = ENV.fetch("LAGO_EVENT_DESTINATION_KINESIS_STREAM_ARN")
+
+    def region = ENV.fetch("LAGO_EVENT_DESTINATION_KINESIS_REGION")
+
+    # Only an explicit "kinesis" opts into real delivery: unset, blank or unrecognized
+    # values must never silently start writing to a live stream.
+    def log_only?
+      transport = ENV["LAGO_EVENT_DESTINATION_TRANSPORT"]
+      return false if transport == LIVE_TRANSPORT
+
+      if transport.present?
+        Rails.logger.warn(
+          "[event_destinations] unrecognized LAGO_EVENT_DESTINATION_TRANSPORT=#{transport.inspect}, falling back to log-only"
+        )
+      end
+
+      true
+    end
+  end
+end

--- a/spec/jobs/deliver_event_job_spec.rb
+++ b/spec/jobs/deliver_event_job_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DeliverEventJob do
+  let(:customer) { create(:customer) }
+  let(:event_type) { "customer_usage.refreshed" }
+
+  describe "uniqueness" do
+    let(:other_customer) { create(:customer) }
+
+    # The read-time version in the payload is only a valid ordering token while deliveries
+    # for one customer cannot overlap.
+    it "serializes deliveries per customer" do
+      expect(described_class.lock_strategy_class).to eq(ActiveJob::Uniqueness::Strategies::UntilAndWhileExecuting)
+
+      job = described_class.new(event_type, customer)
+      same_customer_job = described_class.new(event_type, customer)
+      other_customer_job = described_class.new(event_type, other_customer)
+
+      expect(same_customer_job.lock_key).to eq(job.lock_key)
+      expect(other_customer_job.lock_key).not_to eq(job.lock_key)
+    end
+  end
+
+  describe "#perform" do
+    before { allow(EventDestinations::CustomerUsage::RefreshedService).to receive(:call) }
+
+    it "dispatches to the registered service" do
+      described_class.perform_now(event_type, customer)
+
+      expect(EventDestinations::CustomerUsage::RefreshedService).to have_received(:call).with(object: customer)
+    end
+
+    it "raises for an unregistered event type" do
+      expect { described_class.perform_now("nope.nope", customer) }.to raise_error(KeyError)
+    end
+  end
+end

--- a/spec/services/customers/refresh_wallets_service_spec.rb
+++ b/spec/services/customers/refresh_wallets_service_spec.rb
@@ -99,6 +99,34 @@ RSpec.describe Customers::RefreshWalletsService do
       expect { subject }.to change(customer, :awaiting_wallet_refresh).from(true).to(false)
     end
 
+    context "when no event destination is configured" do
+      it "does not enqueue an event delivery job" do
+        expect { subject }.not_to have_enqueued_job(DeliverEventJob)
+      end
+    end
+
+    context "when an event destination is configured for the organization" do
+      before { stub_const("ENV", ENV.to_h.merge("LAGO_EVENT_DESTINATION_ORG_ID" => organization.id)) }
+
+      it "enqueues an event delivery job for the customer" do
+        expect { subject }.to have_enqueued_job(DeliverEventJob)
+          .with("customer_usage.refreshed", customer)
+          .once
+      end
+
+      # Credits::AppliedPrepaidCreditsService calls this service inside a transaction, and
+      # enqueue_after_transaction_commit is false, so a plain perform_later would publish
+      # usage for a transaction that never commits.
+      it "does not enqueue when the caller's transaction rolls back" do
+        expect do
+          ActiveRecord::Base.transaction do
+            described_class.call(customer:, include_generating_invoices:)
+            raise ActiveRecord::Rollback
+          end
+        end.not_to have_enqueued_job(DeliverEventJob)
+      end
+    end
+
     context "when charges have presentation_group_keys" do
       before do
         allow(Invoices::CustomerUsageService).to receive(:call!).and_call_original

--- a/spec/services/event_destinations/customer_usage/refreshed_service_spec.rb
+++ b/spec/services/event_destinations/customer_usage/refreshed_service_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EventDestinations::CustomerUsage::RefreshedService do
+  subject(:result) { described_class.call(object: customer) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: "count_agg") }
+
+  let(:subscriptions) do
+    [
+      create(:subscription, organization:, customer:, started_at: 2.years.ago),
+      create(:subscription, organization:, customer:, started_at: 1.year.ago)
+    ]
+  end
+
+  # The real SDK client, stubbed: request parameters are still validated, nothing is sent.
+  let(:aws_client) { Aws::Kinesis::Client.new(region: "eu-west-1", stub_responses: true) }
+  let(:put_record_args) { [] }
+
+  before do
+    stub_const("ENV", ENV.to_h.merge(
+      "LAGO_EVENT_DESTINATION_ORG_ID" => organization.id,
+      "LAGO_EVENT_DESTINATION_TRANSPORT" => "log",
+      "LAGO_EVENT_DESTINATION_KINESIS_STREAM_ARN" => "arn:aws:kinesis:eu-west-1:123456789012:stream/usage",
+      "LAGO_EVENT_DESTINATION_KINESIS_REGION" => "eu-west-1"
+    ))
+
+    subscriptions.each do |subscription|
+      create(:standard_charge, organization:, plan: subscription.plan, billable_metric:, properties: {amount: "3"})
+    end
+
+    create(:event, organization:, subscription: subscriptions.first, customer:, code: billable_metric.code)
+
+    allow(Aws::Kinesis::Client).to receive(:new).and_return(aws_client)
+    allow(aws_client).to receive(:put_record).and_wrap_original do |original, **args|
+      put_record_args << args
+      original.call(**args)
+    end
+  end
+
+  describe "#call" do
+    it "puts one record per active subscription" do
+      expect(result).to be_success
+
+      expect(aws_client).to have_received(:put_record).twice
+    end
+
+    it "targets the configured stream and partitions on the customer external id" do
+      result
+
+      expect(put_record_args.map { it[:stream_arn] }.uniq).to eq(["arn:aws:kinesis:eu-west-1:123456789012:stream/usage"])
+      expect(put_record_args.map { it[:partition_key] }.uniq).to eq([customer.external_id])
+    end
+
+    it "writes a webhook-shaped envelope for each subscription" do
+      result
+
+      payloads = put_record_args.map { JSON.parse(it[:data]) }
+
+      expect(payloads.map { it["subscription_external_id"] }).to match_array(subscriptions.map(&:external_id))
+
+      payloads.each do |payload|
+        expect(payload["webhook_type"]).to eq("customer_usage.refreshed")
+        expect(payload["object_type"]).to eq("customer_usage")
+        expect(payload["organization_id"]).to eq(organization.id)
+        expect(payload["customer_external_id"]).to eq(customer.external_id)
+        expect(payload["version"]).to match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z\z/)
+      end
+    end
+
+    it "stamps both records of a delivery with the same version" do
+      result
+
+      versions = put_record_args.map { JSON.parse(it[:data])["version"] }
+
+      expect(versions.uniq.size).to eq(1)
+    end
+
+    it "serializes the usage with the public endpoint serializer" do
+      result
+
+      payloads = put_record_args.map { JSON.parse(it[:data]) }
+      payload = payloads.find { it["subscription_external_id"] == subscriptions.first.external_id }
+
+      usage = ::Invoices::CustomerUsageService.call(customer:, subscription: subscriptions.first, with_cache: true).usage
+      expected = ::V1::Customers::UsageSerializer.new(usage, root_name: "customer_usage", includes: %i[charges_usage]).serialize
+
+      expect(payload["customer_usage"]).to eq(JSON.parse(JSON.generate(expected)))
+      expect(payload["customer_usage"]["charges_usage"]).to be_present
+    end
+
+    context "when no destination is configured for the organization" do
+      before { stub_const("ENV", ENV.to_h.except("LAGO_EVENT_DESTINATION_ORG_ID")) }
+
+      it "does not instantiate a client nor put any record" do
+        expect(result).to be_success
+
+        expect(Aws::Kinesis::Client).not_to have_received(:new)
+        expect(aws_client).not_to have_received(:put_record)
+      end
+    end
+
+    context "when the usage service fails" do
+      before do
+        allow(::Invoices::CustomerUsageService).to receive(:call)
+          .and_return(BaseResult.new.tap { it.service_failure!(code: "boom", message: "boom") })
+      end
+
+      it "skips the subscription without raising" do
+        expect { result }.not_to raise_error
+
+        expect(aws_client).not_to have_received(:put_record)
+      end
+    end
+
+    context "when a put fails" do
+      before do
+        failed = false
+        allow(aws_client).to receive(:put_record) do
+          next nil if failed
+
+          failed = true
+          raise Aws::Kinesis::Errors::ServiceError.new(nil, "boom")
+        end
+      end
+
+      it "keeps publishing the remaining subscriptions and does not raise" do
+        expect { result }.not_to raise_error
+
+        expect(aws_client).to have_received(:put_record).twice
+      end
+    end
+  end
+end

--- a/spec/services/event_destinations/kinesis_producer_spec.rb
+++ b/spec/services/event_destinations/kinesis_producer_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EventDestinations::KinesisProducer do
+  subject(:producer) { described_class.new(stream:) }
+
+  let(:stream_arn) { "arn:aws:kinesis:eu-west-1:123456789012:stream/usage" }
+  let(:log_only) { true }
+  let(:stream) do
+    instance_double(EventDestinations::KinesisStream, stream_arn:, region: "eu-west-1", log_only?: log_only)
+  end
+
+  describe "#produce" do
+    let(:aws_client) { Aws::Kinesis::Client.new(region: "eu-west-1", stub_responses: true) }
+
+    before do
+      allow(Aws::Kinesis::Client).to receive(:new).and_return(aws_client)
+      allow(aws_client).to receive(:put_record).and_call_original
+    end
+
+    it "puts the record on the configured stream" do
+      producer.produce(data: {a: 1}, partition_key: "cust_1")
+
+      expect(aws_client).to have_received(:put_record)
+        .with(stream_arn:, data: '{"a":1}', partition_key: "cust_1")
+    end
+
+    it "logs the record in log mode" do
+      allow(Rails.logger).to receive(:info)
+
+      producer.produce(data: {a: 1}, partition_key: "cust_1")
+
+      expect(Rails.logger).to have_received(:info).with(/\[event_destinations\] put_record .* bytes=7 /)
+    end
+
+    context "when the transport is live" do
+      let(:log_only) { false }
+
+      # Nobody can read a customer's stream, so the shard and sequence number are the only
+      # evidence a record landed. They replace the payload rather than accompanying it.
+      it "logs the shard and sequence number instead of the payload" do
+        allow(Rails.logger).to receive(:info)
+
+        producer.produce(data: {a: 1}, partition_key: "cust_1")
+
+        expect(Rails.logger).to have_received(:info).with(/shard=ShardId sequence=SequenceNumber\z/)
+      end
+
+      it "does not log the payload" do
+        allow(Rails.logger).to receive(:info)
+
+        producer.produce(data: {a: 1}, partition_key: "cust_1")
+
+        expect(Rails.logger).not_to have_received(:info).with(/data=/)
+      end
+    end
+  end
+
+  describe "client configuration" do
+    before { allow(Aws::Kinesis::Client).to receive(:new).and_call_original }
+
+    # The SDK defaults (15s connect, 60s read, 3 retries) allow ~240s per record, which would
+    # hold a Sidekiq thread for minutes when the destination is unreachable.
+    it "bounds the time a dead destination can cost" do
+      producer.produce(data: {a: 1}, partition_key: "cust_1")
+
+      expect(Aws::Kinesis::Client).to have_received(:new).with(
+        hash_including(http_open_timeout: 2, http_read_timeout: 5, retry_limit: 1)
+      )
+    end
+
+    context "when credentials cannot be resolved" do
+      let(:log_only) { false }
+      let(:unauthenticated) { Aws::Kinesis::Client.new(region: "eu-west-1", stub_responses: true) }
+
+      before do
+        allow(Aws::Kinesis::Client).to receive(:new).and_return(unauthenticated)
+        allow(unauthenticated.config).to receive(:credentials).and_return(nil)
+      end
+
+      # Without this guard the SDK fails inside endpoint construction with
+      # `NoMethodError: undefined method 'credentials' for nil`.
+      it "raises a credentials error rather than a NoMethodError" do
+        expect { producer.produce(data: {a: 1}, partition_key: "cust_1") }
+          .to raise_error(Aws::Errors::MissingCredentialsError)
+      end
+    end
+  end
+end

--- a/spec/services/event_destinations/kinesis_stream_spec.rb
+++ b/spec/services/event_destinations/kinesis_stream_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EventDestinations::KinesisStream do
+  let(:organization) { create(:organization) }
+
+  describe ".for" do
+    subject { described_class.for(organization) }
+
+    context "when LAGO_EVENT_DESTINATION_ORG_ID is absent" do
+      before { stub_const("ENV", ENV.to_h.except("LAGO_EVENT_DESTINATION_ORG_ID")) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when LAGO_EVENT_DESTINATION_ORG_ID does not match the organization" do
+      before { stub_const("ENV", ENV.to_h.merge("LAGO_EVENT_DESTINATION_ORG_ID" => create(:organization).id)) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the organization is nil" do
+      subject { described_class.for(nil) }
+
+      before { stub_const("ENV", ENV.to_h.merge("LAGO_EVENT_DESTINATION_ORG_ID" => organization.id)) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when LAGO_EVENT_DESTINATION_ORG_ID matches the organization" do
+      before { stub_const("ENV", ENV.to_h.merge("LAGO_EVENT_DESTINATION_ORG_ID" => organization.id)) }
+
+      it { is_expected.to be_a(described_class) }
+    end
+  end
+
+  describe "#stream_arn" do
+    before { stub_const("ENV", ENV.to_h.merge("LAGO_EVENT_DESTINATION_KINESIS_STREAM_ARN" => "arn:aws:kinesis:eu-west-1:123456789012:stream/usage")) }
+
+    it "returns the configured ARN" do
+      expect(described_class.new.stream_arn).to eq("arn:aws:kinesis:eu-west-1:123456789012:stream/usage")
+    end
+  end
+
+  describe "#region" do
+    before { stub_const("ENV", ENV.to_h.merge("LAGO_EVENT_DESTINATION_KINESIS_REGION" => "eu-west-1")) }
+
+    it "returns the configured region" do
+      expect(described_class.new.region).to eq("eu-west-1")
+    end
+  end
+
+  describe "#log_only?" do
+    context "when LAGO_EVENT_DESTINATION_TRANSPORT is absent" do
+      before { stub_const("ENV", ENV.to_h.except("LAGO_EVENT_DESTINATION_TRANSPORT")) }
+
+      it { expect(described_class.new).to be_log_only }
+    end
+
+    context "when LAGO_EVENT_DESTINATION_TRANSPORT is log" do
+      before { stub_const("ENV", ENV.to_h.merge("LAGO_EVENT_DESTINATION_TRANSPORT" => "log")) }
+
+      it { expect(described_class.new).to be_log_only }
+    end
+
+    context "when LAGO_EVENT_DESTINATION_TRANSPORT is kinesis" do
+      before { stub_const("ENV", ENV.to_h.merge("LAGO_EVENT_DESTINATION_TRANSPORT" => "kinesis")) }
+
+      it { expect(described_class.new).not_to be_log_only }
+    end
+
+    # A declared-but-blank env var is not absent, so it must not fall through to live delivery.
+    context "when LAGO_EVENT_DESTINATION_TRANSPORT is blank" do
+      before { stub_const("ENV", ENV.to_h.merge("LAGO_EVENT_DESTINATION_TRANSPORT" => "")) }
+
+      it { expect(described_class.new).to be_log_only }
+    end
+
+    context "when LAGO_EVENT_DESTINATION_TRANSPORT is unrecognized" do
+      before do
+        stub_const("ENV", ENV.to_h.merge("LAGO_EVENT_DESTINATION_TRANSPORT" => "Kinesis"))
+        allow(Rails.logger).to receive(:warn)
+      end
+
+      it "falls back to log-only and warns" do
+        expect(described_class.new).to be_log_only
+
+        expect(Rails.logger).to have_received(:warn).with(/unrecognized LAGO_EVENT_DESTINATION_TRANSPORT/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
POC: on every wallet refresh, deliver each active subscription's current usage to a customer-owned event destination (Kinesis for now).

No table, no migration: the destination is a PORO fed by `LAGO_EVENT_DESTINATION_*` env vars. Absent env vars, nothing changes. `LAGO_EVENT_DESTINATION_TRANSPORT` defaults to `log`, which stubs the SDK client so request params are still validated but nothing leaves the process; only an explicit `kinesis` opts into real delivery.

Shaped after the webhooks pattern (`DeliverEventJob` registry -> service -> envelope payload) so other event types can be added later. `EventDestinations::` is namespaced by concept rather than transport, so a second one is `EventDestinations::KafkaTopic` + `KafkaProducer` with no renaming.

### Ordering

Each record carries a `version` (fixed-width UTC ISO8601, microseconds). Consumers dedup within `(organization_id, customer_external_id, subscription_external_id)` and drop anything whose version is `<=` what they hold. Kinesis shard ordering is not enough on its own: it breaks on shard splits/merges, batch consumers and replay.

The version is a read-time token, so it only orders correctly while deliveries for one customer cannot overlap. Usage is assembled from per-charge cache fragments, and concurrent readers can interleave such that a later version carries staler content. `DeliverEventJob` therefore takes `unique :until_and_while_executing`, which enforces mutual exclusion during execution while releasing the enqueue lock at execution start, so a refresh landing mid-delivery still enqueues and picks up fresh data. Overlapping executions are dropped and logged: one stale snapshot until the next refresh, never a regression.

### Enqueue timing

The hook uses `ApplicationJob.perform_after_commit`, not `perform_later`. `Credits::AppliedPrepaidCreditsService` calls `RefreshWalletsService` inside a transaction and `ActiveJob::Base.enqueue_after_transaction_commit` is `false` in this app, so `perform_later` published usage for transactions that then rolled back. Reproduced locally, and now covered by a spec that fails against `perform_later`.

### Timeouts and credentials

The client pins `http_open_timeout: 2`, `http_read_timeout: 5`, `retry_limit: 1`. Measured against a black-holed endpoint, the SDK defaults (15s/60s/3) cost **34.2s per record**; these cap it at **4.3s**. Retries are deliberately low because a dropped snapshot is cheap: the next wallet refresh re-emits with a newer version and the consumer never regresses. The producer also raises `Aws::Errors::MissingCredentialsError` when credentials cannot be resolved, because the SDK otherwise fails deep in endpoint construction with `undefined method 'credentials' for nil`.

### Observability

`put_record` is logged in both modes, but with different evidence. Log mode carries the payload; live mode carries `shard` and `sequence`, because with no read access to a customer's stream those are the only proof a record landed. Stubbed responses only return the placeholders `"ShardId"`/`"SequenceNumber"`, which is why the two modes differ rather than always logging both.

### Verified against real AWS Kinesis

Tested against a sandbox stream in eu-west-1 via an assumed IAM role, with records read back off the stream:

- Real SigV4-signed `PutRecord` succeeds; one record per subscription, each with a distinct increasing sequence number.
- **Byte fidelity**: the log-mode payload and the record that actually landed in AWS are byte-identical once `version` is stripped (4157 bytes both sides). Log-only mode is therefore a faithful proxy for the wire.
- Six deliveries observed in the stream: three records per delivery sharing one `version`, versions strictly increasing across deliveries.
- Real error classes reach the per-subscription rescue with the service still returning success and never raising: `ValidationException` for a payload past the 1MB record limit, and `AccessDeniedException` for a stream the role is not scoped to. Note that on real AWS a wrong stream ARN surfaces as **AccessDenied, not ResourceNotFound**, because the role is scoped to a single stream resource, so a typo looks like a permissions problem.
- Also previously verified end to end against a local Kinesis-compatible endpoint: the runtime lock aborting an overlapping delivery with zero records emitted, the env kill switch leaving the queue untouched, a rolled-back invoicing-path transaction emitting nothing, and partition-key affinity across 7 customers on a 2-shard stream.

### Known gaps

- No `usage_watermark`, so consumers can order messages but cannot tell how far behind reality the data is. `CacheService` already stores that watermark as `cached_at`, but only behind the `:lazy_charge_usage_cache` flag and per fragment, and surfacing it means changing the cache layer. Follow-up.
- **Production credentials are unresolved.** This codebase has no role-assumption pattern at all today (the only AWS auth is static `LAGO_AWS_S3_ACCESS_KEY_ID` keys for storage), and `lago-deploy` has no IRSA anywhere. Choosing between IRSA, a static-key SealedSecret, and explicit `Aws::AssumeRoleCredentials` is a real design decision this POC does not settle. Testing used a locally assumed role.
- Setting `AWS_ENDPOINT_URL_KINESIS` to an empty string makes every delivery raise `ArgumentError: expected :endpoint to be a HTTP or HTTPS endpoint`, caught by the rescue, so the destination goes silently dark. SDK behaviour rather than ours, but a sharp edge for whoever writes the deploy config.
- `RefreshWalletsService` emits on the invoicing path as well as the clock path. Whether that is wanted long-term is an open product question, not resolved here.