### PR TITLE
feat(taxes): use product mappings for tax providers

### DIFF
--- a/app/graphql/mutations/integrations/fetch_draft_invoice_taxes.rb
+++ b/app/graphql/mutations/integrations/fetch_draft_invoice_taxes.rb
@@ -45,6 +45,8 @@ module Mutations
 
         def charge? = false
 
+        def product? = false
+
         def fixed_charge? = false
 
         def commitment? = false

--- a/app/services/integrations/aggregator/base_payload.rb
+++ b/app/services/integrations/aggregator/base_payload.rb
@@ -30,6 +30,10 @@ module Integrations
         lookup_mapping("AddOn", fee.fixed_charge_add_on.id)
       end
 
+      def product_item(fee)
+        lookup_mapping("Product", fee.invoiceable_id)
+      end
+
       def account_item
         lookup_collection_mapping(:account)
       end

--- a/app/services/integrations/aggregator/taxes/credit_notes/payloads/anrok.rb
+++ b/app/services/integrations/aggregator/taxes/credit_notes/payloads/anrok.rb
@@ -41,7 +41,9 @@ module Integrations
             def cn_item(item)
               fee = item.fee
 
-              mapped_item = if fee.charge?
+              mapped_item = if fee.product?
+                product_item(fee)
+              elsif fee.charge?
                 billable_metric_item(fee)
               elsif fee.add_on_id.present?
                 add_on_item(fee)

--- a/app/services/integrations/aggregator/taxes/credit_notes/payloads/avalara.rb
+++ b/app/services/integrations/aggregator/taxes/credit_notes/payloads/avalara.rb
@@ -50,7 +50,9 @@ module Integrations
             def cn_item(item)
               fee = item.fee
 
-              mapped_item = if fee.charge?
+              mapped_item = if fee.product?
+                product_item(fee)
+              elsif fee.charge?
                 billable_metric_item(fee)
               elsif fee.add_on_id.present?
                 add_on_item(fee)

--- a/app/services/integrations/aggregator/taxes/invoices/payloads/anrok.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/payloads/anrok.rb
@@ -39,7 +39,9 @@ module Integrations
             end
 
             def fee_item(fee)
-              mapped_item = if fee.charge?
+              mapped_item = if fee.product?
+                product_item(fee)
+              elsif fee.charge?
                 billable_metric_item(fee)
               elsif fee.add_on_id.present?
                 add_on_item(fee)

--- a/app/services/integrations/aggregator/taxes/invoices/payloads/avalara.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/payloads/avalara.rb
@@ -46,7 +46,9 @@ module Integrations
             end
 
             def fee_item(fee)
-              mapped_item = if fee.charge?
+              mapped_item = if fee.product?
+                product_item(fee)
+              elsif fee.charge?
                 billable_metric_item(fee)
               elsif fee.add_on_id.present?
                 add_on_item(fee)

--- a/spec/services/integrations/aggregator/base_payload_spec.rb
+++ b/spec/services/integrations/aggregator/base_payload_spec.rb
@@ -9,33 +9,44 @@ RSpec.describe Integrations::Aggregator::BasePayload do
   let(:billing_entity) { create(:billing_entity, organization:) }
   let(:integration) { create(:anrok_integration, organization:) }
   let(:product) { create(:product, organization:) }
+  let(:fee) { instance_double(Fee, invoiceable_id: product.id) }
 
   describe "Product mapping lookup" do
