### PR TITLE
chore(clickhouse): Update clickhouse version to 26.4

### DIFF
--- a/.github/workflows/migrations-test.yml
+++ b/.github/workflows/migrations-test.yml
@@ -62,7 +62,7 @@ jobs:
           postgresql-version: "15"
       - name: Start Clickhouse database
         run: |
-          docker run -d --rm -p 8123:8123 -p 9000:9000 --ulimit nofile=262144:262144 -v ./clickhouse-s3:/var/lib/clickhouse-s3 -v ./ci/clickhouse/config.xml:/etc/clickhouse-server/config.d/config.xml -e CLICKHOUSE_PASSWORD=password clickhouse/clickhouse-server:25.12-alpine
+          docker run -d --rm -p 8123:8123 -p 9000:9000 --ulimit nofile=262144:262144 -v ./clickhouse-s3:/var/lib/clickhouse-s3 -v ./ci/clickhouse/config.xml:/etc/clickhouse-server/config.d/config.xml -e CLICKHOUSE_PASSWORD=password clickhouse/clickhouse-server:26.4-alpine
         shell: bash
       - name: Generate RSA keys
         run: ./scripts/generate.rsa.sh


### PR DESCRIPTION
This commit updates Clickhouse in migrations workflow to 26.4

