### PR TITLE
feat(catalog): create the catalog_plans storage

### DIFF
--- a/app/models/catalog_plan.rb
+++ b/app/models/catalog_plan.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# The product-catalog plan: a named, priced envelope whose pricing lives in
+# its attached rate cards, not in legacy plan columns. It is the v2 catalog's
+# own table — the legacy `plans` table is untouched and never shared.
+class CatalogPlan < ApplicationRecord
+  include PaperTrailTraceable
+  include Currencies
+  include Discard::Model
+
+  self.discard_column = :deleted_at
+
+  belongs_to :organization
+
+  validates :name, presence: true
+  validates :code, presence: true
+  validates :currency, inclusion: {in: currency_list}
+
+  default_scope -> { kept }
+end
+
+# == Schema Information
+#
+# Table name: catalog_plans
+# Database name: primary
+#
+#  id                   :uuid             not null, primary key
+#  code                 :string           not null
+#  currency             :string           not null
+#  deleted_at           :datetime
+#  description          :string
+#  invoice_display_name :string
+#  name                 :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  organization_id      :uuid             not null
+#
+# Indexes
+#
+#  index_catalog_plans_on_deleted_at                (deleted_at)
+#  index_catalog_plans_on_organization_id           (organization_id)
+#  index_catalog_plans_on_organization_id_and_code  (organization_id,code) UNIQUE WHERE (deleted_at IS NULL)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/models/catalog_plan.rb
+++ b/app/models/catalog_plan.rb
@@ -14,7 +14,7 @@ class CatalogPlan < ApplicationRecord
 
   validates :name, presence: true
   validates :code, presence: true, uniqueness: {scope: :organization_id, conditions: -> { where(deleted_at: nil) }}
-  validates :currency, inclusion: {in: currency_list}
+  validates :currency, presence: true, inclusion: {in: currency_list, allow_nil: true}
 
   default_scope -> { kept }
 end

--- a/app/models/catalog_plan.rb
+++ b/app/models/catalog_plan.rb
@@ -13,7 +13,7 @@ class CatalogPlan < ApplicationRecord
   belongs_to :organization
 
   validates :name, presence: true
-  validates :code, presence: true
+  validates :code, presence: true, uniqueness: {scope: :organization_id, conditions: -> { where(deleted_at: nil) }}
   validates :currency, inclusion: {in: currency_list}
 
   default_scope -> { kept }

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -52,6 +52,7 @@ class Organization < ApplicationRecord
   has_many :product_filters
   has_many :rate_cards
   has_many :rate_card_rates
+  has_many :catalog_plans
   has_many :pricing_units
   has_many :customers
   has_many :subscriptions

--- a/db/migrate/20260904083017_create_catalog_plans.rb
+++ b/db/migrate/20260904083017_create_catalog_plans.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class CreateCatalogPlans < ActiveRecord::Migration[8.0]
+  def change
+    create_table :catalog_plans, id: :uuid do |t|
+      t.references :organization, type: :uuid, null: false, foreign_key: true, index: true
+
+      t.string :name, null: false
+      t.string :code, null: false
+      t.string :invoice_display_name
+      t.string :description
+      t.string :currency, null: false
+
+      t.datetime :deleted_at
+
+      t.timestamps
+    end
+
+    add_index :catalog_plans, %i[organization_id code],
+      unique: true,
+      where: "deleted_at IS NULL",
+      name: "index_catalog_plans_on_organization_id_and_code"
+    add_index :catalog_plans, :deleted_at
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -329,6 +329,7 @@ ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_1db
 ALTER TABLE IF EXISTS ONLY public.applied_usage_thresholds DROP CONSTRAINT IF EXISTS fk_rails_1d112bf8a0;
 ALTER TABLE IF EXISTS ONLY public.rate_phases DROP CONSTRAINT IF EXISTS fk_rails_1c069c1c44;
 ALTER TABLE IF EXISTS ONLY public.billing_entities_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_19c47827ba;
+ALTER TABLE IF EXISTS ONLY public.catalog_plans DROP CONSTRAINT IF EXISTS fk_rails_19759667f5;
 ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk_rails_195153290d;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_189f2a3949;
 ALTER TABLE IF EXISTS ONLY public.quote_owners DROP CONSTRAINT IF EXISTS fk_rails_1811b32fcd;
@@ -887,6 +888,9 @@ DROP INDEX IF EXISTS public.index_charge_filter_values_on_organization_id;
 DROP INDEX IF EXISTS public.index_charge_filter_values_on_deleted_at;
 DROP INDEX IF EXISTS public.index_charge_filter_values_on_charge_filter_id;
 DROP INDEX IF EXISTS public.index_charge_filter_values_on_billable_metric_filter_id;
