### PR TITLE
feat(catalog): attach the plan ecosystem to catalog plans

### DIFF
--- a/app/models/catalog_plan.rb
+++ b/app/models/catalog_plan.rb
@@ -12,6 +12,13 @@ class CatalogPlan < ApplicationRecord
 
   belongs_to :organization
 
+  has_many :coupon_targets
+  has_many :coupons, through: :coupon_targets
+  has_many :applied_taxes, class_name: "Plan::AppliedTax", dependent: :destroy
+  has_many :taxes, through: :applied_taxes
+  has_many :entitlements, class_name: "Entitlement::Entitlement", dependent: :destroy
+  has_many :entitlement_values, through: :entitlements, source: :values, class_name: "Entitlement::EntitlementValue", dependent: :destroy
+
   validates :name, presence: true
   validates :code, presence: true, uniqueness: {scope: :organization_id, conditions: -> { where(deleted_at: nil) }}
   validates :currency, presence: true, inclusion: {in: currency_list, allow_nil: true}

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -13,6 +13,7 @@ class Coupon < ApplicationRecord
   has_many :customers, through: :applied_coupons
   has_many :coupon_targets
   has_many :plans, through: :coupon_targets
+  has_many :catalog_plans, through: :coupon_targets
   has_many :billable_metrics, through: :coupon_targets
 
   has_many :activity_logs,

--- a/app/models/coupon_target.rb
+++ b/app/models/coupon_target.rb
@@ -8,10 +8,24 @@ class CouponTarget < ApplicationRecord
 
   belongs_to :coupon
   belongs_to :plan, optional: true
+  belongs_to :catalog_plan, optional: true
   belongs_to :billable_metric, optional: true
   belongs_to :organization
 
+  validate :single_plan_target
+
   default_scope -> { kept }
+
+  private
+
+  # A target points at a legacy plan or a catalog plan, never both.
+  def single_plan_target
+    has_plan = plan_id.present? || plan.present?
+    has_catalog_plan = catalog_plan_id.present? || catalog_plan.present?
+    return unless has_plan && has_catalog_plan
+
+    errors.add(:base, :single_plan_target)
+  end
 end
 
 # == Schema Information
@@ -24,6 +38,7 @@ end
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  billable_metric_id :uuid
+#  catalog_plan_id    :uuid
 #  coupon_id          :uuid             not null
 #  organization_id    :uuid             not null
 #  plan_id            :uuid
@@ -31,6 +46,7 @@ end
 # Indexes
 #
 #  index_coupon_targets_on_billable_metric_id  (billable_metric_id)
+#  index_coupon_targets_on_catalog_plan_id     (catalog_plan_id)
 #  index_coupon_targets_on_coupon_id           (coupon_id)
 #  index_coupon_targets_on_deleted_at          (deleted_at)
 #  index_coupon_targets_on_organization_id     (organization_id)
@@ -39,6 +55,7 @@ end
 # Foreign Keys
 #
 #  fk_rails_...  (billable_metric_id => billable_metrics.id)
+#  fk_rails_...  (catalog_plan_id => catalog_plans.id)
 #  fk_rails_...  (coupon_id => coupons.id)
 #  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (plan_id => plans.id)

--- a/app/models/entitlement/entitlement.rb
+++ b/app/models/entitlement/entitlement.rb
@@ -11,6 +11,7 @@ module Entitlement
     belongs_to :organization
     belongs_to :feature, class_name: "Entitlement::Feature", foreign_key: :entitlement_feature_id
     belongs_to :plan, optional: true
+    belongs_to :catalog_plan, optional: true
     belongs_to :subscription, optional: true
     has_many :values, class_name: "Entitlement::EntitlementValue", foreign_key: :entitlement_entitlement_id, dependent: :destroy
 
@@ -19,8 +20,7 @@ module Entitlement
     private
 
     def exactly_one_parent_present
-      return if plan_id.present? && subscription_id.blank?
-      return if plan_id.blank? && subscription_id.present?
+      return if [plan_id, catalog_plan_id, subscription_id].count(&:present?) == 1
 
       errors.add(:base, "one_of_plan_or_subscription_required")
     end
@@ -36,6 +36,7 @@ end
 #  deleted_at             :datetime
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  catalog_plan_id        :uuid
 #  entitlement_feature_id :uuid             not null
 #  organization_id        :uuid             not null
 #  plan_id                :uuid
@@ -43,8 +44,10 @@ end
 #
 # Indexes
 #
+#  idx_unique_feature_per_catalog_plan                       (entitlement_feature_id,catalog_plan_id) UNIQUE WHERE (deleted_at IS NULL)
 #  idx_unique_feature_per_plan                               (entitlement_feature_id,plan_id) UNIQUE WHERE (deleted_at IS NULL)
 #  idx_unique_feature_per_subscription                       (entitlement_feature_id,subscription_id) UNIQUE WHERE (deleted_at IS NULL)
+#  index_entitlement_entitlements_on_catalog_plan_id         (catalog_plan_id)
 #  index_entitlement_entitlements_on_entitlement_feature_id  (entitlement_feature_id)
 #  index_entitlement_entitlements_on_organization_id         (organization_id)
 #  index_entitlement_entitlements_on_plan_id                 (plan_id)
@@ -52,6 +55,7 @@ end
 #
 # Foreign Keys
 #
