### PR TITLE
feat(account-tree): add feature flag for account tree feature

### DIFF
--- a/app/config/feature_flags.yaml
+++ b/app/config/feature_flags.yaml
@@ -41,3 +41,7 @@ product_catalog:
 skip_credit_invoice_auto_payment_delay:
   description: "Trigger the auto-payment of credit invoices (wallet top-ups) immediately instead of delaying it behind a possible hosted checkout payment"
   owners: ["@brunomiguelpinto"]
+
+account_tree:
+  description: "Enable the account tree - hierarchy based attributed usage below the customer"
+  owners: ["@lovrocolic"]

--- a/schema.graphql
+++ b/schema.graphql
@@ -6562,6 +6562,7 @@ input ExportFinanceAssistantResultInput {
 Organization Feature Flag Values
 """
 enum FeatureFlagEnum {
+  account_tree
   enriched_events_aggregation
   fixed_charge_usage_delta_migration
   lazy_charge_usage_cache

--- a/schema.json
+++ b/schema.json
@@ -32111,6 +32111,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "account_tree",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null


### PR DESCRIPTION
## Context

Account tree gives a customer an attributed usage tree below it: usage attributed to the customer's own org structure (users, teams, departments, projects, API keys, models), broken down, rolled up and price-aware.

## Description

This PR adds the `account_tree` feature flag.