### PR TITLE
feat(api): serve contracts on the v2 API

### DIFF
--- a/app/controllers/api/v2/contracts_controller.rb
+++ b/app/controllers/api/v2/contracts_controller.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    class ContractsController < Api::BaseController
+      include Api::RequiresProductCatalog
+
+      def create
+        result = ::Contracts::CreateService.call(
+          organization: current_organization,
+          params: create_params.to_h.deep_symbolize_keys
+        )
+
+        if result.success?
+          render_contract(result.contract)
+        else
+          render_error_response(result)
+        end
+      end
+
+      def index
+        filters = params.permit(:plan_code, :external_customer_id, :external_id, status: [])
+        filters[:status] = ["active"] if filters[:status].blank?
+
+        result = ::ContractsQuery.call(
+          organization: current_organization,
+          pagination: {
+            page: params[:page],
+            limit: params[:per_page] || PER_PAGE
+          },
+          filters:
+        )
+
+        if result.success?
+          contracts = result.contracts.includes(:plan, :customer)
+
+          # One grouped query instead of one COUNT per row in the serializer.
+          applied_rate_cards_counts = ContractRateCard.current_and_scheduled
+            .where(contract_id: contracts.map(&:id))
+            .group(:contract_id)
+            .count
+
+          render(
+            json: ::CollectionSerializer.new(
+              contracts,
+              ::V2::ContractSerializer,
+              collection_name: "contracts",
+              meta: pagination_metadata(contracts),
+              applied_rate_cards_counts:
+            )
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
+      def show
+        contract = current_organization.contracts
+          .order(started_at: :desc)
+          .find_by(external_id: params[:external_id], status: requested_status)
+        return not_found_error(resource: "contract") unless contract
+
+        render(
+          json: ::V2::ContractSerializer.new(
+            contract,
+            root_name: "contract",
+            includes: %i[applied_rate_cards]
+          )
+        )
+      end
+
+      private
+
+      # The column is a PostgreSQL enum: an unknown value would be a
+      # database-level cast error, so anything else falls back to active.
+      def requested_status
+        if Contract::STATUSES.value?(params[:status])
+          params[:status]
+        else
+          "active"
+        end
+      end
+
+      def create_params
+        params.require(:contract).permit(
+          :external_customer_id,
+          :external_id,
+          :name,
+          :plan_code,
+          :billing_time,
+          :billing_anchor_date,
+          :started_at,
+          :ended_at
+        )
+      end
+
+      def render_contract(contract)
+        render(json: ::V2::ContractSerializer.new(contract, root_name: "contract", includes: %i[applied_rate_cards]))
+      end
+
+      def resource_name
+        "contract"
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/contracts_controller.rb
+++ b/app/controllers/api/v2/contracts_controller.rb
@@ -19,8 +19,12 @@ module Api
       end
 
       def index
-        filters = params.permit(:plan_code, :external_customer_id, :external_id, status: [])
-        filters[:status] = ["active"] if filters[:status].blank?
+        filters = params.permit(:plan_code, :external_customer_id, :external_id)
+        # Accept both ?status=pending and ?status[]=pending — strong params
+        # would silently drop the scalar form and hand back active contracts
+        # to a caller who believes they filtered.
+        statuses = params[:status].is_a?(Array) ? params[:status] : [params[:status]]
+        filters[:status] = statuses.compact_blank.presence || ["active"]
 
         result = ::ContractsQuery.call(
           organization: current_organization,

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -8,6 +8,7 @@ class ApiKey < ApplicationRecord
     customer event fee invoice organization order order_form payment payment_receipt payment_request payment_method plan subscription lifetime_usage
     tax wallet wallet_transaction webhook_endpoint webhook_jwt_public_key invoice_custom_section
     billing_entity alert feature security_log quote product_category product rate_card plan_rate_card
+    contract
   ].freeze
 
   MODES = %w[read write].freeze

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -75,6 +75,7 @@ end
 # Indexes
 #
 #  index_contracts_on_customer_id                      (customer_id)
+#  index_contracts_on_live_external_id                 (organization_id,external_id,status) UNIQUE WHERE (status = ANY (ARRAY['pending'::contract_status, 'active'::contract_status]))
 #  index_contracts_on_organization_id                  (organization_id)
 #  index_contracts_on_organization_id_and_external_id  (organization_id,external_id)
 #  index_contracts_on_plan_id                          (plan_id)

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -36,9 +36,12 @@ class Contract < ApplicationRecord
   validate :validate_started_before_ended
 
   # The anchor every attached rate card inherits by default: the explicit
-  # anchor when one was signed, otherwise the day the contract starts.
+  # anchor when one was signed, otherwise the day the contract starts — in
+  # the customer's timezone, since the engine interprets dates as
+  # customer-local days. A UTC truncation would shift the day around the
+  # customer's midnight.
   def effective_billing_anchor_date
-    billing_anchor_date || started_at&.to_date
+    billing_anchor_date || started_at&.in_time_zone(customer.applicable_timezone)&.to_date
   end
 
   private

--- a/app/models/contract_rate_card.rb
+++ b/app/models/contract_rate_card.rb
@@ -24,6 +24,11 @@ class ContractRateCard < ApplicationRecord
 
   default_scope -> { kept }
 
+  # The window is day-grained and the end inclusive: the card still bills on
+  # its ended_date, charges stop after it. Ended attachments are history;
+  # upcoming ones stay visible.
+  scope :current_and_scheduled, -> { where("ended_date IS NULL OR ended_date >= ?", Date.current) }
+
   private
 
   def validate_effective_before_ended

--- a/app/models/contract_rate_card.rb
+++ b/app/models/contract_rate_card.rb
@@ -28,11 +28,18 @@ class ContractRateCard < ApplicationRecord
   # its ended_date, charges stop after it. Ended attachments are history;
   # upcoming ones stay visible. "Today" is the customer's day, not the
   # application's — same COALESCE chain as the v1 timezone SQL helpers.
+  #
+  # The plain date bound comes first: the timezone expression cannot use an
+  # index, which turned a similar comparison into a full-scan timeout in the
+  # termination clock (see #6086). Offsets span -12:00..+14:00, so any
+  # customer-local today is at least yesterday's date — the bound is a strict
+  # superset and the exact per-row check decides.
   scope :current_and_scheduled, -> {
     joins(contract: [:customer, :organization]).where(
-      "contract_rate_cards.ended_date IS NULL OR contract_rate_cards.ended_date >= " \
-      "(?::timestamptz AT TIME ZONE COALESCE(customers.timezone, organizations.timezone, 'UTC'))::date",
-      Time.current
+      "contract_rate_cards.ended_date IS NULL OR (contract_rate_cards.ended_date >= ? AND " \
+      "contract_rate_cards.ended_date >= " \
+      "(?::timestamptz AT TIME ZONE COALESCE(customers.timezone, organizations.timezone, 'UTC'))::date)",
+      Time.current.to_date - 1, Time.current
     )
   }
 

--- a/app/models/contract_rate_card.rb
+++ b/app/models/contract_rate_card.rb
@@ -26,8 +26,15 @@ class ContractRateCard < ApplicationRecord
 
   # The window is day-grained and the end inclusive: the card still bills on
   # its ended_date, charges stop after it. Ended attachments are history;
-  # upcoming ones stay visible.
-  scope :current_and_scheduled, -> { where("ended_date IS NULL OR ended_date >= ?", Date.current) }
+  # upcoming ones stay visible. "Today" is the customer's day, not the
+  # application's — same COALESCE chain as the v1 timezone SQL helpers.
+  scope :current_and_scheduled, -> {
+    joins(contract: [:customer, :organization]).where(
+      "contract_rate_cards.ended_date IS NULL OR contract_rate_cards.ended_date >= " \
+      "(?::timestamptz AT TIME ZONE COALESCE(customers.timezone, organizations.timezone, 'UTC'))::date",
+      Time.current
+    )
+  }
 
   private
 

--- a/app/queries/contracts_query.rb
+++ b/app/queries/contracts_query.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class ContractsQuery < BaseQuery
+  Result = BaseResult[:contracts]
+  Filters = BaseFilters[:external_customer_id, :plan_code, :external_id, :status]
+
+  def call
+    contracts = base_scope
+    contracts = paginate(contracts)
+    contracts = apply_consistent_ordering(contracts)
+
+    contracts = with_external_customer(contracts) if filters.external_customer_id.present?
+    contracts = with_plan_code(contracts) if filters.plan_code.present?
+    contracts = with_external_id(contracts) if filters.external_id.present?
+    contracts = with_status(contracts) if filters.status.present?
+
+    result.contracts = contracts
+    result
+  end
+
+  private
+
+  def base_scope
+    Contract.where(organization:)
+  end
+
+  def with_external_customer(scope)
+    scope.where(customer_id: organization.customers.where(external_id: filters.external_customer_id).select(:id))
+  end
+
+  def with_plan_code(scope)
+    scope.where(plan_id: organization.plans.where(code: filters.plan_code).select(:id))
+  end
+
+  def with_external_id(scope)
+    scope.where(external_id: filters.external_id)
+  end
+
+  # The column is a PostgreSQL enum: an unknown value in the IN list would be
+  # a database-level cast error, so unknown values are dropped. A filter left
+  # with no valid value matches nothing rather than everything.
+  def with_status(scope)
+    statuses = Array(filters.status).map(&:to_s) & Contract::STATUSES.values
+
+    scope.where(status: statuses)
+  end
+end

--- a/app/serializers/v2/contract_applied_rate_card_serializer.rb
+++ b/app/serializers/v2/contract_applied_rate_card_serializer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module V2
+  class ContractAppliedRateCardSerializer < ModelSerializer
+    def serialize
+      {
+        lago_id: model.id,
+        external_contract_id: model.contract.external_id,
+        rate_card_code: model.rate_card.code,
+        units: model.units,
+        effective_date: model.effective_date.iso8601,
+        ended_date: model.ended_date&.iso8601,
+        billing_anchor_date: model.billing_anchor_date.iso8601,
+        next_billing_at: model.next_billing_at.iso8601,
+        # size counts the loaded collection when the caller preloaded it.
+        rate_phases_count: model.rate_phases.size,
+        created_at: model.created_at.iso8601,
+        updated_at: model.updated_at.iso8601
+      }
+    end
+  end
+end

--- a/app/serializers/v2/contract_serializer.rb
+++ b/app/serializers/v2/contract_serializer.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module V2
+  # The agreement a customer signed: an optional plan (a plan-less contract
+  # prices through directly attached rate cards), a validity window and the
+  # billing anchor. There are no plan-interval fields — pricing lives on the
+  # applied rate cards.
+  class ContractSerializer < ModelSerializer
+    def serialize
+      payload = {
+        lago_id: model.id,
+        external_id: model.external_id,
+        lago_customer_id: model.customer_id,
+        external_customer_id: model.customer.external_id,
+        name: model.name,
+        plan_code: model.plan&.code,
+        status: model.status,
+        billing_time: model.billing_time,
+        billing_anchor_date: model.billing_anchor_date&.iso8601,
+        started_at: model.started_at&.iso8601,
+        ended_at: model.ended_at&.iso8601,
+        terminated_at: model.terminated_at&.iso8601,
+        canceled_at: model.canceled_at&.iso8601,
+        created_at: model.created_at.iso8601,
+        updated_at: model.updated_at.iso8601,
+        applied_rate_cards_count: applied_rate_cards_count
+      }
+
+      payload[:applied_rate_cards] = applied_rate_cards if include?(:applied_rate_cards)
+
+      payload
+    end
+
+    private
+
+    # The index passes one grouped count for the whole page; show falls back
+    # to the scoped count on the single record. Ended attachments are history,
+    # not cards the contract currently carries.
+    def applied_rate_cards_count
+      counts = options[:applied_rate_cards_counts]
+      return counts.fetch(model.id, 0) if counts
+
+      model.applied_rate_cards.current_and_scheduled.count
+    end
+
+    def applied_rate_cards
+      ::CollectionSerializer.new(
+        model.applied_rate_cards.current_and_scheduled.includes(:rate_phases, :rate_card, :contract),
+        ::V2::ContractAppliedRateCardSerializer,
+        collection_name: "applied_rate_cards"
+      ).serialize[:applied_rate_cards]
+    end
+  end
+end

--- a/app/services/contracts/create_service.rb
+++ b/app/services/contracts/create_service.rb
@@ -33,9 +33,16 @@ module Contracts
         end
       end
 
+      # A window that already closed cannot be created: nothing would ever
+      # terminate it, leaving a zombie active contract.
+      if params[:ended_at].present? && Time.zone.parse(params[:ended_at].to_s) <= Time.current
+        return result.single_validation_failure!(field: :ended_at, error_code: "already_ended")
+      end
+
       # One live agreement per external id. Replacement flows (upgrade,
       # downgrade, renewal) will create their pending sibling explicitly when
       # they exist; a blind second create is a mistake, not a replacement.
+      # Advisory under concurrency — the partial unique index closes the race.
       if organization.contracts.where(status: %w[pending active], external_id: params[:external_id]).exists?
         return result.single_validation_failure!(field: :external_id, error_code: "value_already_exists")
       end
@@ -63,6 +70,10 @@ module Contracts
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
+    rescue ActiveRecord::RecordNotUnique
+      # A concurrent create won the race past the advisory check; same answer
+      # as the check itself.
+      result.single_validation_failure!(field: :external_id, error_code: "value_already_exists")
     rescue BaseService::FailedResult => e
       e.result
     end

--- a/app/services/contracts/create_service.rb
+++ b/app/services/contracts/create_service.rb
@@ -35,7 +35,7 @@ module Contracts
 
       # A window that already closed cannot be created: nothing would ever
       # terminate it, leaving a zombie active contract.
-      if params[:ended_at].present? && Time.zone.parse(params[:ended_at].to_s) <= Time.current
+      if params[:ended_at].present? && parse_in_customer_zone(params[:ended_at]) <= Time.current
         return result.single_validation_failure!(field: :ended_at, error_code: "already_ended")
       end
 
@@ -47,7 +47,7 @@ module Contracts
         return result.single_validation_failure!(field: :external_id, error_code: "value_already_exists")
       end
 
-      started_at = params[:started_at].present? ? Time.zone.parse(params[:started_at].to_s) : Time.current
+      started_at = params[:started_at].present? ? parse_in_customer_zone(params[:started_at]) : Time.current
 
       ActiveRecord::Base.transaction do
         contract = organization.contracts.create!(
@@ -58,7 +58,7 @@ module Contracts
           billing_time: params[:billing_time].presence || "calendar",
           billing_anchor_date: params[:billing_anchor_date],
           started_at:,
-          ended_at: params[:ended_at],
+          ended_at: params[:ended_at].presence && parse_in_customer_zone(params[:ended_at]),
           status: started_at.future? ? :pending : :active
         )
 
@@ -91,6 +91,13 @@ module Contracts
 
     def plan
       @plan ||= organization.plans.parents.find_by(code: params[:plan_code])
+    end
+
+    # A datetime without an offset means the customer's wall clock, not the
+    # application's: "2026-10-01T00:00:00" from a Los Angeles customer is
+    # their midnight. Explicit offsets are respected as provided.
+    def parse_in_customer_zone(value)
+      Time.use_zone(customer.applicable_timezone) { Time.zone.parse(value.to_s) }
     end
   end
 end

--- a/app/services/contracts/create_service.rb
+++ b/app/services/contracts/create_service.rb
@@ -6,6 +6,8 @@ module Contracts
   # active when its start has arrived, pending when it starts in the future
   # — lifecycle state lives in the status, the dates only carry the window.
   class CreateService < BaseService
+    include CustomerTimezone
+
     Result = BaseResult[:contract]
 
     def initialize(organization:, params:)
@@ -35,7 +37,7 @@ module Contracts
 
       # A window that already closed cannot be created: nothing would ever
       # terminate it, leaving a zombie active contract.
-      if params[:ended_at].present? && parse_in_customer_zone(params[:ended_at]) <= Time.current
+      if params[:ended_at].present? && ended_at_in_customer_timezone <= Time.current
         return result.single_validation_failure!(field: :ended_at, error_code: "already_ended")
       end
 
@@ -47,7 +49,7 @@ module Contracts
         return result.single_validation_failure!(field: :external_id, error_code: "value_already_exists")
       end
 
-      started_at = params[:started_at].present? ? parse_in_customer_zone(params[:started_at]) : Time.current
+      started_at = params[:started_at].present? ? started_at_in_customer_timezone : Time.current
 
       ActiveRecord::Base.transaction do
         contract = organization.contracts.create!(
@@ -58,7 +60,7 @@ module Contracts
           billing_time: params[:billing_time].presence || "calendar",
           billing_anchor_date: params[:billing_anchor_date],
           started_at:,
-          ended_at: params[:ended_at].presence && parse_in_customer_zone(params[:ended_at]),
+          ended_at: ended_at_in_customer_timezone,
           status: started_at.future? ? :pending : :active
         )
 
@@ -93,11 +95,16 @@ module Contracts
       @plan ||= organization.plans.parents.find_by(code: params[:plan_code])
     end
 
-    # A datetime without an offset means the customer's wall clock, not the
-    # application's: "2026-10-01T00:00:00" from a Los Angeles customer is
-    # their midnight. Explicit offsets are respected as provided.
-    def parse_in_customer_zone(value)
-      Time.use_zone(customer.applicable_timezone) { Time.zone.parse(value.to_s) }
+    # Read through the CustomerTimezone suffix: a datetime without an offset
+    # means the customer's wall clock, not the application's —
+    # String#in_time_zone parses a naive value in the customer's zone and
+    # respects explicit offsets. Nil when the param is absent.
+    def started_at
+      params[:started_at].presence
+    end
+
+    def ended_at
+      params[:ended_at].presence
     end
   end
 end

--- a/app/services/contracts/create_service.rb
+++ b/app/services/contracts/create_service.rb
@@ -70,9 +70,12 @@ module Contracts
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
-    rescue ActiveRecord::RecordNotUnique
+    rescue ActiveRecord::RecordNotUnique => e
       # A concurrent create won the race past the advisory check; same answer
-      # as the check itself.
+      # as the check itself. Any other uniqueness violation in the transaction
+      # stays loud instead of masquerading as a duplicate external id.
+      raise unless e.message.include?("index_contracts_on_live_external_id")
+
       result.single_validation_failure!(field: :external_id, error_code: "value_already_exists")
     rescue BaseService::FailedResult => e
       e.result

--- a/app/services/contracts/create_service.rb
+++ b/app/services/contracts/create_service.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Contracts
+  # Records a new agreement. The plan is optional by design: a plan-less
+  # contract prices through directly attached rate cards. The contract is
+  # active when its start has arrived, pending when it starts in the future
+  # — lifecycle state lives in the status, the dates only carry the window.
+  class CreateService < BaseService
+    Result = BaseResult[:contract]
+
+    def initialize(organization:, params:)
+      @organization = organization
+      @params = params.to_h.with_indifferent_access
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: "customer") unless customer
+
+      if params[:plan_code].present? && plan.nil?
+        return result.not_found_failure!(resource: "plan")
+      end
+
+      if plan && !plan.product_catalog?
+        return result.single_validation_failure!(field: :plan, error_code: "not_a_product_catalog_plan")
+      end
+
+      # Date columns: a malformed value would silently cast to nil instead of
+      # failing, so formats are rejected explicitly.
+      %i[billing_anchor_date started_at ended_at].each do |field|
+        if params[field].present? && !Utils::Datetime.valid_format?(params[field])
+          return result.single_validation_failure!(field:, error_code: "value_is_invalid")
+        end
+      end
+
+      # One live agreement per external id. Replacement flows (upgrade,
+      # downgrade, renewal) will create their pending sibling explicitly when
+      # they exist; a blind second create is a mistake, not a replacement.
+      if organization.contracts.where(status: %w[pending active], external_id: params[:external_id]).exists?
+        return result.single_validation_failure!(field: :external_id, error_code: "value_already_exists")
+      end
+
+      started_at = params[:started_at].present? ? Time.zone.parse(params[:started_at].to_s) : Time.current
+
+      ActiveRecord::Base.transaction do
+        contract = organization.contracts.create!(
+          customer:,
+          plan:,
+          external_id: params[:external_id],
+          name: params[:name],
+          billing_time: params[:billing_time].presence || "calendar",
+          billing_anchor_date: params[:billing_anchor_date],
+          started_at:,
+          ended_at: params[:ended_at],
+          status: started_at.future? ? :pending : :active
+        )
+
+        Contracts::MaterializeRateCardsService.call!(contract:) if contract.plan
+
+        result.contract = contract
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue BaseService::FailedResult => e
+      e.result
+    end
+
+    private
+
+    attr_reader :organization, :params
+
+    def customer
+      @customer ||= organization.customers.find_by(external_id: params[:external_customer_id])
+    end
+
+    def plan
+      @plan ||= organization.plans.parents.find_by(code: params[:plan_code])
+    end
+  end
+end

