### PR TITLE
feat(billing): add billing segments

### DIFF
--- a/app/models/billing_segment.rb
+++ b/app/models/billing_segment.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+# A durable priced slice of a contract rate card billing cycle. A whole cycle has one
+# segment; a rate change inside the cycle creates several segments sharing cycle_started_at.
+class BillingSegment < ApplicationRecord
+  include Currencies
+
+  STATUSES = {
+    pending: "pending",
+    processing: "processing",
+    done: "done",
+    failed: "failed"
+  }.freeze
+
+  belongs_to :organization
+  belongs_to :contract
+  belongs_to :customer, -> { with_discarded }
+  belongs_to :contract_rate_card, -> { with_discarded }
+  belongs_to :invoice, optional: true
+  belongs_to :rate_card_rate, -> { with_discarded }, optional: true
+  belongs_to :rate_override, -> { with_discarded }, optional: true
+  belongs_to :pricing_unit, optional: true
+
+  enum :status, STATUSES, validate: true, prefix: true
+
+  validates :billing_at, presence: true
+  validates :cycle_started_at, presence: true
+  validates :currency, presence: true, inclusion: {in: currency_list, allow_nil: true}
+  validates :started_at, presence: true
+  validates :ended_at, presence: true
+  validates :proration_ratio, numericality: {greater_than_or_equal_to: 0, less_than_or_equal_to: 1}
+
+  validate :validate_rate_presence
+  validate :validate_period_bounds
+  validate :validate_cycle_bounds
+
+  def rate
+    rate_override || rate_card_rate
+  end
+
+  def pricing_unit_conversion_rate
+    if rate_override
+      rate_override.pricing_unit_conversion_rate
+    else
+      rate_card_rate.applied_pricing_unit_conversion_rate
+    end
+  end
+
+  def min_amount_cents
+    if rate_override
+      rate_override.min_amount_cents
+    else
+      rate_card_rate.min_amount_cents
+    end
+  end
+
+  private
+
+  def validate_rate_presence
+    if rate_card_rate || rate_override
+      return
+    end
+
+    errors.add(:base, :rate_card_rate_or_rate_override_required)
+  end
+
+  def validate_period_bounds
+    if started_at.blank? || ended_at.blank? || started_at <= ended_at
+      return
+    end
+
+    errors.add(:ended_at, :must_be_after_started_at)
+  end
+
+  def validate_cycle_bounds
+    if cycle_started_at.blank? || started_at.blank? || cycle_started_at <= started_at
+      return
+    end
+
+    errors.add(:cycle_started_at, :must_be_before_started_at)
+  end
+end
+
+# == Schema Information
+#
+# Table name: billing_segments
+# Database name: primary
+#
+#  id                    :uuid             not null, primary key
+#  billing_at            :datetime         not null
+#  currency              :string           not null
+#  cycle_started_at      :datetime         not null
+#  ended_at              :datetime         not null
+#  proration_ratio       :decimal(30, 10)  default(1.0), not null
+#  rate_properties       :jsonb            not null
+#  started_at            :datetime         not null
+#  status                :enum             default("pending"), not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  contract_id           :uuid             not null
+#  contract_rate_card_id :uuid             not null
+#  customer_id           :uuid             not null
+#  invoice_id            :uuid
+#  organization_id       :uuid             not null
+#  pricing_unit_id       :uuid
+#  rate_card_rate_id     :uuid
+#  rate_override_id      :uuid
+#
+# Indexes
+#
+#  billing_segments_no_overlapping_periods          (organization_id, contract_id, customer_id, contract_rate_card_id, tsrange(started_at, ended_at, '[]'::text)) USING gist
+#  idx_on_contract_id_billing_at_status_3588bfae7a  (contract_id,billing_at,status)
+#  index_billing_segments_on_card_and_cycle         (contract_rate_card_id,cycle_started_at)
+#  index_billing_segments_on_card_and_period        (contract_rate_card_id,started_at) UNIQUE
+#  index_billing_segments_on_contract_id            (contract_id)
+#  index_billing_segments_on_contract_rate_card_id  (contract_rate_card_id)
+#  index_billing_segments_on_customer_id            (customer_id)
+#  index_billing_segments_on_invoice_id             (invoice_id)
+#  index_billing_segments_on_organization_id        (organization_id)
+#  index_billing_segments_on_pricing_unit_id        (pricing_unit_id)
+#  index_billing_segments_on_rate_card_rate_id      (rate_card_rate_id)
+#  index_billing_segments_on_rate_override_id       (rate_override_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (contract_id => contracts.id)
+#  fk_rails_...  (contract_rate_card_id => contract_rate_cards.id)
+#  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (invoice_id => invoices.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (pricing_unit_id => pricing_units.id)
+#  fk_rails_...  (rate_card_rate_id => rate_card_rates.id)
+#  fk_rails_...  (rate_override_id => rate_overrides.id)
+#

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -27,6 +27,7 @@ class Contract < ApplicationRecord
   belongs_to :plan, -> { with_discarded }, optional: true
 
   has_many :applied_rate_cards, class_name: "ContractRateCard"
