### PR TITLE
feat(graphql): add the contract surface

### DIFF
--- a/app/graphql/mutations/contracts/create.rb
+++ b/app/graphql/mutations/contracts/create.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Contracts
+    class Create < BaseMutation
+      include RequiresProductCatalog
+      include AuthenticableApiUser
+      include RequiredOrganization
+
+      REQUIRED_PERMISSION = "contracts:create"
+
+      graphql_name "CreateContract"
+      description "Creates a new contract"
+
+      input_object_class Types::Contracts::CreateInput
+      type Types::Contracts::Object
+
+      def resolve(**args)
+        result = ::Contracts::CreateService.call(
+          organization: current_organization,
+          params: args
+        )
+
+        result.success? ? result.contract : result_error(result)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/contract_resolver.rb
+++ b/app/graphql/resolvers/contract_resolver.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class ContractResolver < Resolvers::BaseResolver
+    include RequiresProductCatalog
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    REQUIRED_PERMISSION = "contracts:view"
+
+    description "Query a single contract of an organization"
+
+    argument :id, ID, required: true, description: "Uniq ID of the contract"
+
+    type Types::Contracts::Object, null: true
+
+    def resolve(id: nil)
+      current_organization.contracts.find(id)
+    rescue ActiveRecord::RecordNotFound
+      not_found_error(resource: "contract")
+    end
+  end
+end

--- a/app/graphql/resolvers/contracts_resolver.rb
+++ b/app/graphql/resolvers/contracts_resolver.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class ContractsResolver < Resolvers::BaseResolver
+    include RequiresProductCatalog
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    REQUIRED_PERMISSION = "contracts:view"
+
+    description "Query contracts of an organization"
+
+    argument :external_customer_id, String, required: false
+    argument :external_id, String, required: false
+    argument :limit, Integer, required: false
+    argument :page, Integer, required: false
+    argument :plan_code, String, required: false
+    argument :status, [Types::Contracts::StatusEnum], required: false
+
+    type Types::Contracts::Object.collection_type, null: false
+
+    def resolve(page: nil, limit: nil, external_customer_id: nil, external_id: nil, plan_code: nil, status: nil)
+      result = ::ContractsQuery.call(
+        organization: current_organization,
+        pagination: {page:, limit:},
+        filters: {external_customer_id:, external_id:, plan_code:, status:}
+      )
+
+      result.contracts
+    end
+  end
+end

--- a/app/graphql/sources/contract_current_rate_cards.rb
+++ b/app/graphql/sources/contract_current_rate_cards.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Sources
+  # Batches a contract's current-and-scheduled applied rate cards across a
+  # collection: `contracts { appliedRateCards, appliedRateCardsCount }` runs
+  # one grouped query for the whole page instead of one per contract. Ended
+  # attachments stay excluded, matching the per-contract scope; both the list
+  # and the count field read the same loaded set.
+  #
+  #   dataloader.with(Sources::ContractCurrentRateCards).load(object.id)
+  class ContractCurrentRateCards < GraphQL::Dataloader::Source
+    def fetch(contract_ids)
+      by_contract = ContractRateCard
+        .current_and_scheduled
+        .where(contract_id: contract_ids)
+        .includes(:rate_card)
+        .order(:effective_date)
+        .group_by(&:contract_id)
+
+      contract_ids.map { by_contract.fetch(it, []) }
+    end
+  end
+end

--- a/app/graphql/types/contract_applied_rate_cards/object.rb
+++ b/app/graphql/types/contract_applied_rate_cards/object.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Types
+  module ContractAppliedRateCards
+    class Object < Types::BaseObject
+      graphql_name "ContractAppliedRateCard"
+      description "Rate card applied to a contract"
+
+      dataload_association :product, :rate_card
+
+      field :id, ID, null: false
+      field :units, GraphQL::Types::Float, null: true
+
+      field :product, Types::Products::Object, null: false
+      field :rate_card, Types::RateCards::Object, null: false
+
+      # The attachment's validity window, day-grained and end inclusive.
+      field :billing_anchor_date, GraphQL::Types::ISO8601Date, null: false
+      field :effective_date, GraphQL::Types::ISO8601Date, null: false
+      field :ended_date, GraphQL::Types::ISO8601Date, null: true
+      field :next_billing_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      field :rate_phases, [Types::RatePhases::Object], null: false
+      field :rate_phases_count, Integer, null: false
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      def rate_phases_count
+        dataloader.with(Sources::CountByForeignKey, RatePhase, :contract_rate_card_id).load(object.id)
+      end
+
+      def rate_phases
+        dataloader.with(Sources::ActiveRecordAssociation, :rate_phases).load(object).sort_by(&:position)
+      end
+    end
+  end
+end