--- a/app/services/contracts/materialize_rate_cards_service.rb
+++ b/app/services/contracts/materialize_rate_cards_service.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Contracts
+  # Materializes the plan's rate cards onto the contract: one
+  # contract_rate_card per plan_rate_card, carrying the billing lifecycle
+  # (anchor, clock, units). Pricing is not copied — a plan is immutable once
+  # it has contracts, so phases and rates resolve by reference through the
+  # plan entry.
+  class MaterializeRateCardsService < BaseService
+    Result = BaseResult[:contract_rate_cards]
+
+    def initialize(contract:)
+      @contract = contract
+      super
+    end
+
+    def call
+      return result unless contract.plan
+
+      materialized = []
+      ActiveRecord::Base.transaction do
+        contract.plan.applied_rate_cards.find_each do |plan_rate_card|
+          materialized << contract.applied_rate_cards.create!(
+            organization: contract.organization,
+            rate_card: plan_rate_card.rate_card,
+            units: plan_rate_card.units,
+            effective_date: contract.started_at.to_date,
+            billing_anchor_date: contract.effective_billing_anchor_date,
+            next_billing_at: contract.started_at
+          )
+        end
+      end
+
+      result.contract_rate_cards = materialized
+      result
+    end
+
+    private
+
+    attr_reader :contract
+  end
+end

