### PR TITLE
fix(daily-usage): isolate per-organization failures

### DIFF
--- a/app/services/daily_usages/compute_all_service.rb
+++ b/app/services/daily_usages/compute_all_service.rb
@@ -14,19 +14,11 @@ module DailyUsages
 
     def call
       Organization.with_revenue_analytics_support.find_each do |organization|
-        ids = Set.new
-
-        # Each leg runs its (cheap, indexed) selection query ONCE via pluck. We never iterate the
-        # heavy relation with find_each, which would re-execute the whole query per 1000-row batch.
-        ids.merge(event_subscriptions(organization).pluck("subscriptions.id"))
-        ids.merge(time_dependent_subscriptions(organization).pluck("subscriptions.id"))
-        ids.merge(recurring_rollover_subscriptions(organization).pluck("subscriptions.id"))
-
-        # Drop subscriptions already computed for yesterday. Subtracting here runs the dedup query
-        # once per organization, instead of three times (once per leg) if it lived in base_scope.
-        ids.subtract(already_computed_subscription_ids(organization))
-
-        enqueue(ids)
+        schedule_organization(organization)
+      rescue => e
+        # Nothing recomputes an older day and the clock job is not retried, so letting one
+        # organization's failure abort the run would permanently lose the day for all the others.
+        report_failure(organization, e)
       end
 
       result
@@ -35,6 +27,32 @@ module DailyUsages
     private
 
     attr_reader :timestamp
+
+    def schedule_organization(organization)
+      ids = Set.new
+
+      # Each leg runs its (cheap, indexed) selection query ONCE via pluck. We never iterate the
+      # heavy relation with find_each, which would re-execute the whole query per 1000-row batch.
+      ids.merge(event_subscriptions(organization).pluck("subscriptions.id"))
+      ids.merge(time_dependent_subscriptions(organization).pluck("subscriptions.id"))
+      ids.merge(recurring_rollover_subscriptions(organization).pluck("subscriptions.id"))
+
+      # Drop subscriptions already computed for yesterday. Subtracting here runs the dedup query
+      # once per organization, instead of three times (once per leg) if it lived in base_scope.
+      ids.subtract(already_computed_subscription_ids(organization))
+
+      enqueue(ids)
+    end
+
+    def report_failure(organization, error)
+      context = {organization_id: organization.id, timestamp: timestamp.iso8601}
+
+      Rails.logger.warn(
+        "Daily usage computation skipped for an organization: #{error.class} #{error.message} " \
+        "#{context.map { |k, v| "#{k}=#{v}" }.join(" ")}"
+      )
+      Sentry.capture_exception(error, extra: context)
+    end
 
     # Recompute every day for subscriptions that received an event recently: their usage may have
     # changed. Restricted to customers entering a new day in their timezone.

--- a/spec/services/daily_usages/compute_all_service_spec.rb
+++ b/spec/services/daily_usages/compute_all_service_spec.rb
@@ -301,5 +301,48 @@ RSpec.describe DailyUsages::ComputeAllService do
         expect(DailyUsages::ComputeJob).not_to have_been_enqueued
       end
     end
+
+    context "when the selection fails for one organization" do
+      let(:other_organization) { create(:organization, premium_integrations:) }
+      let(:other_customer) { create(:customer, organization: other_organization) }
+      let(:error) { ActiveRecord::StatementTimeout.new("canceling statement due to statement timeout") }
+
+      let(:other_subscription) do
+        create(:subscription, customer: other_customer, last_received_event_on: timestamp.to_date - 1.day)
+      end
+
+      before do
+        other_subscription
+        allow(Sentry).to receive(:capture_exception)
+        # rubocop:disable RSpec/SubjectStub -- simulate a statement timeout on one organization's selection query
+        allow(compute_service).to receive(:event_subscriptions).and_wrap_original do |original, selected|
+          if selected.id == organization.id
+            raise error
+          else
+            original.call(selected)
+          end
+        end
+        # rubocop:enable RSpec/SubjectStub
+      end
+
+      it "still enqueues the jobs of the other organizations" do
+        expect(compute_service.call).to be_success
+        expect(DailyUsages::ComputeJob).to have_been_enqueued.with(other_subscription, timestamp:)
+      end
+
+      it "does not enqueue the jobs of the failing organization" do
+        expect(compute_service.call).to be_success
+        subscriptions.each do |subscription|
+          expect(DailyUsages::ComputeJob).not_to have_been_enqueued.with(subscription, timestamp:)
+        end
+      end
+
+      it "reports the error" do
+        compute_service.call
+
+        expect(Sentry).to have_received(:capture_exception)
+          .with(error, extra: {organization_id: organization.id, timestamp: timestamp.iso8601})
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

`DailyUsages::ComputeAllService#call` walks every organization with revenue analytics support in one
unguarded loop, running three heavy selection queries each. A statement timeout on any of them
propagates out of `find_each` and aborts the whole run, so every organization ordered after the
failing one is never enqueued. Nothing recovers from that: the orchestrator only computes the
previous day, only inside the customer-local 0–2h window, and `Clock::ComputeAllDailyUsagesJob` runs
with `retry: 0`. One organization timing out silently costs all the following ones a full day of
`daily_usages` rows.

## Description

- Process each organization in isolation so a failure skips only that organization and the loop
  continues with the next one.
- Rescue `StandardError` only, so `ActiveRecord::StatementTimeout` is contained while `Interrupt`
  and `Sidekiq::Shutdown` still stop the run.
- Log the skipped organization and run timestamp, and capture the exception in Sentry with the same
  context, so a skip surfaces as an alert instead of as missing rows.
- Add a regression spec proving the other organizations are still enqueued when one raises.

The result stays successful: a skipped organization is not a failed tick, and with `retry: 0`
failing it would only hide the work that did succeed. Selection legs, timezone window, dedup and
enqueue batching are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