--- a/app/graphql/types/contracts/billing_time_enum.rb
+++ b/app/graphql/types/contracts/billing_time_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module Contracts
+    class BillingTimeEnum < Types::BaseEnum
+      graphql_name "ContractBillingTimeEnum"
+
+      Contract::BILLING_TIMES.each_key do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/contracts/create_input.rb
+++ b/app/graphql/types/contracts/create_input.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Types
+  module Contracts
+    class CreateInput < BaseInputObject
+      graphql_name "CreateContractInput"
+      description "Create contract input arguments"
+
+      argument :external_customer_id, String, required: true
+      argument :external_id, String, required: true
+      argument :name, String, required: false
+      # Optional by design: a plan-less contract prices through directly
+      # attached rate cards.
+      argument :plan_code, String, required: false
+
+      argument :billing_anchor_date, GraphQL::Types::ISO8601Date, required: false
+      argument :billing_time, Types::Contracts::BillingTimeEnum, required: false
+      argument :ended_at, GraphQL::Types::ISO8601DateTime, required: false
+      argument :started_at, GraphQL::Types::ISO8601DateTime, required: false
+    end
+  end
+end

--- a/app/graphql/types/contracts/object.rb
+++ b/app/graphql/types/contracts/object.rb
@@ -34,13 +34,14 @@ module Types
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
       # Ended attachments are history, not cards the contract currently
-      # carries; only pay the scoped query when the field is requested.
+      # carries. Batched across the collection so a list of contracts does not
+      # fire one query per contract; both fields read the same loaded set.
       def applied_rate_cards
-        object.applied_rate_cards.current_and_scheduled.includes(:rate_card).order(:effective_date)
+        dataloader.with(Sources::ContractCurrentRateCards).load(object.id)
       end
 
       def applied_rate_cards_count
-        object.applied_rate_cards.current_and_scheduled.count
+        dataloader.with(Sources::ContractCurrentRateCards).load(object.id).size
       end
     end
   end

--- a/app/graphql/types/contracts/object.rb
+++ b/app/graphql/types/contracts/object.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Types
+  module Contracts
+    class Object < Types::BaseObject
+      graphql_name "Contract"
+      description "The agreement a customer signed: an optional plan, a validity window and the billing anchor"
+
+      dataload_association :customer, :plan
+
+      field :external_id, String, null: false
+      field :id, ID, null: false
+      field :name, String, null: true
+
+      field :billing_time, Types::Contracts::BillingTimeEnum, null: false
+      field :status, Types::Contracts::StatusEnum, null: false
+
+      field :billing_anchor_date, GraphQL::Types::ISO8601Date, null: true
+
+      field :canceled_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :ended_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :started_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :terminated_at, GraphQL::Types::ISO8601DateTime, null: true
+
+      field :customer, Types::Customers::Object, null: false
+      # Nullable by design: a plan-less contract prices through directly
+      # attached rate cards.
+      field :plan, Types::Plans::Object, null: true
+
+      field :applied_rate_cards, [Types::ContractAppliedRateCards::Object], null: false
+      field :applied_rate_cards_count, Integer, null: false
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      # Ended attachments are history, not cards the contract currently
+      # carries; only pay the scoped query when the field is requested.
+      def applied_rate_cards
+        object.applied_rate_cards.current_and_scheduled.includes(:rate_card).order(:effective_date)
+      end
+
+      def applied_rate_cards_count
+        object.applied_rate_cards.current_and_scheduled.count
+      end
+    end
+  end
+end

