### PR TITLE
refactor(events): pass event contexts instead of subscription

### DIFF
--- a/app/models/concerns/billing_period_date_diff.rb
+++ b/app/models/concerns/billing_period_date_diff.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module BillingPeriodDateDiff
+  extend ActiveSupport::Concern
+
+  def date_diff_with_timezone(from_datetime, to_datetime)
+    number_of_days = Utils::Datetime.date_diff_with_timezone(
+      from_datetime,
+      to_datetime,
+      customer.applicable_timezone
+    )
+
+    return number_of_days unless upgraded_billing_period?
+
+    number_of_days -= 1
+    number_of_days.negative? ? 0 : number_of_days
+  end
+
+  private
+
+  def upgraded_billing_period?
+    respond_to?(:upgraded?) && terminated? && upgraded?
+  end
+end

--- a/app/models/concerns/terminatable.rb
+++ b/app/models/concerns/terminatable.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Terminatable
+  extend ActiveSupport::Concern
+
+  def terminated_at?(timestamp)
+    return false unless terminated?
+    return false if terminated_at.nil? || timestamp.nil?
+
+    # TODO: should be cleaned up to only use Time
+    timestamp = timestamp.to_time if [Date, DateTime, String].include?(timestamp.class)
+    timestamp = Time.zone.at(timestamp) if timestamp.is_a?(Integer)
+
+    terminated_at.round <= timestamp.round
+  end
+end

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -5,7 +5,9 @@
 # plan-less shape is native (plan_id is nullable). Legacy billing keeps its
 # own `subscriptions` table; the two engines never share rows.
 class Contract < ApplicationRecord
+  include BillingPeriodDateDiff
   include PaperTrailTraceable