+#  fk_rails_...  (catalog_plan_id => catalog_plans.id)
 #  fk_rails_...  (entitlement_feature_id => entitlement_features.id)
 #  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (plan_id => plans.id)

--- a/app/models/entitlement/entitlement.rb
+++ b/app/models/entitlement/entitlement.rb
@@ -20,7 +20,12 @@ module Entitlement
     private
 
     def exactly_one_parent_present
-      return if [plan_id, catalog_plan_id, subscription_id].count(&:present?) == 1
+      parents = [
+        plan_id.present? || plan.present?,
+        catalog_plan_id.present? || catalog_plan.present?,
+        subscription_id.present? || subscription.present?
+      ]
+      return if parents.count(true) == 1
 
       errors.add(:base, "one_of_plan_or_subscription_required")
     end

--- a/app/models/entitlement/feature.rb
+++ b/app/models/entitlement/feature.rb
@@ -13,6 +13,7 @@ module Entitlement
     has_many :entitlements, class_name: "Entitlement::Entitlement", foreign_key: "entitlement_feature_id", dependent: :destroy
     has_many :entitlement_values, through: :entitlements, source: :values, class_name: "Entitlement::EntitlementValue", dependent: :destroy
     has_many :plans, through: :entitlements
+    has_many :catalog_plans, through: :entitlements
 
     validates :code, presence: true, length: {maximum: 255}
     validates :name, length: {maximum: 255}

--- a/app/models/plan/applied_tax.rb
+++ b/app/models/plan/applied_tax.rb
@@ -6,9 +6,23 @@ class Plan
 
     include PaperTrailTraceable
 
-    belongs_to :plan
+    belongs_to :plan, optional: true
+    belongs_to :catalog_plan, optional: true
     belongs_to :tax
     belongs_to :organization
+
+    validate :exactly_one_plan
+
+    private
+
+    # A tax applies to exactly one plan, legacy or catalog.
+    def exactly_one_plan
+      has_plan = plan_id.present? || plan.present?
+      has_catalog_plan = catalog_plan_id.present? || catalog_plan.present?
+      return if has_plan ^ has_catalog_plan
+
+      errors.add(:base, :exactly_one_plan_required)
+    end
   end
 end
 
@@ -20,19 +34,22 @@ end
 #  id              :uuid             not null, primary key
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  catalog_plan_id :uuid
 #  organization_id :uuid             not null
-#  plan_id         :uuid             not null
+#  plan_id         :uuid
 #  tax_id          :uuid             not null
 #
 # Indexes
 #
-#  index_plans_taxes_on_organization_id     (organization_id)
-#  index_plans_taxes_on_plan_id             (plan_id)
-#  index_plans_taxes_on_plan_id_and_tax_id  (plan_id,tax_id) UNIQUE
-#  index_plans_taxes_on_tax_id              (tax_id)
+#  index_plans_taxes_on_catalog_plan_id_and_tax_id  (catalog_plan_id,tax_id) UNIQUE
+#  index_plans_taxes_on_organization_id             (organization_id)
+#  index_plans_taxes_on_plan_id                     (plan_id)
+#  index_plans_taxes_on_plan_id_and_tax_id          (plan_id,tax_id) UNIQUE
+#  index_plans_taxes_on_tax_id                      (tax_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (catalog_plan_id => catalog_plans.id)
 #  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (plan_id => plans.id)
 #  fk_rails_...  (tax_id => taxes.id)

--- a/app/models/tax.rb
+++ b/app/models/tax.rb
@@ -26,6 +26,7 @@ class Tax < ApplicationRecord
   has_many :add_ons, through: :add_ons_taxes
   has_many :plans_taxes, class_name: "Plan::AppliedTax", dependent: :destroy
   has_many :plans, through: :plans_taxes
+  has_many :catalog_plans, through: :plans_taxes
   has_many :charges_taxes, class_name: "Charge::AppliedTax", dependent: :destroy
   has_many :charges, through: :charges_taxes
   has_many :commitments_taxes, class_name: "Commitment::AppliedTax", dependent: :destroy

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,7 @@ en:
         country_must_be_present: country_must_be_present
         country_not_supported: country_not_supported
         does_not_belong_to_product: does_not_belong_to_product
+        exactly_one_plan_required: exactly_one_plan_required
         exclusion: value_is_reserved
         feature_unavailable: feature_unavailable
         file_size_not_less_than: file_too_large
@@ -69,6 +70,7 @@ en:
         present: value_must_be_blank
         required: relation_must_exist
         requires_recurring_metric: requires_recurring_metric
+        single_plan_target: single_plan_target
         taken: value_already_exist
         too_long: value_is_too_long
         too_short: value_is_too_short

