### PR TITLE
[ING-456] feat(connections): effective connection resolution helpers

### DIFF
--- a/app/models/concerns/connection_resolvable.rb
+++ b/app/models/concerns/connection_resolvable.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Resolves the effective connection of each category (payment / tax / accounting / crm) for a
+# billing object, cascading an explicit per-object override to the customer default:
+#
+#   * an override row (billing_object_connections) with behavior "specific" pins its connection
+#   * an override row with behavior "skip" resolves to nil (no connection for that category)
+#   * no override row means "inherit": fall back to the customer's default connection
+#
+# For a single-connection customer with no overrides this returns that connection, so behaviour
+# is unchanged.
+module ConnectionResolvable
+  extend ActiveSupport::Concern
+
+  CATEGORIES = BillingObjectConnection::CATEGORIES
+
+  def effective_payment_connection
+    effective_connection(CATEGORIES[:payment])
+  end
+
+  def effective_tax_connection
+    effective_connection(CATEGORIES[:tax])
+  end
+
+  def effective_accounting_connection
+    effective_connection(CATEGORIES[:accounting])
+  end
+
+  def effective_crm_connection
+    effective_connection(CATEGORIES[:crm])
+  end
+
+  private
+
+  def effective_connection(category)
+    override = billing_object_connections.find_by(category:)
+
+    if override
+      return nil if override.skip?
+
+      return override_connection(override, category)
+    end
+
+    customer_default_connection(category)
+  end
+
+  def override_connection(override, category)
+    if category == CATEGORIES[:payment]
+      override.payment_provider_customer
+    else
+      override.integration_customer
+    end
+  end
+
+  def customer_default_connection(category)
+    return unless customer
+
+    if category == CATEGORIES[:payment]
+      customer.payment_connection
+    else
+      customer.integration_connection(category)
+    end
+  end
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -383,6 +383,11 @@ class Customer < ApplicationRecord
     payment_provider_customers.find_by(is_default: true)
   end
 
+  # The customer's default integration connection for a category (tax / accounting / crm).
+  def integration_connection(category)
+    integration_customers.where(category:).find_by(is_default: true)
+  end
+
   def payment_connection_status
     connection = payment_connection
 

--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -3,10 +3,13 @@
 class RecurringTransactionRule < ApplicationRecord
   include HasPurchaseOrderNumber
   include PaperTrailTraceable
+  include ConnectionResolvable
 
   belongs_to :wallet
   belongs_to :organization
   belongs_to :payment_method, optional: true
+
+  delegate :customer, to: :wallet
 
   has_many :billing_object_connections, as: :owner, dependent: :destroy
   has_many :applied_invoice_custom_sections,

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -4,6 +4,7 @@ class Subscription < ApplicationRecord
   include HasPurchaseOrderNumber
   include PaperTrailTraceable
   include RansackUuidSearch
+  include ConnectionResolvable
 
   self.ignored_columns += %w[incompleted_at cancelation_reason]
 

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -4,6 +4,7 @@ class Wallet < ApplicationRecord
   include HasPurchaseOrderNumber
   include PaperTrailTraceable
   include Currencies
+  include ConnectionResolvable
 
   belongs_to :customer, -> { with_discarded }
   belongs_to :organization

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -1472,6 +1472,19 @@ RSpec.describe Customer do
     end
   end
 
+  describe "#integration_connection" do
+    let(:customer) { create(:customer) }
+    let!(:default_connection) { create(:netsuite_customer, customer:, is_default: true) }
+
+    it "returns the default connection of the category" do
+      expect(customer.integration_connection("accounting")).to eq(default_connection)
+    end
+
+    it "returns nil when no connection is default in the category" do
+      expect(customer.integration_connection("crm")).to be_nil
+    end
+  end
+
   describe "#address_changed?" do
     context "when a billing address field changes" do
       it "returns true" do

--- a/spec/models/recurring_transaction_rule_spec.rb
+++ b/spec/models/recurring_transaction_rule_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe RecurringTransactionRule do
   it_behaves_like "a model with a purchase order number"
 
+  it_behaves_like "a connection-resolvable billing object" do
+    let(:resolvable) { create(:recurring_transaction_rule) }
+  end
+
   describe "associations" do
     it { is_expected.to belong_to(:wallet) }
     it { is_expected.to belong_to(:organization) }

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe Subscription do
   it_behaves_like "paper_trail traceable"
   it_behaves_like "a model with a purchase order number"
 