+  include Terminatable
 
   STATUSES = {
     pending: "pending",

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -312,7 +312,7 @@ class Invoice < ApplicationRecord
     service.new(
       event_store_class: Events::Stores::StoreFactory.store_class(organization:),
       charge: fee.charge,
-      subscription: fee.subscription,
+      context: Events::Stores::EventContext.from(subscription: fee.subscription),
       boundaries: {
         from_datetime: Time.zone.parse(fee.properties["charges_from_datetime"]),
         to_datetime: Time.zone.parse(fee.properties["charges_to_datetime"]),

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class Subscription < ApplicationRecord
+  include BillingPeriodDateDiff
   include HasPurchaseOrderNumber
   include PaperTrailTraceable
   include RansackUuidSearch
+  include Terminatable
 
   self.ignored_columns += %w[incompleted_at cancelation_reason]
 
@@ -252,35 +254,8 @@ class Subscription < ApplicationRecord
     name.presence || plan.invoice_name
   end
 
-  # When upgrade, we want to bill one day less since date of the upgrade will be
-  # included in the first invoice for the new plan
-  def date_diff_with_timezone(from_datetime, to_datetime)
-    number_od_days = Utils::Datetime.date_diff_with_timezone(
-      from_datetime,
-      to_datetime,
-      customer.applicable_timezone
-    )
-
-    return number_od_days unless terminated? && upgraded?
-
-    number_od_days -= 1
-
-    number_od_days.negative? ? 0 : number_od_days
-  end
-
   def should_sync_hubspot_subscription?
     customer.integration_customers.hubspot_kind.any? { |c| c.integration.sync_subscriptions }
-  end
-
-  def terminated_at?(timestamp)
-    return false unless terminated?
-    return false if terminated_at.nil? || timestamp.nil?
-
-    # TODO: should be cleaned up to only use Time
-    timestamp = timestamp.to_time if [Date, DateTime, String].include?(timestamp.class)
-    timestamp = Time.zone.at(timestamp) if timestamp.is_a?(Integer)
-
-    terminated_at.round <= timestamp.round
   end
 
   # TODO: Apply this method in CreateInvoiceSubscriptionService

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -8,7 +8,6 @@ class Subscription < ApplicationRecord
   include Terminatable
   include ConnectionResolvable
 
-
   self.ignored_columns += %w[incompleted_at cancelation_reason]
 
   belongs_to :customer, -> { with_discarded }

--- a/app/services/billable_metrics/aggregation_factory.rb
+++ b/app/services/billable_metrics/aggregation_factory.rb
@@ -2,10 +2,11 @@
 
 module BillableMetrics
   class AggregationFactory
-    def self.new_instance(charge:, current_usage: false, **attributes)
+    def self.new_instance(charge:, context:, current_usage: false, **attributes)
       aggregator_class(charge, current_usage).new(
         event_store_class: Events::Stores::StoreFactory.store_class(organization: charge.billable_metric.organization),
         charge:,
+        context:,
         **attributes
       )
     end

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -48,11 +48,11 @@ module BillableMetrics
         result
       end
 
-      def initialize(event_store_class:, charge:, subscription:, boundaries:, filters: {}, bypass_aggregation: false)
+      def initialize(event_store_class:, charge:, context:, boundaries:, filters: {}, bypass_aggregation: false)
         super(nil)
         @event_store_class = event_store_class
         @charge = charge
-        @subscription = subscription
+        @context = context
 
         @filters = filters
         @charge_filter = filters[:charge_filter]
@@ -133,7 +133,7 @@ module BillableMetrics
 
       attr_accessor :event_store_class,
         :charge,
-        :subscription,
+        :context,
         :filters,
         :charge_filter,
         :event,
@@ -146,12 +146,12 @@ module BillableMetrics
 
       delegate :billable_metric, to: :charge
 
-      delegate :customer, to: :subscription
+      delegate :customer, to: :context
 
       def event_store
         @event_store ||= event_store_class.new(
           code: billable_metric.code,
-          subscription:,
+          context:,
           boundaries:,
           filters:,
           deduplicate: deduplicate?
@@ -162,7 +162,7 @@ module BillableMetrics
         override = Events::Stores::StoreFactory.override
         return override[:deduplicate] if override
 
-        organization = subscription&.organization
+        organization = context&.organization
         return false unless organization
 
         organization.clickhouse_events_store? && organization.clickhouse_deduplication_enabled?
@@ -230,7 +230,7 @@ module BillableMetrics
       def find_cached_aggregation(with_from_datetime:, with_to_datetime:, grouped_by: nil)
         query = CachedAggregation
           .where(organization_id: billable_metric.organization_id)
-          .where(external_subscription_id: subscription.external_id)
+          .where(external_subscription_id: context.external_id)
           .where(charge_id: charge.id)
           .from_datetime(with_from_datetime)
           .to_datetime(with_to_datetime)

--- a/app/services/billable_metrics/aggregations/custom_service.rb
+++ b/app/services/billable_metrics/aggregations/custom_service.rb
@@ -96,7 +96,7 @@ module BillableMetrics
 
         query = CachedAggregation
           .where(organization_id: billable_metric.organization_id)
-          .where(external_subscription_id: subscription.external_id)
+          .where(external_subscription_id: context.external_id)
           .where(charge_id: charge.id)
           .where("cached_aggregations.timestamp < ?", truncated_datetime)
           .where(grouped_by: grouped_by_values.presence || {})
@@ -128,7 +128,7 @@ module BillableMetrics
         if grouped_by_values
           store = event_store_class.new(
             code: billable_metric.code,
-            subscription:,
+            context:,
             boundaries:,
             filters: filters.merge(grouped_by_values:)
           )

--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -101,7 +101,7 @@ module BillableMetrics
           return @latest_value = latest_cached_aggregation.current_aggregation
         end
 
-        if subscription.previous_subscription_id?
+        if context.previous_subscription_id?
           return @latest_value = latest_value_from_events.first
         end
 
@@ -115,7 +115,7 @@ module BillableMetrics
           return @latest_breakdowns = latest_cached_aggregation.presentation_breakdowns
         end
 
-        if subscription.previous_subscription_id?
+        if context.previous_subscription_id?
           return @latest_breakdowns = latest_value_from_events.second
         end
 
@@ -135,7 +135,7 @@ module BillableMetrics
 
         query = CachedAggregation
           .where(organization_id: billable_metric.organization_id)
-          .where(external_subscription_id: subscription.external_id)
+          .where(external_subscription_id: context.external_id)
           .where(charge_id: charge.id)
           .where(timestamp: ...from_datetime)
           .order(timestamp: :desc, created_at: :desc)
@@ -152,7 +152,7 @@ module BillableMetrics
 
         event_store = event_store_class.new(
           code: billable_metric.code,
-          subscription:,
+          context:,
           boundaries: {to_datetime: from_datetime - 1.second},
           filters:
         )
@@ -178,7 +178,7 @@ module BillableMetrics
           end
         end
 
-        if subscription.previous_subscription_id?
+        if context.previous_subscription_id?
           return @grouped_latest_values = grouped_latest_values_from_events.first
         end
 
@@ -192,7 +192,7 @@ module BillableMetrics
           return @grouped_latest_breakdowns = grouped_latest_cached_aggregations.flat_map(&:presentation_breakdowns)
         end
 
-        if subscription.previous_subscription_id?
+        if context.previous_subscription_id?
           return @grouped_latest_breakdowns = grouped_latest_values_from_events.second
         end
 
@@ -214,7 +214,7 @@ module BillableMetrics
       def grouped_latest_values_from_events
         event_store = event_store_class.new(
           code: billable_metric.code,
-          subscription:,
+          context:,
           boundaries: {to_datetime: from_datetime - 1.second},
           filters:
         )

--- a/app/services/billable_metrics/breakdown/sum_service.rb
+++ b/app/services/billable_metrics/breakdown/sum_service.rb
@@ -27,7 +27,7 @@ module BillableMetrics
       def persisted_breakdown
         event_store = event_store_class.new(
           code: billable_metric.code,
-          subscription:,
+          context:,
           boundaries: {to_datetime: from_datetime},
           filters:
         )

--- a/app/services/billable_metrics/prorated_aggregations/base_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/base_service.rb
@@ -101,7 +101,7 @@ module BillableMetrics
       #       we want to bill the persisted metrics at prorata of the full period duration.
       #       ie: the number of day of the terminated period divided by number of days without termination
       def persisted_pro_rata
-        subscription.date_diff_with_timezone(from_datetime, to_datetime).fdiv(period_duration)
+        context.date_diff_with_timezone(from_datetime, to_datetime).fdiv(period_duration)
       end
 
       attr_accessor :options

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -148,7 +148,7 @@ module BillableMetrics
         @persisted_event_store_instance ||= begin
           event_store = event_store_class.new(
             code: billable_metric.code,
-            subscription:,
+            context:,
             boundaries: {to_datetime: from_datetime - PERSISTED_TOP_BOUNDARY_DELAY}, # Note: Avoid counting events exactly on `from_datetime` twice
             filters:,
             deduplicate: deduplicate?
@@ -175,7 +175,7 @@ module BillableMetrics
       def persisted_prorated_result
         @persisted_prorated_result ||= persisted_event_store_instance.prorated_sum(
           period_duration:,
-          persisted_duration: subscription.date_diff_with_timezone(from_datetime, to_datetime)
+          persisted_duration: context.date_diff_with_timezone(from_datetime, to_datetime)
         )
       end
 
@@ -242,7 +242,7 @@ module BillableMetrics
       def persisted_grouped_prorated_results
         @persisted_grouped_prorated_results ||= persisted_event_store_instance.grouped_prorated_sum(
           period_duration:,
-          persisted_duration: subscription.date_diff_with_timezone(from_datetime, to_datetime)
+          persisted_duration: context.date_diff_with_timezone(from_datetime, to_datetime)
         )
       end
     end

--- a/app/services/charges/pay_in_advance_aggregation_service.rb
+++ b/app/services/charges/pay_in_advance_aggregation_service.rb
@@ -17,7 +17,7 @@ module Charges
     def call
       aggregator = BillableMetrics::AggregationFactory.new_instance(
         charge:,
-        subscription:,
+        context: Events::Stores::EventContext.from(subscription:),
         boundaries: {
           from_datetime: boundaries.charges_from_datetime,
           to_datetime: boundaries.charges_to_datetime,

--- a/app/services/events/billing_period_filters/charges_resolver.rb
+++ b/app/services/events/billing_period_filters/charges_resolver.rb
@@ -31,7 +31,7 @@ module Events
       def event_store
         @event_store ||= Events::Stores::StoreFactory.new_instance(
           organization: organization,
-          subscription:,
+          context: Events::Stores::EventContext.from(subscription:),
           boundaries: {
             from_datetime: boundaries.charges_from_datetime,
             to_datetime: boundaries.charges_to_datetime

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -56,9 +56,9 @@ module Events
         :events_count
       )
 
-      def initialize(subscription:, boundaries:, code: nil, filters: {}, deduplicate: false)
+      def initialize(context:, boundaries:, code: nil, filters: {}, deduplicate: false)
         @code = code
-        @subscription = subscription
+        @context = context
         @boundaries = boundaries
 
         @filters = filters
@@ -213,16 +213,12 @@ module Events
 
       protected
 
-      attr_accessor :code, :subscription, :boundaries, :grouped_by_values, :filters, :matching_filters, :ignored_filters, :deduplicate
+      attr_accessor :code, :context, :boundaries, :grouped_by_values, :filters, :matching_filters, :ignored_filters, :deduplicate
 
-      delegate :customer, to: :subscription
+      delegate :customer, to: :context
 
       def period_duration
-        @period_duration ||= Subscriptions::DatesService.new_instance(
-          subscription,
-          to_datetime + 1.day,
-          current_usage: subscription.terminated? && subscription.upgraded?
-        ).charges_duration_in_days
+        @period_duration ||= context.charges_duration_at(to_datetime + 1.day)
       end
 
       def build_aggregation_result(row)

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -39,7 +39,7 @@ module Events
         effective_to = to_datetime || applicable_to_datetime
 
         if needs_code_based_fallback?(force_from:)
-          current_query = charge_id_based_query(from_datetime: subscription.started_at, to_datetime: effective_to)
+          current_query = charge_id_based_query(from_datetime: context.started_at, to_datetime: effective_to)
           fallback_query = code_based_fallback_query(from_datetime: (from_datetime if force_from))
 
           current_sql = current_query.project(select).to_sql
@@ -66,7 +66,7 @@ module Events
 
         # Should we include recurring events from previous subscription by relying on the code instead of the charge_id
         use_fallback = needs_code_based_fallback?(force_from:)
-        current_from = use_fallback ? subscription.started_at : (from_datetime if force_from || use_from_boundary)
+        current_from = use_fallback ? context.started_at : (from_datetime if force_from || use_from_boundary)
 
         ctes = {
           "latest_enriched_current" => latest_enriched_current_sql(from_datetime: current_from, to_datetime: effective_to)
@@ -158,8 +158,8 @@ module Events
         lower_bound = include_all_history ? nil : from_datetime
         Events::Stores::Utils::ClickhouseConnection.with_retry do
           scope = ::Clickhouse::EventsEnrichedExpanded
-            .where(external_subscription_id: subscription.external_id)
-            .where(organization_id: subscription.organization_id)
+            .where(external_subscription_id: context.external_id)
+            .where(organization_id: context.organization_id)
             .where(timestamp: lower_bound..to_datetime)
 
           scope = scope.where(code: codes) unless codes.nil?
@@ -863,9 +863,9 @@ module Events
         prefix = alias_prefix ? "#{alias_prefix}." : ""
 
         conditions = [
-          sql_condition("#{prefix}organization_id = ?", subscription.organization_id),
+          sql_condition("#{prefix}organization_id = ?", context.organization_id),
           sql_condition("#{prefix}code = ?", code),
-          sql_condition("#{prefix}external_subscription_id = ?", subscription.external_id),
+          sql_condition("#{prefix}external_subscription_id = ?", context.external_id),
           sql_condition("#{prefix}charge_id = ?", charge_id),
           sql_condition("#{prefix}charge_filter_id = ?", charge_filter_id || "")
         ]
@@ -881,10 +881,10 @@ module Events
         prefix = alias_prefix ? "#{alias_prefix}." : ""
 
         conditions = [
-          sql_condition("#{prefix}organization_id = ?", subscription.organization_id),
+          sql_condition("#{prefix}organization_id = ?", context.organization_id),
           sql_condition("#{prefix}code = ?", code),
-          sql_condition("#{prefix}external_subscription_id = ?", subscription.external_id),
-          sql_condition("#{prefix}timestamp < ?", subscription.started_at)
+          sql_condition("#{prefix}external_subscription_id = ?", context.external_id),
+          sql_condition("#{prefix}timestamp < ?", context.started_at)
         ]
 
         conditions << sql_condition("#{prefix}timestamp >= ?", from_datetime) if from_datetime
@@ -934,11 +934,11 @@ module Events
       end
 
       def needs_code_based_fallback?(force_from:)
-        return false if subscription.previous_subscription_id.blank?
+        return false if context.previous_subscription_id.blank?
         return false if use_from_boundary
 
         effective_from = from_datetime if force_from
-        effective_from.nil? || effective_from < subscription.started_at
+        effective_from.nil? || effective_from < context.started_at
       end
 
       def charge_id_based_query(from_datetime:, to_datetime:)

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -27,8 +27,8 @@ module Events
             ::Clickhouse::EventsEnriched.from("(#{deduplicated_subquery}) AS events_enriched")
           else
             query = ::Clickhouse::EventsEnriched
-              .where(external_subscription_id: subscription.external_id)
-              .where(organization_id: subscription.organization_id)
+              .where(external_subscription_id: context.external_id)
+              .where(organization_id: context.organization_id)
               .where(code:)
 
             query = query.where("events_enriched.timestamp >= ?", from_datetime) if force_from || use_from_boundary
@@ -50,8 +50,8 @@ module Events
 
       def events_cte_queries_without_deduplication(force_from: false, ordered: false, select: arel_table[Arel.star], deduplicated_columns: [])
         query = arel_table.where(
-          arel_table[:external_subscription_id].eq(subscription.external_id)
-          .and(arel_table[:organization_id].eq(subscription.organization.id)
+          arel_table[:external_subscription_id].eq(context.external_id)
+          .and(arel_table[:organization_id].eq(context.organization.id)
           .and(arel_table[:code].eq(code)))
         )
 
@@ -118,9 +118,9 @@ module Events
           ActiveRecord::Base.sanitize_sql_for_conditions(
             [
               "organization_id = ? AND code = ? AND external_subscription_id = ?",
-              subscription.organization_id,
+              context.organization_id,
               code,
-              subscription.external_id
+              context.external_id
             ]
           )
         ]
@@ -134,7 +134,7 @@ module Events
         # Implementation relies directly on the events_enriched_expanded table,
         # so we delegate the implementation to the ClickhouseEnrichedStore
         Events::Stores::ClickhouseEnrichedStore.new(
-          subscription:,
+          context:,
           boundaries:
         ).distinct_charges_and_filters(codes:, include_all_history:, with_last_seen_at:)
       end
@@ -154,8 +154,8 @@ module Events
 
         Events::Stores::Utils::ClickhouseConnection.with_retry do
           scope = ::Clickhouse::EventsEnriched
-            .where(external_subscription_id: subscription.external_id)
-            .where(organization_id: subscription.organization_id)
+            .where(external_subscription_id: context.external_id)
+            .where(organization_id: context.organization_id)
             .where(code: codes)
             .where("events_enriched.timestamp <= ?", applicable_to_datetime)
           scope = scope.where("events_enriched.timestamp >= ?", from_datetime) unless include_all_history

--- a/app/services/events/stores/event_context.rb
+++ b/app/services/events/stores/event_context.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    class EventContext
+      def self.from(subscription: nil, contract: nil)
+        if subscription.present? && contract.present?
+          raise ArgumentError, "subscription or contract is required"
+        end
+
+        new(subscription:, contract:)
+      end
+
+      def initialize(subscription: nil, contract: nil)
+        if [subscription, contract].compact.one?
+          @record = subscription || contract
+        else
+          raise ArgumentError, "subscription or contract is required"
+        end
+      end
+
+      delegate :external_id,
+        :organization,
+        :organization_id,
+        :customer,
+        :plan,
+        :started_at,
+        :terminated_at,
+        :terminated?,
+        :terminated_at?,
+        :date_diff_with_timezone,
+        :calendar?,
+        :anniversary?,
+        to: :record
+
+      def id
+        return record.id if subscription?
+
+        raise NotImplementedError, "contract-backed event contexts do not have a subscription id"
+      end
+
+      def subscription_at
+        return record.subscription_at if subscription?
+
+        record.started_at
+      end
+
+      def invoice_subscriptions
+        return record.invoice_subscriptions if subscription?
+
+        raise_contract_context_not_supported(:invoice_subscriptions)
+      end
+
+      def previous_subscription
+        return record.previous_subscription if subscription?
+
+        raise_contract_context_not_supported(:previous_subscription)
+      end
+
+      def previous_subscription_id
+        return record.previous_subscription_id if subscription?
+
+        raise_contract_context_not_supported(:previous_subscription_id)
+      end
+
+      def previous_subscription_id?
+        return previous_subscription_id.present? if subscription?
+
+        raise_contract_context_not_supported(:previous_subscription_id?)
+      end
+
+      def next_subscription
+        return record.next_subscription if subscription?
+
+        raise_contract_context_not_supported(:next_subscription)
+      end
+
+      def upgraded?
+        return record.upgraded? if subscription?
+
+        raise_contract_context_not_supported(:upgraded?)
+      end
+
+      def downgraded?
+        return record.downgraded? if subscription?
+
+        raise_contract_context_not_supported(:downgraded?)
+      end
+
+      def charges_duration_at(billing_at)
+        unless subscription?
+          raise NotImplementedError, "contract-backed event contexts do not have charge durations yet"
+        end
+
+        Subscriptions::DatesService.new_instance(
+          record,
+          billing_at,
+          current_usage: terminated? && upgraded?
+        ).charges_duration_in_days
+      end
+
+      private
+
+      attr_reader :record
+
+      def subscription?
+        record.is_a?(::Subscription)
+      end
+
+      def raise_contract_context_not_supported(method_name)
+        raise NotImplementedError, "contract-backed event contexts do not have #{method_name} yet"
+      end
+    end
+  end
+end

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -4,8 +4,8 @@ module Events
   module Stores
     class PostgresStore < BaseStore
       def events(force_from: false, ordered: false)
-        scope = Event.where(external_subscription_id: subscription.external_id)
-          .where(organization_id: subscription.organization.id)
+        scope = Event.where(external_subscription_id: context.external_id)
+          .where(organization_id: context.organization.id)
           .where(code:)
 
         scope = scope.order(timestamp: :asc) if ordered
@@ -28,8 +28,8 @@ module Events
       # callers that never read it use to avoid scanning the column (see BillingPeriodFilterService).
       def distinct_charges_and_filters(codes: nil, include_all_history: false, with_last_seen_at: true)
         lower_bound = include_all_history ? nil : from_datetime
-        scope = EnrichedEvent.where(organization_id: subscription.organization_id)
-          .where(subscription_id: subscription.id)
+        scope = EnrichedEvent.where(organization_id: context.organization_id)
+          .where(subscription_id: context.id)
           .where(timestamp: lower_bound..to_datetime)
 
         scope = scope.where(code: codes) unless codes.nil?
@@ -46,8 +46,8 @@ module Events
       # with_last_seen_at disabled the aggregate is not computed and last_seen_at is nil, which
       # callers that never read it use to avoid scanning the column (see BillingPeriodFilterService).
       def distinct_codes_and_property_combinations(codes:, filter_keys:, include_all_history: false, with_last_seen_at: true)
-        scope = Event.where(external_subscription_id: subscription.external_id)
-          .where(organization_id: subscription.organization_id)
+        scope = Event.where(external_subscription_id: context.external_id)
+          .where(organization_id: context.organization_id)
           .where(code: codes)
           .to_datetime(applicable_to_datetime)
         scope = scope.from_datetime(from_datetime) unless include_all_history

--- a/app/services/events/stores/store_factory.rb
+++ b/app/services/events/stores/store_factory.rb
@@ -46,8 +46,8 @@ module Events
         event_store
       end
 
-      def self.new_instance(organization:, **kwargs)
-        store_class(organization: organization).new(**kwargs)
+      def self.new_instance(organization:, context:, **kwargs)
+        store_class(organization: organization).new(context:, **kwargs)
       end
     end
   end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -435,7 +435,7 @@ module Fees
       BillableMetrics::AggregationFactory.new_instance(
         charge: selected_metered_item.charge,
         current_usage: options.current_usage?,
-        subscription:,
+        context: Events::Stores::EventContext.from(subscription:),
         boundaries: {
           from_datetime: selected_metered_item.boundaries.charges_from_datetime,
           to_datetime: selected_metered_item.boundaries.charges_to_datetime,

--- a/app/services/fees/projection_service.rb
+++ b/app/services/fees/projection_service.rb
@@ -113,7 +113,7 @@ module Fees
 
       aggregator = BillableMetrics::AggregationFactory.new_instance(
         charge: charge,
-        subscription: subscription,
+        context: Events::Stores::EventContext.from(subscription:),
         boundaries: boundaries,
         filters: aggregation_filters,
         current_usage: true

--- a/spec/models/concerns/billing_period_date_diff_spec.rb
+++ b/spec/models/concerns/billing_period_date_diff_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BillingPeriodDateDiff do
+  describe "#date_diff_with_timezone" do
+    subject(:date_diff_with_timezone) { record.date_diff_with_timezone(from_datetime, to_datetime) }
+
+    let(:from_datetime) { Time.zone.parse("2023-08-31T23:10:00") }
+    let(:to_datetime) { Time.zone.parse("2023-09-30T22:59:59") }
+    let(:customer) { create(:customer, timezone: "Europe/Paris") }
+    let(:record) { create(:subscription, customer:, plan:) }
+    let(:plan) { create(:plan) }
+
+    it "returns the number of days between the two datetimes in the customer timezone" do
+      expect(date_diff_with_timezone).to eq(30)
+    end
+
+    context "with terminated and upgraded subscription" do
+      let(:record) do
+        create(
+          :subscription,
+          customer:,
+          plan:,
+          terminated_at: Time.zone.parse("2023-09-30T22:59:59")
+        )
+      end
+
+      before do
+        record.terminated!
+        create(:subscription, customer:, plan:, previous_subscription_id: record.id)
+      end
+
+      it "removes the first day billed by the new subscription" do
+        expect(date_diff_with_timezone).to eq(29)
+      end
+    end
+
+    context "with a contract" do
+      let(:record) { create(:contract, customer:, organization: customer.organization) }
+
+      it "returns the number of days between the two datetimes in the customer timezone" do
+        expect(date_diff_with_timezone).to eq(30)
+      end
+    end
+  end
+end

--- a/spec/models/concerns/terminatable_spec.rb
+++ b/spec/models/concerns/terminatable_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Terminatable do
+  describe "#terminated_at?" do
+    subject(:terminated_at?) { record.terminated_at?(timestamp) }
+
+    let(:record) { build(:subscription, status:, terminated_at:) }
+    let(:status) { :terminated }
+    let(:terminated_at) { Time.zone.parse("2026-03-15 12:00:00") }
+    let(:timestamp) { Time.zone.parse("2026-03-15 12:00:01") }
+
+    it "returns true when the record was terminated at or before the timestamp" do
+      expect(terminated_at?).to eq(true)
+    end
+
+    context "when the record is not terminated" do
+      let(:status) { :active }
+
+      it { expect(terminated_at?).to eq(false) }
+    end
+
+    context "when terminated_at is blank" do
+      let(:terminated_at) { nil }
+
+      it { expect(terminated_at?).to eq(false) }
+    end
+
+    context "when timestamp is blank" do
+      let(:timestamp) { nil }
+
+      it { expect(terminated_at?).to eq(false) }
+    end
+
+    context "when timestamp is before terminated_at" do
+      let(:timestamp) { Time.zone.parse("2026-03-15 11:59:59") }
+
+      it { expect(terminated_at?).to eq(false) }
+    end
+
+    context "when timestamp is a date" do
+      let(:terminated_at) { Time.zone.parse("2026-03-15 00:00:00") }
+      let(:timestamp) { Date.parse("2026-03-15") }
+
+      it { expect(terminated_at?).to eq(true) }
+    end
+
+    context "when timestamp is an integer" do
+      let(:timestamp) { Time.zone.parse("2026-03-15 12:00:01").to_i }
+
+      it { expect(terminated_at?).to eq(true) }
+    end
+
+    context "with a contract" do
+      let(:record) { build(:contract, status:, terminated_at:) }
+
+      it "uses the same predicate" do
+        expect(terminated_at?).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/services/billable_metrics/aggregation_factory_spec.rb
+++ b/spec/services/billable_metrics/aggregation_factory_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe BillableMetrics::AggregationFactory do
 
   let(:current_usage) { false }
 
-  let(:result) { factory.new_instance(charge:, current_usage:, subscription:, boundaries:) }
+  let(:result) { factory.new_instance(charge:, current_usage:, context: Events::Stores::EventContext.from(subscription:), boundaries:) }
 
   describe "#new_instance" do
     context "with count_agg aggregation" do

--- a/spec/services/billable_metrics/aggregations/base_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/base_service_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe BillableMetrics::Aggregations::BaseService do
       described_class.new(
         event_store_class: Events::Stores::PostgresStore,
         charge:,
-        subscription:,
+        context: Events::Stores::EventContext.from(subscription:),
         boundaries: {from_datetime: Time.current, to_datetime: Time.current},
         filters:
       )

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService do
     described_class.new(
       event_store_class:,
       charge:,
-      subscription:,
+      context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
         to_datetime:

--- a/spec/services/billable_metrics/aggregations/custom_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/custom_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BillableMetrics::Aggregations::CustomService do
     described_class.new(
       event_store_class:,
       charge:,
-      subscription:,
+      context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
         to_datetime:

--- a/spec/services/billable_metrics/aggregations/latest_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/latest_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BillableMetrics::Aggregations::LatestService do
     described_class.new(
       event_store_class:,
       charge:,
-      subscription:,
+      context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
         to_datetime:

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService do
     described_class.new(
       event_store_class:,
       charge:,
-      subscription:,
+      context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
         to_datetime:

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, transaction: false do
     described_class.new(
       event_store_class:,
       charge:,
-      subscription:,
+      context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
         to_datetime:

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, transaction: f
     described_class.new(
       event_store_class:,
       charge:,
-      subscription:,
+      context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
         to_datetime:

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, transaction: f
     described_class.new(
       event_store_class:,
       charge:,
-      subscription:,
+      context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
         to_datetime:,

--- a/spec/services/billable_metrics/breakdown/sum_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/sum_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BillableMetrics::Breakdown::SumService, transaction: false do
     described_class.new(
       event_store_class:,
       charge:,
-      subscription:,
+      context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
         to_datetime:,

--- a/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BillableMetrics::Breakdown::UniqueCountService, transaction: fals
     described_class.new(
       event_store_class:,
       charge:,
-      subscription:,
+      context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
         to_datetime:,

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, transaction: f
     described_class.new(
       event_store_class:,
       charge:,
-      subscription:,
+      context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
         to_datetime:,
@@ -831,7 +831,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, transaction: f
         described_class.new(
           event_store_class:,
           charge:,
-          subscription:,
+          context: Events::Stores::EventContext.from(subscription:),
           boundaries: {
             from_datetime:,
             to_datetime:,
@@ -871,7 +871,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, transaction: f
         described_class.new(
           event_store_class:,
           charge:,
-          subscription:,
+          context: Events::Stores::EventContext.from(subscription:),
           boundaries: {
             from_datetime:,
             to_datetime:,

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transa
     described_class.new(
       event_store_class:,
       charge:,
-      subscription:,
+      context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
         to_datetime:,
@@ -1049,7 +1049,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transa
         described_class.new(
           event_store_class:,
           charge:,
-          subscription:,
+          context: Events::Stores::EventContext.from(subscription:),
           boundaries: {
             from_datetime:,
             to_datetime:,
@@ -1087,7 +1087,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transa
         described_class.new(
           event_store_class:,
           charge:,
-          subscription:,
+          context: Events::Stores::EventContext.from(subscription:),
           boundaries: {
             from_datetime:,
             to_datetime:,

--- a/spec/services/charge_models/percentage_service_spec.rb
+++ b/spec/services/charge_models/percentage_service_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe ChargeModels::PercentageService do
       BillableMetrics::Aggregations::SumService.new(
         event_store_class:,
         charge:,
-        subscription:,
+        context: Events::Stores::EventContext.from(subscription:),
         boundaries: nil
       )
     end

--- a/spec/services/charge_models/prorated_graduated_service_spec.rb
+++ b/spec/services/charge_models/prorated_graduated_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ChargeModels::ProratedGraduatedService do
     BillableMetrics::ProratedAggregations::SumService.new(
       event_store_class:,
       charge:,
-      subscription:,
+      context: Events::Stores::EventContext.from(subscription:),
       boundaries: nil
     )
   end

--- a/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
+++ b/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService do
     BillableMetrics::Aggregations::CountService.new(
       event_store_class: Events::Stores::PostgresStore,
       charge:,
-      subscription: nil,
+      context: Events::Stores::EventContext.from(subscription:),
       boundaries: nil
     )
   end
@@ -221,7 +221,7 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService do
         BillableMetrics::Aggregations::SumService.new(
           event_store_class: Events::Stores::PostgresStore,
           charge:,
-          subscription:,
+          context: Events::Stores::EventContext.from(subscription:),
           boundaries: nil
         )
       end

--- a/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
   end
 
   let(:agg_result) { BaseService::Result.new }
+  let(:subscription_context) { have_attributes(external_id: subscription.external_id, organization: subscription.organization) }
 
   describe "#call" do
     describe "when count aggregation" do
@@ -47,7 +48,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
           .with(
             event_store_class: Events::Stores::PostgresStore,
             charge:,
-            subscription:,
+            context: subscription_context,
             boundaries: {
               from_datetime: boundaries.charges_from_datetime,
               to_datetime: boundaries.charges_to_datetime,
@@ -94,7 +95,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
             .with(
               event_store_class: Events::Stores::PostgresStore,
               charge:,
-              subscription:,
+              context: subscription_context,
               boundaries: {
                 from_datetime: boundaries.charges_from_datetime,
                 to_datetime: boundaries.charges_to_datetime,
@@ -142,7 +143,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
             .with(
               event_store_class: Events::Stores::PostgresStore,
               charge:,
-              subscription:,
+              context: subscription_context,
               boundaries: {
                 from_datetime: boundaries.charges_from_datetime,
                 to_datetime: boundaries.charges_to_datetime,
@@ -193,7 +194,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
               .with(
                 event_store_class: Events::Stores::PostgresStore,
                 charge:,
-                subscription:,
+                context: subscription_context,
                 boundaries: {
                   from_datetime: boundaries.charges_from_datetime,
                   to_datetime: boundaries.charges_to_datetime,
@@ -239,7 +240,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
             .with(
               event_store_class: Events::Stores::PostgresStore,
               charge:,
-              subscription:,
+              context: subscription_context,
               boundaries: {
                 from_datetime: boundaries.charges_from_datetime,
                 to_datetime: boundaries.charges_to_datetime,
@@ -287,7 +288,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
             .with(
               event_store_class: Events::Stores::PostgresStore,
               charge:,
-              subscription:,
+              context: subscription_context,
               boundaries: {
                 from_datetime: boundaries.charges_from_datetime,
                 to_datetime: boundaries.charges_to_datetime,
@@ -331,7 +332,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
             .with(
               event_store_class: Events::Stores::PostgresStore,
               charge:,
-              subscription:,
+              context: subscription_context,
               boundaries: {
                 from_datetime: boundaries.charges_from_datetime,
                 to_datetime: boundaries.charges_to_datetime,
@@ -370,7 +371,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
           .with(
             event_store_class: Events::Stores::PostgresStore,
             charge:,
-            subscription:,
+            context: subscription_context,
             boundaries: {
               from_datetime: boundaries.charges_from_datetime,
               to_datetime: boundaries.charges_to_datetime,
@@ -404,7 +405,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
           .with(
             event_store_class: Events::Stores::PostgresStore,
             charge:,
-            subscription:,
+            context: subscription_context,
             boundaries: {
               from_datetime: boundaries.charges_from_datetime,
               to_datetime: boundaries.charges_to_datetime,

--- a/spec/services/events/stores/base_store_spec.rb
+++ b/spec/services/events/stores/base_store_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::Stores::BaseStore do
+  describe "#period_duration" do
+    subject(:period_duration) { store.send(:period_duration) }
+
+    let(:subscription) { create(:subscription) }
+    let(:store) do
+      described_class.new(
+        context:,
+        boundaries: {
+          from_datetime: Time.zone.parse("2026-03-01"),
+          to_datetime: Time.zone.parse("2026-03-31").end_of_day,
+          charges_duration: 30
+        }
+      )
+    end
+    let(:context) { Events::Stores::EventContext.from(subscription:) }
+
+    it "computes duration through the event context" do
+      allow(context).to receive(:charges_duration_at).and_return(31)
+
+      expect(period_duration).to eq(31)
+      expect(context).to have_received(:charges_duration_at)
+        .with(Time.zone.parse("2026-03-31").end_of_day + 1.day)
+    end
+
+    it "uses the explicit boundary duration for the charges duration" do
+      expect(store.charges_duration).to eq(30)
+    end
+
+    context "when context is contract-backed" do
+      let(:context) { Events::Stores::EventContext.from(contract: create(:contract)) }
+
+      it "raises when duration is requested" do
+        expect { period_duration }
+          .to raise_error(NotImplementedError, "contract-backed event contexts do not have charge durations yet")
+      end
+    end
+  end
+end

--- a/spec/services/events/stores/clickhouse_enriched_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_enriched_store_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Events::Stores::ClickhouseEnrichedStore, clickhouse: {clean_befor
     subject(:event_store) do
       described_class.new(
         code: billable_metric.code,
-        subscription:,
+        context: Events::Stores::EventContext.from(subscription:),
         boundaries:,
         filters: {
           grouped_by:,
@@ -133,7 +133,7 @@ RSpec.describe Events::Stores::ClickhouseEnrichedStore, clickhouse: {clean_befor
     def event_store(filters)
       described_class.new(
         code: billable_metric.code,
-        subscription:,
+        context: Events::Stores::EventContext.from(subscription:),
         boundaries: {
           from_datetime: subscription.started_at.beginning_of_day,
           to_datetime: subscription.started_at.end_of_month.end_of_day,

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
       subject(:event_store) do
         described_class.new(
           code: billable_metric.code,
-          subscription:,
+          context: Events::Stores::EventContext.from(subscription:),
           boundaries:,
           filters: {
             grouped_by: nil,
@@ -147,7 +147,7 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
   # deduplicated rows; non-deduplicated counts must not use `FINAL`.
   describe "#count_query" do
     subject(:event_store) do
-      described_class.new(code: billable_metric.code, subscription:, boundaries:, filters:, deduplicate:)
+      described_class.new(code: billable_metric.code, context: Events::Stores::EventContext.from(subscription:), boundaries:, filters:, deduplicate:)
     end
 
     let(:billable_metric) { create(:sum_billable_metric, field_name: "value", code: "bm:code") }
@@ -243,7 +243,7 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
   # identical data, across re-enrichment duplicates and boundary edges.
   describe "#count fast-path equivalence with the CTE-based query" do
     subject(:event_store) do
-      described_class.new(code: billable_metric.code, subscription:, boundaries:, filters: {}, deduplicate: true)
+      described_class.new(code: billable_metric.code, context: Events::Stores::EventContext.from(subscription:), boundaries:, filters: {}, deduplicate: true)
     end
 
     let(:billable_metric) { create(:sum_billable_metric, field_name: "value", code: "bm:code") }
@@ -331,7 +331,7 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
     def event_store_for(boundary_transaction_id, deduplicate:)
       described_class.new(
         code: billable_metric.code,
-        subscription:,
+        context: Events::Stores::EventContext.from(subscription:),
         boundaries: {
           from_datetime: subscription.started_at.beginning_of_day,
           to_datetime: subscription.started_at.end_of_month.end_of_day,

--- a/spec/services/events/stores/event_context_spec.rb
+++ b/spec/services/events/stores/event_context_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::Stores::EventContext do
+  describe ".from" do
+    it "wraps a subscription" do
+      subscription = create(:subscription)
+
+      context = described_class.from(subscription:)
+
+      expect(context.external_id).to eq(subscription.external_id)
+      expect(context.id).to eq(subscription.id)
+      expect(context.organization).to eq(subscription.organization)
+      expect(context.customer).to eq(subscription.customer)
+      expect(context.subscription_at).to eq(subscription.subscription_at)
+      expect(context.anniversary?).to eq(subscription.anniversary?)
+    end
+
+    it "wraps a contract for raw event lookup" do
+      contract = create(:contract)
+
+      context = described_class.from(contract:)
+
+      expect(context.external_id).to eq(contract.external_id)
+      expect(context.organization).to eq(contract.organization)
+      expect(context.customer).to eq(contract.customer)
+      expect(context.started_at).to eq(contract.started_at)
+    end
+
+    it "rejects missing records" do
+      expect { described_class.from }.to raise_error(ArgumentError, "subscription or contract is required")
+    end
+
+    it "rejects ambiguous records" do
+      expect { described_class.from(subscription: build(:subscription), contract: build(:contract)) }
+        .to raise_error(ArgumentError, "subscription or contract is required")
+    end
+  end
+
+  describe "#id" do
+    it "rejects subscription ids for contract-backed contexts" do
+      context = described_class.from(contract: create(:contract))
+
+      expect { context.id }
+        .to raise_error(NotImplementedError, "contract-backed event contexts do not have a subscription id")
+    end
+  end
+
+  describe "#date_diff_with_timezone" do
+    it "uses the customer timezone for contracts" do
+      customer = create(:customer, timezone: "America/New_York")
+      contract = create(:contract, customer:, organization: customer.organization)
+      context = described_class.from(contract:)
+
+      expect(
+        context.date_diff_with_timezone(
+          Time.zone.parse("2026-03-01 05:00:00"),
+          Time.zone.parse("2026-03-31 03:59:59")
+        )
+      ).to eq(30)
+    end
+  end
+
+  describe "#terminated_at?" do
+    it "delegates to a contract-backed context" do
+      contract = create(:contract, status: :terminated, terminated_at: Time.zone.parse("2026-03-15 12:00:00"))
+      context = described_class.from(contract:)
+
+      expect(context.terminated_at?(Time.zone.parse("2026-03-15 12:00:01"))).to eq(true)
+    end
+  end
+
+  describe "subscription-only methods" do
+    it "raises for contract-backed contexts" do
+      context = described_class.from(contract: create(:contract))
+
+      %i[
+        invoice_subscriptions
+        previous_subscription
+        previous_subscription_id
+        previous_subscription_id?
+        next_subscription
+        upgraded?
+        downgraded?
+      ].each do |method_name|
+        expect { context.public_send(method_name) }
+          .to raise_error(NotImplementedError, "contract-backed event contexts do not have #{method_name} yet")
+      end
+    end
+  end
+
+  describe "#charges_duration_at" do
+    it "delegates period duration computation through Subscriptions::DatesService" do
+      subscription = create(:subscription, started_at: Time.zone.parse("2026-03-01"))
+      context = described_class.from(subscription:)
+
+      dates_service = instance_double(Subscriptions::DatesService, charges_duration_in_days: 31)
+      allow(Subscriptions::DatesService).to receive(:new_instance).and_return(dates_service)
+
+      expect(context.charges_duration_at(Time.zone.parse("2026-04-01"))).to eq(31)
+      expect(Subscriptions::DatesService).to have_received(:new_instance)
+        .with(subscription, Time.zone.parse("2026-04-01"), current_usage: false)
+    end
+
+    it "rejects charge duration computation for contracts" do
+      context = described_class.from(contract: create(:contract))
+
+      expect { context.charges_duration_at(Time.current) }
+        .to raise_error(NotImplementedError, "contract-backed event contexts do not have charge durations yet")
+    end
+  end
+end

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Events::Stores::PostgresStore do
     let(:event_store) do
       described_class.new(
         code: billable_metric.code,
-        subscription:,
+        context: Events::Stores::EventContext.from(subscription:),
         boundaries: {
           from_datetime: subscription.started_at.beginning_of_day,
           to_datetime: Time.current.end_of_day
@@ -109,7 +109,7 @@ RSpec.describe Events::Stores::PostgresStore do
       def store_for(event)
         described_class.new(
           code: billable_metric.code,
-          subscription:,
+          context: Events::Stores::EventContext.from(subscription:),
           boundaries: {
             from_datetime: subscription.started_at.beginning_of_day,
             to_datetime: subscription.started_at.end_of_month.end_of_day,
@@ -142,7 +142,7 @@ RSpec.describe Events::Stores::PostgresStore do
 
         event_store = described_class.new(
           code: billable_metric.code,
-          subscription:,
+          context: Events::Stores::EventContext.from(subscription:),
           boundaries: {
             from_datetime: subscription.started_at.beginning_of_day,
             to_datetime: subscription.started_at.end_of_month.end_of_day,
@@ -167,7 +167,7 @@ RSpec.describe Events::Stores::PostgresStore do
       let(:event_store) do
         described_class.new(
           code: billable_metric.code,
-          subscription:,
+          context: Events::Stores::EventContext.from(subscription:),
           boundaries: {
             from_datetime: datetime,
             to_datetime: datetime,
@@ -196,7 +196,7 @@ RSpec.describe Events::Stores::PostgresStore do
     let(:event_store) do
       described_class.new(
         code: billable_metric.code,
-        subscription:,
+        context: Events::Stores::EventContext.from(subscription:),
         boundaries: {
           from_datetime: started_at,
           to_datetime: started_at.end_of_month.end_of_day,

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -4,7 +4,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
   subject(:event_store) do
     described_class.new(
       code:,
-      subscription:,
+      context: Events::Stores::EventContext.from(subscription:),
       boundaries:,
       filters: {
         grouped_by:,
@@ -824,7 +824,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         subject(:event_store) do
           described_class.new(
             code:,
-            subscription:,
+            context: Events::Stores::EventContext.from(subscription:),
             boundaries:,
             filters: {
               grouped_by:,
@@ -1580,7 +1580,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
       subject(:event_store) do
         described_class.new(
           code:,
-          subscription:,
+          context: Events::Stores::EventContext.from(subscription:),
           boundaries:,
           filters: {
             grouped_by:,
@@ -1645,7 +1645,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
       subject(:event_store) do
         described_class.new(
           code:,
-          subscription:,
+          context: Events::Stores::EventContext.from(subscription:),
           boundaries:,
           filters: {
             grouped_by:,
@@ -1705,7 +1705,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
       subject(:event_store) do
         described_class.new(
           code:,
-          subscription:,
+          context: Events::Stores::EventContext.from(subscription:),
           boundaries:,
           filters: {
             grouped_by:,
@@ -1768,7 +1768,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
       subject(:event_store) do
         described_class.new(
           code:,
-          subscription:,
+          context: Events::Stores::EventContext.from(subscription:),
           boundaries:,
           filters: {
             grouped_by:,
@@ -1833,7 +1833,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
       subject(:event_store) do
         described_class.new(
           code:,
-          subscription:,
+          context: Events::Stores::EventContext.from(subscription:),
           boundaries:,
           filters: {
             grouped_by:,
@@ -1900,7 +1900,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
       subject(:event_store) do
         described_class.new(
           code:,
-          subscription:,
+          context: Events::Stores::EventContext.from(subscription:),
           boundaries:,
           filters: {
             grouped_by:,

--- a/spec/services/events/stores/store_factory_spec.rb
+++ b/spec/services/events/stores/store_factory_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Events::Stores::StoreFactory do
     time = Time.current
 
     {
-      subscription: create(:subscription, organization:),
+      context: Events::Stores::EventContext.from(subscription: create(:subscription, organization:)),
       boundaries: {
         from_datetime: time.beginning_of_month,
         to_datetime: time.end_of_month,

--- a/spec/services/fees/projection_service_spec.rb
+++ b/spec/services/fees/projection_service_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Fees::ProjectionService do
         service.call
         expect(BillableMetrics::AggregationFactory).to have_received(:new_instance).with(
           charge: charge,
-          subscription: subscription,
+          context: have_attributes(external_id: subscription.external_id, organization: subscription.organization),
           boundaries: {
             from_datetime: match_datetime(from_datetime),
             to_datetime: match_datetime(to_datetime),
@@ -224,7 +224,7 @@ RSpec.describe Fees::ProjectionService do
         service.call
         expect(BillableMetrics::AggregationFactory).to have_received(:new_instance).with(
           charge: charge,
-          subscription: subscription,
+          context: have_attributes(external_id: subscription.external_id, organization: subscription.organization),
           boundaries: {
             from_datetime: match_datetime(from_datetime),
             to_datetime: match_datetime(to_datetime),


### PR DESCRIPTION
## Context

This change unblocks the initial BillingSegment refactor needed to support BillingPeriodFilterService. BillingSegment filtering queries raw events through contract data, while the existing event stores and billable metric aggregators assumed every event context was a Subscription.

## Description

Introduce Events::Stores::EventContext as the explicit object passed into event stores and aggregators. The stores now ask the context for external ids, organization, customer, duration, subscription history, and date calculations instead of depending directly on a subscription.

Contract-backed contexts currently support the raw event lookup surface needed by BillingSegment, and intentionally raise NotImplementedError for subscription-specific methods that are not defined yet: invoice_subscriptions, previous_subscription, previous_subscription_id, previous_subscription_id?, next_subscription, upgraded?, downgraded?, id, and charges_duration_at. Those contract behaviours will be addressed in a separate PR.

This refactor is necessary to unblock products and plans (contract) https://github.com/getlago/lago-api/pull/6296
