### PR TITLE
feat(streaming): store where an organization's events should be streamed

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -72,6 +72,7 @@ class Organization < ApplicationRecord
   has_many :payment_providers, class_name: "PaymentProviders::BaseProvider"
   has_many :payment_receipts
   has_many :payment_requests
+  has_many :streaming_destinations, class_name: "StreamingDestinations::BaseDestination"
   has_many :taxes
   has_many :wallets
   has_many :wallet_transactions

--- a/app/models/streaming_destinations/base_destination.rb
+++ b/app/models/streaming_destinations/base_destination.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module StreamingDestinations
+  class BaseDestination < ApplicationRecord
+    include PaperTrailTraceable
+    include SecretsStorable
+    include SettingsStorable
+
+    self.table_name = "streaming_destinations"
+
+    EVENT_TYPES = %w[customer_usage.refreshed].freeze
+
+    belongs_to :organization
+
+    validates :event_types, presence: true
+    validate :event_types_are_known
+    validate :event_types_not_already_claimed
+
+    scope :for_event, lambda { |organization, event_type|
+      where(organization:).where("event_types @> ARRAY[?]::varchar[]", event_type)
+    }
+
+    private
+
+    def event_types_are_known
+      return if event_types.blank?
+      return if (event_types - EVENT_TYPES).empty?
+
+      errors.add(:event_types, :inclusion)
+    end
+
+    def event_types_not_already_claimed
+      return if organization_id.nil? || event_types.blank?
+
+      claimed = BaseDestination.where(organization_id:)
+      claimed = claimed.where.not(id:) if persisted?
+
+      return unless claimed.where("event_types && ARRAY[?]::varchar[]", event_types).exists?
+
+      errors.add(:event_types, :taken)
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: streaming_destinations
+# Database name: primary
+#
+#  id              :uuid             not null, primary key
+#  event_types     :string           default([]), not null, is an Array
+#  secrets         :string
+#  settings        :jsonb            not null
+#  type            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_streaming_destinations_on_event_types      (event_types) USING gin
+#  index_streaming_destinations_on_organization_id  (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/models/streaming_destinations/base_destination.rb
+++ b/app/models/streaming_destinations/base_destination.rb
@@ -8,7 +8,7 @@ module StreamingDestinations
 
     self.table_name = "streaming_destinations"
 
-    EVENT_TYPES = %w[customer_usage.refreshed].freeze
+    EVENT_TYPES = %w[customer_usage.refreshed.v1].freeze
 
     belongs_to :organization
 

--- a/app/models/streaming_destinations/base_destination.rb
+++ b/app/models/streaming_destinations/base_destination.rb
@@ -17,7 +17,7 @@ module StreamingDestinations
     validate :event_types_not_already_claimed
 
     scope :for_event, lambda { |organization, event_type|
-      where(organization:).where("event_types @> ARRAY[?]::varchar[]", event_type)
+      where(organization:, active: true).where("event_types @> ARRAY[?]::varchar[]", event_type)
     }
 
     private
@@ -48,6 +48,7 @@ end
 # Database name: primary
 #
 #  id              :uuid             not null, primary key
+#  active          :boolean          default(FALSE), not null
 #  event_types     :string           default([]), not null, is an Array
 #  secrets         :string
 #  settings        :jsonb            not null

--- a/app/models/streaming_destinations/kinesis_destination.rb
+++ b/app/models/streaming_destinations/kinesis_destination.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module StreamingDestinations
+  class KinesisDestination < BaseDestination
+    PARTITION_KEYS = %w[customer_external_id].freeze
+    DEFAULT_PARTITION_KEY = "customer_external_id"
+
+    settings_accessors :stream_arn, :region, :role_arn
+    settings_accessors :partition_key, default: DEFAULT_PARTITION_KEY
+
+    validates :stream_arn, presence: true
+    validates :region, presence: true
+    validates :role_arn, presence: true
+    validates :partition_key, inclusion: {in: PARTITION_KEYS}
+  end
+end
+
+# == Schema Information
+#
+# Table name: streaming_destinations
+# Database name: primary
+#
+#  id              :uuid             not null, primary key
+#  event_types     :string           default([]), not null, is an Array
+#  secrets         :string
+#  settings        :jsonb            not null
+#  type            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_streaming_destinations_on_event_types      (event_types) USING gin
+#  index_streaming_destinations_on_organization_id  (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/models/streaming_destinations/kinesis_destination.rb
+++ b/app/models/streaming_destinations/kinesis_destination.rb
@@ -21,6 +21,7 @@ end
 # Database name: primary
 #
 #  id              :uuid             not null, primary key