+  it_behaves_like "a connection-resolvable billing object" do
+    let(:resolvable) { create(:subscription) }
+  end
+
   describe "enums" do
     it do
       expect(subject).to define_enum_for(:status).with_values(

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Wallet do
   it_behaves_like "paper_trail traceable"
   it_behaves_like "a model with a purchase order number"
 
+  it_behaves_like "a connection-resolvable billing object" do
+    let(:resolvable) { create(:wallet) }
+  end
+
   describe "associations" do
     it do
       expect(subject).to belong_to(:organization)

--- a/spec/support/shared_examples/connection_resolvable.rb
+++ b/spec/support/shared_examples/connection_resolvable.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+# Shared coverage for ConnectionResolvable. The including spec must define `let(:resolvable)`,
+# a billing object whose customer's default connections are inherited.
+RSpec.shared_examples "a connection-resolvable billing object" do
+  let(:resolution_customer) { resolvable.customer }
+  let(:organization) { resolution_customer.organization }
+
+  describe "#effective_payment_connection" do
+    context "when the customer has a default payment connection" do
+      let!(:default_connection) do
+        create(:stripe_customer, customer: resolution_customer, organization:, is_default: true)
+      end
+
+      it "returns the customer default" do
+        expect(resolvable.effective_payment_connection).to eq(default_connection)
+      end
+
+      context "when the object pins a specific connection" do
+        let(:override_connection) { create(:gocardless_customer, customer: resolution_customer, organization:) }
+
+        before do
+          create(:billing_object_connection, owner: resolvable, organization:, category: :payment,
+            behavior: :specific, payment_provider_customer: override_connection)
+        end
+
+        it "returns the override connection" do
+          expect(resolvable.effective_payment_connection).to eq(override_connection)
+        end
+      end
+
+      context "when the object skips the category" do
+        before do
+          create(:billing_object_connection, owner: resolvable, organization:, category: :payment, behavior: :skip)
+        end
+
+        it "returns nil" do
+          expect(resolvable.effective_payment_connection).to be_nil
+        end
+      end
+    end
+
+    context "when the customer has no default payment connection" do
+      it "returns nil" do
+        expect(resolvable.effective_payment_connection).to be_nil
+      end
+    end
+  end
+
+  describe "#effective_accounting_connection" do
+    context "when the customer has a default accounting connection" do
+      let!(:default_connection) do
+        create(:netsuite_customer, customer: resolution_customer, organization:, is_default: true)
+      end
+
+      it "returns the customer default" do
+        expect(resolvable.effective_accounting_connection).to eq(default_connection)
+      end
+
+      context "when the object pins a specific connection" do
+        let(:override_connection) { create(:xero_customer, customer: resolution_customer, organization:) }
+
+        before do
+          create(:billing_object_connection, owner: resolvable, organization:, category: :accounting,
+            behavior: :specific, integration_customer: override_connection)
+        end
+
+        it "returns the override connection" do
+          expect(resolvable.effective_accounting_connection).to eq(override_connection)
+        end
+      end
+
+      context "when the object skips the category" do
+        before do
+          create(:billing_object_connection, owner: resolvable, organization:, category: :accounting, behavior: :skip)
+        end
+
+        it "returns nil" do
+          expect(resolvable.effective_accounting_connection).to be_nil
+        end
+      end
+    end
+  end
+
+  describe "#effective_tax_connection" do
+    let!(:default_connection) do
+      create(:anrok_customer, customer: resolution_customer, organization:, is_default: true)
+    end
+
+    it "returns the customer default tax connection" do
+      expect(resolvable.effective_tax_connection).to eq(default_connection)
+    end
+  end
+
+  describe "#effective_crm_connection" do
+    let!(:default_connection) do
+      create(:hubspot_customer, customer: resolution_customer, organization:, is_default: true)
+    end
+
+    it "returns the customer default crm connection" do
+      expect(resolvable.effective_crm_connection).to eq(default_connection)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Downstream reads (tax / accounting / CRM / payment) need one way to resolve which connection applies to a billing object, honoring an explicit per-object override and otherwise inheriting the customer default. For a single-connection customer this returns that connection, so behaviour is unchanged.

## Description

Add a ConnectionResolvable concern to Subscription, Wallet and RecurringTransactionRule exposing effective_payment_connection, effective_tax_connection, effective_accounting_connection and effective_crm_connection. Each cascades a billing_object_connections override (specific pins the connection, skip resolves to nil) to the customer default, reusing Customer#payment_connection and a new Customer#integration_connection helper. RecurringTransactionRule delegates customer to its wallet.