--- a/app/services/contracts/materialize_rate_cards_service.rb
+++ b/app/services/contracts/materialize_rate_cards_service.rb
@@ -24,7 +24,7 @@ module Contracts
             organization: contract.organization,
             rate_card: plan_rate_card.rate_card,
             units: plan_rate_card.units,
-            effective_date: contract.started_at.to_date,
+            effective_date:,
             billing_anchor_date: contract.effective_billing_anchor_date,
             next_billing_at: contract.started_at
           )
@@ -38,5 +38,12 @@ module Contracts
     private
 
     attr_reader :contract
+
+    # Customer-local day of the start instant: the engine interprets card
+    # dates in the customer's timezone, so a UTC truncation would attach the
+    # card one day early or late around the customer's midnight.
+    def effective_date
+      @effective_date ||= contract.started_at.in_time_zone(contract.customer.applicable_timezone).to_date
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,8 @@ en:
         missing_volume_ranges: missing_volume_ranges
         modification_not_allowed: modification_not_allowed
         must_be_after_active_rate: must_be_after_active_rate
+        must_be_after_effective_date: must_be_after_effective_date
+        must_be_after_started_at: must_be_after_started_at
         must_be_array: must_be_array
         must_be_greater_than_or_equal_min: must_be_greater_than_or_equal_min
         must_be_greater_than_or_equal_threshold: must_be_greater_than_or_equal_threshold

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,9 @@ Rails.application.routes.draw do
         end
         draw(:plan_nested_api)
       end