+#  active          :boolean          default(FALSE), not null
 #  event_types     :string           default([]), not null, is an Array
 #  secrets         :string
 #  settings        :jsonb            not null

--- a/db/migrate/20260904162803_create_streaming_destinations.rb
+++ b/db/migrate/20260904162803_create_streaming_destinations.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateStreamingDestinations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :streaming_destinations, id: :uuid do |t|
+      t.references :organization, null: false, foreign_key: true, type: :uuid
+
+      t.string :type, null: false
+
+      t.string :event_types, array: true, null: false, default: []
+
+      t.jsonb :settings, null: false, default: {}
+      t.string :secrets
+
+      t.timestamps
+
+      t.index :event_types, using: :gin
+    end
+  end
+end

--- a/db/migrate/20260904162803_create_streaming_destinations.rb
+++ b/db/migrate/20260904162803_create_streaming_destinations.rb
@@ -9,6 +9,8 @@ class CreateStreamingDestinations < ActiveRecord::Migration[8.0]
 
       t.string :event_types, array: true, null: false, default: []
 
+      t.boolean :active, null: false, default: false
+
       t.jsonb :settings, null: false, default: {}
       t.string :secrets
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5861,6 +5861,7 @@ CREATE TABLE public.streaming_destinations (
     organization_id uuid NOT NULL,
     type character varying NOT NULL,
     event_types character varying[] DEFAULT '{}'::character varying[] NOT NULL,
+    active boolean DEFAULT false NOT NULL,
     settings jsonb DEFAULT '{}'::jsonb NOT NULL,
     secrets character varying,
     created_at timestamp(6) without time zone NOT NULL,

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -65,6 +65,7 @@ ALTER TABLE IF EXISTS ONLY public.customers_invoice_custom_sections DROP CONSTRA
 ALTER TABLE IF EXISTS ONLY public.contract_rate_cards DROP CONSTRAINT IF EXISTS fk_rails_da12dd4c55;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_d9ffb8b4a1;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alerts DROP CONSTRAINT IF EXISTS fk_rails_d9ea200904;
+ALTER TABLE IF EXISTS ONLY public.streaming_destinations DROP CONSTRAINT IF EXISTS fk_rails_d94733afa1;
 ALTER TABLE IF EXISTS ONLY public.integration_resources DROP CONSTRAINT IF EXISTS fk_rails_d9448a540b;
 ALTER TABLE IF EXISTS ONLY public.wallets DROP CONSTRAINT IF EXISTS fk_rails_d9342a8ca7;
 ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP CONSTRAINT IF EXISTS fk_rails_d72a9877be;
@@ -485,6 +486,8 @@ DROP INDEX IF EXISTS public.index_subscription_rate_cards_on_deleted_at;
 DROP INDEX IF EXISTS public.index_subscription_fixed_charge_units_overrides_on_deleted_at;
 DROP INDEX IF EXISTS public.index_subscription_activation_rules_on_organization_id;
 DROP INDEX IF EXISTS public.index_sub_fc_units_overrides_on_sub_id_and_fc_id;
+DROP INDEX IF EXISTS public.index_streaming_destinations_on_organization_id;
+DROP INDEX IF EXISTS public.index_streaming_destinations_on_event_types;
 DROP INDEX IF EXISTS public.index_search_quantified_events;
 DROP INDEX IF EXISTS public.index_rtr_invoice_custom_sections_unique;
 DROP INDEX IF EXISTS public.index_roles_on_organization_id;
@@ -1075,6 +1078,7 @@ ALTER TABLE IF EXISTS ONLY public.subscriptions_invoice_custom_sections DROP CON
 ALTER TABLE IF EXISTS ONLY public.subscription_rate_cards DROP CONSTRAINT IF EXISTS subscription_rate_cards_pkey;
 ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP CONSTRAINT IF EXISTS subscription_fixed_charge_units_overrides_pkey;
 ALTER TABLE IF EXISTS ONLY public.subscription_activation_rules DROP CONSTRAINT IF EXISTS subscription_activation_rules_pkey;
+ALTER TABLE IF EXISTS ONLY public.streaming_destinations DROP CONSTRAINT IF EXISTS streaming_destinations_pkey;
 ALTER TABLE IF EXISTS ONLY public.schema_migrations DROP CONSTRAINT IF EXISTS schema_migrations_pkey;
 ALTER TABLE IF EXISTS ONLY public.roles DROP CONSTRAINT IF EXISTS roles_pkey;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS refunds_pkey;
@@ -1214,6 +1218,7 @@ DROP TABLE IF EXISTS public.subscriptions_invoice_custom_sections;
 DROP TABLE IF EXISTS public.subscription_rate_cards;
 DROP TABLE IF EXISTS public.subscription_fixed_charge_units_overrides;
 DROP TABLE IF EXISTS public.subscription_activation_rules;
+DROP TABLE IF EXISTS public.streaming_destinations;
 DROP TABLE IF EXISTS public.schema_migrations;
 DROP TABLE IF EXISTS public.roles;
 DROP TABLE IF EXISTS public.refunds;
@@ -5848,6 +5853,22 @@ CREATE TABLE public.schema_migrations (
 
 
 --
+-- Name: streaming_destinations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.streaming_destinations (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    type character varying NOT NULL,
+    event_types character varying[] DEFAULT '{}'::character varying[] NOT NULL,
+    settings jsonb DEFAULT '{}'::jsonb NOT NULL,
+    secrets character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: subscription_activation_rules; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -7108,6 +7129,14 @@ ALTER TABLE ONLY public.roles
 
 ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: streaming_destinations streaming_destinations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.streaming_destinations
+    ADD CONSTRAINT streaming_destinations_pkey PRIMARY KEY (id);
 
 
 --
@@ -11295,6 +11324,20 @@ CREATE INDEX index_search_quantified_events ON public.quantified_events USING bt
 
 
 --
+-- Name: index_streaming_destinations_on_event_types; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_streaming_destinations_on_event_types ON public.streaming_destinations USING gin (event_types);
+
+
+--
+-- Name: index_streaming_destinations_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_streaming_destinations_on_organization_id ON public.streaming_destinations USING btree (organization_id);
+
+
+--
 -- Name: index_sub_fc_units_overrides_on_sub_id_and_fc_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -14450,6 +14493,14 @@ ALTER TABLE ONLY public.integration_resources
 
 
 --
+-- Name: streaming_destinations fk_rails_d94733afa1; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.streaming_destinations
+    ADD CONSTRAINT fk_rails_d94733afa1 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: usage_monitoring_alerts fk_rails_d9ea200904; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -14909,6 +14960,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260905223041'),
 ('20260904173416'),
 ('20260904173415'),
+('20260904162803'),
 ('20260904132835'),
 ('20260904083017'),
 ('20260902143604'),

--- a/spec/factories/streaming_destinations.rb
+++ b/spec/factories/streaming_destinations.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :kinesis_destination, class: "StreamingDestinations::KinesisDestination" do
+    organization
+    type { "StreamingDestinations::KinesisDestination" }
+    event_types { ["customer_usage.refreshed"] }
+
+    settings do
+      {
+        stream_arn: "arn:aws:kinesis:eu-west-1:123456789012:stream/lago-streaming-sandbox",
+        region: "eu-west-1",
+        role_arn: "arn:aws:iam::123456789012:role/lago-streaming-sandbox-writer",
+        partition_key: "customer_external_id"
+      }
+    end
+  end
+end

--- a/spec/factories/streaming_destinations.rb
+++ b/spec/factories/streaming_destinations.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :kinesis_destination, class: "StreamingDestinations::KinesisDestination" do
     organization
     type { "StreamingDestinations::KinesisDestination" }
-    event_types { ["customer_usage.refreshed"] }
+    event_types { ["customer_usage.refreshed.v1"] }
 
     settings do
       {

--- a/spec/factories/streaming_destinations.rb
+++ b/spec/factories/streaming_destinations.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     organization
     type { "StreamingDestinations::KinesisDestination" }
     event_types { ["customer_usage.refreshed.v1"] }
+    active { true }
 
     settings do
       {

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Organization do
       expect(subject).to have_many(:wallet_transactions)
       expect(subject).to have_one(:default_billing_entity).class_name("BillingEntity")
       expect(subject).to have_many(:webhook_endpoints)
+      expect(subject).to have_many(:streaming_destinations).class_name("StreamingDestinations::BaseDestination")
       expect(subject).to have_many(:webhooks)
       expect(subject).to have_many(:hubspot_integrations)
       expect(subject).to have_many(:netsuite_integrations)

--- a/spec/models/streaming_destinations/base_destination_spec.rb
+++ b/spec/models/streaming_destinations/base_destination_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StreamingDestinations::BaseDestination, type: :model do
+  subject(:destination) { create(:kinesis_destination) }
+
+  it_behaves_like "paper_trail traceable"
+
+  describe "associations" do
+    it do
+      expect(destination).to belong_to(:organization)
+    end
+  end
+
+  describe "validations" do
+    it do
+      expect(destination).to validate_presence_of(:event_types)
+    end
+
+    describe "event_types validation" do
+      it "rejects an empty array" do
+        destination = build(:kinesis_destination, event_types: [])
+
+        expect(destination).not_to be_valid
+        expect(destination.errors.where(:event_types, :blank)).to be_present
+      end
+
+      it "rejects an unknown event type" do
+        destination = build(:kinesis_destination, event_types: ["customer_usage.refresed"])
+
+        expect(destination).not_to be_valid
+        expect(destination.errors.where(:event_types, :inclusion)).to be_present
+      end
+
+      it "rejects an event type already claimed by another destination of the organization" do
+        organization = create(:organization)
+        create(:kinesis_destination, organization:, event_types: ["customer_usage.refreshed"])
+
+        destination = build(:kinesis_destination, organization:, event_types: ["customer_usage.refreshed"])
+
+        expect(destination).not_to be_valid
+        expect(destination.errors.where(:event_types, :taken)).to be_present
+      end
+
+      it "allows the same event type on another organization" do
+        create(:kinesis_destination, event_types: ["customer_usage.refreshed"])
+
+        expect(build(:kinesis_destination, event_types: ["customer_usage.refreshed"])).to be_valid
+      end
+
+      it "does not conflict with itself on update" do
+        destination = create(:kinesis_destination)
+
+        expect(destination.update(settings: destination.settings.merge("region" => "us-east-1"))).to be true
+      end
+    end
+  end
+
+  describe ".for_event" do
+    let(:organization) { create(:organization) }
+    let!(:destination) { create(:kinesis_destination, organization:, event_types: ["customer_usage.refreshed"]) }
+
+    it "returns a destination whose event_types contain the event type" do
+      expect(described_class.for_event(organization, "customer_usage.refreshed")).to eq([destination])
+    end
+
+    it "does not return a destination without the event type" do
+      destination.update_column(:event_types, ["wallet.updated"]) # rubocop:disable Rails/SkipsModelValidations
+
+      expect(described_class.for_event(organization, "customer_usage.refreshed")).to be_empty
+    end
+
+    it "does not return another organization's destination" do
+      expect(described_class.for_event(create(:organization), "customer_usage.refreshed")).to be_empty
+    end
+
+    it "is the only lookup that works, find_by on the array column raises" do
+      expect { described_class.find_by(event_types: "customer_usage.refreshed") }
+        .to raise_error(ActiveRecord::StatementInvalid, /malformed array literal/)
+    end
+  end
+
+  describe "secrets" do
+    it "round-trips through SecretsStorable" do
+      destination.push_to_secrets(key: "api_key", value: "secret-value")
+      destination.save!
+
+      expect(destination.reload.get_from_secrets("api_key")).to eq("secret-value")
+    end
+  end
+end

--- a/spec/models/streaming_destinations/base_destination_spec.rb
+++ b/spec/models/streaming_destinations/base_destination_spec.rb
@@ -49,6 +49,16 @@ RSpec.describe StreamingDestinations::BaseDestination, type: :model do
         expect(destination.errors.where(:event_types, :taken)).to be_present
       end
 
+      it "keeps the claim while inactive, so one destination per event type holds whatever its state" do
+        organization = create(:organization)
+        create(:kinesis_destination, organization:, event_types: ["customer_usage.refreshed.v1"], active: false)
+
+        destination = build(:kinesis_destination, organization:, event_types: ["customer_usage.refreshed.v1"])
+
+        expect(destination).not_to be_valid
+        expect(destination.errors.where(:event_types, :taken)).to be_present
+      end
+
       it "allows the same event type on another organization" do
         create(:kinesis_destination, event_types: ["customer_usage.refreshed.v1"])
 
@@ -69,6 +79,12 @@ RSpec.describe StreamingDestinations::BaseDestination, type: :model do
 
     it "returns a destination whose event_types contain the event type" do
       expect(described_class.for_event(organization, "customer_usage.refreshed.v1")).to eq([destination])
+    end
+
+    it "excludes an inactive destination, so deactivating stops delivery without losing its settings" do
+      destination.update!(active: false)
+
+      expect(described_class.for_event(organization, "customer_usage.refreshed.v1")).to be_empty
     end
 
     it "does not return a destination without the event type" do

--- a/spec/models/streaming_destinations/base_destination_spec.rb
+++ b/spec/models/streaming_destinations/base_destination_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe StreamingDestinations::BaseDestination, type: :model do
 
   it_behaves_like "paper_trail traceable"
 
+  describe "EVENT_TYPES" do
+    it "versions every event type, so a breaking payload change can ship as a new type" do
+      expect(described_class::EVENT_TYPES).to all(match(/\.v\d+\z/))
+    end
+  end
+
   describe "associations" do
     it do
       expect(destination).to belong_to(:organization)
@@ -27,7 +33,7 @@ RSpec.describe StreamingDestinations::BaseDestination, type: :model do
       end
 
       it "rejects an unknown event type" do
-        destination = build(:kinesis_destination, event_types: ["customer_usage.refresed"])
+        destination = build(:kinesis_destination, event_types: ["customer_usage.refresed.v1"])
 
         expect(destination).not_to be_valid
         expect(destination.errors.where(:event_types, :inclusion)).to be_present
@@ -35,18 +41,18 @@ RSpec.describe StreamingDestinations::BaseDestination, type: :model do
 
       it "rejects an event type already claimed by another destination of the organization" do
         organization = create(:organization)
-        create(:kinesis_destination, organization:, event_types: ["customer_usage.refreshed"])
+        create(:kinesis_destination, organization:, event_types: ["customer_usage.refreshed.v1"])
 
-        destination = build(:kinesis_destination, organization:, event_types: ["customer_usage.refreshed"])
+        destination = build(:kinesis_destination, organization:, event_types: ["customer_usage.refreshed.v1"])
 
         expect(destination).not_to be_valid
         expect(destination.errors.where(:event_types, :taken)).to be_present
       end
 
       it "allows the same event type on another organization" do
-        create(:kinesis_destination, event_types: ["customer_usage.refreshed"])
+        create(:kinesis_destination, event_types: ["customer_usage.refreshed.v1"])
 
-        expect(build(:kinesis_destination, event_types: ["customer_usage.refreshed"])).to be_valid
+        expect(build(:kinesis_destination, event_types: ["customer_usage.refreshed.v1"])).to be_valid
       end
 
       it "does not conflict with itself on update" do
@@ -59,24 +65,24 @@ RSpec.describe StreamingDestinations::BaseDestination, type: :model do
 
   describe ".for_event" do
     let(:organization) { create(:organization) }
-    let!(:destination) { create(:kinesis_destination, organization:, event_types: ["customer_usage.refreshed"]) }
+    let!(:destination) { create(:kinesis_destination, organization:, event_types: ["customer_usage.refreshed.v1"]) }
 
     it "returns a destination whose event_types contain the event type" do
-      expect(described_class.for_event(organization, "customer_usage.refreshed")).to eq([destination])
+      expect(described_class.for_event(organization, "customer_usage.refreshed.v1")).to eq([destination])
     end
 
     it "does not return a destination without the event type" do
       destination.update_column(:event_types, ["wallet.updated"]) # rubocop:disable Rails/SkipsModelValidations
 
-      expect(described_class.for_event(organization, "customer_usage.refreshed")).to be_empty
+      expect(described_class.for_event(organization, "customer_usage.refreshed.v1")).to be_empty
     end
 
     it "does not return another organization's destination" do
-      expect(described_class.for_event(create(:organization), "customer_usage.refreshed")).to be_empty
+      expect(described_class.for_event(create(:organization), "customer_usage.refreshed.v1")).to be_empty
     end
 
     it "is the only lookup that works, find_by on the array column raises" do
-      expect { described_class.find_by(event_types: "customer_usage.refreshed") }
+      expect { described_class.find_by(event_types: "customer_usage.refreshed.v1") }
         .to raise_error(ActiveRecord::StatementInvalid, /malformed array literal/)
     end
   end

--- a/spec/models/streaming_destinations/kinesis_destination_spec.rb
+++ b/spec/models/streaming_destinations/kinesis_destination_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StreamingDestinations::KinesisDestination, type: :model do
+  subject(:destination) { create(:kinesis_destination) }
+
+  describe "validations" do
+    it do
+      expect(destination).to validate_presence_of(:stream_arn)
+      expect(destination).to validate_presence_of(:region)
+      expect(destination).to validate_presence_of(:role_arn)
+    end
+
+    it "rejects an unsupported partition key" do
+      destination = build(:kinesis_destination)
+      destination.partition_key = "subscription_external_id"
+
+      expect(destination).not_to be_valid
+      expect(destination.errors.where(:partition_key, :inclusion)).to be_present
+    end
+  end
+
+  describe "settings" do
+    it "reads the settings back" do
+      expect(destination.stream_arn).to eq("arn:aws:kinesis:eu-west-1:123456789012:stream/lago-streaming-sandbox")
+      expect(destination.region).to eq("eu-west-1")
+      expect(destination.role_arn).to eq("arn:aws:iam::123456789012:role/lago-streaming-sandbox-writer")
+      expect(destination.partition_key).to eq("customer_external_id")
+    end
+
+    it "defaults the partition key when unset" do
+      destination = build(:kinesis_destination, settings: {stream_arn: "arn", region: "eu-west-1", role_arn: "role"})
+
+      expect(destination.partition_key).to eq(described_class::DEFAULT_PARTITION_KEY)
+    end
+  end
+end


### PR DESCRIPTION
First of four stacked PRs adding Kinesis streaming destinations.

## Context

Delivery is driven by config: an organization that wants its events streamed has a destination row, and one that has none gets nothing delivered. This is the table and the models that hold it.

## Description

`streaming_destinations` follows the STI convention already used by `Integrations::BaseIntegration` and `PaymentProviders::BaseProvider`: a base model with `SettingsStorable` and `SecretsStorable`, and a `KinesisDestination` subtype holding `stream_arn`, `region`, `role_arn` and `partition_key` in settings. A role ARN is infrastructure config rather than a credential, since holding it grants nothing unless the workload identity is already allowed to assume it, so it lives in `settings` and `secrets` stays empty for this type.

`event_types` is its own array column rather than a settings key, so it is shared across every destination type and can be indexed. Lookup goes through `for_event`, which queries array containment and is the only form that works: `find_by(event_types: "...")` compares the whole array against one string, and Postgres rejects it outright. There is a spec pinning that, because a lookup that silently matches nothing means delivery never happens and nothing raises.

## The overlap rule is enforced in the model, not the database

Two destinations for one organization must never claim the same event type, or `for_event` becomes ambiguous. Postgres cannot express that constraint on this column: an exclusion constraint needs a GiST operator class for `varchar[] && varchar[]`, which does not exist, and GIN backs neither exclusion constraints nor unique indexes.

```
ERROR:  data type character varying[] has no default operator class for access method "gist"
ERROR:  access method "gin" does not support exclusion constraints
```

So it is a model validation, and `insert_all` or `update_column` can still create an overlap. GIN is still the right index for the containment lookup and is present.