-    let!(:fallback_mapping) do
-      create(
+    it "returns the Billing Entity Product mapping" do
+      create(:anrok_mapping, integration:, organization:, mappable: product)
+      product_mapping = create(:anrok_mapping, integration:, organization:, billing_entity:, mappable: product)
+
+      expect(payload.product_item(fee)).to eq(product_mapping)
+    end
+
+    it "returns the organization Product mapping when no Billing Entity mapping exists" do
+      product_mapping = create(:anrok_mapping, integration:, organization:, mappable: product)
+
+      expect(payload.product_item(fee)).to eq(product_mapping)
+    end
+
+    it "returns the Billing Entity fallback when the Product has no mapping" do
+      create(:anrok_collection_mapping, integration:, organization:, mapping_type: :fallback_item)
+      fallback_mapping = create(
+        :anrok_collection_mapping,
+        integration:,
+        organization:,
+        billing_entity:,
+        mapping_type: :fallback_item
+      )
+
+      expect(payload.product_item(fee)).to eq(fallback_mapping)
+    end
+
+    it "returns the organization fallback when no Product or Billing Entity mapping exists" do
+      fallback_mapping = create(
         :anrok_collection_mapping,
         integration:,
         organization:,
         mapping_type: :fallback_item
       )
-    end
 
-    it "returns the integration fallback when the Product has no mapping" do
-      mapping = payload.send(:lookup_mapping, "Product", product.id)
-
-      expect(mapping).to eq(fallback_mapping)
-    end
-
-    context "when the Product has a mapping" do
-      let!(:product_mapping) do
-        create(:anrok_mapping, integration:, organization:, mappable: product)
-      end
-
-      it "returns the Product mapping" do
-        mapping = payload.send(:lookup_mapping, "Product", product.id)
-
-        expect(mapping).to eq(product_mapping)
-      end
+      expect(payload.product_item(fee)).to eq(fallback_mapping)
     end
   end
 end

--- a/spec/services/integrations/aggregator/taxes/credit_notes/payloads/anrok_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/credit_notes/payloads/anrok_spec.rb
@@ -56,6 +56,45 @@ RSpec.describe Integrations::Aggregator::Taxes::CreditNotes::Payloads::Anrok do
       end
     end
 
+    context "with a Product fee" do
+      subject(:fee_payload) do
+        described_class.new(integration:, customer:, integration_customer:, credit_note:).body.sole["fees"].sole
+      end
+
+      let(:organization) { create(:organization) }
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:integration) { create(:anrok_integration, organization:) }
+      let(:customer) { create(:customer, organization:, billing_entity:) }
+      let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+      let(:invoice) { create(:invoice, organization:, billing_entity:, customer:) }
+      let(:subscription) { create(:subscription, organization:, customer:) }
+      let(:product) { create(:product, organization:) }
+      let(:rate_card) { create(:rate_card, organization:, product:) }
+      let(:rate) { create(:rate_card_rate, organization:, rate_card:) }
+      let(:fee) { create(:product_fee, invoice:, subscription:, rate_card_rate: rate, units: 2, amount_cents: 250) }
+      let(:credit_note) { create(:credit_note, organization:, customer:, invoice:) }
+
+      before do
+        create(:credit_note_item, credit_note:, fee:, amount_cents: 190)
+        create(
+          :anrok_mapping,
+          integration:,
+          organization:,
+          billing_entity:,
+          mappable: product,
+          settings: {external_id: "product-code"}
+        )
+      end
+
+      it "uses the Product mapping" do
+        expect(fee_payload).to eq(
+          "item_id" => fee.item_id,
+          "item_code" => "product-code",
+          "amount_cents" => -190
+        )
+      end
+    end
+
     context "with precision edge case" do
       let(:integration) { create(:anrok_integration) }
       let(:customer) { create(:customer, organization: integration.organization) }

--- a/spec/services/integrations/aggregator/taxes/credit_notes/payloads/avalara_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/credit_notes/payloads/avalara_spec.rb
@@ -146,4 +146,44 @@ RSpec.describe Integrations::Aggregator::Taxes::CreditNotes::Payloads::Avalara d
       ]
     end
   end
+
+  context "with a Product fee" do
+    subject(:fee_payload) do
+      described_class.new(integration:, customer:, integration_customer:, credit_note:).body.sole["fees"].sole
+    end
+
+    let(:organization) { create(:organization) }
+    let(:billing_entity) { create(:billing_entity, organization:) }
+    let(:integration) { create(:avalara_integration, organization:) }
+    let(:customer) { create(:customer, organization:, billing_entity:) }
+    let(:integration_customer) { create(:avalara_customer, integration:, customer:) }
+    let(:invoice) { create(:invoice, organization:, billing_entity:, customer:) }
+    let(:subscription) { create(:subscription, organization:, customer:) }
+    let(:product) { create(:product, :fixed, organization:) }
+    let(:rate_card) { create(:rate_card, organization:, product:) }
+    let(:rate) { create(:rate_card_rate, organization:, rate_card:) }
+    let(:fee) { create(:product_fee, invoice:, subscription:, rate_card_rate: rate, units: 2, amount_cents: 250) }
+    let(:credit_note) { create(:credit_note, organization:, customer:, invoice:) }
+
+    before do
+      create(:credit_note_item, credit_note:, fee:, amount_cents: 190)
+      create(
+        :avalara_mapping,
+        integration:,
+        organization:,
+        billing_entity:,
+        mappable: product,
+        settings: {external_id: "product-code"}
+      )
+    end
+
+    it "uses the Product mapping" do
+      expect(fee_payload).to eq(
+        "item_id" => fee.item_id,
+        "item_code" => "product-code",
+        "unit" => 2.0,
+        "amount" => "-1.9"
+      )
+    end
+  end
 end