+      # The constraint mirrors v1: without it, an external id containing a
+      # dot is truncated at the format separator.
+      resources :contracts, only: %i[index show create], param: :external_id, constraints: {external_id: /[^\/]+/}
     end
 
     namespace :v2, module: :v1 do

--- a/db/migrate/20260902143604_add_live_external_id_index_to_contracts.rb
+++ b/db/migrate/20260902143604_add_live_external_id_index_to_contracts.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddLiveExternalIdIndexToContracts < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    # One live agreement per external id, per status: the create service's
+    # check is only advisory under concurrency, this closes the race. Unique
+    # per status on purpose — replacement flows need one pending and one
+    # active to coexist, never two of either.
+    add_index :contracts, %i[organization_id external_id status],
+      unique: true,
+      where: "status IN ('pending', 'active')",
+      name: "index_contracts_on_live_external_id",
+      algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -836,6 +836,7 @@ DROP INDEX IF EXISTS public.index_coupon_targets_on_billable_metric_id;
 DROP INDEX IF EXISTS public.index_contracts_on_plan_id;
 DROP INDEX IF EXISTS public.index_contracts_on_organization_id_and_external_id;
 DROP INDEX IF EXISTS public.index_contracts_on_organization_id;
+DROP INDEX IF EXISTS public.index_contracts_on_live_external_id;
 DROP INDEX IF EXISTS public.index_contracts_on_customer_id;
 DROP INDEX IF EXISTS public.index_contract_rate_cards_on_rate_card_id;
 DROP INDEX IF EXISTS public.index_contract_rate_cards_on_organization_id;
