### PR TITLE
feat(streaming): make delivery failures and silence observable

### DIFF
--- a/app/jobs/deliver_event_job.rb
+++ b/app/jobs/deliver_event_job.rb
@@ -3,7 +3,16 @@
 class DeliverEventJob < ApplicationJob
   queue_as :streaming
 
-  unique :until_and_while_executing, on_conflict: :log, lock_ttl: 10.minutes
+  ON_CONFLICT = lambda do |job|
+    EventDestinations::DeliveryLogger.emit(
+      :superseded,
+      event_type: job.arguments.first,
+      customer_id: job.arguments.second.try(:id),
+      lock_key: job.lock_key
+    )
+  end
+
+  unique :until_and_while_executing, on_conflict: ON_CONFLICT, lock_ttl: 10.minutes
 
   EVENT_SERVICES = {
     EventDestinations::CustomerUsage::RefreshedService::EVENT_TYPE =>

--- a/app/services/event_destinations/customer_full_usage/refreshed_service.rb
+++ b/app/services/event_destinations/customer_full_usage/refreshed_service.rb
@@ -22,9 +22,7 @@ module EventDestinations
 
           deliver(subscription)
         rescue => e
-          Rails.logger.error(
-            "[streaming] #{EVENT_TYPE} failed for subscription #{subscription.id}: #{e.class} #{e.message}"
-          )
+          log(:failed, subscription, error: e.class, message: e.message)
         end
 
         result
@@ -69,15 +67,24 @@ module EventDestinations
         )
 
         unless usage_result.success?
-          Rails.logger.warn(
-            "[streaming] #{EVENT_TYPE} skipped for subscription #{subscription.id}: #{usage_result.error}"
-          )
+          log(:skipped, subscription, error: usage_result.error.class, message: usage_result.error)
           return
         end
 
         producer.produce(
           data: envelope(subscription, usage_result.usage),
           partition_key: destination.partition_key_for(customer:)
+        )
+      end
+
+      def log(outcome, subscription, **fields)
+        EventDestinations::DeliveryLogger.emit(
+          outcome,
+          destination:,
+          event_type: EVENT_TYPE,
+          customer_id: customer.id,
+          subscription_id: subscription.id,
+          **fields
         )
       end
 

--- a/app/services/event_destinations/customer_usage/refreshed_service.rb
+++ b/app/services/event_destinations/customer_usage/refreshed_service.rb
@@ -22,9 +22,7 @@ module EventDestinations
 
           deliver(subscription)
         rescue => e
-          Rails.logger.error(
-            "[streaming] #{EVENT_TYPE} failed for subscription #{subscription.id}: #{e.class} #{e.message}"
-          )
+          log(:failed, subscription, error: e.class, message: e.message)
         end
 
         result
@@ -65,15 +63,24 @@ module EventDestinations
         )
 
         unless usage_result.success?
-          Rails.logger.warn(
-            "[streaming] #{EVENT_TYPE} skipped for subscription #{subscription.id}: #{usage_result.error}"
-          )
+          log(:skipped, subscription, error: usage_result.error.class, message: usage_result.error)
           return
         end
 
         producer.produce(
           data: envelope(subscription, usage_result.usage),
           partition_key: destination.partition_key_for(customer:)
+        )
+      end
+
+      def log(outcome, subscription, **fields)
+        EventDestinations::DeliveryLogger.emit(
+          outcome,
+          destination:,
+          event_type: EVENT_TYPE,
+          customer_id: customer.id,
+          subscription_id: subscription.id,
+          **fields
         )
       end
 