--- a/db/migrate/20260904173415_add_catalog_plan_to_ecosystem.rb
+++ b/db/migrate/20260904173415_add_catalog_plan_to_ecosystem.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class AddCatalogPlanToEcosystem < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    add_reference :coupon_targets, :catalog_plan, type: :uuid, null: true, index: {algorithm: :concurrently}
+    add_foreign_key :coupon_targets, :catalog_plans, validate: false
+
+    # A tax now attaches to a legacy plan or a catalog plan, so plan_id is no
+    # longer mandatory. The composite unique index mirrors the legacy
+    # (plan_id, tax_id) one and also serves catalog_plan_id FK lookups
+    # (leftmost), so the column needs no standalone index.
+    add_reference :plans_taxes, :catalog_plan, type: :uuid, null: true, index: false
+    add_foreign_key :plans_taxes, :catalog_plans, validate: false
+    change_column_null :plans_taxes, :plan_id, true
+    add_index :plans_taxes, %i[catalog_plan_id tax_id], unique: true, algorithm: :concurrently
+
+    add_reference :entitlement_entitlements, :catalog_plan, type: :uuid, null: true, index: {algorithm: :concurrently}
+    add_foreign_key :entitlement_entitlements, :catalog_plans, validate: false
+    add_index :entitlement_entitlements, %i[entitlement_feature_id catalog_plan_id],
+      unique: true,
+      where: "deleted_at IS NULL",
+      name: "idx_unique_feature_per_catalog_plan",
+      algorithm: :concurrently
+
+    # The catalog plan joins plan and subscription as a valid parent, so the
+    # exactly-one-parent check must count all three, not just plan XOR
+    # subscription. Existing rows already satisfy it, so it validates in the
+    # follow-up migration.
+    remove_check_constraint :entitlement_entitlements, name: "entitlement_check_exactly_one_parent"
+    add_check_constraint :entitlement_entitlements,
+      "num_nonnulls(plan_id, catalog_plan_id, subscription_id) = 1",
+      name: "entitlement_check_exactly_one_parent",
+      validate: false
+  end
+
+  def down
+    remove_check_constraint :entitlement_entitlements, name: "entitlement_check_exactly_one_parent"
+    add_check_constraint :entitlement_entitlements,
+      "(plan_id IS NOT NULL) <> (subscription_id IS NOT NULL)",
+      name: "entitlement_check_exactly_one_parent"
+
+    remove_index :entitlement_entitlements, name: "idx_unique_feature_per_catalog_plan"
+    remove_foreign_key :entitlement_entitlements, :catalog_plans
+    remove_reference :entitlement_entitlements, :catalog_plan
+
+    remove_index :plans_taxes, name: "index_plans_taxes_on_catalog_plan_id_and_tax_id"
+    change_column_null :plans_taxes, :plan_id, false
+    remove_foreign_key :plans_taxes, :catalog_plans
+    remove_reference :plans_taxes, :catalog_plan
+
+    remove_foreign_key :coupon_targets, :catalog_plans
+    remove_reference :coupon_targets, :catalog_plan
+  end
+end

--- a/db/migrate/20260904173415_add_catalog_plan_to_ecosystem.rb
+++ b/db/migrate/20260904173415_add_catalog_plan_to_ecosystem.rb
@@ -15,6 +15,12 @@ class AddCatalogPlanToEcosystem < ActiveRecord::Migration[8.0]
     add_foreign_key :plans_taxes, :catalog_plans, validate: false
     change_column_null :plans_taxes, :plan_id, true
     add_index :plans_taxes, %i[catalog_plan_id tax_id], unique: true, algorithm: :concurrently
+    # plan_id was NOT NULL; keep the "exactly one plan" guarantee at the
+    # database level now that a tax may point at a catalog plan instead.
+    add_check_constraint :plans_taxes,
+      "num_nonnulls(plan_id, catalog_plan_id) = 1",
+      name: "plans_taxes_check_exactly_one_plan",
+      validate: false
 
     add_reference :entitlement_entitlements, :catalog_plan, type: :uuid, null: true, index: {algorithm: :concurrently}
     add_foreign_key :entitlement_entitlements, :catalog_plans, validate: false
@@ -45,6 +51,7 @@ class AddCatalogPlanToEcosystem < ActiveRecord::Migration[8.0]
     remove_foreign_key :entitlement_entitlements, :catalog_plans
     remove_reference :entitlement_entitlements, :catalog_plan
 
+    remove_check_constraint :plans_taxes, name: "plans_taxes_check_exactly_one_plan"
     remove_index :plans_taxes, name: "index_plans_taxes_on_catalog_plan_id_and_tax_id"
     change_column_null :plans_taxes, :plan_id, false
     remove_foreign_key :plans_taxes, :catalog_plans

--- a/db/migrate/20260904173415_add_catalog_plan_to_ecosystem.rb
+++ b/db/migrate/20260904173415_add_catalog_plan_to_ecosystem.rb
@@ -6,6 +6,13 @@ class AddCatalogPlanToEcosystem < ActiveRecord::Migration[8.0]
   def up
     add_reference :coupon_targets, :catalog_plan, type: :uuid, null: true, index: {algorithm: :concurrently}
     add_foreign_key :coupon_targets, :catalog_plans, validate: false
+    # A coupon target points at a legacy plan, a catalog plan, or a billable
+    # metric (neither) — never at two plans at once. "At most one" (<= 1)
+    # because the billable-metric case legitimately has no plan.
+    add_check_constraint :coupon_targets,
+      "num_nonnulls(plan_id, catalog_plan_id) <= 1",
+      name: "coupon_targets_check_single_plan",
+      validate: false
 
     # A tax now attaches to a legacy plan or a catalog plan, so plan_id is no
     # longer mandatory. The composite unique index mirrors the legacy
@@ -57,6 +64,7 @@ class AddCatalogPlanToEcosystem < ActiveRecord::Migration[8.0]
     remove_foreign_key :plans_taxes, :catalog_plans
     remove_reference :plans_taxes, :catalog_plan
 