--- a/app/graphql/types/contracts/status_enum.rb
+++ b/app/graphql/types/contracts/status_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module Contracts
+    class StatusEnum < Types::BaseEnum
+      graphql_name "ContractStatusEnum"
+
+      Contract::STATUSES.each_key do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -35,6 +35,7 @@ module Types
     field :update_rate_phase, mutation: Mutations::RatePhases::Update
 
     field :create_charge, mutation: Mutations::Charges::Create
+    field :create_contract, mutation: Mutations::Contracts::Create
     field :destroy_charge, mutation: Mutations::Charges::Destroy
     field :update_charge, mutation: Mutations::Charges::Update
 

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -27,6 +27,8 @@ module Types
     field :billing_entities, resolver: Resolvers::BillingEntitiesResolver
     field :billing_entity, resolver: Resolvers::BillingEntityResolver
     field :billing_entity_taxes, resolver: Resolvers::BillingEntityTaxesResolver
+    field :contract, resolver: Resolvers::ContractResolver
+    field :contracts, resolver: Resolvers::ContractsResolver
     field :coupon, resolver: Resolvers::CouponResolver
     field :coupons, resolver: Resolvers::CouponsResolver
     field :credit_note, resolver: Resolvers::CreditNoteResolver

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -38,6 +38,9 @@ charges:
   create:
   update:
   delete:
+contracts:
+  view:
+  create:
 coupons:
   view:
     - finance

--- a/schema.graphql
+++ b/schema.graphql
@@ -1467,6 +1467,73 @@ enum CommitmentTypeEnum {
   minimum_commitment
 }
 
