### PR TITLE
fix(exports): emit deleted invoices instead of filtering them out

### DIFF
--- a/db/migrate/20260902120000_update_exports_invoices_to_version_4.rb
+++ b/db/migrate/20260902120000_update_exports_invoices_to_version_4.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UpdateExportsInvoicesToVersion4 < ActiveRecord::Migration[8.0]
+  def change
+    update_view :exports_invoices, version: 4, revert_to_version: 3
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4129,6 +4129,7 @@ CREATE VIEW public.exports_invoices AS
             WHEN 5 THEN 'open'::text
             WHEN 6 THEN 'close'::text
             WHEN 7 THEN 'pending'::text
+            WHEN 8 THEN 'deleted'::text
             ELSE NULL::text
         END AS status,
         CASE i.payment_status
@@ -4163,7 +4164,7 @@ CREATE VIEW public.exports_invoices AS
            FROM public.error_details ed
           WHERE (ed.owner_id = i.id)) AS error_details
    FROM public.invoices i
-  WHERE (i.status = ANY (ARRAY[0, 1, 2, 4, 7]));
+  WHERE (i.status = ANY (ARRAY[0, 1, 2, 4, 7, 8]));
 
 
 --
@@ -14446,6 +14447,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260902143604'),
+('20260902120000'),
 ('20260826235314'),
 ('20260826235313'),
 ('20260826235312'),

--- a/db/views/exports_invoices_v04.sql
+++ b/db/views/exports_invoices_v04.sql
@@ -1,0 +1,82 @@
+SELECT
+    i.organization_id,
+    i.id AS lago_id,
+    i.sequential_id,
+    i.customer_id,
+    i.number,
+    i.issuing_date::timestamptz AS issuing_date,
+    i.payment_due_date::timestamptz AS payment_due_date,
+    i.net_payment_term,
+    CASE i.invoice_type
+        WHEN 0 THEN 'subscription'
+        WHEN 1 THEN 'add_on'
+        WHEN 2 THEN 'credit'
+        WHEN 3 THEN 'one_off'
+        WHEN 4 THEN 'advance_charges'
+        WHEN 5 THEN 'progressive_billing'
+    END AS invoice_type,
+    CASE i.status
+        WHEN 0 THEN 'draft'
+        WHEN 1 THEN 'finalized'
+        WHEN 2 THEN 'voided'
+        WHEN 3 THEN 'generating'
+        WHEN 4 THEN 'failed'
+        WHEN 5 THEN 'open'
+        WHEN 6 THEN 'close'
+        WHEN 7 THEN 'pending'
+        WHEN 8 THEN 'deleted'
+    END AS status,
+    CASE i.payment_status
+        WHEN 0 THEN 'pending'
+        WHEN 1 THEN 'succeeded'
+        WHEN 2 THEN 'failed'
+    END AS payment_status,
+    i.payment_dispute_lost_at::timestamptz AS payment_dispute_lost_at,
+    i.payment_overdue,
+    i.currency,
+    i.fees_amount_cents,
+    i.taxes_amount_cents,
+    i.progressive_billing_credit_amount_cents,
+    i.coupons_amount_cents,
+    i.credit_notes_amount_cents,
+    i.sub_total_excluding_taxes_amount_cents,
+    i.sub_total_including_taxes_amount_cents,
+    i.total_amount_cents,
+    i.total_amount_cents - i.total_paid_amount_cents AS total_due_amount_cents,
+    i.prepaid_credit_amount_cents,
+    i.prepaid_granted_credit_amount_cents,
+    i.prepaid_purchased_credit_amount_cents,
+    i.version_number,
+    i.created_at,
+    i.updated_at,
+    i.voided_at,
+    (
+        SELECT json_agg(
+            json_build_object(
+                'lago_id', m.id,
+                'key', m.key,
+                'value', m.value,
+                'created_at', m.created_at
+            )
+        )
+        FROM invoice_metadata AS m
+        WHERE m.invoice_id = i.id
+    ) AS metadata,
+    (
+        SELECT json_agg(
+            json_build_object(
+                'lago_id', ed.id,
+                'error_code', ed.error_code,
+                'details', ed.details
+            )
+        )
+        FROM error_details AS ed
+        WHERE ed.owner_id = i.id
+    ) AS error_details
+FROM invoices AS i
+-- Deleted invoices (status 8) are exported on purpose. The Data Pipeline is
+-- upsert-only and cannot propagate a deletion, so filtering them here would
+-- freeze the last synced copy in the customer's warehouse forever. Emitting the
+-- row with status 'deleted' lets the destination receive the tombstone as a
+-- normal update. Statuses 3 (generating), 5 (open) and 6 (closed) stay excluded.
+WHERE i.status IN (0, 1, 2, 4, 7, 8);