+    remove_check_constraint :coupon_targets, name: "coupon_targets_check_single_plan"
     remove_foreign_key :coupon_targets, :catalog_plans
     remove_reference :coupon_targets, :catalog_plan
   end

--- a/db/migrate/20260904173416_validate_catalog_plan_ecosystem_foreign_keys.rb
+++ b/db/migrate/20260904173416_validate_catalog_plan_ecosystem_foreign_keys.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ValidateCatalogPlanEcosystemForeignKeys < ActiveRecord::Migration[8.0]
+  def up
+    validate_foreign_key :coupon_targets, :catalog_plans
+    validate_foreign_key :plans_taxes, :catalog_plans
+    validate_foreign_key :entitlement_entitlements, :catalog_plans
+
+    validate_check_constraint :entitlement_entitlements, name: "entitlement_check_exactly_one_parent"
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20260904173416_validate_catalog_plan_ecosystem_foreign_keys.rb
+++ b/db/migrate/20260904173416_validate_catalog_plan_ecosystem_foreign_keys.rb
@@ -7,6 +7,7 @@ class ValidateCatalogPlanEcosystemForeignKeys < ActiveRecord::Migration[8.0]
     validate_foreign_key :entitlement_entitlements, :catalog_plans
 
     validate_check_constraint :entitlement_entitlements, name: "entitlement_check_exactly_one_parent"
+    validate_check_constraint :plans_taxes, name: "plans_taxes_check_exactly_one_plan"
   end
 
   def down

--- a/db/migrate/20260904173416_validate_catalog_plan_ecosystem_foreign_keys.rb
+++ b/db/migrate/20260904173416_validate_catalog_plan_ecosystem_foreign_keys.rb
@@ -8,6 +8,7 @@ class ValidateCatalogPlanEcosystemForeignKeys < ActiveRecord::Migration[8.0]
 
     validate_check_constraint :entitlement_entitlements, name: "entitlement_check_exactly_one_parent"
     validate_check_constraint :plans_taxes, name: "plans_taxes_check_exactly_one_plan"
+    validate_check_constraint :coupon_targets, name: "coupon_targets_check_single_plan"
   end
 
   def down

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4475,7 +4475,8 @@ CREATE TABLE public.plans_taxes (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     organization_id uuid NOT NULL,
-    catalog_plan_id uuid
+    catalog_plan_id uuid,
+    CONSTRAINT plans_taxes_check_exactly_one_plan CHECK ((num_nonnulls(plan_id, catalog_plan_id) = 1))
 );
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -125,6 +125,7 @@ ALTER TABLE IF EXISTS ONLY public.integration_items DROP CONSTRAINT IF EXISTS fk
 ALTER TABLE IF EXISTS ONLY public.rate_phases DROP CONSTRAINT IF EXISTS fk_rails_a9ba49506f;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_a7f20c73bb;
 ALTER TABLE IF EXISTS ONLY public.charges DROP CONSTRAINT IF EXISTS fk_rails_a710519346;
+ALTER TABLE IF EXISTS ONLY public.plans_taxes DROP CONSTRAINT IF EXISTS fk_rails_a6d07eec6e;
 ALTER TABLE IF EXISTS ONLY public.rate_phases DROP CONSTRAINT IF EXISTS fk_rails_a5cd897b6f;
 ALTER TABLE IF EXISTS ONLY public.billing_object_connections DROP CONSTRAINT IF EXISTS fk_rails_a5a0718a08;
 ALTER TABLE IF EXISTS ONLY public.contracts DROP CONSTRAINT IF EXISTS fk_rails_a48f7202cc;
@@ -156,6 +157,7 @@ ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXIST
 ALTER TABLE IF EXISTS ONLY public.data_export_parts DROP CONSTRAINT IF EXISTS fk_rails_909197908c;
 ALTER TABLE IF EXISTS ONLY public.fixed_charge_events DROP CONSTRAINT IF EXISTS fk_rails_90302b3ca3;
 ALTER TABLE IF EXISTS ONLY public.commitments_taxes DROP CONSTRAINT IF EXISTS fk_rails_8fa6f0d920;
+ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_8eeaaf6494;
 ALTER TABLE IF EXISTS ONLY public.applied_pricing_units DROP CONSTRAINT IF EXISTS fk_rails_8e0c3d0c5b;
 ALTER TABLE IF EXISTS ONLY public.usage_thresholds DROP CONSTRAINT IF EXISTS fk_rails_8df9bf2b6c;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alerts DROP CONSTRAINT IF EXISTS fk_rails_8c18828b53;
@@ -241,6 +243,7 @@ ALTER TABLE IF EXISTS ONLY public.customers DROP CONSTRAINT IF EXISTS fk_rails_5
 ALTER TABLE IF EXISTS ONLY public.charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_56b7167125;
 ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS fk_rails_56b3626631;
 ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_5628a713de;
+ALTER TABLE IF EXISTS ONLY public.entitlement_entitlements DROP CONSTRAINT IF EXISTS fk_rails_54c6fe0506;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlement_values DROP CONSTRAINT IF EXISTS fk_rails_533b639bac;
 ALTER TABLE IF EXISTS ONLY public.product_filter_values DROP CONSTRAINT IF EXISTS fk_rails_530173fa8d;
 ALTER TABLE IF EXISTS ONLY public.applied_usage_thresholds DROP CONSTRAINT IF EXISTS fk_rails_52b72c9b0e;