@@ -8388,6 +8389,13 @@ CREATE INDEX index_contracts_on_customer_id ON public.contracts USING btree (cus
 
 
 --
+-- Name: index_contracts_on_live_external_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_contracts_on_live_external_id ON public.contracts USING btree (organization_id, external_id, status) WHERE (status = ANY (ARRAY['pending'::public.contract_status, 'active'::public.contract_status]));
+
+
+--
 -- Name: index_contracts_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -14437,6 +14445,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260902143604'),
 ('20260826235314'),
 ('20260826235313'),
 ('20260826235312'),

--- a/spec/models/contract_rate_card_spec.rb
+++ b/spec/models/contract_rate_card_spec.rb
@@ -26,6 +26,32 @@ RSpec.describe ContractRateCard do
 
         expect(described_class.current_and_scheduled).to contain_exactly(open_card, ending_today)
       end
+
+      it "cuts off on the customer's day, not the application's" do
+        travel_to(Time.zone.parse("2026-10-01T02:00:00Z")) do
+          la_customer = create(:customer, timezone: "America/Los_Angeles")
+          la_contract = create(:contract, organization: la_customer.organization, customer: la_customer)
+          still_current = create(
+            :contract_rate_card,
+            organization: la_customer.organization,
+            contract: la_contract,
+            effective_date: Date.new(2026, 9, 1),
+            ended_date: Date.new(2026, 9, 30)
+          )
+
+          utc_customer = create(:customer, timezone: "UTC")
+          utc_contract = create(:contract, organization: utc_customer.organization, customer: utc_customer)
+          create(
+            :contract_rate_card,
+            organization: utc_customer.organization,
+            contract: utc_contract,
+            effective_date: Date.new(2026, 9, 1),
+            ended_date: Date.new(2026, 9, 30)
+          )
+
+          expect(described_class.current_and_scheduled).to contain_exactly(still_current)
+        end
+      end
     end
   end
 

--- a/spec/models/contract_rate_card_spec.rb
+++ b/spec/models/contract_rate_card_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe ContractRateCard do
     end
   end
 
+  describe "Scopes" do
+    describe ".current_and_scheduled" do
+      it "keeps open and upcoming attachments, hides ended ones" do
+        open_card = create(:contract_rate_card)
+        ending_today = create(:contract_rate_card, effective_date: 10.days.ago.to_date, ended_date: Date.current)
+        create(:contract_rate_card, effective_date: 10.days.ago.to_date, ended_date: 1.day.ago.to_date)
+
+        expect(described_class.current_and_scheduled).to contain_exactly(open_card, ending_today)
+      end
+    end
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:billing_anchor_date) }
     it { is_expected.to validate_presence_of(:next_billing_at) }

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -50,6 +50,27 @@ RSpec.describe Contract do
       expect(contract).not_to be_valid
       expect(contract.errors.where(:ended_at, :must_be_after_started_at)).to be_present
     end
+
+    describe "live external id uniqueness (database)" do
+      it "allows one pending and one active but never two of either" do
+        organization = create(:organization)
+        customer = create(:customer, organization:)
+        create(:contract, organization:, customer:, external_id: "c-1")
+        create(:contract, :pending, organization:, customer:, external_id: "c-1")
+
+        expect { create(:contract, organization:, customer:, external_id: "c-1") }
+          .to raise_error(ActiveRecord::RecordNotUnique)
+      end
+
+      it "does not constrain finished contracts" do
+        organization = create(:organization)
+        customer = create(:customer, organization:)
+        create(:contract, :terminated, organization:, customer:, external_id: "c-1")
+        create(:contract, :terminated, organization:, customer:, external_id: "c-1")
+
+        expect { create(:contract, organization:, customer:, external_id: "c-1") }.not_to raise_error
+      end
+    end
   end
 
   describe "#effective_billing_anchor_date" do

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -87,5 +87,18 @@ RSpec.describe Contract do
       upcoming = build(:contract, :pending, billing_anchor_date: nil, started_at: Time.zone.parse("2026-03-01"))
       expect(upcoming.effective_billing_anchor_date).to eq(Date.new(2026, 3, 1))
     end
+
+    it "derives the fallback in the customer's timezone" do
+      customer = create(:customer, timezone: "America/Los_Angeles")
+      contract = build(
+        :contract,
+        customer:,
+        organization: customer.organization,
+        billing_anchor_date: nil,
+        started_at: Time.zone.parse("2026-10-01T02:00:00Z")
+      )
+
+      expect(contract.effective_billing_anchor_date).to eq(Date.new(2026, 9, 30))
+    end
   end
 end