+  has_many :billing_segments
 
   enum :status, STATUSES, validate: true
   enum :billing_time, BILLING_TIMES, validate: true

--- a/app/models/contract_rate_card.rb
+++ b/app/models/contract_rate_card.rb
@@ -13,6 +13,7 @@ class ContractRateCard < ApplicationRecord
   has_one :product, through: :rate_card
 
   has_many :rate_phases, -> { order(:position) }
+  has_many :billing_segments
 
   validates :billing_anchor_date, presence: true
   validates :next_billing_at, presence: true

--- a/db/migrate/20260904132835_create_billing_segments.rb
+++ b/db/migrate/20260904132835_create_billing_segments.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class CreateBillingSegments < ActiveRecord::Migration[8.0]
+  def up
+    enable_extension "btree_gist"
+
+    create_enum :billing_segment_status, %w[pending processing done failed]
+
+    create_table :billing_segments, id: :uuid do |t|
+      t.references :organization, null: false, foreign_key: true, type: :uuid
+      t.references :contract, null: false, foreign_key: true, type: :uuid
+      t.references :customer, null: false, foreign_key: true, type: :uuid
+      t.references :contract_rate_card, null: false, foreign_key: true, type: :uuid
+
+      t.references :invoice, foreign_key: true, type: :uuid
+      t.references :rate_card_rate, foreign_key: true, type: :uuid
+      t.references :rate_override, foreign_key: true, type: :uuid
+      t.references :pricing_unit, foreign_key: true, type: :uuid
+      t.jsonb :rate_properties, null: false, default: {}
+      t.string :currency, null: false
+
+      t.datetime :billing_at, null: false
+      t.datetime :started_at, null: false
+      t.datetime :ended_at, null: false
+      t.datetime :cycle_started_at, null: false
+
+      t.decimal :proration_ratio, precision: 30, scale: 10, null: false, default: 1
+      t.enum :status, enum_type: :billing_segment_status, null: false, default: "pending"
+
+      t.timestamps
+
+      t.check_constraint "started_at <= ended_at", name: "billing_segments_period_bounds"
+      t.check_constraint "cycle_started_at <= started_at", name: "billing_segments_cycle_bounds"
+      t.check_constraint "proration_ratio >= 0 AND proration_ratio <= 1", name: "billing_segments_proration_ratio_bounds"
+      t.check_constraint "rate_card_rate_id IS NOT NULL OR rate_override_id IS NOT NULL", name: "billing_segments_rate_presence"
+
+      t.index [:contract_rate_card_id, :started_at], unique: true, name: "index_billing_segments_on_card_and_period"
+      t.index [:contract_id, :billing_at, :status]
+      t.index [:contract_rate_card_id, :cycle_started_at], name: "index_billing_segments_on_card_and_cycle"
+    end
+
+    safety_assured do
+      execute <<~SQL
+        ALTER TABLE billing_segments
+        ADD CONSTRAINT billing_segments_no_overlapping_periods
+        EXCLUDE USING gist (
+          organization_id WITH =,
+          contract_id WITH =,
+          customer_id WITH =,
+          contract_rate_card_id WITH =,
+          tsrange(started_at, ended_at, '[]') WITH &&
+        )
+      SQL
+    end
+  end
+
+  def down
+    drop_table :billing_segments # rubocop:disable Lago/NoDropColumnOrTable
+    drop_enum :billing_segment_status
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -42,6 +42,7 @@ ALTER TABLE IF EXISTS ONLY public.integration_customers DROP CONSTRAINT IF EXIST
 ALTER TABLE IF EXISTS ONLY public.fixed_charges DROP CONSTRAINT IF EXISTS fk_rails_e95f72749e;
 ALTER TABLE IF EXISTS ONLY public.rate_card_rates DROP CONSTRAINT IF EXISTS fk_rails_e910b02a08;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules DROP CONSTRAINT IF EXISTS fk_rails_e8bac9c5bb;
+ALTER TABLE IF EXISTS ONLY public.billing_segments DROP CONSTRAINT IF EXISTS fk_rails_e88ab4465f;
 ALTER TABLE IF EXISTS ONLY public.plans_taxes DROP CONSTRAINT IF EXISTS fk_rails_e88403f4b9;
 ALTER TABLE IF EXISTS ONLY public.customers_taxes DROP CONSTRAINT IF EXISTS fk_rails_e86903e081;
 ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS fk_rails_e744efbe51;
@@ -102,10 +103,12 @@ ALTER TABLE IF EXISTS ONLY public.applied_coupons DROP CONSTRAINT IF EXISTS fk_r
 ALTER TABLE IF EXISTS ONLY public.lifetime_usages DROP CONSTRAINT IF EXISTS fk_rails_ba128983c2;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_b974dac270;
 ALTER TABLE IF EXISTS ONLY public.presentation_breakdowns DROP CONSTRAINT IF EXISTS fk_rails_b8f3cabc8e;