--- a/spec/services/integrations/aggregator/taxes/invoices/payloads/anrok_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/payloads/anrok_spec.rb
@@ -67,6 +67,70 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::Payloads::Anrok do
       end
     end
 
+    context "with Product fees" do
+      subject(:fees_payload) do
+        described_class.new(integration:, customer:, invoice:, integration_customer:, fees:).body.sole["fees"]
+      end
+
+      let(:organization) { create(:organization) }
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:integration) { create(:anrok_integration, organization:) }
+      let(:customer) { create(:customer, organization:, billing_entity:) }
+      let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+      let(:invoice) { create(:invoice, organization:, billing_entity:, customer:) }
+      let(:subscription) { create(:subscription, organization:, customer:) }
+      let(:fixed_product) { create(:product, :fixed, organization:) }
+      let(:usage_product) { create(:product, organization:) }
+      let(:fixed_rate_card) { create(:rate_card, organization:, product: fixed_product) }
+      let(:usage_rate_card) { create(:rate_card, organization:, product: usage_product) }
+      let(:fixed_rate) { create(:rate_card_rate, organization:, rate_card: fixed_rate_card) }
+      let(:usage_rate) { create(:rate_card_rate, organization:, rate_card: usage_rate_card) }
+      let(:fixed_fee) do
+        create(:product_fee, invoice:, subscription:, rate_card_rate: fixed_rate, units: 2, amount_cents: 250)
+      end
+      let(:usage_fee) do
+        create(:product_fee, invoice:, subscription:, rate_card_rate: usage_rate, units: 3, amount_cents: 375)
+      end
+      let(:fees) { [fixed_fee, usage_fee] }
+
+      before do
+        create(
+          :anrok_mapping,
+          integration:,
+          organization:,
+          billing_entity:,
+          mappable: fixed_product,
+          settings: {external_id: "fixed-product"}
+        )
+        create(
+          :anrok_mapping,
+          integration:,
+          organization:,
+          mappable: usage_product,
+          settings: {external_id: "usage-product"}
+        )
+      end
+
+      it "uses Product mappings for fixed and usage fees" do
+        expect(fees_payload).to match_array(
+          [
+            {
+              "item_key" => fixed_fee.item_key,
+              "item_id" => fixed_fee.id,
+              "item_code" => "fixed-product",
+              "amount_cents" => 250
+            },
+            {
+              "item_key" => usage_fee.item_key,
+              "item_id" => usage_fee.id,
+              "item_code" => "usage-product",
+              "amount_cents" => 375
+            }
+          ]
+        )
+      end
+    end
+
     describe "shipping address fallback" do
       let(:integration) { create(:anrok_integration) }
       let(:customer) do

--- a/spec/services/integrations/aggregator/taxes/invoices/payloads/avalara_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/payloads/avalara_spec.rb
@@ -80,6 +80,72 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::Payloads::Avalara do
       end
     end
 
+    context "with Product fees" do
+      subject(:fees_payload) do
+        described_class.new(integration:, customer:, invoice:, integration_customer:, fees:).body.sole["fees"]
+      end
+
+      let(:organization) { create(:organization) }
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:integration) { create(:avalara_integration, organization:) }
+      let(:customer) { create(:customer, organization:, billing_entity:) }
+      let(:integration_customer) { create(:avalara_customer, integration:, customer:) }
+      let(:invoice) { create(:invoice, organization:, billing_entity:, customer:) }
+      let(:subscription) { create(:subscription, organization:, customer:) }
+      let(:fixed_product) { create(:product, :fixed, organization:) }
+      let(:usage_product) { create(:product, organization:) }
+      let(:fixed_rate_card) { create(:rate_card, organization:, product: fixed_product) }
+      let(:usage_rate_card) { create(:rate_card, organization:, product: usage_product) }
+      let(:fixed_rate) { create(:rate_card_rate, organization:, rate_card: fixed_rate_card) }
+      let(:usage_rate) { create(:rate_card_rate, organization:, rate_card: usage_rate_card) }
+      let(:fixed_fee) do
+        create(:product_fee, invoice:, subscription:, rate_card_rate: fixed_rate, units: 2, amount_cents: 250)
+      end
+      let(:usage_fee) do
+        create(:product_fee, invoice:, subscription:, rate_card_rate: usage_rate, units: 3, amount_cents: 375)
+      end
+      let(:fees) { [fixed_fee, usage_fee] }
+
+      before do
+        create(
+          :avalara_mapping,
+          integration:,
+          organization:,
+          billing_entity:,
+          mappable: fixed_product,
+          settings: {external_id: "fixed-product"}
+        )
+        create(
+          :avalara_mapping,
+          integration:,
+          organization:,
+          mappable: usage_product,
+          settings: {external_id: "usage-product"}
+        )
+      end
+
+      it "uses Product mappings for fixed and usage fees" do
+        expect(fees_payload).to match_array(
+          [
+            {
+              "item_key" => fixed_fee.item_key,
+              "item_id" => fixed_fee.id,
+              "item_code" => "fixed-product",
+              "unit" => 2.0,
+              "amount" => "2.5"
+            },
+            {
+              "item_key" => usage_fee.item_key,
+              "item_id" => usage_fee.id,
+              "item_code" => "usage-product",
+              "unit" => 3.0,
+              "amount" => "3.75"
+            }
+          ]
+        )
+      end
+    end
+
     describe "shipping address fallback" do
       let(:integration) { create(:avalara_integration) }
       let(:customer) do