@@ -563,6 +566,7 @@ DROP INDEX IF EXISTS public.index_plans_taxes_on_tax_id;
 DROP INDEX IF EXISTS public.index_plans_taxes_on_plan_id_and_tax_id;
 DROP INDEX IF EXISTS public.index_plans_taxes_on_plan_id;
 DROP INDEX IF EXISTS public.index_plans_taxes_on_organization_id;
+DROP INDEX IF EXISTS public.index_plans_taxes_on_catalog_plan_id_and_tax_id;
 DROP INDEX IF EXISTS public.index_plans_on_parent_id;
 DROP INDEX IF EXISTS public.index_plans_on_organization_id_name_gin_trgm_ops;
 DROP INDEX IF EXISTS public.index_plans_on_organization_id_code_gin_trgm_ops;
@@ -780,6 +784,7 @@ DROP INDEX IF EXISTS public.index_entitlement_entitlements_on_subscription_id;
 DROP INDEX IF EXISTS public.index_entitlement_entitlements_on_plan_id;
 DROP INDEX IF EXISTS public.index_entitlement_entitlements_on_organization_id;
 DROP INDEX IF EXISTS public.index_entitlement_entitlements_on_entitlement_feature_id;
+DROP INDEX IF EXISTS public.index_entitlement_entitlements_on_catalog_plan_id;
 DROP INDEX IF EXISTS public.index_entitlement_entitlement_values_on_organization_id;
 DROP INDEX IF EXISTS public.index_enriched_store_migrations_on_organization_id;
 DROP INDEX IF EXISTS public.index_dunning_campaigns_on_organization_id_and_code;
@@ -848,6 +853,7 @@ DROP INDEX IF EXISTS public.index_coupon_targets_on_plan_id;
 DROP INDEX IF EXISTS public.index_coupon_targets_on_organization_id;
 DROP INDEX IF EXISTS public.index_coupon_targets_on_deleted_at;
 DROP INDEX IF EXISTS public.index_coupon_targets_on_coupon_id;
+DROP INDEX IF EXISTS public.index_coupon_targets_on_catalog_plan_id;
 DROP INDEX IF EXISTS public.index_coupon_targets_on_billable_metric_id;
 DROP INDEX IF EXISTS public.index_contracts_on_plan_id;
 DROP INDEX IF EXISTS public.index_contracts_on_organization_id_and_external_id;
@@ -973,6 +979,7 @@ DROP INDEX IF EXISTS public.idx_unique_privilege_removal_per_subscription;
 DROP INDEX IF EXISTS public.idx_unique_feature_removal_per_subscription;
 DROP INDEX IF EXISTS public.idx_unique_feature_per_subscription;
 DROP INDEX IF EXISTS public.idx_unique_feature_per_plan;
+DROP INDEX IF EXISTS public.idx_unique_feature_per_catalog_plan;
 DROP INDEX IF EXISTS public.idx_subscription_unique;
 DROP INDEX IF EXISTS public.idx_privileges_code_unique_per_feature;
 DROP INDEX IF EXISTS public.idx_pif_values_on_filter_metric_filter_and_value;
@@ -2690,7 +2697,8 @@ CREATE TABLE public.coupon_targets (
     updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp(6) without time zone,
     billable_metric_id uuid,
-    organization_id uuid NOT NULL
+    organization_id uuid NOT NULL,
+    catalog_plan_id uuid
 );
 
 
@@ -3146,7 +3154,8 @@ CREATE TABLE public.entitlement_entitlements (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     subscription_id uuid,
-    CONSTRAINT entitlement_check_exactly_one_parent CHECK (((plan_id IS NOT NULL) <> (subscription_id IS NOT NULL)))
+    catalog_plan_id uuid,
+    CONSTRAINT entitlement_check_exactly_one_parent CHECK ((num_nonnulls(plan_id, catalog_plan_id, subscription_id) = 1))
 );
 
 
@@ -4461,11 +4470,12 @@ CREATE VIEW public.exports_payments AS
 
 CREATE TABLE public.plans_taxes (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
-    plan_id uuid NOT NULL,
+    plan_id uuid,
     tax_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid NOT NULL
+    organization_id uuid NOT NULL,
+    catalog_plan_id uuid
 );
 
 
@@ -7796,6 +7806,13 @@ CREATE UNIQUE INDEX idx_subscription_unique ON public.usage_monitoring_subscript
 
 
 --
+-- Name: idx_unique_feature_per_catalog_plan; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_unique_feature_per_catalog_plan ON public.entitlement_entitlements USING btree (entitlement_feature_id, catalog_plan_id) WHERE (deleted_at IS NULL);
+
+
+--
 -- Name: idx_unique_feature_per_plan; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8675,6 +8692,13 @@ CREATE INDEX index_coupon_targets_on_billable_metric_id ON public.coupon_targets
 
 
 --
+-- Name: index_coupon_targets_on_catalog_plan_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_coupon_targets_on_catalog_plan_id ON public.coupon_targets USING btree (catalog_plan_id);
+
+
+--
 -- Name: index_coupon_targets_on_coupon_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9148,6 +9172,13 @@ CREATE UNIQUE INDEX index_enriched_store_migrations_on_organization_id ON public
 --
 
 CREATE INDEX index_entitlement_entitlement_values_on_organization_id ON public.entitlement_entitlement_values USING btree (organization_id);
