### PR TITLE
fix(daily-usages): stop leaking the compute lock

### DIFF
--- a/app/jobs/daily_usages/compute_job.rb
+++ b/app/jobs/daily_usages/compute_job.rb
@@ -11,7 +11,14 @@ module DailyUsages
     end
 
     retry_on ActiveRecord::ActiveRecordError, wait: :polynomially_longer, attempts: 6
-    unique :until_executing, on_conflict: :log, lock_ttl: 2.hours
+    # The enqueue lock must outlive the three hourly ticks that share one lock key (customer-local
+    # 00/01/02) plus the enqueue jitter, so a job still queued dedups the later ticks. The runtime
+    # lock serialises ComputeService's check-then-insert, and stays short because a killed worker
+    # strands it for its whole TTL.
+    unique :until_and_while_executing,
+      on_conflict: :log,
+      lock_ttl: 3.hours,
+      runtime_lock_ttl: 30.minutes
 
     def perform(subscription, timestamp:)
       DailyUsages::ComputeService.call(subscription:, timestamp:).raise_if_error!

--- a/app/jobs/daily_usages/compute_job.rb
+++ b/app/jobs/daily_usages/compute_job.rb
@@ -11,10 +11,6 @@ module DailyUsages
     end
 
     retry_on ActiveRecord::ActiveRecordError, wait: :polynomially_longer, attempts: 6
-    # The enqueue lock must outlive the three hourly ticks that share one lock key (customer-local
-    # 00/01/02) plus the enqueue jitter, so a job still queued dedups the later ticks. The runtime
-    # lock serialises ComputeService's check-then-insert, and stays short because a killed worker
-    # strands it for its whole TTL.
     unique :until_and_while_executing,
       on_conflict: :log,
       lock_ttl: 3.hours,

--- a/app/jobs/daily_usages/compute_job.rb
+++ b/app/jobs/daily_usages/compute_job.rb
@@ -11,7 +11,7 @@ module DailyUsages
     end
 
     retry_on ActiveRecord::ActiveRecordError, wait: :polynomially_longer, attempts: 6
-    unique :until_executed, on_conflict: :log, lock_ttl: 12.hours
+    unique :until_executing, on_conflict: :log, lock_ttl: 2.hours
 
     def perform(subscription, timestamp:)
       DailyUsages::ComputeService.call(subscription:, timestamp:).raise_if_error!

--- a/app/services/daily_usages/compute_service.rb
+++ b/app/services/daily_usages/compute_service.rb
@@ -43,8 +43,6 @@ module DailyUsages
       end
 
       result
-    rescue ActiveRecord::RecordInvalid => e
-      result.record_validation_failure!(record: e.record)
     end
 
     private

--- a/spec/jobs/daily_usages/compute_job_spec.rb
+++ b/spec/jobs/daily_usages/compute_job_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe DailyUsages::ComputeJob do
     end
   end
 
-  describe "retries" do
+  describe "uniqueness" do
     let(:database_error) { ActiveRecord::StatementInvalid.new("PG::ConnectionBad") }
 
     around do |example|
@@ -36,25 +36,44 @@ RSpec.describe DailyUsages::ComputeJob do
 
     def enqueue_and_deserialize
       described_class.perform_later(subscription, timestamp:)
-      job = ActiveJob::Base.deserialize(enqueued_jobs.last)
-      job.send(:deserialize_arguments_if_needed)
-      job
+      ActiveJob::Base.deserialize(enqueued_jobs.last)
     end
 
-    it "re-enqueues the job when the service raises an ActiveRecord error" do
+    it "lets a retry be enqueued from inside perform" do
       allow(DailyUsages::ComputeService).to receive(:call).and_raise(database_error)
       job = enqueue_and_deserialize
 
       expect { job.perform_now }.to have_enqueued_job(described_class)
     end
 
-    it "does not hold the uniqueness lock past a dying execution" do
+    it "does not hold the enqueue lock past a dying execution" do
       allow(DailyUsages::ComputeService).to receive(:call).and_raise("worker killed")
       job = enqueue_and_deserialize
       expect { job.perform_now }.to raise_error("worker killed")
 
       expect { described_class.perform_later(subscription, timestamp:) }
         .to have_enqueued_job(described_class)
+    end
+
+    it "does not run a concurrent job for the same subscription and date" do
+      overlapping_run = nil
+      overlapped = false
+
+      # The enqueue lock is released before perform, so a later tick does get enqueued while
+      # this job runs: only the runtime lock keeps the two executions from overlapping.
+      allow(DailyUsages::ComputeService).to receive(:call) do
+        unless overlapped
+          overlapped = true
+          overlapping_run = enqueue_and_deserialize.perform_now
+        end
+
+        result
+      end
+
+      enqueue_and_deserialize.perform_now
+
+      expect(overlapping_run).to be(false)
+      expect(DailyUsages::ComputeService).to have_received(:call).once
     end
   end
 

