### PR TITLE
fix(exports): serialize the charge on fixed-charge fees

### DIFF
--- a/db/migrate/20260902120100_update_exports_fees_to_version_4.rb
+++ b/db/migrate/20260902120100_update_exports_fees_to_version_4.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UpdateExportsFeesToVersion4 < ActiveRecord::Migration[8.0]
+  def change
+    update_view :exports_fees, version: 4, revert_to_version: 3
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1219,7 +1219,6 @@ DROP TABLE IF EXISTS public.groups;
 DROP TABLE IF EXISTS public.group_properties;
 DROP VIEW IF EXISTS public.flat_filters;
 DROP TABLE IF EXISTS public.fixed_charges_taxes;
-DROP TABLE IF EXISTS public.fixed_charges;
 DROP TABLE IF EXISTS public.fixed_charge_events;
 DROP VIEW IF EXISTS public.exports_wallets;
 DROP TABLE IF EXISTS public.wallets;
@@ -1260,6 +1259,7 @@ DROP VIEW IF EXISTS public.exports_fees;
 DROP TABLE IF EXISTS public.subscriptions;
 DROP TABLE IF EXISTS public.plans;
 DROP TABLE IF EXISTS public.invoices;
+DROP TABLE IF EXISTS public.fixed_charges;
 DROP TABLE IF EXISTS public.fees;
 DROP VIEW IF EXISTS public.exports_entitlement_features;
 DROP VIEW IF EXISTS public.exports_entitlement_entitlements;