--- a/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
+++ b/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
@@ -239,6 +239,78 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService do
         expect(result.invoice.total_amount_cents).to eq(3_350)
       end
 
+      context "when the invoice contains Product fees" do
+        let(:fixed_product) { create(:product, :fixed, organization:) }
+        let(:usage_product) { create(:product, organization:) }
+        let(:fixed_rate_card) { create(:rate_card, organization:, product: fixed_product) }
+        let(:usage_rate_card) { create(:rate_card, organization:, product: usage_product) }
+        let(:fixed_rate) { create(:rate_card_rate, organization:, rate_card: fixed_rate_card) }
+        let(:usage_rate) { create(:rate_card_rate, organization:, rate_card: usage_rate_card) }
+        let(:local_tax) { create(:tax, organization:, rate: 42) }
+        let(:fixed_product_fee) do
+          create(
+            :product_fee,
+            invoice:,
+            subscription:,
+            rate_card_rate: fixed_rate,
+            amount_cents: 2_000,
+            precise_amount_cents: 2_000
+          )
+        end
+        let(:usage_product_fee) do
+          create(
+            :product_fee,
+            invoice:,
+            subscription:,
+            rate_card_rate: usage_rate,
+            amount_cents: 1_000,
+            precise_amount_cents: 1_000
+          )
+        end
+        let(:fee_subscription) { fixed_product_fee }
+        let(:fee_charge) { usage_product_fee }
+
+        before do
+          create(:rate_card_applied_tax, rate_card: fixed_rate_card, tax: local_tax, organization:)
+          create(:rate_card_applied_tax, rate_card: usage_rate_card, tax: local_tax, organization:)
+        end
+
+        it "applies provider taxes to the Product fees and finalizes the invoice" do
+          result = pull_taxes_service.call
+
+          expect(result).to be_success
+          expect(result.invoice).to be_finalized
+          expect(fixed_product_fee.reload.applied_taxes.sole).to have_attributes(
+            tax: nil,
+            tax_code: "gst_hst",
+            tax_rate: 10,
+            amount_cents: 200
+          )
+          expect(usage_product_fee.reload.applied_taxes.sole).to have_attributes(
+            tax: nil,
+            tax_code: "gst_hst",
+            tax_rate: 15,
+            amount_cents: 150
+          )
+          expect(result.invoice).to have_attributes(taxes_amount_cents: 350, total_amount_cents: 3_350)
+          expect(result.invoice.applied_taxes.count).to eq(2)
+        end
+
+        context "when the invoice is a draft" do
+          before { invoice.update!(status: :draft) }
+
+          it "applies provider taxes and keeps the invoice as a draft" do
+            result = pull_taxes_service.call
+
+            expect(result).to be_success
+            expect(result.invoice).to be_draft
+            expect(fixed_product_fee.reload.applied_taxes.sole.tax).to be_nil
+            expect(usage_product_fee.reload.applied_taxes.sole.tax).to be_nil
+            expect(result.invoice).to have_attributes(taxes_amount_cents: 350, total_amount_cents: 3_350)
+          end
+        end
+      end
+
       it_behaves_like "syncs invoice" do
         let(:service_call) { pull_taxes_service.call }
       end


### PR DESCRIPTION
## Context

_Part of the "products and plans" project._

Product fees did not include their Anrok or Avalara item code when sent to the tax provider.

## Description

- Add the item code to product fees sent for tax calculation.
- Support invoices and credit notes.
- Add tests for fixed and usage products.