+"""
+The agreement a customer signed: an optional plan, a validity window and the billing anchor
+"""
+type Contract {
+  appliedRateCards: [ContractAppliedRateCard!]!
+  appliedRateCardsCount: Int!
+  billingAnchorDate: ISO8601Date
+  billingTime: ContractBillingTimeEnum!
+  canceledAt: ISO8601DateTime
+  createdAt: ISO8601DateTime!
+  customer: Customer!
+  endedAt: ISO8601DateTime
+  externalId: String!
+  id: ID!
+  name: String
+  plan: Plan
+  startedAt: ISO8601DateTime
+  status: ContractStatusEnum!
+  terminatedAt: ISO8601DateTime
+  updatedAt: ISO8601DateTime!
+}
+
+"""
+Rate card applied to a contract
+"""
+type ContractAppliedRateCard {
+  billingAnchorDate: ISO8601Date!
+  createdAt: ISO8601DateTime!
+  effectiveDate: ISO8601Date!
+  endedDate: ISO8601Date
+  id: ID!
+  nextBillingAt: ISO8601DateTime!
+  product: Product!
+  rateCard: RateCard!
+  ratePhases: [RatePhase!]!
+  ratePhasesCount: Int!
+  units: Float
+  updatedAt: ISO8601DateTime!
+}
+
+enum ContractBillingTimeEnum {
+  anniversary
+  calendar
+}
+
+"""
+ContractCollection type
+"""
+type ContractCollection {
+  """
+  A collection of paginated ContractCollection
+  """
+  collection: [Contract!]!
+
+  """
+  Pagination Metadata for navigating the Pagination
+  """
+  metadata: CollectionMetadata!
+}
+
+enum ContractStatusEnum {
+  active
+  canceled
+  pending
+  terminated
+}
+
 enum CountryCode {
   """
   Andorra
@@ -2970,6 +3037,25 @@ input CreateCatalogPlanInput {
   description: String
   invoiceDisplayName: String
   name: String!
+}
+
+"""
+Create contract input arguments
+"""
+input CreateContractInput {
+  billingAnchorDate: ISO8601Date
+  billingTime: ContractBillingTimeEnum
+
+  """
+  A unique identifier for the client performing the mutation.
+  """
+  clientMutationId: String
+  endedAt: ISO8601DateTime
+  externalCustomerId: String!
+  externalId: String!
+  name: String
+  planCode: String
+  startedAt: ISO8601DateTime
 }
 
 """
@@ -8121,6 +8207,16 @@ type Mutation {
   ): ChargeFilter
 
   """
+  Creates a new contract
+  """
+  createContract(
+    """
+    Parameters for CreateContract
+    """
+    input: CreateContractInput!
+  ): Contract
+
+  """
   Creates a new Coupon
   """
   createCoupon(
@@ -10571,6 +10667,8 @@ enum PermissionEnum {
   charges_create
   charges_delete
   charges_update
+  contracts_create
+  contracts_view
   coupons_attach
   coupons_create
   coupons_delete
@@ -10707,6 +10805,8 @@ type Permissions {
   chargesCreate: Boolean!
   chargesDelete: Boolean!
   chargesUpdate: Boolean!
+  contractsCreate: Boolean!
+  contractsView: Boolean!
   couponsAttach: Boolean!
   couponsCreate: Boolean!
   couponsDelete: Boolean!
@@ -11502,6 +11602,21 @@ type Query {
     """
     billingEntityId: ID!
   ): TaxCollection!
+
+  """
+  Query a single contract of an organization
+  """
+  contract(
+    """
+    Uniq ID of the contract
+    """
+    id: ID!
+  ): Contract
+
+  """
+  Query contracts of an organization
+  """
+  contracts(externalCustomerId: String, externalId: String, limit: Int, page: Int, planCode: String, status: [ContractStatusEnum!]): ContractCollection!
 
   """
   Query a single coupon of an organization

--- a/schema.json
+++ b/schema.json
@@ -8661,6 +8661,565 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "Contract",
+          "description": "The agreement a customer signed: an optional plan, a validity window and the billing anchor",
+          "fields": [
+            {
+              "name": "appliedRateCards",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ContractAppliedRateCard",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "appliedRateCardsCount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "billingAnchorDate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "billingTime",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ContractBillingTimeEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canceledAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customer",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Customer",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "endedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "externalId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "plan",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Plan",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "status",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ContractStatusEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "terminatedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ContractAppliedRateCard",
+          "description": "Rate card applied to a contract",
+          "fields": [
+            {
+              "name": "billingAnchorDate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601Date",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "effectiveDate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601Date",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "endedDate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nextBillingAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "product",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Product",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rateCard",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "RateCard",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ratePhases",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "RatePhase",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ratePhasesCount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "units",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "ContractBillingTimeEnum",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "calendar",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "anniversary",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ContractCollection",
+          "description": "ContractCollection type",
+          "fields": [
+            {
+              "name": "collection",
+              "description": "A collection of paginated ContractCollection",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Contract",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "metadata",
+              "description": "Pagination Metadata for navigating the Pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "ContractStatusEnum",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "pending",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "active",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "terminated",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canceled",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
           "kind": "ENUM",
           "name": "CountryCode",
           "description": null,
@@ -11987,6 +12546,133 @@
                   "name": "String",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CreateContractInput",
+          "description": "Create contract input arguments",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "externalCustomerId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "externalId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "planCode",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "billingAnchorDate",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "billingTime",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "ContractBillingTimeEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "endedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -41678,6 +42364,35 @@
               "deprecationReason": null
             },
             {
+              "name": "createContract",
+              "description": "Creates a new contract",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for CreateContract",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "CreateContractInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Contract",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "createCoupon",
               "description": "Creates a new Coupon",
               "args": [
@@ -50983,6 +51698,18 @@
               "deprecationReason": null
             },
             {
+              "name": "contracts_view",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "contracts_create",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "coupons_view",
               "description": null,
               "isDeprecated": false,
@@ -51966,6 +52693,38 @@
             },
             {
               "name": "chargesUpdate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "contractsCreate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "contractsView",
               "description": null,
               "args": [],
               "type": {
@@ -59424,6 +60183,132 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "TaxCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "contract",
+              "description": "Query a single contract of an organization",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Uniq ID of the contract",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Contract",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "contracts",
+              "description": "Query contracts of an organization",
+              "args": [
+                {
+                  "name": "externalCustomerId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "externalId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "planCode",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "status",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ContractStatusEnum",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ContractCollection",
                   "ofType": null
                 }
               },

--- a/spec/graphql/mutations/contracts/create_spec.rb
+++ b/spec/graphql/mutations/contracts/create_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Mutations::Contracts::Create do
+  subject(:execution) do
+    execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query: mutation,
+      variables: {input:}
+    )
+  end
+
+  let(:required_permission) { "contracts:create" }
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, :product_catalog, organization:) }
+
+  let(:input) do
+    {
+      externalCustomerId: customer.external_id,
+      externalId: "contract-1",
+      planCode: plan.code
+    }
+  end
+
+  let(:mutation) do
+    <<-GQL
+      mutation($input: CreateContractInput!) {
+        createContract(input: $input) {
+          id externalId status billingTime
+          plan { id }
+          appliedRateCards { id }
+          appliedRateCardsCount
+        }
+      }
+    GQL
+  end
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "contracts:create"
+
+  it "creates a contract and materializes the plan's rate cards" do
+    create(:plan_rate_card, organization:, plan:, rate_card: create(:rate_card, organization:))
+
+    result_data = execution["data"]["createContract"]
+
+    expect(result_data["id"]).to be_present
+    expect(result_data["externalId"]).to eq("contract-1")
+    expect(result_data["status"]).to eq("active")
+    expect(result_data["billingTime"]).to eq("calendar")
+    expect(result_data["plan"]["id"]).to eq(plan.id)
+    expect(result_data["appliedRateCardsCount"]).to eq(1)
+  end
+
+  context "without a plan" do
+    let(:input) { {externalCustomerId: customer.external_id, externalId: "contract-1"} }
+
+    it "creates a plan-less contract" do
+      result_data = execution["data"]["createContract"]
+
+      expect(result_data["plan"]).to be_nil
+      expect(result_data["appliedRateCards"]).to be_empty
+    end
+  end
+
+  context "with a future start" do
+    let(:input) { super().merge(startedAt: 1.month.from_now.iso8601) }
+
+    it "creates a pending contract" do
+      expect(execution["data"]["createContract"]["status"]).to eq("pending")
+    end
+  end
+
+  context "when a live contract already uses the external id" do
+    before { create(:contract, organization:, customer:, external_id: "contract-1") }
+
+    it "returns a validation error" do
+      expect_unprocessable_entity(execution)
+    end
+  end
+end

--- a/spec/graphql/resolvers/contract_resolver_spec.rb
+++ b/spec/graphql/resolvers/contract_resolver_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::ContractResolver do
+  subject(:execution) do
+    execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query:,
+      variables: {contractId: contract.id}
+    )
+  end
+
+  let(:required_permission) { "contracts:view" }
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, :product_catalog, organization:) }
+  let(:contract) { create(:contract, organization:, customer:, plan:) }
+
+  let(:query) do
+    <<~GQL
+      query($contractId: ID!) {
+        contract(id: $contractId) {
+          id externalId status billingTime
+          customer { id }
+          plan { id }
+          appliedRateCards { id rateCard { id } effectiveDate }
+          appliedRateCardsCount
+        }
+      }
+    GQL
+  end
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "contracts:view"
+
+  it "returns the contract with its rate cards" do
+    card = create(:contract_rate_card, organization:, contract:)
+
+    response = execution["data"]["contract"]
+
+    expect(response["id"]).to eq(contract.id)
+    expect(response["customer"]["id"]).to eq(customer.id)
+    expect(response["plan"]["id"]).to eq(plan.id)
+    expect(response["appliedRateCards"].sole["id"]).to eq(card.id)
+    expect(response["appliedRateCardsCount"]).to eq(1)
+  end
+
+  context "when the contract belongs to another organization" do
+    let(:contract) { create(:contract) }
+
+    it "returns a not found error" do
+      expect_graphql_error(result: execution, message: "Resource not found")
+    end
+  end
+end

--- a/spec/graphql/resolvers/contracts_resolver_spec.rb
+++ b/spec/graphql/resolvers/contracts_resolver_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::ContractsResolver do
+  subject(:execution) do
+    execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query:,
+      variables:
+    )
+  end
+
+  let(:required_permission) { "contracts:view" }
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:variables) { {} }
+
+  let(:query) do
+    <<~GQL
+      query($status: [ContractStatusEnum!], $externalCustomerId: String) {
+        contracts(limit: 5, status: $status, externalCustomerId: $externalCustomerId) {
+          collection { id externalId status }
+          metadata { currentPage totalCount }
+        }
+      }
+    GQL
+  end
+
+  let!(:active_contract) { create(:contract, organization:, customer:) }
+  let!(:pending_contract) { create(:contract, :pending, organization:) }
+
+  before { create(:contract) }
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "contracts:view"
+
+  it "returns the contracts of the organization" do
+    response = execution["data"]["contracts"]
+
+    expect(response["collection"].map { it["id"] }).to match_array([active_contract.id, pending_contract.id])
+    expect(response["metadata"]["totalCount"]).to eq(2)
+  end
+
+  context "with a status filter" do
+    let(:variables) { {status: ["pending"]} }
+
+    it "returns only the matching contracts" do
+      expect(execution["data"]["contracts"]["collection"].map { it["id"] }).to eq([pending_contract.id])
+    end
+  end
+
+  context "with a customer filter" do
+    let(:variables) { {externalCustomerId: customer.external_id} }
+
+    it "returns only the customer's contracts" do
+      expect(execution["data"]["contracts"]["collection"].map { it["id"] }).to eq([active_contract.id])
+    end
+  end
+end

--- a/spec/graphql/resolvers/contracts_resolver_spec.rb
+++ b/spec/graphql/resolvers/contracts_resolver_spec.rb
@@ -61,4 +61,42 @@ RSpec.describe Resolvers::ContractsResolver do
       expect(execution["data"]["contracts"]["collection"].map { it["id"] }).to eq([active_contract.id])
     end
   end
+
+  context "when the applied rate cards are requested for several contracts" do
+    let(:query) do
+      <<~GQL
+        query {
+          contracts(limit: 10) {
+            collection { id appliedRateCardsCount appliedRateCards { id rateCard { id } } }
+          }
+        }
+      GQL
+    end
+
+    before do
+      [active_contract, pending_contract].each do |c|
+        create(:contract_rate_card, organization:, contract: c)
+      end
+    end
+
+    def count_queries(table)
+      queries = []
+      sub = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        queries << payload[:sql] if payload[:sql].include?(%("#{table}"))
+      end
+      yield
+      queries
+    ensure
+      ActiveSupport::Notifications.unsubscribe(sub)
+    end
+
+    it "loads the cards in one query, not one per contract" do
+      cards_queries = count_queries("contract_rate_cards") { execution }
+
+      # one batched query for the whole page, not one per contract
+      expect(cards_queries.size).to eq(1)
+      counts = execution["data"]["contracts"]["collection"].map { it["appliedRateCardsCount"] }
+      expect(counts.sum).to eq(2)
+    end
+  end
 end

--- a/spec/support/product_catalog_shared.rb
+++ b/spec/support/product_catalog_shared.rb
@@ -4,7 +4,7 @@
 # not repeat the setup.
 CATALOG_SPEC_PATHS = %r{
   requests/api/v2 |
-  graphql/(mutations|resolvers)/.*(product|rate_card|rate_phase|plan_applied)
+  graphql/(mutations|resolvers)/.*(product|rate_card|rate_phase|plan_applied|contract)
 }x
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Context

GraphQL slice of the contract runtime, on top of #6270
## Description

- `Contract` object type with `ContractStatusEnum` / `ContractBillingTimeEnum`, the nullable plan (plan-less contracts are native), the customer, and the current-and-scheduled applied rate cards.
- `ContractAppliedRateCard` type carrying the day-grained validity window (`effective_date` / `ended_date`), the anchor, the clock and the phase references.
- `contract` / `contracts` queries gated with `RequiresProductCatalog`, backed by `ContractsQuery` (same filters as the REST index, enum-typed status).
- `createContract` mutation on `Contracts::CreateService` with a strict catalog input shape — all the REST semantics apply (plan-less, one live agreement per external id, customer-wall-clock dates). `updateContract` / `terminateContract` deliberately ride the lifecycle milestone once their services exist, keeping GraphQL at parity with REST.
- `contracts:view` / `contracts:create` permissions (admin-only for now, like the other catalog surfaces); schema dumps regenerated — the front-compatibility workflow will run codegen against the new schema.