--- a/spec/queries/contracts_query_spec.rb
+++ b/spec/queries/contracts_query_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ContractsQuery do
+  subject(:result) { described_class.call(organization:, pagination: nil, filters:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, :product_catalog, organization:) }
+  let(:filters) { {} }
+
+  let!(:contract) { create(:contract, organization:, customer:, plan:) }
+  let!(:other_contract) { create(:contract, organization:) }
+
+  before { create(:contract) }
+
+  it "returns the organization's contracts only" do
+    expect(result.contracts).to contain_exactly(contract, other_contract)
+  end
+
+  context "when filtering by external_customer_id" do
+    let(:filters) { {external_customer_id: customer.external_id} }
+
+    it "returns the customer's contracts" do
+      expect(result.contracts).to contain_exactly(contract)
+    end
+  end
+
+  context "when filtering by plan_code" do
+    let(:filters) { {plan_code: plan.code} }
+
+    it "returns the plan's contracts" do
+      expect(result.contracts).to contain_exactly(contract)
+    end
+  end
+
+  context "when filtering by external_id" do
+    let(:filters) { {external_id: contract.external_id} }
+
+    it "returns the matching contracts" do
+      expect(result.contracts).to contain_exactly(contract)
+    end
+  end
+
+  context "when filtering by status" do
+    let(:filters) { {status: ["pending"]} }
+    let!(:pending_contract) { create(:contract, :pending, organization:) }
+
+    before { create(:contract, :terminated, organization:) }
+
+    it "returns the matching contracts" do
+      expect(result.contracts).to contain_exactly(pending_contract)
+    end
+  end
+
+  context "when filtering by an unknown status" do
+    let(:filters) { {status: ["bogus"]} }
+
+    it "matches nothing instead of raising on the enum cast" do
+      expect(result.contracts).to be_empty
+    end
+  end
+end

--- a/spec/requests/api/v2/contracts_controller_spec.rb
+++ b/spec/requests/api/v2/contracts_controller_spec.rb
@@ -102,6 +102,12 @@ RSpec.describe Api::V2::ContractsController do
 
         expect(json[:contracts].map { |c| c[:lago_id] }).to eq([pending_contract.id])
       end
+
+      it "accepts the scalar status form" do
+        get_with_token(organization, "/api/v2/contracts?status=pending")
+
+        expect(json[:contracts].map { |c| c[:lago_id] }).to eq([pending_contract.id])
+      end
     end
   end
 

--- a/spec/requests/api/v2/contracts_controller_spec.rb
+++ b/spec/requests/api/v2/contracts_controller_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V2::ContractsController do
+  let(:organization) { create(:organization, feature_flags: ["product_catalog"]) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, :product_catalog, organization:) }
+
+  describe "POST /api/v2/contracts" do
+    subject { post_with_token(organization, "/api/v2/contracts", {contract: create_params}) }
+
+    let(:create_params) do
+      {
+        external_customer_id: customer.external_id,
+        external_id: "contract-1",
+        plan_code: plan.code
+      }
+    end
+
+    include_examples "requires API permission", "contract", "write"
+
+    it "creates the contract and returns it with its materialized rate cards" do
+      rate_card = create(:rate_card, organization:)
+      create(:plan_rate_card, organization:, plan:, rate_card:, units: 2)
+
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:contract][:external_id]).to eq("contract-1")
+      expect(json[:contract][:plan_code]).to eq(plan.code)
+      expect(json[:contract][:status]).to eq("active")
+      expect(json[:contract][:applied_rate_cards_count]).to eq(1)
+      expect(json[:contract][:applied_rate_cards].sole[:rate_card_code]).to eq(rate_card.code)
+    end
+
+    context "without a plan" do
+      let(:create_params) { {external_customer_id: customer.external_id, external_id: "contract-1"} }
+
+      it "creates a plan-less contract" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:contract][:plan_code]).to be_nil
+        expect(json[:contract][:applied_rate_cards]).to be_empty
+      end
+    end
+
+    context "when the customer does not exist" do
+      let(:create_params) { super().merge(external_customer_id: "unknown") }
+
+      it "returns a not found error" do
+        subject
+
+        expect(response).to be_not_found_error("customer")
+      end
+    end
+
+    context "when a live contract already uses the external id" do
+      before { create(:contract, organization:, customer:, external_id: "contract-1") }
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json.dig(:error_details, :external_id)).to eq(["value_already_exists"])
+      end
+    end
+  end
+
+  describe "GET /api/v2/contracts" do
+    subject { get_with_token(organization, "/api/v2/contracts") }
+
+    let!(:contract) { create(:contract, organization:, customer:, plan:) }
+
+    include_examples "requires API permission", "contract", "read"
+
+    it "lists active contracts with their card counts" do
+      create(:contract_rate_card, organization:, contract:)
+      # An ended attachment must not inflate the grouped count.
+      create(:contract_rate_card, organization:, contract:, effective_date: 10.days.ago.to_date, ended_date: 1.day.ago.to_date)
+
+      subject
+
+      expect(response).to have_http_status(:success)
+      result = json[:contracts].sole
+      expect(result[:lago_id]).to eq(contract.id)
+      expect(result[:applied_rate_cards_count]).to eq(1)
+    end
+
+    context "with a pending contract" do
+      let!(:pending_contract) { create(:contract, :pending, organization:, customer:) }
+
+      it "lists only active contracts by default" do
+        subject
+
+        expect(json[:contracts].map { |c| c[:lago_id] }).to eq([contract.id])
+      end
+
+      it "lists pending contracts when the status filter asks for them" do
+        get_with_token(organization, "/api/v2/contracts?status[]=pending")
+
+        expect(json[:contracts].map { |c| c[:lago_id] }).to eq([pending_contract.id])
+      end
+    end
+  end
+
+  describe "GET /api/v2/contracts/:external_id" do
+    subject { get_with_token(organization, "/api/v2/contracts/#{contract.external_id}") }
+
+    let!(:contract) { create(:contract, organization:, customer:, plan:) }
+
+    include_examples "requires API permission", "contract", "read"
+
+    it "returns the contract with its rate cards" do
+      card = create(:contract_rate_card, organization:, contract:)
+
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:contract][:lago_id]).to eq(contract.id)
+      expect(json[:contract][:applied_rate_cards].sole[:lago_id]).to eq(card.id)
+    end
+
+    context "when the external id contains a dot" do
+      let(:contract) { create(:contract, organization:, customer:, external_id: "contract.2026-01") }
+
+      it "matches the full id instead of truncating at the format separator" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:contract][:external_id]).to eq("contract.2026-01")
+      end
+    end
+
+    context "with an unknown status filter value" do
+      it "falls back to the active contract instead of raising on the enum cast" do
+        get_with_token(organization, "/api/v2/contracts/#{contract.external_id}?status=bogus")
+
+        expect(response).to have_http_status(:success)
+        expect(json[:contract][:lago_id]).to eq(contract.id)
+      end
+    end
+
+    context "when it does not exist" do
+      subject { get_with_token(organization, "/api/v2/contracts/unknown") }
+
+      it "returns a not found error" do
+        subject
+
+        expect(response).to be_not_found_error("contract")
+      end
+    end
+  end
+end