+ALTER TABLE IF EXISTS ONLY public.billing_segments DROP CONSTRAINT IF EXISTS fk_rails_b868d0440a;
 ALTER TABLE IF EXISTS ONLY public.subscription_activation_rules DROP CONSTRAINT IF EXISTS fk_rails_b749d2045d;
 ALTER TABLE IF EXISTS ONLY public.orders DROP CONSTRAINT IF EXISTS fk_rails_b687c6e23a;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlements DROP CONSTRAINT IF EXISTS fk_rails_b61aa73940;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_b50dc82c1e;
+ALTER TABLE IF EXISTS ONLY public.billing_segments DROP CONSTRAINT IF EXISTS fk_rails_b3bd992995;
 ALTER TABLE IF EXISTS ONLY public.entitlement_subscription_feature_removals DROP CONSTRAINT IF EXISTS fk_rails_b3864df641;
 ALTER TABLE IF EXISTS ONLY public.billing_entities_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_b283a89721;
 ALTER TABLE IF EXISTS ONLY public.daily_usages DROP CONSTRAINT IF EXISTS fk_rails_b07fc711f7;
@@ -161,6 +164,7 @@ ALTER TABLE IF EXISTS ONLY public.entitlement_entitlement_values DROP CONSTRAINT
 ALTER TABLE IF EXISTS ONLY public.adjusted_fees DROP CONSTRAINT IF EXISTS fk_rails_885dc100ef;
 ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXISTS fk_rails_88349fc20a;
 ALTER TABLE IF EXISTS ONLY public.wallets_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_87bc3bd4cb;
+ALTER TABLE IF EXISTS ONLY public.billing_segments DROP CONSTRAINT IF EXISTS fk_rails_86cc43f205;
 ALTER TABLE IF EXISTS ONLY public.payment_provider_customers DROP CONSTRAINT IF EXISTS fk_rails_86676be631;
 ALTER TABLE IF EXISTS ONLY public.wallet_transaction_consumptions DROP CONSTRAINT IF EXISTS fk_rails_85b9e72931;
 ALTER TABLE IF EXISTS ONLY public.payments DROP CONSTRAINT IF EXISTS fk_rails_84f4587409;
@@ -230,6 +234,7 @@ ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS fk_rails_5bb4
 ALTER TABLE IF EXISTS ONLY public.add_ons_taxes DROP CONSTRAINT IF EXISTS fk_rails_5ade8984b1;
 ALTER TABLE IF EXISTS ONLY public.invoice_settlements DROP CONSTRAINT IF EXISTS fk_rails_5a4b906a16;
 ALTER TABLE IF EXISTS ONLY public.data_exports DROP CONSTRAINT IF EXISTS fk_rails_5a43da571b;
+ALTER TABLE IF EXISTS ONLY public.billing_segments DROP CONSTRAINT IF EXISTS fk_rails_59357d1f82;
 ALTER TABLE IF EXISTS ONLY public.customers DROP CONSTRAINT IF EXISTS fk_rails_58234c715e;
 ALTER TABLE IF EXISTS ONLY public.charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_56b7167125;
 ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS fk_rails_56b3626631;
@@ -282,6 +287,7 @@ ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_34ab15
 ALTER TABLE IF EXISTS ONLY public.lifetime_usages DROP CONSTRAINT IF EXISTS fk_rails_348acbd245;
 ALTER TABLE IF EXISTS ONLY public.customers_taxes DROP CONSTRAINT IF EXISTS fk_rails_33d169382f;
 ALTER TABLE IF EXISTS ONLY public.payment_requests DROP CONSTRAINT IF EXISTS fk_rails_32600e5a72;
+ALTER TABLE IF EXISTS ONLY public.billing_segments DROP CONSTRAINT IF EXISTS fk_rails_322fa429f9;
 ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_310fcb3585;
 ALTER TABLE IF EXISTS ONLY public.invoices DROP CONSTRAINT IF EXISTS fk_rails_309d3a4412;
 ALTER TABLE IF EXISTS ONLY public.wallets_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_3092f5f2e0;
@@ -290,6 +296,7 @@ ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_2fd
 ALTER TABLE IF EXISTS ONLY public.payment_requests DROP CONSTRAINT IF EXISTS fk_rails_2fb2147151;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_2ea4db3a4c;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_2dc6171f57;
+ALTER TABLE IF EXISTS ONLY public.billing_segments DROP CONSTRAINT IF EXISTS fk_rails_2cad4a133e;
 ALTER TABLE IF EXISTS ONLY public.product_filters DROP CONSTRAINT IF EXISTS fk_rails_2c40f5b85c;
 ALTER TABLE IF EXISTS ONLY public.ai_conversations DROP CONSTRAINT IF EXISTS fk_rails_2c06a74f41;
 ALTER TABLE IF EXISTS ONLY public.wallets DROP CONSTRAINT IF EXISTS fk_rails_2b35eef34b;