@@ -3682,6 +3682,29 @@ CREATE TABLE public.fees (
 
 
 --
+-- Name: fixed_charges; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.fixed_charges (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    plan_id uuid NOT NULL,
+    add_on_id uuid NOT NULL,
+    parent_id uuid,
+    charge_model public.fixed_charge_charge_model DEFAULT 'standard'::public.fixed_charge_charge_model NOT NULL,
+    properties jsonb DEFAULT '{}'::jsonb NOT NULL,
+    invoice_display_name character varying,
+    pay_in_advance boolean DEFAULT false NOT NULL,
+    prorated boolean DEFAULT false NOT NULL,
+    units numeric(30,10) DEFAULT 0.0 NOT NULL,
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    code character varying NOT NULL
+);
+
+
+--
 -- Name: invoices; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -3821,6 +3844,7 @@ CREATE VIEW public.exports_fees AS
  SELECT f.organization_id,
     f.id AS lago_id,
     f.charge_id AS lago_charge_id,
+    f.fixed_charge_id AS lago_fixed_charge_id,
     f.charge_filter_id AS lago_charge_filter_id,
     f.invoice_id AS lago_invoice_id,
     f.subscription_id AS lago_subscription_id,
@@ -3832,30 +3856,35 @@ CREATE VIEW public.exports_fees AS
             WHEN 2 THEN 'subscription'::text
             WHEN 3 THEN 'credit'::text
             WHEN 4 THEN 'commitment'::text
+            WHEN 5 THEN 'fixed_charge'::text
             ELSE 'unknown'::text
         END, 'code',
         CASE f.fee_type
             WHEN 0 THEN bm.code
             WHEN 1 THEN ao.code
             WHEN 3 THEN 'credit'::character varying
+            WHEN 5 THEN fao.code
             ELSE p.code
         END, 'name',
         CASE f.fee_type
             WHEN 0 THEN bm.name
             WHEN 1 THEN ao.name
             WHEN 3 THEN 'credit'::character varying
+            WHEN 5 THEN fao.name
             ELSE p.name
         END, 'description',
         CASE f.fee_type
             WHEN 0 THEN bm.description
             WHEN 1 THEN ao.description
             WHEN 3 THEN 'credit'::character varying
+            WHEN 5 THEN fao.description
             ELSE p.description
         END, 'invoice_display_name', COALESCE(f.invoice_display_name,
         CASE f.fee_type
             WHEN 0 THEN COALESCE(ch.invoice_display_name, bm.name)
             WHEN 1 THEN COALESCE(ao.invoice_display_name, ao.name)
             WHEN 3 THEN 'credit'::character varying
+            WHEN 5 THEN COALESCE(fc.invoice_display_name, fao.invoice_display_name, fao.name)
             ELSE p.invoice_display_name
         END), 'filters', ( SELECT json_agg(json_build_object('id', cf.id, 'charge_id', cf.charge_id, 'properties', cf.properties, 'invoice_display_name', cf.invoice_display_name)) AS json_agg
            FROM public.charge_filters cf
@@ -3864,12 +3893,14 @@ CREATE VIEW public.exports_fees AS
             WHEN 0 THEN bm.id
             WHEN 1 THEN ao.id
             WHEN 3 THEN f.invoiceable_id
+            WHEN 5 THEN fao.id
             ELSE f.subscription_id
         END, 'item_type',
         CASE f.fee_type
             WHEN 0 THEN 'billable_metric'::text
             WHEN 1 THEN 'add_on'::text
             WHEN 3 THEN 'wallet_transaction'::text
+            WHEN 5 THEN 'add_on'::text
             ELSE 'subscription'::text
         END, 'grouped_by', f.grouped_by) AS item,
     f.pay_in_advance,
@@ -3903,18 +3934,22 @@ CREATE VIEW public.exports_fees AS
     f.updated_at,
         CASE f.fee_type
             WHEN 0 THEN (((f.properties ->> 'charges_from_datetime'::text))::timestamp with time zone)::text
+            WHEN 5 THEN (((f.properties ->> 'fixed_charges_from_datetime'::text))::timestamp with time zone)::text
             ELSE (((f.properties ->> 'from_datetime'::text))::timestamp with time zone)::text
         END AS from_date,
         CASE f.fee_type
             WHEN 0 THEN (((f.properties ->> 'charges_to_datetime'::text))::timestamp with time zone)::text
+            WHEN 5 THEN (((f.properties ->> 'fixed_charges_to_datetime'::text))::timestamp with time zone)::text
             ELSE (((f.properties ->> 'to_datetime'::text))::timestamp with time zone)::text
         END AS to_date
-   FROM (((((((public.fees f
+   FROM (((((((((public.fees f
      LEFT JOIN public.subscriptions s ON ((f.subscription_id = s.id)))
      LEFT JOIN public.customers c ON ((s.customer_id = c.id)))
      LEFT JOIN public.charges ch ON ((f.charge_id = ch.id)))
      LEFT JOIN public.billable_metrics bm ON ((ch.billable_metric_id = bm.id)))
      LEFT JOIN public.add_ons ao ON ((f.add_on_id = ao.id)))
+     LEFT JOIN public.fixed_charges fc ON ((f.fixed_charge_id = fc.id)))
+     LEFT JOIN public.add_ons fao ON ((fc.add_on_id = fao.id)))
      LEFT JOIN public.plans p ON ((s.plan_id = p.id)))
      LEFT JOIN public.invoices i ON ((i.id = f.invoice_id)))
   WHERE (i.status IS DISTINCT FROM 8);
@@ -4783,29 +4818,6 @@ CREATE TABLE public.fixed_charge_events (
     deleted_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
-);
-
-
---
--- Name: fixed_charges; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.fixed_charges (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    organization_id uuid NOT NULL,
-    plan_id uuid NOT NULL,
-    add_on_id uuid NOT NULL,
-    parent_id uuid,
-    charge_model public.fixed_charge_charge_model DEFAULT 'standard'::public.fixed_charge_charge_model NOT NULL,
-    properties jsonb DEFAULT '{}'::jsonb NOT NULL,
-    invoice_display_name character varying,
-    pay_in_advance boolean DEFAULT false NOT NULL,
-    prorated boolean DEFAULT false NOT NULL,
-    units numeric(30,10) DEFAULT 0.0 NOT NULL,
-    deleted_at timestamp(6) without time zone,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    code character varying NOT NULL
 );
 
 
@@ -14446,6 +14458,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260902143604'),
+('20260902120100'),
 ('20260826235314'),
 ('20260826235313'),
 ('20260826235312'),

--- a/db/views/exports_fees_v04.sql
+++ b/db/views/exports_fees_v04.sql
@@ -1,0 +1,140 @@
+SELECT
+    f.organization_id,
+    f.id AS lago_id,
+    f.charge_id AS lago_charge_id,
+    f.fixed_charge_id AS lago_fixed_charge_id,
+    f.charge_filter_id AS lago_charge_filter_id,
+    f.invoice_id AS lago_invoice_id,
+    f.subscription_id AS lago_subscription_id,
+    c.id AS lago_customer_id,
+    json_build_object(
+        'type', CASE f.fee_type
+            WHEN 0 THEN 'charge'       -- Assuming 0 maps to :charge
+            WHEN 1 THEN 'add_on'       -- Assuming 1 maps to :add_on
+            WHEN 2 THEN 'subscription' -- Assuming 2 maps to :subscription
+            WHEN 3 THEN 'credit'       -- Assuming 3 maps to :credit
+            WHEN 4 THEN 'commitment'   -- Assuming 4 maps to :commitment
+            WHEN 5 THEN 'fixed_charge' -- Assuming 5 maps to :fixed_charge
+            ELSE 'unknown'
+        END,
+        'code', CASE f.fee_type
+            WHEN 0 THEN bm.code -- 0 is charge
+            WHEN 1 THEN ao.code -- 1 is add_on
+            WHEN 3 THEN 'credit' -- 3 is credit
+            WHEN 5 THEN fao.code -- 5 is fixed_charge
+            ELSE p.code -- everything else is subscription
+        END,
+        'name', CASE f.fee_type
+            WHEN 0 THEN bm.name -- 0 is charge
+            WHEN 1 THEN ao.name -- 1 is add_on
+            WHEN 3 THEN 'credit' -- 3 is credit
+            WHEN 5 THEN fao.name -- 5 is fixed_charge
+            ELSE p.name -- everything else is subscription
+        END,
+        'description', CASE f.fee_type
+            WHEN 0 THEN bm.description -- 0 is charge
+            WHEN 1 THEN ao.description -- 1 is add_on
+            WHEN 3 THEN 'credit' -- 3 is credit
+            WHEN 5 THEN fao.description -- 5 is fixed_charge
+            ELSE p.description -- everything else is subscription
+        END,
+        'invoice_display_name', COALESCE(
+            f.invoice_display_name,
+            CASE f.fee_type
+                WHEN 0 THEN COALESCE(
+                    ch.invoice_display_name,
+                    bm.name
+                ) -- 0 is charge
+                WHEN 1 THEN COALESCE(ao.invoice_display_name, ao.name) -- 1 is add_on
+                WHEN 3 THEN 'credit' -- 3 is credit
+                WHEN 5 THEN COALESCE(
+                    fc.invoice_display_name,
+                    fao.invoice_display_name,
+                    fao.name
+                ) -- 5 is fixed_charge
+                ELSE p.invoice_display_name -- everything else is subscription
+            END
+        ),
+        'filters', (
+            SELECT json_agg(
+                json_build_object(
+                    'id', cf.id,
+                    'charge_id', cf.charge_id,
+                    'properties', cf.properties,
+                    'invoice_display_name', cf.invoice_display_name
+                )
+            )
+            FROM charge_filters AS cf
+            WHERE cf.charge_id = f.charge_id
+        ),
+        'lago_item_id', CASE f.fee_type
+            WHEN 0 THEN bm.id -- 0 is charge
+            WHEN 1 THEN ao.id -- 1 is add_on
+            WHEN 3 THEN f.invoiceable_id -- 3 is credit
+            WHEN 5 THEN fao.id -- 5 is fixed_charge
+            ELSE f.subscription_id -- everything else is subscription
+        END,
+        'item_type', CASE f.fee_type
+            WHEN 0 THEN 'billable_metric' -- 0 is charge
+            WHEN 1 THEN 'add_on' -- 1 is add_on
+            WHEN 3 THEN 'wallet_transaction' -- 3 is credit
+            WHEN 5 THEN 'add_on' -- 5 is fixed_charge, whose item is the add-on behind it
+            ELSE 'subscription' -- everything else is subscription
+        END,
+        'grouped_by', f.grouped_by
+    ) AS item,
+    f.pay_in_advance,
+    f.amount_cents,
+    ch.invoiceable AS invoiceable,
+    f.taxes_amount_cents,
+    f.taxes_precise_amount_cents,
+    f.taxes_rate,
+    f.amount_cents + f.taxes_amount_cents AS total_amount_cents,
+    f.amount_currency AS currency,
+    f.units,
+    f.description,
+    f.precise_amount_cents,
+    f.precise_unit_amount,
+    f.precise_coupons_amount_cents,
+    f.precise_amount_cents + f.taxes_precise_amount_cents AS precise_total_amount_cents,
+    f.precise_credit_notes_amount_cents,
+    f.events_count,
+    -- payment-status
+    CASE f.payment_status
+        WHEN 0 THEN 'pending'    -- Assuming 0 maps to :pending
+        WHEN 1 THEN 'succeeded'  -- Assuming 1 maps to :succeeded
+        WHEN 2 THEN 'failed'     -- Assuming 2 maps to :failed
+        WHEN 3 THEN 'refunded'   -- Assuming 3 maps to :refunded
+        ELSE 'unknown'
+    END AS payment_status,
+    f.created_at,
+    f.succeeded_at,
+    f.failed_at,
+    f.refunded_at,
+    f.amount_details,
+    f.updated_at,
+    CASE f.fee_type
+        WHEN 0 THEN (f.properties->>'charges_from_datetime')::timestamptz::text
+        WHEN 5 THEN (f.properties->>'fixed_charges_from_datetime')::timestamptz::text
+        ELSE (f.properties->>'from_datetime')::timestamptz::text
+    END AS from_date,
+    CASE f.fee_type
+        WHEN 0 THEN (f.properties->>'charges_to_datetime')::timestamptz::text
+        WHEN 5 THEN (f.properties->>'fixed_charges_to_datetime')::timestamptz::text
+        ELSE (f.properties->>'to_datetime')::timestamptz::text
+    END AS to_date
+FROM fees AS f
+LEFT JOIN subscriptions AS s ON f.subscription_id = s.id
+LEFT JOIN customers AS c ON s.customer_id = c.id
+LEFT JOIN charges AS ch ON f.charge_id = ch.id
+LEFT JOIN billable_metrics AS bm ON ch.billable_metric_id = bm.id
+LEFT JOIN add_ons AS ao ON f.add_on_id = ao.id
+-- Fixed-charge fees carry fixed_charge_id, not charge_id. Their item is the
+-- add-on the fixed charge is built from, so both hops are needed.
+LEFT JOIN fixed_charges AS fc ON f.fixed_charge_id = fc.id
+LEFT JOIN add_ons AS fao ON fc.add_on_id = fao.id
+LEFT JOIN plans AS p ON s.plan_id = p.id
+-- LEFT JOIN so fees with no invoice (e.g. recurring non-invoiceable fees) are kept.
+-- IS DISTINCT FROM keeps those NULL-invoice rows while excluding deleted invoices.
+LEFT JOIN invoices AS i ON i.id = f.invoice_id
+WHERE i.status IS DISTINCT FROM 8; -- exclude deleted invoices

--- a/spec/db/views/exports_fees_spec.rb
+++ b/spec/db/views/exports_fees_spec.rb
@@ -23,4 +23,92 @@ RSpec.describe "exports_fees view" do # rubocop:disable RSpec/DescribeClass
     expect(exported_fee_ids).to include(finalized_fee.id, invoiceless_fee.id)
     expect(exported_fee_ids).not_to include(deleted_fee.id)
   end
+
+  describe "fixed-charge fees" do
+    # Fee::FEE_TYPES gained fixed_charge at index 5, but every CASE f.fee_type in
+    # the view stopped at 4, so fixed-charge fees fell through to the subscription
+    # ELSE branch: they were exported with the plan's code, name and description,
+    # item_type 'subscription', lago_item_id set to the subscription, and type
+    # resolving to the literal 'unknown'.
+    let(:add_on) do
+      create(:add_on, organization:, code: "byos", name: "BYOS", description: "Bring your own storage")
+    end
+    let(:fixed_charge) do
+      create(
+        :fixed_charge,
+        organization:,
+        plan: subscription.plan,
+        add_on:,
+        invoice_display_name: "Storage add-on"
+      )
+    end
+    # subscription is set so the plans join resolves. Without it the old ELSE
+    # branch returned NULL rather than the plan, which would hide the defect.
+    let!(:fixed_charge_fee) do
+      create(
+        :fixed_charge_fee,
+        invoice: finalized_invoice,
+        organization:,
+        subscription:,
+        fixed_charge:,
+        invoice_display_name: nil
+      )
+    end
+
+    # Read the item JSON through ->> so the assertions do not depend on how the
+    # adapter casts a json column.
+    def item_for(id)
+      ActiveRecord::Base.connection.select_one(<<~SQL.squish)
+        SELECT item->>'type' AS type,
+               item->>'code' AS code,
+               item->>'name' AS name,
+               item->>'description' AS description,
+               item->>'item_type' AS item_type,
+               item->>'lago_item_id' AS lago_item_id,
+               item->>'invoice_display_name' AS invoice_display_name
+        FROM exports_fees
+        WHERE lago_id = #{ActiveRecord::Base.connection.quote(id)}
+      SQL
+    end
+
+    def row_for(id)
+      ActiveRecord::Base.connection.select_one(
+        "SELECT * FROM exports_fees WHERE lago_id = #{ActiveRecord::Base.connection.quote(id)}"
+      )
+    end
+
+    it "serializes the add-on behind the fixed charge rather than the plan" do
+      item = item_for(fixed_charge_fee.id)
+
+      expect(item["type"]).to eq("fixed_charge")
+      expect(item["item_type"]).to eq("add_on")
+      expect(item["code"]).to eq(add_on.code)
+      expect(item["name"]).to eq(add_on.name)
+      expect(item["description"]).to eq(add_on.description)
+      expect(item["lago_item_id"]).to eq(add_on.id)
+
+      expect(item["code"]).not_to eq(subscription.plan.code)
+      expect(item["lago_item_id"]).not_to eq(subscription.id)
+    end
+
+    it "exposes lago_fixed_charge_id and leaves lago_charge_id null" do
+      row = row_for(fixed_charge_fee.id)
+
+      expect(row["lago_fixed_charge_id"]).to eq(fixed_charge.id)
+      expect(row["lago_charge_id"]).to be_nil
+    end
+
+    it "prefers the fixed charge's invoice_display_name over the add-on's" do
+      expect(item_for(fixed_charge_fee.id)["invoice_display_name"]).to eq("Storage add-on")
+    end
+
+    it "reads the date boundaries from the fixed_charges_* properties" do
+      row = row_for(fixed_charge_fee.id)
+
+      expect(Time.zone.parse(row["from_date"]).to_date).to eq(Date.new(2022, 7, 1))
+      expect(Time.zone.parse(row["to_date"]).to_date).to eq(Date.new(2022, 7, 31))
+      # the generic from_datetime on the same fee is 2022-08-01
+      expect(Time.zone.parse(row["from_date"]).to_date).not_to eq(Date.new(2022, 8, 1))
+    end
+  end
 end


### PR DESCRIPTION
## Context

Every `CASE f.fee_type` block in `exports_fees_v03` handled values 0 to 4 only. `Fee::FEE_TYPES` now has `fixed_charge` at index 5, so fixed-charge fees fell into the `ELSE` branches and were exported with the plan's code, name and description, `item_type` `'subscription'`, `lago_item_id` set to the subscription id, and `type` resolving to the literal `'unknown'`. `lago_fixed_charge_id` was not exposed at all, so the fee could not be attributed to the charge that produced it.

Reported by Foxglove across all 540 of their fixed-charge fees from June to August. On one invoice a `byos` add-on and 47 `developer_seats` carried byte-identical `item` payloads naming the plan, distinguishable only by units and amount.

Unlike the other Foxglove issues this one is not grace-period dependent. It affects every fixed-charge fee for every Data Pipeline customer, always.

## Change

`exports_fees_v04` adds a `WHEN 5` branch to each block, sourcing the item from the add-on behind the fixed charge, which is what `Fee#item_code`, `#item_name`, `#item_description`, `#item_id` and `#item_type` already do and what `V1::FeeSerializer` exports. `invoice_display_name` follows `Fee#invoice_name`, letting the fixed charge override the add-on. Date boundaries use the `fixed_charges_*` property keys per `Fee#date_boundaries`. `lago_fixed_charge_id` is exposed alongside `lago_charge_id`.

## Notes for review

**The `structure.sql` diff moves the `fixed_charges` table block earlier.** That is `pg_dump` reordering, not an edit: `exports_fees` now depends on `fixed_charges`, so the table has to be emitted before the view. Unavoidable.

**`item_type` is `'add_on'`, not `'fixed_charge'`.** The ticket asks for `'fixed_charge'` and `lago_item_id` = the charge id. I followed the API instead, where `item.type` is the fee type (`fixed_charge`) and `item.item_type` is the item's class (`AddOn`), because deviating would create a third convention for the same field alongside the API and the UI CSV export. The new `lago_fixed_charge_id` column gives the attribution the customer actually needs. Worth confirming with them before this ships.

**`lago_charge_id` stays null** on fixed-charge fees, since they carry `fixed_charge_id` instead. **`invoiceable` also stays null**, because it comes from `charges.invoiceable` and `fixed_charges` has no equivalent column, same as add-on, subscription and credit fees today.

**Fee type 6 (`product`) is deliberately untouched** and left on the existing fallback, tracked separately.

## Testing

Extends `spec/db/views/exports_fees_spec.rb` with a fixed-charge block covering the item payload, the new column, the display-name precedence and the date boundaries. The fee is built with a subscription so the plans join resolves: without it the old `ELSE` branch returned NULL rather than the plan's identity, which would have hidden the defect.

Refs INT-252