--- a/spec/services/contracts/create_service_spec.rb
+++ b/spec/services/contracts/create_service_spec.rb
@@ -74,6 +74,21 @@ RSpec.describe Contracts::CreateService do
     end
   end
 
+  context "with naive datetimes and a customer timezone" do
+    let(:customer) { create(:customer, organization:, timezone: "America/Los_Angeles") }
+    let(:params) { super().merge(started_at: "2026-10-01T00:00:00", ended_at: "2027-10-01T00:00:00") }
+
+    it "reads the customer's wall clock, not the application's" do
+      rate_card = create(:rate_card, organization:)
+      create(:plan_rate_card, organization:, plan:, rate_card:)
+
+      contract = result.contract
+      expect(contract.started_at).to eq(Time.zone.parse("2026-10-01T07:00:00Z"))
+      expect(contract.ended_at).to eq(Time.zone.parse("2027-10-01T07:00:00Z"))
+      expect(contract.applied_rate_cards.sole.effective_date).to eq(Date.new(2026, 10, 1))
+    end
+  end
+
   context "with a malformed date" do
     let(:params) { super().merge(billing_anchor_date: "hello") }
 

--- a/spec/services/contracts/create_service_spec.rb
+++ b/spec/services/contracts/create_service_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::CreateService do
+  subject(:result) { described_class.call(organization:, params:) }
+
+  let(:organization) { create(:organization, feature_flags: ["product_catalog"]) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, :product_catalog, organization:) }
+
+  let(:params) do
+    {
+      external_customer_id: customer.external_id,
+      external_id: "contract-1",
+      plan_code: plan.code
+    }
+  end
+
+  it "creates an active contract on the plan and materializes its rate cards" do
+    rate_card = create(:rate_card, organization:)
+    create(:plan_rate_card, organization:, plan:, rate_card:, units: 5)
+
+    expect { result }.to change(Contract, :count).by(1).and change(ContractRateCard, :count).by(1)
+
+    contract = result.contract
+    expect(contract).to have_attributes(
+      customer:,
+      plan:,
+      external_id: "contract-1",
+      status: "active",
+      billing_time: "calendar"
+    )
+    expect(contract.started_at).to be_within(5.seconds).of(Time.current)
+    expect(contract.applied_rate_cards.sole).to have_attributes(rate_card:, units: 5)
+  end
+
+  context "without a plan" do
+    let(:params) { {external_customer_id: customer.external_id, external_id: "contract-1"} }
+
+    it "creates a plan-less contract with no rate cards" do
+      expect { result }.to change(Contract, :count).by(1)
+
+      expect(result.contract.plan).to be_nil
+      expect(result.contract.applied_rate_cards).to be_empty
+    end
+  end
+
+  context "when the contract starts in the future" do
+    let(:params) { super().merge(started_at: 1.month.from_now.iso8601) }
+
+    it "creates a pending contract" do
+      expect(result).to be_success
+      expect(result.contract.status).to eq("pending")
+      expect(result.contract.started_at).to be_within(5.seconds).of(1.month.from_now)
+    end
+  end
+
+  context "with explicit dates" do
+    let(:params) do
+      super().merge(
+        started_at: "2026-10-01T00:00:00Z",
+        ended_at: "2027-09-30T23:59:59Z",
+        billing_anchor_date: "2026-10-15"
+      )
+    end
+
+    it "stores the validity window and the anchor" do
+      contract = result.contract
+
+      expect(contract.started_at).to eq(Time.zone.parse("2026-10-01"))
+      expect(contract.ended_at).to eq(Time.zone.parse("2027-09-30T23:59:59Z"))
+      expect(contract.billing_anchor_date).to eq(Date.new(2026, 10, 15))
+    end
+  end
+
+  context "with a malformed date" do
+    let(:params) { super().merge(billing_anchor_date: "hello") }
+
+    it "returns a validation failure instead of silently dropping it" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:billing_anchor_date]).to eq(["value_is_invalid"])
+    end
+  end
+
+  context "when ended_at is before started_at" do
+    let(:params) { super().merge(started_at: "2026-10-01T00:00:00Z", ended_at: "2026-09-01T00:00:00Z") }
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:ended_at]).to eq(["must_be_after_started_at"])
+    end
+  end
+
+  context "when the customer does not exist" do
+    let(:params) { super().merge(external_customer_id: "unknown") }
+
+    it "returns a not found failure" do
+      expect(result).not_to be_success
+      expect(result.error.resource).to eq("customer")
+    end
+  end
+
+  context "when the plan does not exist" do
+    let(:params) { super().merge(plan_code: "unknown") }
+
+    it "returns a not found failure" do
+      expect(result).not_to be_success
+      expect(result.error.resource).to eq("plan")
+    end
+  end
+
+  context "when the plan is a legacy plan" do
+    let(:plan) { create(:plan, organization:) }
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:plan]).to eq(["not_a_product_catalog_plan"])
+    end
+  end
+
+  context "when a live contract already uses the external id" do
+    before { create(:contract, organization:, customer:, external_id: "contract-1") }
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:external_id]).to eq(["value_already_exists"])
+    end
+  end
+
+  context "when a terminated contract used the external id" do
+    before { create(:contract, :terminated, organization:, customer:, external_id: "contract-1") }
+
+    it "creates the new contract" do
+      expect(result).to be_success
+    end
+  end
+
+  context "with an invalid billing_time" do
+    let(:params) { super().merge(billing_time: "weekly") }
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:billing_time]).to be_present
+    end
+  end
+
+  context "without an external_id" do
+    let(:params) { super().merge(external_id: nil) }
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:external_id]).to be_present
+    end
+  end
+end