--- a/app/services/event_destinations/delivery_logger.rb
+++ b/app/services/event_destinations/delivery_logger.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module EventDestinations
+  module DeliveryLogger
+    PREFIX = "[streaming] event=delivery"
+
+    OUTCOMES = {
+      delivered: :info,
+      throttled: :error,
+      dropped: :error,
+      superseded: :info,
+      skipped: :warn,
+      failed: :error
+    }.freeze
+
+    SAFE_VALUE = /\A[\w.:@\/+-]*\z/
+
+    class << self
+      def emit(outcome, destination: nil, **fields)
+        Rails.logger.public_send(OUTCOMES.fetch(outcome), line(outcome, destination, fields))
+      end
+
+      private
+
+      def line(outcome, destination, fields)
+        pairs = {outcome:}
+
+        if destination
+          pairs[:destination_id] = destination.id
+          pairs[:organization_id] = destination.organization_id
+        end
+
+        pairs.merge!(fields.compact)
+
+        "#{PREFIX} #{pairs.map { |key, value| "#{key}=#{format_value(value)}" }.join(" ")}"
+      end
+
+      def format_value(value)
+        string = value.to_s
+
+        string.match?(SAFE_VALUE) ? string : string.inspect
+      end
+    end
+  end
+end

--- a/lib/lago/kinesis/producer.rb
+++ b/lib/lago/kinesis/producer.rb
@@ -11,12 +11,16 @@ module Lago
 
       ROLE_SESSION_NAME = "lago-event-destinations"
 