@@ -335,6 +342,7 @@ ALTER TABLE IF EXISTS ONLY public.applied_invoice_custom_sections DROP CONSTRAIN
 ALTER TABLE IF EXISTS ONLY public.fees_taxes DROP CONSTRAINT IF EXISTS fk_rails_103e187859;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_triggered_alerts DROP CONSTRAINT IF EXISTS fk_rails_0f807322b1;
 ALTER TABLE IF EXISTS ONLY public.integration_mappings DROP CONSTRAINT IF EXISTS fk_rails_0f762162b0;
+ALTER TABLE IF EXISTS ONLY public.billing_segments DROP CONSTRAINT IF EXISTS fk_rails_0f69bb4d01;
 ALTER TABLE IF EXISTS ONLY public.integration_customers DROP CONSTRAINT IF EXISTS fk_rails_0e464363cb;
 ALTER TABLE IF EXISTS ONLY public.ai_conversations DROP CONSTRAINT IF EXISTS fk_rails_0da056ac92;
 ALTER TABLE IF EXISTS ONLY public.invoices DROP CONSTRAINT IF EXISTS fk_rails_0d349e632f;
@@ -875,6 +883,16 @@ DROP INDEX IF EXISTS public.index_charge_filter_values_on_billable_metric_filter
 DROP INDEX IF EXISTS public.index_cached_aggregations_on_external_subscription_id;
 DROP INDEX IF EXISTS public.index_cached_aggregations_on_event_transaction_id;
 DROP INDEX IF EXISTS public.index_cached_aggregations_on_charge_id;
+DROP INDEX IF EXISTS public.index_billing_segments_on_rate_override_id;
+DROP INDEX IF EXISTS public.index_billing_segments_on_rate_card_rate_id;
+DROP INDEX IF EXISTS public.index_billing_segments_on_pricing_unit_id;
+DROP INDEX IF EXISTS public.index_billing_segments_on_organization_id;
+DROP INDEX IF EXISTS public.index_billing_segments_on_invoice_id;
+DROP INDEX IF EXISTS public.index_billing_segments_on_customer_id;
+DROP INDEX IF EXISTS public.index_billing_segments_on_contract_rate_card_id;
+DROP INDEX IF EXISTS public.index_billing_segments_on_contract_id;
+DROP INDEX IF EXISTS public.index_billing_segments_on_card_and_period;
+DROP INDEX IF EXISTS public.index_billing_segments_on_card_and_cycle;
 DROP INDEX IF EXISTS public.index_billing_object_connections_on_organization_id;
 DROP INDEX IF EXISTS public.index_billing_object_connections_on_integration_customer_id;
 DROP INDEX IF EXISTS public.index_billing_entities_taxes_on_tax_id;
@@ -992,6 +1010,7 @@ DROP INDEX IF EXISTS public.idx_on_entitlement_feature_id_821ae72311;
 DROP INDEX IF EXISTS public.idx_on_entitlement_entitlement_id_48c0b3356a;
 DROP INDEX IF EXISTS public.idx_on_enriched_store_migration_id_e409c5dc43;
 DROP INDEX IF EXISTS public.idx_on_dunning_campaign_id_currency_fbf233b2ae;
+DROP INDEX IF EXISTS public.idx_on_contract_id_billing_at_status_3588bfae7a;
 DROP INDEX IF EXISTS public.idx_on_billing_entity_id_invoice_custom_section_id_bd78c547d3;
 DROP INDEX IF EXISTS public.idx_on_billing_entity_id_customer_id_invoice_custom_e7aada65cb;
 DROP INDEX IF EXISTS public.idx_on_billing_entity_id_billing_entity_sequential__bd26b2e655;
@@ -1132,6 +1151,8 @@ ALTER TABLE IF EXISTS ONLY public.charges DROP CONSTRAINT IF EXISTS charges_pkey
 ALTER TABLE IF EXISTS ONLY public.charge_filters DROP CONSTRAINT IF EXISTS charge_filters_pkey;
 ALTER TABLE IF EXISTS ONLY public.charge_filter_values DROP CONSTRAINT IF EXISTS charge_filter_values_pkey;
 ALTER TABLE IF EXISTS ONLY public.cached_aggregations DROP CONSTRAINT IF EXISTS cached_aggregations_pkey;
+ALTER TABLE IF EXISTS ONLY public.billing_segments DROP CONSTRAINT IF EXISTS billing_segments_pkey;
+ALTER TABLE IF EXISTS ONLY public.billing_segments DROP CONSTRAINT IF EXISTS billing_segments_no_overlapping_periods;
 ALTER TABLE IF EXISTS ONLY public.billing_object_connections DROP CONSTRAINT IF EXISTS billing_object_connections_pkey;
 ALTER TABLE IF EXISTS ONLY public.billing_entities_taxes DROP CONSTRAINT IF EXISTS billing_entities_taxes_pkey;
 ALTER TABLE IF EXISTS ONLY public.billing_entities DROP CONSTRAINT IF EXISTS billing_entities_pkey;
@@ -1311,6 +1332,7 @@ DROP TABLE IF EXISTS public.charges;
 DROP TABLE IF EXISTS public.charge_filters;
 DROP TABLE IF EXISTS public.charge_filter_values;
 DROP TABLE IF EXISTS public.cached_aggregations;