--- a/spec/services/contracts/create_service_spec.rb
+++ b/spec/services/contracts/create_service_spec.rb
@@ -84,11 +84,20 @@ RSpec.describe Contracts::CreateService do
   end
 
   context "when ended_at is before started_at" do
-    let(:params) { super().merge(started_at: "2026-10-01T00:00:00Z", ended_at: "2026-09-01T00:00:00Z") }
+    let(:params) { super().merge(started_at: 2.months.from_now.iso8601, ended_at: 1.month.from_now.iso8601) }
 
     it "returns a validation failure" do
       expect(result).not_to be_success
       expect(result.error.messages[:ended_at]).to eq(["must_be_after_started_at"])
+    end
+  end
+
+  context "when the window already closed" do
+    let(:params) { super().merge(started_at: 2.months.ago.iso8601, ended_at: 1.month.ago.iso8601) }
+
+    it "rejects the already-ended contract" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:ended_at]).to eq(["already_ended"])
     end
   end
 

--- a/spec/services/contracts/materialize_rate_cards_service_spec.rb
+++ b/spec/services/contracts/materialize_rate_cards_service_spec.rb
@@ -46,6 +46,19 @@ RSpec.describe Contracts::MaterializeRateCardsService do
     end
   end
 
+  context "when the customer's day differs from UTC at the start instant" do
+    let(:customer) { create(:customer, organization:, timezone: "America/Los_Angeles") }
+    let(:contract) { create(:contract, organization:, customer:, plan:, started_at: Time.zone.parse("2026-10-01T02:00:00Z")) }
+
+    it "materializes on the customer-local day" do
+      result
+
+      card = contract.reload.applied_rate_cards.sole
+      expect(card.effective_date).to eq(Date.new(2026, 9, 30))
+      expect(card.billing_anchor_date).to eq(Date.new(2026, 9, 30))
+    end
+  end
+
   it "does not copy the plan entry's phases: pricing resolves by reference" do
     plan_rate_card = plan.applied_rate_cards.sole
     create(:rate_phase, organization:, plan_rate_card:, position: 1)

--- a/spec/services/contracts/materialize_rate_cards_service_spec.rb
+++ b/spec/services/contracts/materialize_rate_cards_service_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::MaterializeRateCardsService do
+  subject(:result) { described_class.call(contract:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, :product_catalog, organization:) }
+  let(:contract) { create(:contract, organization:, customer:, plan:, started_at: Time.zone.parse("2026-10-01")) }
+
+  let(:rate_card) { create(:rate_card, organization:) }
+
+  before do
+    create(:plan_rate_card, organization:, plan:, rate_card:, units: 5)
+  end
+
+  it "materializes one contract rate card per plan rate card" do
+    expect { result }.to change(ContractRateCard, :count).by(1)
+
+    card = contract.reload.applied_rate_cards.sole
+    expect(card).to have_attributes(rate_card:, units: 5)
+    expect(card.effective_date).to eq(Date.new(2026, 10, 1))
+    expect(card.billing_anchor_date).to eq(Date.new(2026, 10, 1))
+    expect(card.next_billing_at).to eq(contract.started_at)
+    expect(result.contract_rate_cards).to eq([card])
+  end
+
+  context "when the contract carries its own billing anchor" do
+    let(:contract) do
+      create(
+        :contract,
+        organization:,
+        customer:,
+        plan:,
+        started_at: Time.zone.parse("2026-10-15"),
+        billing_anchor_date: Date.new(2026, 10, 1)
+      )
+    end
+
+    it "materializes cards on the contract's anchor, not its start date" do
+      result
+
+      expect(contract.reload.applied_rate_cards.sole.billing_anchor_date).to eq(Date.new(2026, 10, 1))
+    end
+  end
+
+  it "does not copy the plan entry's phases: pricing resolves by reference" do
+    plan_rate_card = plan.applied_rate_cards.sole
+    create(:rate_phase, organization:, plan_rate_card:, position: 1)
+
+    expect { result }.not_to change(RatePhase, :count)
+    expect(contract.reload.applied_rate_cards.sole.rate_phases).to be_empty
+  end
+
+  context "when the contract has no plan" do
+    let(:contract) { create(:contract, organization:, customer:, plan: nil) }
+
+    it "materializes nothing" do
+      expect { result }.not_to change(ContractRateCard, :count)
+      expect(result.contract_rate_cards).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Context

First runtime slice on the dedicated contracts storage (#6235): the catalog API records agreements as contracts instead of falling through to the legacy subscription flow. The applied-rate-card attach endpoints ship separately (coordinating with the units-versioning work).

## Description

- `POST /api/v2/contracts` creates the agreement: optional plan (a plan-less contract prices through directly attached cards), catalog plans only (`not_a_product_catalog_plan`), date validations, pending when the start is in the future, and **one live agreement per external id** — a duplicate among pending/active is rejected with `value_already_exists`; replacement flows will create their pending sibling explicitly when they exist.
- Creating a contract on a plan materializes one `contract_rate_card` per plan card (anchor, clock, units); pricing resolves by reference — phases are not copied.
- `GET /api/v2/contracts` and `/:external_id` serve the v2 shape with current and scheduled cards: grouped card counts on index (no per-row COUNT), status filters guarded against unknown PG-enum values, and external ids may contain dots (same constraint as v1).
- `contract` joins the ApiKey permission resources; missing locale entries for the contract window validations (`must_be_after_started_at`, `must_be_after_effective_date`) are added — they returned "Translation missing" before.