+DROP INDEX IF EXISTS public.index_catalog_plans_on_organization_id_and_code;
+DROP INDEX IF EXISTS public.index_catalog_plans_on_organization_id;
+DROP INDEX IF EXISTS public.index_catalog_plans_on_deleted_at;
 DROP INDEX IF EXISTS public.index_cached_aggregations_on_external_subscription_id;
 DROP INDEX IF EXISTS public.index_cached_aggregations_on_event_transaction_id;
 DROP INDEX IF EXISTS public.index_cached_aggregations_on_charge_id;
@@ -1158,6 +1162,7 @@ ALTER TABLE IF EXISTS ONLY public.charges_taxes DROP CONSTRAINT IF EXISTS charge
 ALTER TABLE IF EXISTS ONLY public.charges DROP CONSTRAINT IF EXISTS charges_pkey;
 ALTER TABLE IF EXISTS ONLY public.charge_filters DROP CONSTRAINT IF EXISTS charge_filters_pkey;
 ALTER TABLE IF EXISTS ONLY public.charge_filter_values DROP CONSTRAINT IF EXISTS charge_filter_values_pkey;
+ALTER TABLE IF EXISTS ONLY public.catalog_plans DROP CONSTRAINT IF EXISTS catalog_plans_pkey;
 ALTER TABLE IF EXISTS ONLY public.cached_aggregations DROP CONSTRAINT IF EXISTS cached_aggregations_pkey;
 ALTER TABLE IF EXISTS ONLY public.billing_segments DROP CONSTRAINT IF EXISTS billing_segments_pkey;
 ALTER TABLE IF EXISTS ONLY public.billing_segments DROP CONSTRAINT IF EXISTS billing_segments_no_overlapping_periods;
@@ -1340,6 +1345,7 @@ DROP TABLE IF EXISTS public.charges_taxes;
 DROP TABLE IF EXISTS public.charges;
 DROP TABLE IF EXISTS public.charge_filters;
 DROP TABLE IF EXISTS public.charge_filter_values;
+DROP TABLE IF EXISTS public.catalog_plans;
 DROP TABLE IF EXISTS public.cached_aggregations;
 DROP TABLE IF EXISTS public.billing_segments;
 DROP TABLE IF EXISTS public.billing_object_connections;
