### PR TITLE
feat(add_ons): add lifecycle webhooks

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -17,6 +17,9 @@ class SendWebhookJob < ApplicationJob
   retry_on "Aws::S3::Errors::SlowDown", wait: :polynomially_longer, attempts: 6
 
   WEBHOOK_SERVICES = {
+    "add_on.created" => Webhooks::AddOns::CreatedService,
+    "add_on.updated" => Webhooks::AddOns::UpdatedService,
+    "add_on.deleted" => Webhooks::AddOns::DeletedService,
     "alert.triggered" => Webhooks::UsageMonitoring::AlertTriggeredService,
     "billable_metric.created" => Webhooks::BillableMetrics::CreatedService,
     "billable_metric.updated" => Webhooks::BillableMetrics::UpdatedService,

--- a/app/services/add_ons/create_service.rb
+++ b/app/services/add_ons/create_service.rb
@@ -30,6 +30,7 @@ module AddOns
       end
 
       track_add_on_created(result.add_on)
+      SendWebhookJob.perform_after_commit("add_on.created", result.add_on)
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)

--- a/app/services/add_ons/destroy_service.rb
+++ b/app/services/add_ons/destroy_service.rb
@@ -18,6 +18,7 @@ module AddOns
       end
 
       result.add_on = add_on
+      SendWebhookJob.perform_after_commit("add_on.deleted", add_on)
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)

--- a/app/services/add_ons/update_service.rb
+++ b/app/services/add_ons/update_service.rb
@@ -30,6 +30,7 @@ module AddOns
       end
 
       result.add_on = add_on
+      SendWebhookJob.perform_after_commit("add_on.updated", add_on)
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)

--- a/app/services/webhooks/add_ons/created_service.rb
+++ b/app/services/webhooks/add_ons/created_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module AddOns
+    class CreatedService < Webhooks::BaseService
+      private
+
+      def object_serializer
+        ::V1::AddOnSerializer.new(
+          object,
+          root_name: "add_on"
+        )
+      end
+
+      def webhook_type
+        "add_on.created"
+      end
+
+      def object_type
+        "add_on"
+      end
+    end
+  end
+end

--- a/app/services/webhooks/add_ons/deleted_service.rb
+++ b/app/services/webhooks/add_ons/deleted_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module AddOns
+    class DeletedService < Webhooks::BaseService
+      private
+
+      def object_serializer
+        ::V1::AddOnSerializer.new(
+          object,
+          root_name: "add_on"
+        )
+      end
+
+      def webhook_type
+        "add_on.deleted"
+      end
+
+      def object_type
+        "add_on"
+      end
+    end
+  end
+end

--- a/app/services/webhooks/add_ons/updated_service.rb
+++ b/app/services/webhooks/add_ons/updated_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module AddOns
+    class UpdatedService < Webhooks::BaseService
+      private
+
+      def object_serializer
+        ::V1::AddOnSerializer.new(
+          object,
+          root_name: "add_on"
+        )
+      end
+
+      def webhook_type
+        "add_on.updated"
+      end
+
+      def object_type
+        "add_on"
+      end
+    end
+  end
+end

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -725,6 +725,22 @@ RSpec.describe SendWebhookJob do
       end
     end
 
+    context "with add_on webhooks" do
+      let(:object) { create(:add_on, organization:) }
+
+      it_behaves_like "a webhook service",
+        "add_on.created",
+        Webhooks::AddOns::CreatedService
+
+      it_behaves_like "a webhook service",
+        "add_on.updated",
+        Webhooks::AddOns::UpdatedService
+
+      it_behaves_like "a webhook service",
+        "add_on.deleted",
+        Webhooks::AddOns::DeletedService
+    end
+
     context "with billable metric webhooks" do
       let(:object) { create(:billable_metric, organization:) }
 

--- a/spec/services/add_ons/create_service_spec.rb
+++ b/spec/services/add_ons/create_service_spec.rb
@@ -47,6 +47,12 @@ RSpec.describe AddOns::CreateService do
       )
     end
 
+    it "enqueues an add_on.created webhook" do
+      result = create_service.call
+
+      expect(SendWebhookJob).to have_been_enqueued.with("add_on.created", result.add_on)
+    end
+
     context "with code already used by a deleted add_on" do
       it "creates an add_on with the same code" do
         create(:add_on, :deleted, organization:, code: add_on_code)