+DROP TABLE IF EXISTS public.billing_segments;
 DROP TABLE IF EXISTS public.billing_object_connections;
 DROP TABLE IF EXISTS public.billing_entities_taxes;
 DROP TABLE IF EXISTS public.billing_entities_invoice_custom_sections;
@@ -1377,6 +1399,7 @@ DROP TYPE IF EXISTS public.customer_account_type;
 DROP TYPE IF EXISTS public.contract_status;
 DROP TYPE IF EXISTS public.contract_billing_time;
 DROP TYPE IF EXISTS public.connection_category;
+DROP TYPE IF EXISTS public.billing_segment_status;
 DROP TYPE IF EXISTS public.billing_object_connection_behavior;
 DROP TYPE IF EXISTS public.billable_metric_weighted_interval;
 DROP TYPE IF EXISTS public.billable_metric_rounding_function;
@@ -1384,6 +1407,7 @@ DROP EXTENSION IF EXISTS unaccent;
 DROP EXTENSION IF EXISTS pgcrypto;
 DROP EXTENSION IF EXISTS pg_trgm;
 DROP EXTENSION IF EXISTS pg_partman;
+DROP EXTENSION IF EXISTS btree_gist;
 DROP EXTENSION IF EXISTS btree_gin;
 DROP SCHEMA IF EXISTS partman;
 --
@@ -1398,6 +1422,13 @@ CREATE SCHEMA partman;
 --
 
 CREATE EXTENSION IF NOT EXISTS btree_gin WITH SCHEMA public;
+
+
+--
+-- Name: btree_gist; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS btree_gist WITH SCHEMA public;
 
 
 --