--- a/spec/jobs/daily_usages/compute_job_spec.rb
+++ b/spec/jobs/daily_usages/compute_job_spec.rb
@@ -23,6 +23,41 @@ RSpec.describe DailyUsages::ComputeJob do
     end
   end
 
+  describe "retries" do
+    let(:database_error) { ActiveRecord::StatementInvalid.new("PG::ConnectionBad") }
+
+    around do |example|
+      ActiveJob::Uniqueness.reset_manager!
+      described_class.unlock!
+      example.run
+      described_class.unlock!
+      ActiveJob::Uniqueness.test_mode!
+    end
+
+    def enqueue_and_deserialize
+      described_class.perform_later(subscription, timestamp:)
+      job = ActiveJob::Base.deserialize(enqueued_jobs.last)
+      job.send(:deserialize_arguments_if_needed)
+      job
+    end
+
+    it "re-enqueues the job when the service raises an ActiveRecord error" do
+      allow(DailyUsages::ComputeService).to receive(:call).and_raise(database_error)
+      job = enqueue_and_deserialize
+
+      expect { job.perform_now }.to have_enqueued_job(described_class)
+    end
+
+    it "does not hold the uniqueness lock past a dying execution" do
+      allow(DailyUsages::ComputeService).to receive(:call).and_raise("worker killed")
+      job = enqueue_and_deserialize
+      expect { job.perform_now }.to raise_error("worker killed")
+
+      expect { described_class.perform_later(subscription, timestamp:) }
+        .to have_enqueued_job(described_class)
+    end
+  end
+
   describe "#lock_key_arguments" do
     let(:customer) { create(:customer, timezone: "Europe/Paris") }
     let(:subscription) { create(:subscription, customer:) }

--- a/spec/services/daily_usages/compute_service_spec.rb
+++ b/spec/services/daily_usages/compute_service_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe DailyUsages::ComputeService do
             .and_raise(ActiveRecord::RecordInvalid.new(DailyUsage.new))
         end
 
-        it "lets the error bubble up so the job can retry" do
+        it "does not swallow the error into a failed result" do
           travel_to(timestamp) do
             expect { compute_service.call }.to raise_error(ActiveRecord::RecordInvalid)
           end

--- a/spec/services/daily_usages/compute_service_spec.rb
+++ b/spec/services/daily_usages/compute_service_spec.rb
@@ -205,6 +205,19 @@ RSpec.describe DailyUsages::ComputeService do
         end
       end
 
+      context "when the daily usage cannot be persisted" do
+        before do
+          allow_any_instance_of(DailyUsage).to receive(:save!) # rubocop:disable RSpec/AnyInstance
+            .and_raise(ActiveRecord::RecordInvalid.new(DailyUsage.new))
+        end
+
+        it "lets the error bubble up so the job can retry" do
+          travel_to(timestamp) do
+            expect { compute_service.call }.to raise_error(ActiveRecord::RecordInvalid)
+          end
+        end
+      end
+
       context "with customer timezone" do
         let(:customer) { create(:customer, organization:, timezone: "Australia/Sydney") }
         let(:timestamp) { Time.zone.parse("2024-10-21 15:05:00") }


### PR DESCRIPTION
## Context

`DailyUsages::ComputeJob` locked with `until_executed`, which releases its lock only after a
successful `perform`. An execution that never completes — retries exhausted, worker killed
mid-perform — held the lock for its whole 12 hour TTL, and with `on_conflict: :log` every later
orchestrator tick for that key was dropped silently, so the row was never written.

## Description

- Lock with `until_and_while_executing`: the enqueue lock is released before `perform`, and a
  separate runtime lock covers the execution.
- Raise the enqueue lock TTL to 3 hours, outliving the three hourly ticks that share one lock key
  plus the enqueue jitter.
- Cap the runtime lock at 30 minutes, since a worker killed mid-perform strands it until it expires.
- Add a regression test that a duplicate job does not execute while the first one is still running.
- Drop the dead `ActiveRecord::RecordInvalid` rescue in `ComputeService`; `DailyUsage` declares no
  validations beyond its `belongs_to` presence checks, and real database failures raise
  `StatementInvalid`, which `retry_on` already matches.

Plain `until_executing` was rejected: `ComputeService` reads before inserting and `daily_usages` has
no unique index on `(subscription_id, usage_date)`, so nothing would keep two overlapping executions
apart. That index is not an option yet — production rows violate it through a separate, still-open
bug.

## Known limitation

The runtime lock is a lease, so it serialises the insert on a best-effort basis only: a worker killed
mid-`perform` strands it for its TTL, and a run outliving the TTL can overlap a later job. No lock
strategy or TTL removes that — the property actually wanted is idempotent persistence, via a unique
index on `(subscription_id, usage_date)` plus `rescue ActiveRecord::RecordNotUnique`, which would
also cover the writers this lock never touched (`FillFromInvoiceService`, `FillHistoryService`,
manual backfills).

Resolving that separate bug is the prerequisite for the index, and is the real fix. This PR is
scoped to removing the
12-hour stranded lock that silently dropped every subsequent tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


