### PR TITLE
perf: reuse current usage for full-usage recurring metrics

### DIFF
--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -4,6 +4,10 @@ module Invoices
   class CustomerUsageService < BaseService
     Result = BaseResult[:invoice, :usage, :fees_taxes]
 
+    # Recurring metrics of these types set use_from_boundary to false, so they aggregate all history
+    # up to the upper boundary whatever lower boundary they are given.
+    LIFETIME_BY_DEFAULT_AGGREGATIONS = %w[sum_agg unique_count_agg].freeze
+
     def initialize(
       customer:,
       subscription:,
@@ -132,7 +136,7 @@ module Invoices
         charge:,
         to_datetime: boundaries.charges_to_datetime,
         cache: charge_cache_enabled?,
-        full_usage: usage_filters.full_usage,
+        full_usage: usage_filters.full_usage && !lifetime_by_default?(charge),
         last_seen_at: applied_filters
       )
 
@@ -156,6 +160,21 @@ module Invoices
           )
         )
         .fees
+    end
+
+    # A recurring sum or unique count aggregates all history whatever lower boundary it is given, so
+    # its full usage is the number the ordinary current period entry already holds. Only the cache
+    # key changes: the window it is computed over is irrelevant to the result.
+    #
+    # Pay in advance is excluded because find_cached_aggregation is scoped by the lower boundary,
+    # and prorated because the period ratio is applied to it.
+    def lifetime_by_default?(charge)
+      return false unless usage_filters.full_usage
+      return false if calculate_projected_usage || max_timestamp
+      return false if charge.pay_in_advance? || charge.prorated?
+
+      metric = charge.billable_metric
+      metric.recurring? && LIFETIME_BY_DEFAULT_AGGREGATIONS.include?(metric.aggregation_type)
     end
 
     def boundaries

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -763,6 +763,80 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
             end
           end
         end
+
+        context "when a recurring metric already covers full history" do
+          subject(:usage_service) do
+            described_class.new(
+              customer:,
+              subscription:,
+              apply_taxes: false,
+              with_cache: true,
+              usage_filters: UsageFilters.new(filter_by_charge_id: charge.id, full_usage: true)
+            )
+          end
+
+          let(:current_date) { DateTime.parse("2025-06-15") }
+          let(:timestamp) { current_date }
+
+          let(:subscription) do
+            create(:subscription, plan:, customer:, started_at: DateTime.parse("2025-01-01"))
+          end
+
+          let(:billable_metric) { create(:billable_metric, :recurring, aggregation_type: "sum_agg", field_name: "value") }
+          let(:charge) { create(:standard_charge, plan:, billable_metric:, properties: {amount: "2"}) }
+
+          before do
+            create(:event, organization:, subscription:, customer:, code: billable_metric.code,
+              timestamp: current_date, properties: {value: 5}, created_at: current_date - 1.hour)
+          end
+
+          it "reads the current period entry instead of a full-usage one" do
+            travel_to(current_date) do
+              expect { usage_service.call }.to change { Rails.cache.exist?(current_usage_cache_key) }.from(false).to(true)
+
+              expect(Rails.cache.exist?(full_usage_cache_key)).to be(false)
+            end
+          end
+
+          context "when the charge is pay in advance" do
+            let(:charge) { create(:standard_charge, plan:, billable_metric:, pay_in_advance: true, properties: {amount: "2"}) }
+
+            it "does not take the shortcut and uses the full-usage entry instead" do
+              travel_to(current_date) do
+                expect { usage_service.call }.to change { Rails.cache.exist?(full_usage_cache_key) }.from(false).to(true)
+
+                expect(Rails.cache.exist?(current_usage_cache_key)).to be(false)
+              end
+            end
+          end
+
+          context "when the charge is prorated" do
+            let(:charge) { create(:standard_charge, plan:, billable_metric:, prorated: true, properties: {amount: "2"}) }
+
+            it "is refused before reaching the shortcut" do
+              travel_to(current_date) do
+                result = usage_service.call
+
+                expect(result).not_to be_success
+                expect(result.error.code).to eq("full_usage_not_allowed")
+              end
+            end
+          end
+
+          context "when the metric aggregation is unique_count_agg" do
+            let(:billable_metric) do
+              create(:billable_metric, :recurring, aggregation_type: "unique_count_agg", field_name: "value")
+            end
+
+            it "reads the current period entry instead of a full-usage one" do
+              travel_to(current_date) do
+                expect { usage_service.call }.to change { Rails.cache.exist?(current_usage_cache_key) }.from(false).to(true)
+
+                expect(Rails.cache.exist?(full_usage_cache_key)).to be(false)
+              end
+            end
+          end
+        end
       end
     end
 


### PR DESCRIPTION
## Context

recurring metrics already calculate full-usage for their current_usage, which means for them we can reuse already saved cache