--- a/spec/services/add_ons/destroy_service_spec.rb
+++ b/spec/services/add_ons/destroy_service_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe AddOns::DestroyService do
         .and change { add_on.reload.deleted_at }.from(nil)
     end
 
+    it "enqueues an add_on.deleted webhook" do
+      result = destroy_service.call
+
+      expect(SendWebhookJob).to have_been_enqueued.with("add_on.deleted", result.add_on)
+    end
+
     context "when there are fixed charges associated with the add-on" do
       let(:fixed_charges) { create_list(:fixed_charge, 2, add_on:) }
 

--- a/spec/services/add_ons/update_service_spec.rb
+++ b/spec/services/add_ons/update_service_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe AddOns::UpdateService do
       expect(result.add_on.taxes.map { |t| t[:code] }).to contain_exactly(tax2.code)
     end
 
+    it "enqueues an add_on.updated webhook" do
+      result = add_ons_service.call
+
+      expect(SendWebhookJob).to have_been_enqueued.with("add_on.updated", result.add_on)
+    end
+
     context "when tax is not found" do
       let(:tax_codes) { ["unknown"] }
 

--- a/spec/services/webhooks/add_ons/created_service_spec.rb
+++ b/spec/services/webhooks/add_ons/created_service_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Webhooks::AddOns::CreatedService do
+  subject(:webhook_service) { described_class.new(object: add_on) }
+
+  let(:organization) { create(:organization) }
+  let(:add_on) { create(:add_on, organization:) }
+
+  describe ".call" do
+    it_behaves_like "creates webhook", "add_on.created", "add_on", {
+      "lago_id" => String,
+      "name" => String,
+      "code" => String,
+      "amount_cents" => Integer
+    }
+  end
+end

--- a/spec/services/webhooks/add_ons/deleted_service_spec.rb
+++ b/spec/services/webhooks/add_ons/deleted_service_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Webhooks::AddOns::DeletedService do
+  subject(:webhook_service) { described_class.new(object: add_on) }
+
+  let(:organization) { create(:organization) }
+  let(:add_on) { create(:add_on, organization:) }
+
+  describe ".call" do
+    it_behaves_like "creates webhook", "add_on.deleted", "add_on"
+  end
+end

--- a/spec/services/webhooks/add_ons/updated_service_spec.rb
+++ b/spec/services/webhooks/add_ons/updated_service_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Webhooks::AddOns::UpdatedService do
+  subject(:webhook_service) { described_class.new(object: add_on) }
+
+  let(:organization) { create(:organization) }
+  let(:add_on) { create(:add_on, organization:) }
+
+  describe ".call" do
+    it_behaves_like "creates webhook", "add_on.updated", "add_on", {
+      "lago_id" => String,
+      "name" => String,
+      "code" => String,
+      "amount_cents" => Integer
+    }
+  end
+end


### PR DESCRIPTION
Fixes #6309 

## Problem

`AddOn` lifecycle (create/update/destroy) fires no webhooks and produces no activity logs at
all, unlike sibling catalog resources `Plan`, `BillableMetric`, and `Coupon`, which all fire
`*.created`/`*.updated`/`*.deleted` webhooks.

## Change

- Added `Webhooks::AddOns::{Created,Updated,Deleted}Service`, mirroring the existing
  `Webhooks::BillableMetrics::*Service`/`Webhooks::Coupons::*Service` classes exactly.
- Registered the three new events in `SendWebhookJob::WEBHOOK_SERVICES`.
- Wired `SendWebhookJob.perform_after_commit` calls into `AddOns::CreateService`,
  `AddOns::UpdateService`, and `AddOns::DestroyService`.
- Added specs for the three new webhook services, webhook-enqueue assertions to the
  existing `AddOns::{Create,Update,Destroy}Service` specs, and a new context in the
  dispatcher-level `send_webhook_job_spec.rb`.

Purely additive wiring -- no billing/pricing math touched.

## Verified

- 74 RSpec examples passing (`spec/services/add_ons/*_service_spec.rb`,
  `spec/services/webhooks/add_ons/*_spec.rb`, `spec/jobs/send_webhook_job_spec.rb`) against a
  real Postgres (`getlago/postgres-partman:15.0-alpine`, matching CI) + Redis environment.
- Rubocop clean across all 15 touched/new files.