+      THROTTLE_ERRORS = [
+        Aws::Kinesis::Errors::ProvisionedThroughputExceededException
+      ].freeze
+
       DELIVERY_ERRORS = [
         Aws::Kinesis::Errors::ResourceNotFoundException,
         Aws::Kinesis::Errors::AccessDeniedException,
         Aws::Kinesis::Errors::ValidationException,
         Aws::Kinesis::Errors::InvalidArgumentException,
-        Aws::Kinesis::Errors::ProvisionedThroughputExceededException,
+        *THROTTLE_ERRORS,
         Aws::STS::Errors::AccessDenied,
         Aws::Errors::MissingCredentialsError,
         Seahorse::Client::NetworkingError
@@ -32,22 +36,32 @@ module Lago
       def produce(data:, partition_key:)
         payload = JSON.generate(data)
 
+        started_at = Time.current
+
         response = client.put_record(
           stream_arn: destination.stream_arn,
           data: payload,
           partition_key:
         )
 
-        Rails.logger.info(
-          "#{log_prefix} delivered partition_key=#{partition_key} bytes=#{payload.bytesize} " \
-          "shard=#{response.shard_id} sequence=#{response.sequence_number}"
+        log(
+          :delivered,
+          partition_key:,
+          bytes: payload.bytesize,
+          shard: response.shard_id,
+          sequence: response.sequence_number,
+          duration_ms: duration_ms(started_at)
         )
 
         response
       rescue *DELIVERY_ERRORS => e
-        Rails.logger.error(
-          "#{log_prefix} dropped partition_key=#{partition_key} bytes=#{payload&.bytesize} " \
-          "error=#{e.class} message=#{e.message}"
+        log(
+          outcome_for(e),
+          partition_key:,
+          bytes: payload&.bytesize,
+          duration_ms: duration_ms(started_at),
+          error: e.class,
+          message: e.message
         )
 
         nil
@@ -57,8 +71,18 @@ module Lago
 
       attr_reader :destination
 
-      def log_prefix
-        "[streaming] destination=#{destination.id} stream=#{destination.stream_arn}"
+      def outcome_for(error)
+        return :throttled if THROTTLE_ERRORS.any? { error.is_a?(it) }
+
+        :dropped
+      end
+
+      def log(outcome, **fields)
+        EventDestinations::DeliveryLogger.emit(outcome, destination:, stream: destination.stream_arn, **fields)
+      end
+
+      def duration_ms(started_at)
+        ((Time.current - started_at) * 1000).round
       end
 
       def client

--- a/spec/jobs/deliver_event_job_spec.rb
+++ b/spec/jobs/deliver_event_job_spec.rb
@@ -50,6 +50,18 @@ RSpec.describe DeliverEventJob, type: :job do
 
       expect(EventDestinations::CustomerUsage::RefreshedService).to have_received(:call).with(object: customer)
     end
+
+    it "logs the drop in the shape the monitors match on" do
+      allow(Rails.logger).to receive(:info)
+      job = described_class.new("customer_usage.refreshed", customer)
+      contend_on_runtime_lock(job)
+
+      job.perform_now
+
+      expect(Rails.logger).to have_received(:info).with(
+        a_string_matching(/outcome=superseded event_type=customer_usage.refreshed customer_id=#{customer.id}/)
+      )
+    end
   end
 
   # The global test lock manager always grants a lock, so contention has to be forced. Only the

--- a/spec/jobs/deliver_event_job_spec.rb
+++ b/spec/jobs/deliver_event_job_spec.rb
@@ -53,13 +53,13 @@ RSpec.describe DeliverEventJob, type: :job do
 
     it "logs the drop in the shape the monitors match on" do
       allow(Rails.logger).to receive(:info)
-      job = described_class.new("customer_usage.refreshed", customer)
+      job = described_class.new("customer_usage.refreshed.v1", customer)
       contend_on_runtime_lock(job)
 
       job.perform_now
 
       expect(Rails.logger).to have_received(:info).with(
-        a_string_matching(/outcome=superseded event_type=customer_usage.refreshed customer_id=#{customer.id}/)
+        a_string_matching(/outcome=superseded event_type=customer_usage\.refreshed\.v1 customer_id=#{customer.id}/)
       )
     end
   end

--- a/spec/lib/lago/kinesis/producer_spec.rb
+++ b/spec/lib/lago/kinesis/producer_spec.rb
@@ -40,7 +40,9 @@ RSpec.describe Lago::Kinesis::Producer do
       producer.produce(data: {hello: "world"}, partition_key: "cust_1")
 
       expect(Rails.logger).to have_received(:info).with(
-        a_string_matching(/delivered partition_key=cust_1 bytes=17 shard=shardId-000000000000 sequence=4966/)
+        a_string_matching(
+          /outcome=delivered destination_id=#{destination.id} organization_id=#{destination.organization_id} .*partition_key=cust_1 bytes=17 shard=shardId-000000000000 sequence=4966/
+        )
       )
     end
 
@@ -49,10 +51,22 @@ RSpec.describe Lago::Kinesis::Producer do
         allow(client).to receive(:put_record).and_raise(build_aws_error(error_class))
         allow(Rails.logger).to receive(:error)
 
+        outcome = described_class::THROTTLE_ERRORS.include?(error_class) ? "throttled" : "dropped"
+
         expect(producer.produce(data: {hello: "world"}, partition_key: "cust_1")).to be_nil
         expect(Rails.logger).to have_received(:error)
-          .with(a_string_matching(/dropped .*#{Regexp.escape(error_class.name)}/))
+          .with(a_string_matching(/outcome=#{outcome} .*error=#{Regexp.escape(error_class.name)}/))
       end
+    end
+
+    it "separates a throttle from a configuration fault" do
+      allow(client).to receive(:put_record)
+        .and_raise(Aws::Kinesis::Errors::ProvisionedThroughputExceededException.new(nil, "slow down"))
+      allow(Rails.logger).to receive(:error)
+
+      producer.produce(data: {hello: "world"}, partition_key: "cust_1")
+
+      expect(Rails.logger).to have_received(:error).with(a_string_matching(/outcome=throttled/))
     end
 
     it "does not swallow an error that is not a delivery failure" do

--- a/spec/services/event_destinations/customer_full_usage/refreshed_service_spec.rb
+++ b/spec/services/event_destinations/customer_full_usage/refreshed_service_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe EventDestinations::CustomerFullUsage::RefreshedService do
       it "skips rather than raising, so the current period record is unaffected" do
         expect(service.call).to be_success
         expect(producer_calls).to be_empty
-        expect(Rails.logger).to have_received(:warn).with(a_string_matching(/skipped for subscription/))
+        expect(Rails.logger).to have_received(:warn).with(a_string_matching(/outcome=skipped/))
       end
     end
   end

--- a/spec/services/event_destinations/customer_usage/refreshed_service_spec.rb
+++ b/spec/services/event_destinations/customer_usage/refreshed_service_spec.rb
@@ -138,7 +138,8 @@ RSpec.describe EventDestinations::CustomerUsage::RefreshedService do
 
         expect(service.call).to be_success
         expect(call_count).to eq(2)
-        expect(Rails.logger).to have_received(:error).with(a_string_matching(/failed for subscription/))
+        expect(Rails.logger).to have_received(:error)
+          .with(a_string_matching(/outcome=failed .*error=RuntimeError message=boom/))
       end
     end
 
@@ -150,7 +151,8 @@ RSpec.describe EventDestinations::CustomerUsage::RefreshedService do
 
       expect(service.call).to be_success
       expect(producer).not_to have_received(:produce)
-      expect(Rails.logger).to have_received(:warn).with(a_string_matching(/skipped for subscription/))
+      expect(Rails.logger).to have_received(:warn)
+        .with(a_string_matching(/outcome=skipped .*subscription_id=#{subscription.id}/))
     end
   end
 end

--- a/spec/services/event_destinations/delivery_logger_spec.rb
+++ b/spec/services/event_destinations/delivery_logger_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EventDestinations::DeliveryLogger do
+  let(:destination) { create(:kinesis_destination) }
+
+  before { allow(Rails.logger).to receive(:info).and_call_original }
+
+  it "emits the destination and organization on every line" do
+    described_class.emit(:delivered, destination:, partition_key: "cust_1")
+
+    expect(Rails.logger).to have_received(:info).with(
+      "[streaming] event=delivery outcome=delivered destination_id=#{destination.id} " \
+      "organization_id=#{destination.organization_id} partition_key=cust_1"
+    )
+  end
+
+  it "omits the destination when there is none to name" do
+    described_class.emit(:superseded, customer_id: "cust_1")
+
+    expect(Rails.logger).to have_received(:info).with(
+      "[streaming] event=delivery outcome=superseded customer_id=cust_1"
+    )
+  end
+
+  it "quotes a value that would otherwise break logfmt parsing" do
+    allow(Rails.logger).to receive(:error)
+
+    described_class.emit(:dropped, message: "User is not authorized to perform: kinesis:PutRecord")
+
+    expect(Rails.logger).to have_received(:error).with(
+      '[streaming] event=delivery outcome=dropped message="User is not authorized to perform: kinesis:PutRecord"'
+    )
+  end
+
+  it "drops keys with no value rather than emitting an empty one" do
+    described_class.emit(:delivered, partition_key: "cust_1", bytes: nil)
+
+    expect(Rails.logger).to have_received(:info).with(
+      "[streaming] event=delivery outcome=delivered partition_key=cust_1"
+    )
+  end
+
+  it "logs each outcome at its own severity" do
+    expect(described_class::OUTCOMES).to eq(
+      delivered: :info, throttled: :error, dropped: :error,
+      superseded: :info, skipped: :warn, failed: :error
+    )
+  end
+
+  it "raises on an outcome it does not know, rather than logging something unmatchable" do
+    expect { described_class.emit(:vanished) }.to raise_error(KeyError)
+  end
+end


### PR DESCRIPTION
Stacked on #6298.

## Context

The delivery path persists nothing and retries nothing, so a snapshot that fails to reach the stream is simply gone. That makes its log lines the only observable, and it makes silence indistinguishable from health unless something watches for it.

## Description

Every delivery emits exactly one line through `EventDestinations::DeliveryLogger`, in one of six outcomes: `delivered`, `throttled`, `dropped`, `superseded`, `skipped`, `failed`. Throttling is separate from failure because the remediation is different and sits with whoever owns the stream: they have to add shards. The uniqueness drop gets a custom `on_conflict` handler rather than the gem's prose line, so it is matchable too.

Both delivery services route through it, the current-period one and the full-usage one, so an organization receiving both event types is observable on each independently.

`delivered` is emitted on the happy path even though nothing is wrong, because its absence is the signal a went-quiet monitor alerts on. It carries `destination_id`, so one organization going quiet while another stays healthy is still visible.