@@ -1455,6 +1486,18 @@ CREATE TYPE public.billable_metric_weighted_interval AS ENUM (
 CREATE TYPE public.billing_object_connection_behavior AS ENUM (
     'specific',
     'skip'
+);
+
+
+--
+-- Name: billing_segment_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.billing_segment_status AS ENUM (
+    'pending',
+    'processing',
+    'done',
+    'failed'
 );
 
 
@@ -2396,6 +2439,37 @@ CREATE TABLE public.billing_object_connections (
     behavior public.billing_object_connection_behavior NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: billing_segments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.billing_segments (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    contract_id uuid NOT NULL,
+    customer_id uuid NOT NULL,
+    contract_rate_card_id uuid NOT NULL,
+    invoice_id uuid,
+    rate_card_rate_id uuid,
+    rate_override_id uuid,
+    pricing_unit_id uuid,
+    rate_properties jsonb DEFAULT '{}'::jsonb NOT NULL,
+    currency character varying NOT NULL,
+    billing_at timestamp(6) without time zone NOT NULL,
+    started_at timestamp(6) without time zone NOT NULL,
+    ended_at timestamp(6) without time zone NOT NULL,
+    cycle_started_at timestamp(6) without time zone NOT NULL,
+    proration_ratio numeric(30,10) DEFAULT 1.0 NOT NULL,
+    status public.billing_segment_status DEFAULT 'pending'::public.billing_segment_status NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT billing_segments_cycle_bounds CHECK ((cycle_started_at <= started_at)),
+    CONSTRAINT billing_segments_period_bounds CHECK ((started_at <= ended_at)),
+    CONSTRAINT billing_segments_proration_ratio_bounds CHECK (((proration_ratio >= (0)::numeric) AND (proration_ratio <= (1)::numeric))),
+    CONSTRAINT billing_segments_rate_presence CHECK (((rate_card_rate_id IS NOT NULL) OR (rate_override_id IS NOT NULL)))
 );
 
 
@@ -6174,6 +6248,22 @@ ALTER TABLE ONLY public.billing_object_connections
 
 
 --
+-- Name: billing_segments billing_segments_no_overlapping_periods; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.billing_segments
+    ADD CONSTRAINT billing_segments_no_overlapping_periods EXCLUDE USING gist (organization_id WITH =, contract_id WITH =, customer_id WITH =, contract_rate_card_id WITH =, tsrange(started_at, ended_at, '[]'::text) WITH &&);
+
+
+--
+-- Name: billing_segments billing_segments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.billing_segments
+    ADD CONSTRAINT billing_segments_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: cached_aggregations cached_aggregations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7300,6 +7390,13 @@ CREATE UNIQUE INDEX idx_on_billing_entity_id_invoice_custom_section_id_bd78c547d
 
 
 --
+-- Name: idx_on_contract_id_billing_at_status_3588bfae7a; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_on_contract_id_billing_at_status_3588bfae7a ON public.billing_segments USING btree (contract_id, billing_at, status);
+
+
+--
 -- Name: idx_on_dunning_campaign_id_currency_fbf233b2ae; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8120,6 +8217,76 @@ CREATE INDEX index_billing_object_connections_on_integration_customer_id ON publ
 --
 
 CREATE INDEX index_billing_object_connections_on_organization_id ON public.billing_object_connections USING btree (organization_id);
+
+
+--
+-- Name: index_billing_segments_on_card_and_cycle; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_billing_segments_on_card_and_cycle ON public.billing_segments USING btree (contract_rate_card_id, cycle_started_at);
+
+
+--
+-- Name: index_billing_segments_on_card_and_period; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_billing_segments_on_card_and_period ON public.billing_segments USING btree (contract_rate_card_id, started_at);
+
+
+--
+-- Name: index_billing_segments_on_contract_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_billing_segments_on_contract_id ON public.billing_segments USING btree (contract_id);
+
+
+--
+-- Name: index_billing_segments_on_contract_rate_card_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_billing_segments_on_contract_rate_card_id ON public.billing_segments USING btree (contract_rate_card_id);
+
+
+--
+-- Name: index_billing_segments_on_customer_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_billing_segments_on_customer_id ON public.billing_segments USING btree (customer_id);
+
+
+--
+-- Name: index_billing_segments_on_invoice_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_billing_segments_on_invoice_id ON public.billing_segments USING btree (invoice_id);
+
+
+--
+-- Name: index_billing_segments_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_billing_segments_on_organization_id ON public.billing_segments USING btree (organization_id);
+
+
+--
+-- Name: index_billing_segments_on_pricing_unit_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_billing_segments_on_pricing_unit_id ON public.billing_segments USING btree (pricing_unit_id);
+
+
+--
+-- Name: index_billing_segments_on_rate_card_rate_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_billing_segments_on_rate_card_rate_id ON public.billing_segments USING btree (rate_card_rate_id);
+
+
+--
+-- Name: index_billing_segments_on_rate_override_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_billing_segments_on_rate_override_id ON public.billing_segments USING btree (rate_override_id);
 
 
 --
@@ -11831,6 +11998,14 @@ ALTER TABLE ONLY public.integration_customers
 
 
 --
+-- Name: billing_segments fk_rails_0f69bb4d01; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.billing_segments
+    ADD CONSTRAINT fk_rails_0f69bb4d01 FOREIGN KEY (rate_card_rate_id) REFERENCES public.rate_card_rates(id);
+
+
+--
 -- Name: integration_mappings fk_rails_0f762162b0; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -12191,6 +12366,14 @@ ALTER TABLE ONLY public.product_filters
 
 
 --
+-- Name: billing_segments fk_rails_2cad4a133e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.billing_segments
+    ADD CONSTRAINT fk_rails_2cad4a133e FOREIGN KEY (customer_id) REFERENCES public.customers(id);
+
+
+--
 -- Name: refunds fk_rails_2dc6171f57; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -12252,6 +12435,14 @@ ALTER TABLE ONLY public.invoices
 
 ALTER TABLE ONLY public.credits
     ADD CONSTRAINT fk_rails_310fcb3585 FOREIGN KEY (credit_note_id) REFERENCES public.credit_notes(id);
+
+
+--
+-- Name: billing_segments fk_rails_322fa429f9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.billing_segments
+    ADD CONSTRAINT fk_rails_322fa429f9 FOREIGN KEY (contract_rate_card_id) REFERENCES public.contract_rate_cards(id);
 
 
 --
@@ -12668,6 +12859,14 @@ ALTER TABLE ONLY public.charges_taxes
 
 ALTER TABLE ONLY public.customers
     ADD CONSTRAINT fk_rails_58234c715e FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: billing_segments fk_rails_59357d1f82; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.billing_segments
+    ADD CONSTRAINT fk_rails_59357d1f82 FOREIGN KEY (invoice_id) REFERENCES public.invoices(id);
 
 
 --
@@ -13223,6 +13422,14 @@ ALTER TABLE ONLY public.payment_provider_customers
 
 
 --
+-- Name: billing_segments fk_rails_86cc43f205; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.billing_segments
+    ADD CONSTRAINT fk_rails_86cc43f205 FOREIGN KEY (rate_override_id) REFERENCES public.rate_overrides(id);
+
+
+--
 -- Name: wallets_invoice_custom_sections fk_rails_87bc3bd4cb; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -13663,6 +13870,14 @@ ALTER TABLE ONLY public.entitlement_subscription_feature_removals
 
 
 --
+-- Name: billing_segments fk_rails_b3bd992995; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.billing_segments
+    ADD CONSTRAINT fk_rails_b3bd992995 FOREIGN KEY (contract_id) REFERENCES public.contracts(id);
+
+
+--
 -- Name: fees fk_rails_b50dc82c1e; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -13692,6 +13907,14 @@ ALTER TABLE ONLY public.orders
 
 ALTER TABLE ONLY public.subscription_activation_rules
     ADD CONSTRAINT fk_rails_b749d2045d FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: billing_segments fk_rails_b868d0440a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.billing_segments
+    ADD CONSTRAINT fk_rails_b868d0440a FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -14175,6 +14398,14 @@ ALTER TABLE ONLY public.plans_taxes
 
 
 --
+-- Name: billing_segments fk_rails_e88ab4465f; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.billing_segments
+    ADD CONSTRAINT fk_rails_e88ab4465f FOREIGN KEY (pricing_unit_id) REFERENCES public.pricing_units(id);
+
+
+--
 -- Name: recurring_transaction_rules fk_rails_e8bac9c5bb; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -14445,6 +14676,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260904132835'),
 ('20260902143604'),
 ('20260826235314'),
 ('20260826235313'),
@@ -15559,4 +15791,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220530091046'),
 ('20220526101535'),
 ('20220525122759');
-

--- a/spec/factories/billing_segments.rb
+++ b/spec/factories/billing_segments.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :billing_segment do
+    organization
+    customer { association(:customer, organization:) }
+    contract { association(:contract, organization:, customer:) }
+    contract_rate_card { association(:contract_rate_card, organization:, contract:) }
+    rate_card_rate { association(:rate_card_rate, organization:, rate_card: contract_rate_card.rate_card) }
+    rate_override { nil }
+    pricing_unit { nil }
+    invoice { nil }
+    rate_properties { (rate_override || rate_card_rate)&.properties || {} }
+    currency { rate_card_rate&.rate_card&.currency || "EUR" }
+    billing_at { Time.current }
+    cycle_started_at { Time.current.beginning_of_day }
+    started_at { cycle_started_at }
+    ended_at { cycle_started_at + 1.month - Rational(1, 1_000_000) }
+    status { :pending }
+  end
+end

--- a/spec/models/billing_segment_spec.rb
+++ b/spec/models/billing_segment_spec.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BillingSegment do
+  subject(:billing_segment) { build(:billing_segment) }
+
+  describe "enums" do
+    it do
+      expect(subject).to define_enum_for(:status)
+        .backed_by_column_of_type(:enum)
+        .validating
+        .with_prefix(:status)
+        .with_values(pending: "pending", processing: "processing", done: "done", failed: "failed")
+    end
+  end
+
+  describe "associations" do
+    it do
+      expect(billing_segment).to belong_to(:organization)
+      expect(billing_segment).to belong_to(:contract)
+      expect(billing_segment).to belong_to(:customer)
+      expect(billing_segment).to belong_to(:contract_rate_card)
+      expect(billing_segment).to belong_to(:invoice).optional
+      expect(billing_segment).to belong_to(:rate_card_rate).optional
+      expect(billing_segment).to belong_to(:rate_override).optional
+      expect(billing_segment).to belong_to(:pricing_unit).optional
+      expect(described_class.reflect_on_association(:customer).scope).to be_present
+      expect(described_class.reflect_on_association(:contract_rate_card).scope).to be_present
+      expect(described_class.reflect_on_association(:rate_card_rate).scope).to be_present
+      expect(described_class.reflect_on_association(:rate_override).scope).to be_present
+    end
+  end
+
+  describe "validations" do
+    it do
+      expect(subject).to validate_presence_of(:billing_at)
+      expect(subject).to validate_presence_of(:cycle_started_at)
+      expect(subject).to validate_presence_of(:currency)
+      expect(subject).to validate_inclusion_of(:currency).in_array(described_class.currency_list)
+      expect(subject).to validate_presence_of(:started_at)
+      expect(subject).to validate_presence_of(:ended_at)
+      expect(subject).to validate_numericality_of(:proration_ratio)
+        .is_greater_than_or_equal_to(0)
+        .is_less_than_or_equal_to(1)
+    end
+
+    describe "rate validation" do
+      it "requires a rate card rate or a rate override" do
+        segment = build(:billing_segment, rate_card_rate: nil, rate_override: nil)
+
+        expect(segment).not_to be_valid
+        expect(segment.errors.where(:base, :rate_card_rate_or_rate_override_required)).to be_present
+      end
+
+      it "accepts a rate override without a rate card rate" do
+        segment = build(:billing_segment, rate_card_rate: nil, rate_override: build(:rate_override))
+
+        expect(segment).to be_valid
+      end
+    end
+
+    describe "period bounds validation" do
+      it "rejects a period ending before it starts" do
+        segment = build(:billing_segment, started_at: Time.zone.parse("2026-09-15"), ended_at: Time.zone.parse("2026-09-01"))
+
+        expect(segment).not_to be_valid
+        expect(segment.errors.where(:ended_at, :must_be_after_started_at)).to be_present
+      end
+    end
+
+    describe "cycle bounds validation" do
+      it "rejects a cycle opening after the segment starts" do
+        segment = build(:billing_segment, cycle_started_at: Time.zone.parse("2026-09-15"), started_at: Time.zone.parse("2026-09-01"))
+
+        expect(segment).not_to be_valid
+        expect(segment.errors.where(:cycle_started_at, :must_be_before_started_at)).to be_present
+      end
+    end
+  end
+
+  describe "#rate" do
+    let(:rate_card_rate) { build_stubbed(:rate_card_rate) }
+    let(:billing_segment) { described_class.new(rate_card_rate:) }
+
+    it "returns the rate card rate" do
+      expect(billing_segment.rate).to eq(rate_card_rate)
+    end
+
+    context "with a rate override" do
+      let(:rate_override) { build_stubbed(:rate_override) }
+      let(:billing_segment) { described_class.new(rate_card_rate:, rate_override:) }
+
+      it "returns the override" do
+        expect(billing_segment.rate).to eq(rate_override)
+      end
+    end
+  end
+
+  describe "#rate_properties" do
+    let(:rate_card_rate) { build_stubbed(:rate_card_rate, rate_properties: {"amount" => "10.00"}) }
+    let(:billing_segment) { described_class.new(rate_card_rate:, rate_properties: {"amount" => "10.00"}) }
+
+    it "returns the stored rate properties" do
+      expect(billing_segment.rate_properties).to eq("amount" => "10.00")
+    end
+
+    context "with a rate override" do
+      let(:rate_override) { build_stubbed(:rate_override, rate_properties: {"amount" => "5.00"}) }
+      let(:billing_segment) { described_class.new(rate_card_rate:, rate_override:, rate_properties: {"amount" => "5.00"}) }
+
+      it "keeps the stored snapshot" do
+        rate_override.rate_properties = {"amount" => "8.00"}
+
+        expect(billing_segment.rate_properties).to eq("amount" => "5.00")
+      end
+    end
+  end
+
+  describe "#currency" do
+    it "returns the rate card currency" do
+      segment = described_class.new(currency: "EUR")
+
+      expect(segment.currency).to eq("EUR")
+    end
+  end
+
+  describe "#pricing_unit_conversion_rate" do
+    let(:rate_card_rate) { build_stubbed(:rate_card_rate, applied_pricing_unit_conversion_rate: 0.5) }
+    let(:billing_segment) { described_class.new(rate_card_rate:) }
+
+    it "returns the rate conversion rate" do
+      expect(billing_segment.pricing_unit_conversion_rate).to eq(0.5)
+    end
+
+    context "with a rate override" do
+      let(:rate_override) { build_stubbed(:rate_override, pricing_unit_conversion_rate: 0.25) }
+      let(:billing_segment) { described_class.new(rate_card_rate:, rate_override:) }
+
+      it "returns the override conversion rate" do
+        expect(billing_segment.pricing_unit_conversion_rate).to eq(0.25)
+      end
+    end
+  end
+
+  describe "#min_amount_cents" do
+    let(:rate_card_rate) { build_stubbed(:rate_card_rate, min_amount_cents: 1_000) }
+    let(:billing_segment) { described_class.new(rate_card_rate:) }
+
+    it "returns the rate minimum amount" do
+      expect(billing_segment.min_amount_cents).to eq(1_000)
+    end
+
+    context "with a rate override" do
+      let(:rate_override) { build_stubbed(:rate_override, min_amount_cents: 2_000) }
+      let(:billing_segment) { described_class.new(rate_card_rate:, rate_override:) }
+
+      it "returns the override minimum amount" do
+        expect(billing_segment.min_amount_cents).to eq(2_000)
+      end
+    end
+  end
+
+  describe "#cycle_started_at" do
+    it "groups segments created by one cycle" do
+      cycle_started_at = Time.zone.parse("2026-09-01")
+      cut = Time.zone.parse("2026-09-15")
+      contract_rate_card = create(:contract_rate_card)
+      attributes = {
+        organization: contract_rate_card.organization,
+        contract: contract_rate_card.contract,
+        customer: contract_rate_card.contract.customer,
+        contract_rate_card:,
+        rate_card_rate: create(:rate_card_rate, organization: contract_rate_card.organization, rate_card: contract_rate_card.rate_card),
+        cycle_started_at:
+      }
+      first = create(:billing_segment, **attributes, started_at: cycle_started_at, ended_at: cut - Rational(1, 1_000_000))
+      second = create(:billing_segment, **attributes, started_at: cut, ended_at: Time.zone.parse("2026-10-01") - Rational(1, 1_000_000))
+
+      expect(described_class.where(contract_rate_card:, cycle_started_at:)).to match_array([first, second])
+    end
+  end
+end

--- a/spec/models/contract_rate_card_spec.rb
+++ b/spec/models/contract_rate_card_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe ContractRateCard do
       expect(contract_rate_card).to belong_to(:contract)
       expect(contract_rate_card).to belong_to(:rate_card)
       expect(contract_rate_card).to have_many(:rate_phases).order(:position)
+      expect(contract_rate_card).to have_many(:billing_segments)
       expect(contract_rate_card).to have_one(:product).through(:rate_card)
     end
   end

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Contract do
       expect(contract).to belong_to(:customer)
       expect(contract).to belong_to(:plan).optional
       expect(contract).to have_many(:applied_rate_cards).class_name("ContractRateCard")
+      expect(contract).to have_many(:billing_segments)
     end
 
     it "resolves a discarded customer and plan" do


### PR DESCRIPTION
## Context

Billing needs a durable representation of priced contract rate card slices so future processing can persist the exact rate snapshot and period boundaries used for invoicing.

## Description

Add the BillingSegment model, table, constraints, indexes, factory, and model specs. Link billing segments to contracts and contract rate cards, persist the cycle start as cycle_started_at, and enforce period, proration, and rate presence invariants at both model and database level.