@@ -2503,6 +2509,24 @@ CREATE TABLE public.cached_aggregations (
     current_amount numeric,
     event_transaction_id character varying,
     presentation_breakdowns jsonb DEFAULT '[]'::jsonb NOT NULL
+);
+
+
+--
+-- Name: catalog_plans; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.catalog_plans (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    name character varying NOT NULL,
+    code character varying NOT NULL,
+    invoice_display_name character varying,
+    description character varying,
+    currency character varying NOT NULL,
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 
@@ -6295,6 +6319,14 @@ ALTER TABLE ONLY public.cached_aggregations
 
 
 --
+-- Name: catalog_plans catalog_plans_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.catalog_plans
+    ADD CONSTRAINT catalog_plans_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: charge_filter_values charge_filter_values_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8339,6 +8371,27 @@ CREATE INDEX index_cached_aggregations_on_event_transaction_id ON public.cached_
 --
 
 CREATE INDEX index_cached_aggregations_on_external_subscription_id ON public.cached_aggregations USING btree (external_subscription_id);
+
+
+--
+-- Name: index_catalog_plans_on_deleted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_catalog_plans_on_deleted_at ON public.catalog_plans USING btree (deleted_at);
+
+
+--
+-- Name: index_catalog_plans_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_catalog_plans_on_organization_id ON public.catalog_plans USING btree (organization_id);
+
+
+--
+-- Name: index_catalog_plans_on_organization_id_and_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_catalog_plans_on_organization_id_and_code ON public.catalog_plans USING btree (organization_id, code) WHERE (deleted_at IS NULL);
 
 
 --
@@ -12193,6 +12246,14 @@ ALTER TABLE ONLY public.customer_metadata
 
 
 --
+-- Name: catalog_plans fk_rails_19759667f5; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.catalog_plans
+    ADD CONSTRAINT fk_rails_19759667f5 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: billing_entities_invoice_custom_sections fk_rails_19c47827ba; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -14760,6 +14821,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260904132835'),
+('20260904083017'),
 ('20260902143604'),
 ('20260826235314'),
 ('20260826235313'),
@@ -15875,3 +15937,4 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220530091046'),
 ('20220526101535'),
 ('20220525122759');
+

--- a/spec/factories/catalog_plans.rb
+++ b/spec/factories/catalog_plans.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :catalog_plan do
+    organization
+    name { Faker::Commerce.product_name }
+    sequence(:code) { |n| "catalog-plan-#{n}" }
+    currency { "EUR" }
+  end
+end

--- a/spec/models/catalog_plan_spec.rb
+++ b/spec/models/catalog_plan_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CatalogPlan do
+  subject(:catalog_plan) { build(:catalog_plan) }
+
+  it_behaves_like "paper_trail traceable"
+
+  describe "associations" do
+    it do
+      expect(catalog_plan).to belong_to(:organization)
+    end
+  end
+
+  describe "validations" do
+    it do
+      expect(catalog_plan).to validate_presence_of(:name)
+      expect(catalog_plan).to validate_presence_of(:code)
+      expect(build(:catalog_plan, currency: "EUR")).to be_valid
+      expect(build(:catalog_plan, currency: "INVALID")).not_to be_valid
+    end
+  end
+
+  describe "soft deletion" do
+    it "hides discarded records behind the default scope" do
+      catalog_plan.save!
+      catalog_plan.discard!
+
+      expect(described_class.all).not_to include(catalog_plan)
+      expect(described_class.with_discarded).to include(catalog_plan)
+    end
+
+    it "enforces code uniqueness per organization only on kept rows" do
+      organization = create(:organization)
+      first = create(:catalog_plan, organization:, code: "dup")
+
+      expect { create(:catalog_plan, organization:, code: "dup") }.to raise_error(ActiveRecord::RecordNotUnique)
+
+      first.discard!
+      expect { create(:catalog_plan, organization:, code: "dup") }.not_to raise_error
+    end
+  end
+end

--- a/spec/models/catalog_plan_spec.rb
+++ b/spec/models/catalog_plan_spec.rb
@@ -20,6 +20,30 @@ RSpec.describe CatalogPlan do
       expect(build(:catalog_plan, currency: "EUR")).to be_valid
       expect(build(:catalog_plan, currency: "INVALID")).not_to be_valid
     end
+
+    describe "code uniqueness" do
+      let(:organization) { create(:organization) }
+
+      it "rejects a duplicate code within the organization" do
+        create(:catalog_plan, organization:, code: "dup")
+        duplicate = build(:catalog_plan, organization:, code: "dup")
+
+        expect(duplicate).not_to be_valid
+        expect(duplicate.errors.where(:code, :taken)).to be_present
+      end
+
+      it "allows the same code in another organization" do
+        create(:catalog_plan, organization:, code: "shared")
+
+        expect(build(:catalog_plan, organization: create(:organization), code: "shared")).to be_valid
+      end
+
+      it "frees the code once the holder is discarded" do
+        create(:catalog_plan, organization:, code: "dup").discard!
+
+        expect(build(:catalog_plan, organization:, code: "dup")).to be_valid
+      end
+    end
   end
 
   describe "soft deletion" do
@@ -31,14 +55,12 @@ RSpec.describe CatalogPlan do
       expect(described_class.with_discarded).to include(catalog_plan)
     end
 
-    it "enforces code uniqueness per organization only on kept rows" do
+    it "enforces code uniqueness among kept rows at the database level" do
       organization = create(:organization)
-      first = create(:catalog_plan, organization:, code: "dup")
+      create(:catalog_plan, organization:, code: "dup")
+      duplicate = build(:catalog_plan, organization:, code: "dup")
 
-      expect { create(:catalog_plan, organization:, code: "dup") }.to raise_error(ActiveRecord::RecordNotUnique)
-
-      first.discard!
-      expect { create(:catalog_plan, organization:, code: "dup") }.not_to raise_error
+      expect { duplicate.save(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
     end
   end
 end

--- a/spec/models/catalog_plan_spec.rb
+++ b/spec/models/catalog_plan_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe CatalogPlan do
     it do
       expect(catalog_plan).to validate_presence_of(:name)
       expect(catalog_plan).to validate_presence_of(:code)
+      expect(catalog_plan).to validate_presence_of(:currency)
       expect(build(:catalog_plan, currency: "EUR")).to be_valid
       expect(build(:catalog_plan, currency: "INVALID")).not_to be_valid
     end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Organization do
       expect(subject).to have_many(:product_filters)
       expect(subject).to have_many(:rate_cards)
       expect(subject).to have_many(:rate_card_rates)
+      expect(subject).to have_many(:catalog_plans)
       expect(subject).to have_many(:customers)
       expect(subject).to have_many(:subscriptions)
       expect(subject).to have_many(:contracts)


### PR DESCRIPTION
## What this is

The v2 catalog gets its **own** plan table, so a product-catalog plan stops being a `pricing_type: product_catalog` row on the shared `plans` table (carrying nil `interval`/`amount_cents`/`pay_in_advance`).

## Changes

- `catalog_plans` table — the plan **envelope only**: `name`, `code`, `invoice_display_name`, `description`, `currency`, `organization_id`, timestamps, `deleted_at`. No legacy pricing columns, and **no self-reference** (catalog plans don't use plan parent/child overrides — the dive-in's open question, resolved).
- `CatalogPlan` model — paper-trailed, soft-deletable (`default_scope { kept }`), validates name/code presence and currency inclusion.
- Partial unique index on `(organization_id, code) WHERE deleted_at IS NULL` — code unique per org among kept rows.

## Not in scope

No `product_category_id` (plans link to categories through products, not a column) and no `pending_deletion` yet — added later if the catalog destroy flow needs it.