--- a/spec/db/views/exports_invoices_spec.rb
+++ b/spec/db/views/exports_invoices_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "exports_invoices view" do # rubocop:disable RSpec/DescribeClass
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+
+  def rows_for(id)
+    ActiveRecord::Base.connection.select_all(
+      "SELECT * FROM exports_invoices WHERE lago_id = #{ActiveRecord::Base.connection.quote(id)}"
+    ).to_a
+  end
+
+  describe "deleted invoices" do
+    # The Data Pipeline is upsert-only and cannot propagate a deletion. Filtering
+    # deleted invoices out of the view dropped them from the feed entirely, so the
+    # destination never learned they had changed and kept the last copy it received
+    # as a draft forever. The row has to stay, carrying its deleted status, so the
+    # tombstone arrives as an ordinary upsert.
+    let!(:invoice) { create(:invoice, status: :draft, organization:, customer:) }
+
+    it "keeps the invoice in the feed once deleted, carrying status 'deleted'" do
+      expect(rows_for(invoice.id).first["status"]).to eq("draft")
+
+      invoice.mark_as_deleted!
+
+      rows = rows_for(invoice.id)
+      expect(rows.size).to eq(1)
+      expect(rows.first["status"]).to eq("deleted")
+    end
+  end
+
+  describe "statuses that stay out of the feed" do
+    # generating is transient, open and closed are deliberate product states that
+    # were never part of the export contract. Only deleted (8) was added.
+    %i[generating open closed].each do |status|
+      context "when the invoice is #{status}" do
+        let!(:invoice) { create(:invoice, status:, organization:, customer:) }
+
+        it "is not exported" do
+          expect(rows_for(invoice.id)).to be_empty
+        end
+      end
+    end
+  end
+
+  describe "exported statuses" do
+    %i[draft finalized voided failed pending].each do |status|
+      context "when the invoice is #{status}" do
+        let!(:invoice) { create(:invoice, status:, organization:, customer:) }
+
+        it "is exported with status '#{status}'" do
+          rows = rows_for(invoice.id)
+
+          expect(rows.size).to eq(1)
+          expect(rows.first["status"]).to eq(status.to_s)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

The Data Pipeline is upsert-only: Prequel matches rows on their primary key and has no mechanism to remove a row that no longer exists in Lago. The only purge path is a manual full refresh, and object-storage destinations cannot be purged at all.

Invoices are soft deleted. `Invoices::DeleteService` calls `invoice.mark_as_deleted!`, setting status 8, and the row survives in Postgres. But `exports_invoices_v03` ended with `WHERE i.status IN (0, 1, 2, 4, 7)` and its status `CASE` stopped at 7, so the row dropped out of the view entirely. The destination never learned the invoice had changed and kept the last copy it received, frozen as a draft, forever.

Reported by Foxglove: 64 of their 91 August draft invoices return 404 from our API but are still present in their BigQuery.

## Change

`exports_invoices_v04` maps status 8 to `'deleted'` and includes it in the `WHERE`, so the tombstone reaches the destination as an ordinary upsert. Statuses 3 (generating), 5 (open) and 6 (closed) stay excluded, unchanged.

`aasm` is configured `timestamps: true`, so `mark_as_deleted!` is a normal save and `updated_at` is bumped, which is what the pipeline's last-modified cursor needs to pick the change up.

## Notes for review

The `structure.sql` diff is three lines: the CASE mapping, the widened `WHERE`, and the migration version.

Filtering deleted rows server-side is the wrong pattern on an upsert-only pipeline. `exports_plans_v01` and `exports_billable_metrics_v01` both end in `WHERE deleted_at IS NULL` and have the same latent problem, tracked separately.

## Testing

New `spec/db/views/exports_invoices_spec.rb`, following the existing `spec/db/views` pattern. Asserts a draft invoice stays in the feed after `mark_as_deleted!` and returns with status `deleted`, and pins which statuses are and are not exported.

Refs INT-250