+
+
+--
+-- Name: index_entitlement_entitlements_on_catalog_plan_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_entitlement_entitlements_on_catalog_plan_id ON public.entitlement_entitlements USING btree (catalog_plan_id);
 
 
 --
@@ -10667,6 +10698,13 @@ CREATE INDEX index_plans_on_organization_id_name_gin_trgm_ops ON public.plans US
 --
 
 CREATE INDEX index_plans_on_parent_id ON public.plans USING btree (parent_id);
+
+
+--
+-- Name: index_plans_taxes_on_catalog_plan_id_and_tax_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_plans_taxes_on_catalog_plan_id_and_tax_id ON public.plans_taxes USING btree (catalog_plan_id, tax_id);
 
 
 --
@@ -12958,6 +12996,14 @@ ALTER TABLE ONLY public.entitlement_entitlement_values
 
 
 --
+-- Name: entitlement_entitlements fk_rails_54c6fe0506; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.entitlement_entitlements
+    ADD CONSTRAINT fk_rails_54c6fe0506 FOREIGN KEY (catalog_plan_id) REFERENCES public.catalog_plans(id);
+
+
+--
 -- Name: credits fk_rails_5628a713de; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -13638,6 +13684,14 @@ ALTER TABLE ONLY public.applied_pricing_units
 
 
 --
+-- Name: coupon_targets fk_rails_8eeaaf6494; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.coupon_targets
+    ADD CONSTRAINT fk_rails_8eeaaf6494 FOREIGN KEY (catalog_plan_id) REFERENCES public.catalog_plans(id);
+
+
+--
 -- Name: commitments_taxes fk_rails_8fa6f0d920; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -13883,6 +13937,14 @@ ALTER TABLE ONLY public.billing_object_connections
 
 ALTER TABLE ONLY public.rate_phases
     ADD CONSTRAINT fk_rails_a5cd897b6f FOREIGN KEY (plan_rate_card_id) REFERENCES public.plan_rate_cards(id);
+
+
+--
+-- Name: plans_taxes fk_rails_a6d07eec6e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.plans_taxes
+    ADD CONSTRAINT fk_rails_a6d07eec6e FOREIGN KEY (catalog_plan_id) REFERENCES public.catalog_plans(id);
 
 
 --
@@ -14820,6 +14882,8 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260904173416'),
+('20260904173415'),
 ('20260904132835'),
 ('20260904083017'),
 ('20260902143604'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2698,7 +2698,8 @@ CREATE TABLE public.coupon_targets (
     deleted_at timestamp(6) without time zone,
     billable_metric_id uuid,
     organization_id uuid NOT NULL,
-    catalog_plan_id uuid
+    catalog_plan_id uuid,
+    CONSTRAINT coupon_targets_check_single_plan CHECK ((num_nonnulls(plan_id, catalog_plan_id) <= 1))
 );
 
 

--- a/spec/factories/coupon_targets.rb
+++ b/spec/factories/coupon_targets.rb
@@ -12,4 +12,10 @@ FactoryBot.define do
     billable_metric
     organization { billable_metric&.organization || coupon&.organization || association(:organization) }
   end
+
+  factory :coupon_catalog_plan, class: "CouponTarget" do
+    coupon
+    catalog_plan
+    organization { catalog_plan&.organization || coupon&.organization || association(:organization) }
+  end
 end

--- a/spec/factories/entitlement/entitlements.rb
+++ b/spec/factories/entitlement/entitlements.rb
@@ -10,5 +10,10 @@ FactoryBot.define do
       plan { nil }
       association :subscription
     end
+
+    trait :catalog_plan do
+      plan { nil }
+      association :catalog_plan
+    end
   end
 end

--- a/spec/factories/plan_applied_taxes.rb
+++ b/spec/factories/plan_applied_taxes.rb
@@ -5,5 +5,10 @@ FactoryBot.define do
     plan
     tax
     organization { plan&.organization || tax&.organization || association(:organization) }
+
+    trait :catalog_plan do
+      plan { nil }
+      catalog_plan { association(:catalog_plan, organization:) }
+    end
   end
 end

--- a/spec/models/catalog_plan_spec.rb
+++ b/spec/models/catalog_plan_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe CatalogPlan do
   describe "associations" do
     it do
       expect(catalog_plan).to belong_to(:organization)
+      expect(catalog_plan).to have_many(:coupon_targets)
+      expect(catalog_plan).to have_many(:coupons).through(:coupon_targets)
+      expect(catalog_plan).to have_many(:applied_taxes).class_name("Plan::AppliedTax").dependent(:destroy)
+      expect(catalog_plan).to have_many(:taxes).through(:applied_taxes)
+      expect(catalog_plan).to have_many(:entitlements).class_name("Entitlement::Entitlement").dependent(:destroy)
+      expect(catalog_plan).to have_many(:entitlement_values).through(:entitlements).source(:values)
     end
   end
 

--- a/spec/models/coupon_spec.rb
+++ b/spec/models/coupon_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Coupon do
 
   it_behaves_like "paper_trail traceable"
 
+  it { is_expected.to have_many(:catalog_plans).through(:coupon_targets) }
+
   describe "Clickhouse associations", clickhouse: true do
     it { is_expected.to have_many(:activity_logs).class_name("Clickhouse::ActivityLog") }
   end

--- a/spec/models/coupon_target_spec.rb
+++ b/spec/models/coupon_target_spec.rb
@@ -3,5 +3,28 @@
 RSpec.describe CouponTarget do
   subject(:coupon_target) { build(:coupon_plan) }
 
-  it { is_expected.to belong_to(:organization) }
+  describe "associations" do
+    it do
+      expect(coupon_target).to belong_to(:coupon)
+      expect(coupon_target).to belong_to(:organization)
+      expect(coupon_target).to belong_to(:plan).optional
+      expect(coupon_target).to belong_to(:catalog_plan).optional
+      expect(coupon_target).to belong_to(:billable_metric).optional
+    end
+  end
+
+  describe "validations" do
+    describe "single_plan_target" do
+      it "allows targeting only a catalog plan" do
+        expect(build(:coupon_catalog_plan)).to be_valid
+      end
+
+      it "rejects targeting a legacy and a catalog plan at once" do
+        target = build(:coupon_plan, catalog_plan: build(:catalog_plan))
+
+        expect(target).not_to be_valid
+        expect(target.errors.where(:base, :single_plan_target)).to be_present
+      end
+    end
+  end
 end

--- a/spec/models/coupon_target_spec.rb
+++ b/spec/models/coupon_target_spec.rb
@@ -26,5 +26,14 @@ RSpec.describe CouponTarget do
         expect(target.errors.where(:base, :single_plan_target)).to be_present
       end
     end
+
+    describe "database parent guard" do
+      it "rejects a target with both plans even past model validation" do
+        target = create(:coupon_plan)
+        target.catalog_plan = create(:catalog_plan, organization: target.organization)
+
+        expect { target.save(validate: false) }.to raise_error(ActiveRecord::StatementInvalid)
+      end
+    end
   end
 end

--- a/spec/models/coupon_target_spec.rb
+++ b/spec/models/coupon_target_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe CouponTarget do
 
         expect(target).not_to be_valid
         expect(target.errors.where(:base, :single_plan_target)).to be_present
+        expect(target.errors.messages[:base]).to eq(["single_plan_target"])
       end
     end
 

--- a/spec/models/entitlement/entitlement_spec.rb
+++ b/spec/models/entitlement/entitlement_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Entitlement::Entitlement do
       expect(subject).to belong_to(:organization)
       expect(subject).to belong_to(:feature).class_name("Entitlement::Feature")
       expect(subject).to belong_to(:plan).optional
+      expect(subject).to belong_to(:catalog_plan).optional
       expect(subject).to belong_to(:subscription).optional
       expect(subject).to have_many(:values).class_name("Entitlement::EntitlementValue").dependent(:destroy)
     end
@@ -32,6 +33,19 @@ RSpec.describe Entitlement::Entitlement do
       it "is valid when only subscription is present" do
         entitlement = build(:entitlement, organization:, feature:, plan: nil, subscription:)
         expect(entitlement).to be_valid
+      end
+
+      it "is valid when only catalog_plan is present" do
+        catalog_plan = create(:catalog_plan, organization:)
+        entitlement = build(:entitlement, organization:, feature:, plan: nil, catalog_plan:)
+        expect(entitlement).to be_valid
+      end
+
+      it "is invalid when a plan and a catalog_plan are both present" do
+        catalog_plan = create(:catalog_plan, organization:)
+        entitlement = build(:entitlement, organization:, feature:, plan:, catalog_plan:)
+        expect(entitlement).not_to be_valid
+        expect(entitlement.errors[:base]).to eq(["one_of_plan_or_subscription_required"])
       end
 
       it "is invalid when both plan_id and subscription are present" do

--- a/spec/models/entitlement/entitlement_spec.rb
+++ b/spec/models/entitlement/entitlement_spec.rb
@@ -65,5 +65,28 @@ RSpec.describe Entitlement::Entitlement do
         expect(entitlement.errors[:base]).to eq(["one_of_plan_or_subscription_required"])
       end
     end
+
+    describe "database parent guard" do
+      let(:organization) { create(:organization) }
+      let(:feature) { create(:feature, organization:) }
+
+      it "rejects a row with no parent even past model validation" do
+        entitlement = build(:entitlement, organization:, feature:, plan: nil, subscription: nil)
+
+        expect { entitlement.save(validate: false) }.to raise_error(ActiveRecord::StatementInvalid)
+      end
+
+      it "rejects a row with two parents even past model validation" do
+        entitlement = build(
+          :entitlement,
+          organization:,
+          feature:,
+          plan: create(:plan, organization:),
+          subscription: create(:subscription, organization:)
+        )
+
+        expect { entitlement.save(validate: false) }.to raise_error(ActiveRecord::StatementInvalid)
+      end
+    end
   end
 end

--- a/spec/models/entitlement/entitlement_spec.rb
+++ b/spec/models/entitlement/entitlement_spec.rb
@@ -41,6 +41,11 @@ RSpec.describe Entitlement::Entitlement do
         expect(entitlement).to be_valid
       end
 
+      it "counts an unsaved parent through the association" do
+        entitlement = build(:entitlement, organization:, feature:, plan: build(:plan, organization:), subscription: nil)
+        expect(entitlement).to be_valid
+      end
+
       it "is invalid when a plan and a catalog_plan are both present" do
         catalog_plan = create(:catalog_plan, organization:)
         entitlement = build(:entitlement, organization:, feature:, plan:, catalog_plan:)

--- a/spec/models/entitlement/feature_spec.rb
+++ b/spec/models/entitlement/feature_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Entitlement::Feature do
       expect(subject).to have_many(:entitlements).class_name("Entitlement::Entitlement").dependent(:destroy)
       expect(subject).to have_many(:entitlement_values).through(:entitlements).source(:values).class_name("Entitlement::EntitlementValue").dependent(:destroy)
       expect(subject).to have_many(:plans).through(:entitlements)
+      expect(subject).to have_many(:catalog_plans).through(:entitlements)
     end
   end
 

--- a/spec/models/plan/applied_tax_spec.rb
+++ b/spec/models/plan/applied_tax_spec.rb
@@ -32,5 +32,20 @@ RSpec.describe Plan::AppliedTax do
         expect(applied_tax.errors.where(:base, :exactly_one_plan_required)).to be_present
       end
     end
+
+    describe "database parent guard" do
+      it "rejects a row with no plan even past model validation" do
+        applied_tax = build(:plan_applied_tax, plan: nil)
+
+        expect { applied_tax.save(validate: false) }.to raise_error(ActiveRecord::StatementInvalid)
+      end
+
+      it "rejects a row with both plans even past model validation" do
+        applied_tax = create(:plan_applied_tax)
+        applied_tax.catalog_plan = create(:catalog_plan, organization: applied_tax.organization)
+
+        expect { applied_tax.save(validate: false) }.to raise_error(ActiveRecord::StatementInvalid)
+      end
+    end
   end
 end

--- a/spec/models/plan/applied_tax_spec.rb
+++ b/spec/models/plan/applied_tax_spec.rb
@@ -3,5 +3,34 @@
 RSpec.describe Plan::AppliedTax do
   subject(:plan_applied_tax) { create(:plan_applied_tax) }
 
-  it { is_expected.to belong_to(:organization) }
+  describe "associations" do
+    it do
+      expect(plan_applied_tax).to belong_to(:tax)
+      expect(plan_applied_tax).to belong_to(:organization)
+      expect(plan_applied_tax).to belong_to(:plan).optional
+      expect(plan_applied_tax).to belong_to(:catalog_plan).optional
+    end
+  end
+
+  describe "validations" do
+    describe "exactly_one_plan" do
+      it "allows a catalog plan on its own" do
+        expect(build(:plan_applied_tax, :catalog_plan)).to be_valid
+      end
+
+      it "rejects both a legacy and a catalog plan" do
+        applied_tax = build(:plan_applied_tax, catalog_plan: build(:catalog_plan))
+
+        expect(applied_tax).not_to be_valid
+        expect(applied_tax.errors.where(:base, :exactly_one_plan_required)).to be_present
+      end
+
+      it "rejects neither" do
+        applied_tax = build(:plan_applied_tax, plan: nil)
+
+        expect(applied_tax).not_to be_valid
+        expect(applied_tax.errors.where(:base, :exactly_one_plan_required)).to be_present
+      end
+    end
+  end
 end

--- a/spec/models/plan/applied_tax_spec.rb
+++ b/spec/models/plan/applied_tax_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Plan::AppliedTax do
 
         expect(applied_tax).not_to be_valid
         expect(applied_tax.errors.where(:base, :exactly_one_plan_required)).to be_present
+        expect(applied_tax.errors.messages[:base]).to eq(["exactly_one_plan_required"])
       end
 
       it "rejects neither" do

--- a/spec/models/tax_spec.rb
+++ b/spec/models/tax_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Tax do
 
   it { is_expected.to have_many(:billing_entities_taxes).dependent(:destroy) }
   it { is_expected.to have_many(:billing_entities).through(:billing_entities_taxes) }
+  it { is_expected.to have_many(:catalog_plans).through(:plans_taxes) }
 
   it { expect(described_class).to be_soft_deletable }
 


### PR DESCRIPTION
## What this is

The shared plan ecosystem — coupon targets, plan taxes, entitlements — must be able to point at a **catalog plan**, not only a legacy `Plan`. Additive: existing rows keep their `plan_id`.

## Changes

Nullable `catalog_plan_id` (+ index + a NOT VALID → validated FK) added to `coupon_targets`, `plans_taxes`, `entitlement_entitlements` — the `rate_phase` XOR pattern, real Postgres FKs.

- **plans_taxes**: `plan_id` relaxed to nullable; unique `(catalog_plan_id, tax_id)` index mirroring the legacy `(plan_id, tax_id)` one (also serves the FK lookup, so no standalone column index). Model validates exactly one of plan / catalog_plan.
- **entitlement_entitlements**: unique partial `(entitlement_feature_id, catalog_plan_id)` index mirroring the plan one; the DB `exactly_one_parent` check swapped from `plan XOR subscription` to `num_nonnulls(plan, catalog_plan, subscription) = 1`, and the model validation counts all three.
- **coupon_targets**: model validates a target points at a legacy **or** a catalog plan, never both (billable-metric targets unaffected).
