### PR TITLE
feat(catalog): point plan rate cards and contracts at catalog plans

### DIFF
--- a/app/models/catalog_plan.rb
+++ b/app/models/catalog_plan.rb
@@ -12,6 +12,9 @@ class CatalogPlan < ApplicationRecord
 
   belongs_to :organization
 
+  has_many :applied_rate_cards, class_name: "PlanRateCard"
+  has_many :contracts
+
   validates :name, presence: true
   validates :code, presence: true, uniqueness: {scope: :organization_id, conditions: -> { where(deleted_at: nil) }}
   validates :currency, presence: true, inclusion: {in: currency_list, allow_nil: true}

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -94,7 +94,9 @@ class Contract < ApplicationRecord
   # A contract prices through a legacy plan or a catalog plan, never both; a
   # plan-less contract prices through its directly attached rate cards.
   def validate_single_plan
-    return unless plan.present? && catalog_plan.present?
+    has_plan = plan_id.present? || plan.present?
+    has_catalog_plan = catalog_plan_id.present? || catalog_plan.present?
+    return unless has_plan && has_catalog_plan
 
     errors.add(:base, :single_plan)
   end

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -25,6 +25,7 @@ class Contract < ApplicationRecord
   # through these associations.
   belongs_to :customer, -> { with_discarded }
   belongs_to :plan, -> { with_discarded }, optional: true
+  belongs_to :catalog_plan, -> { with_discarded }, optional: true
 
   has_many :applied_rate_cards, class_name: "ContractRateCard"
   has_many :billing_segments
@@ -46,6 +47,7 @@ class Contract < ApplicationRecord
   validates :external_id, presence: true
 
   validate :validate_started_before_ended
+  validate :validate_single_plan
 
   # The anchor every attached rate card inherits by default: the explicit
   # anchor when one was signed, otherwise the day the contract starts — in
@@ -66,7 +68,7 @@ class Contract < ApplicationRecord
   # The currency fees bill in: the plan's when there is one, otherwise the
   # customer's (a plan-less contract), falling back to the organization default.
   def currency
-    plan&.amount_currency || customer.currency || organization.default_currency
+    plan&.amount_currency || catalog_plan&.currency || customer.currency || organization.default_currency
   end
 
   # The billing lifecycle a rate card inherits when attached: it starts on the
@@ -88,6 +90,14 @@ class Contract < ApplicationRecord
 
     errors.add(:ended_at, :must_be_after_started_at)
   end
+
+  # A contract prices through a legacy plan or a catalog plan, never both; a
+  # plan-less contract prices through its directly attached rate cards.
+  def validate_single_plan
+    return unless plan.present? && catalog_plan.present?
+
+    errors.add(:base, :single_plan)
+  end
 end
 
 # == Schema Information
@@ -106,6 +116,7 @@ end
 #  terminated_at       :datetime
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  catalog_plan_id     :uuid
 #  customer_id         :uuid             not null
 #  external_id         :string           not null
 #  organization_id     :uuid             not null
@@ -113,6 +124,7 @@ end
 #
 # Indexes
 #
+#  index_contracts_on_catalog_plan_id                  (catalog_plan_id)
 #  index_contracts_on_customer_id                      (customer_id)
 #  index_contracts_on_live_external_id                 (organization_id,external_id,status) UNIQUE WHERE (status = ANY (ARRAY['pending'::contract_status, 'active'::contract_status]))
 #  index_contracts_on_organization_id                  (organization_id)
@@ -121,6 +133,7 @@ end
 #
 # Foreign Keys
 #
+#  fk_rails_...  (catalog_plan_id => catalog_plans.id)
 #  fk_rails_...  (customer_id => customers.id)
 #  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (plan_id => plans.id)

--- a/app/models/plan_rate_card.rb
+++ b/app/models/plan_rate_card.rb
@@ -7,20 +7,33 @@ class PlanRateCard < ApplicationRecord
   self.discard_column = :deleted_at
 
   belongs_to :organization
-  belongs_to :plan
+  belongs_to :plan, optional: true
+  belongs_to :catalog_plan, optional: true
   belongs_to :rate_card
 
   has_one :product, through: :rate_card
 
   has_many :rate_phases, -> { order(:position) }
 
-  validates :rate_card_id, uniqueness: {scope: :plan_id, conditions: -> { where(deleted_at: nil) }}
+  validates :rate_card_id, uniqueness: {scope: %i[plan_id catalog_plan_id], conditions: -> { where(deleted_at: nil) }}
   validates :units, numericality: {greater_than_or_equal_to: 0}, allow_nil: true
+
+  validate :exactly_one_plan
 
   default_scope -> { kept }
 
   def edit_error_code
-    "plan_locked" if plan.attached_to_subscriptions?
+    "plan_locked" if plan&.attached_to_subscriptions?
+  end
+
+  private
+
+  # A rate card is applied to exactly one plan, legacy or catalog. The
+  # association is checked, not the id, so an unsaved parent still counts.
+  def exactly_one_plan
+    return if plan.present? ^ catalog_plan.present?
+
+    errors.add(:base, :exactly_one_plan_required)
   end
 end
 
@@ -34,20 +47,23 @@ end
 #  units           :decimal(, )
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  catalog_plan_id :uuid
 #  organization_id :uuid             not null
-#  plan_id         :uuid             not null
+#  plan_id         :uuid
 #  rate_card_id    :uuid             not null
 #
 # Indexes
 #
-#  index_plan_rate_cards_on_deleted_at                (deleted_at)
-#  index_plan_rate_cards_on_organization_id           (organization_id)
-#  index_plan_rate_cards_on_plan_id                   (plan_id)
-#  index_plan_rate_cards_on_plan_id_and_rate_card_id  (plan_id,rate_card_id) UNIQUE WHERE (deleted_at IS NULL)
-#  index_plan_rate_cards_on_rate_card_id              (rate_card_id)
+#  index_plan_rate_cards_on_catalog_plan_id_and_rate_card_id  (catalog_plan_id,rate_card_id) UNIQUE WHERE (deleted_at IS NULL)
+#  index_plan_rate_cards_on_deleted_at                        (deleted_at)
+#  index_plan_rate_cards_on_organization_id                   (organization_id)
+#  index_plan_rate_cards_on_plan_id                           (plan_id)
+#  index_plan_rate_cards_on_plan_id_and_rate_card_id          (plan_id,rate_card_id) UNIQUE WHERE (deleted_at IS NULL)
+#  index_plan_rate_cards_on_rate_card_id                      (rate_card_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (catalog_plan_id => catalog_plans.id)
 #  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (plan_id => plans.id)
 #  fk_rails_...  (rate_card_id => rate_cards.id)

--- a/app/models/plan_rate_card.rb
+++ b/app/models/plan_rate_card.rb
@@ -28,10 +28,14 @@ class PlanRateCard < ApplicationRecord
 
   private
 
-  # A rate card is applied to exactly one plan, legacy or catalog. The
-  # association is checked, not the id, so an unsaved parent still counts.
+  # A rate card is applied to exactly one plan, legacy or catalog. Both the id
+  # and the association are checked (the rate_phase idiom): the id covers a
+  # persisted parent — even a soft-deleted one, outside the kept scope — and
+  # the association covers an unsaved one.
   def exactly_one_plan
-    return if plan.present? ^ catalog_plan.present?
+    has_plan = plan_id.present? || plan.present?
+    has_catalog_plan = catalog_plan_id.present? || catalog_plan.present?
+    return if has_plan ^ has_catalog_plan
 
     errors.add(:base, :exactly_one_plan_required)
   end

--- a/app/services/plan_rate_cards/destroy_service.rb
+++ b/app/services/plan_rate_cards/destroy_service.rb
@@ -14,7 +14,7 @@ module PlanRateCards
     def call
       return result.not_found_failure!(resource: "applied_rate_card") unless plan_rate_card
 
-      if plan_rate_card.plan.attached_to_subscriptions?
+      if plan_rate_card.plan&.attached_to_subscriptions?
         return result.single_validation_failure!(field: :plan, error_code: "plan_locked")
       end
 

--- a/app/services/plan_rate_cards/update_service.rb
+++ b/app/services/plan_rate_cards/update_service.rb
@@ -15,7 +15,7 @@ module PlanRateCards
     def call
       return result.not_found_failure!(resource: "applied_rate_card") unless plan_rate_card
 
-      if plan_rate_card.plan.attached_to_subscriptions?
+      if plan_rate_card.plan&.attached_to_subscriptions?
         return result.single_validation_failure!(field: :plan, error_code: "plan_locked")
       end
 

--- a/db/migrate/20260905170744_add_catalog_plan_to_pricing.rb
+++ b/db/migrate/20260905170744_add_catalog_plan_to_pricing.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class AddCatalogPlanToPricing < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    # A plan rate card belongs to a legacy plan or a catalog plan, so plan_id
+    # is no longer mandatory; a check keeps the "exactly one plan" guarantee.
+    # The composite unique index mirrors the legacy (plan_id, rate_card_id)
+    # one and also serves catalog_plan_id FK lookups (leftmost), so the column
+    # needs no standalone index.
+    add_reference :plan_rate_cards, :catalog_plan, type: :uuid, null: true, index: false
+    add_foreign_key :plan_rate_cards, :catalog_plans, validate: false
+    change_column_null :plan_rate_cards, :plan_id, true
+    add_index :plan_rate_cards, %i[catalog_plan_id rate_card_id],
+      unique: true,
+      where: "deleted_at IS NULL",
+      name: "index_plan_rate_cards_on_catalog_plan_id_and_rate_card_id",
+      algorithm: :concurrently
+    add_check_constraint :plan_rate_cards,
+      "num_nonnulls(plan_id, catalog_plan_id) = 1",
+      name: "plan_rate_cards_check_exactly_one_plan",
+      validate: false
+
+    # A contract prices through a legacy plan, a catalog plan, or neither
+    # (plan-less), never both.
+    add_reference :contracts, :catalog_plan, type: :uuid, null: true, index: {algorithm: :concurrently}
+    add_foreign_key :contracts, :catalog_plans, validate: false
+    add_check_constraint :contracts,
+      "num_nonnulls(plan_id, catalog_plan_id) <= 1",
+      name: "contracts_check_single_plan",
+      validate: false
+  end
+
+  def down
+    remove_check_constraint :contracts, name: "contracts_check_single_plan"
+    remove_foreign_key :contracts, :catalog_plans
+    remove_reference :contracts, :catalog_plan
+
+    remove_check_constraint :plan_rate_cards, name: "plan_rate_cards_check_exactly_one_plan"
+    remove_index :plan_rate_cards, name: "index_plan_rate_cards_on_catalog_plan_id_and_rate_card_id"
+    change_column_null :plan_rate_cards, :plan_id, false
+    remove_foreign_key :plan_rate_cards, :catalog_plans
+    remove_reference :plan_rate_cards, :catalog_plan
+  end
+end

--- a/db/migrate/20260905170745_validate_catalog_plan_pricing_constraints.rb
+++ b/db/migrate/20260905170745_validate_catalog_plan_pricing_constraints.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ValidateCatalogPlanPricingConstraints < ActiveRecord::Migration[8.0]
+  def up
+    validate_foreign_key :plan_rate_cards, :catalog_plans
+    validate_check_constraint :plan_rate_cards, name: "plan_rate_cards_check_exactly_one_plan"
+
+    validate_foreign_key :contracts, :catalog_plans
+    validate_check_constraint :contracts, name: "contracts_check_single_plan"
+  end
+
+  def down
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -53,6 +53,7 @@ ALTER TABLE IF EXISTS ONLY public.usage_monitoring_triggered_alerts DROP CONSTRA
 ALTER TABLE IF EXISTS ONLY public.rate_cards_taxes DROP CONSTRAINT IF EXISTS fk_rails_e2dbfbb01e;
 ALTER TABLE IF EXISTS ONLY public.integration_collection_mappings DROP CONSTRAINT IF EXISTS fk_rails_e148d17c1f;
 ALTER TABLE IF EXISTS ONLY public.product_categories DROP CONSTRAINT IF EXISTS fk_rails_e13d306a35;
+ALTER TABLE IF EXISTS ONLY public.plan_rate_cards DROP CONSTRAINT IF EXISTS fk_rails_e05bca64df;
 ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk_rails_dfac602b2c;
 ALTER TABLE IF EXISTS ONLY public.credit_note_items DROP CONSTRAINT IF EXISTS fk_rails_dea748e529;
 ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS fk_rails_de7694c307;
@@ -196,6 +197,7 @@ ALTER TABLE IF EXISTS ONLY public.integrations DROP CONSTRAINT IF EXISTS fk_rail
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_75577c354e;
 ALTER TABLE IF EXISTS ONLY public.fixed_charge_events DROP CONSTRAINT IF EXISTS fk_rails_752665cc51;
 ALTER TABLE IF EXISTS ONLY public.fees_taxes DROP CONSTRAINT IF EXISTS fk_rails_745b4ca7dd;
+ALTER TABLE IF EXISTS ONLY public.contracts DROP CONSTRAINT IF EXISTS fk_rails_7418f461c3;
 ALTER TABLE IF EXISTS ONLY public.data_exports DROP CONSTRAINT IF EXISTS fk_rails_73d83e23b6;
 ALTER TABLE IF EXISTS ONLY public.invoice_connections DROP CONSTRAINT IF EXISTS fk_rails_7286421039;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alert_thresholds DROP CONSTRAINT IF EXISTS fk_rails_710f37148d;
@@ -576,6 +578,7 @@ DROP INDEX IF EXISTS public.index_plan_rate_cards_on_plan_id_and_rate_card_id;
 DROP INDEX IF EXISTS public.index_plan_rate_cards_on_plan_id;
 DROP INDEX IF EXISTS public.index_plan_rate_cards_on_organization_id;
 DROP INDEX IF EXISTS public.index_plan_rate_cards_on_deleted_at;
+DROP INDEX IF EXISTS public.index_plan_rate_cards_on_catalog_plan_id_and_rate_card_id;
 DROP INDEX IF EXISTS public.index_pending_vies_checks_on_organization_id;
 DROP INDEX IF EXISTS public.index_pending_vies_checks_on_customer_id;
 DROP INDEX IF EXISTS public.index_pending_vies_checks_on_billing_entity_id;
@@ -854,6 +857,7 @@ DROP INDEX IF EXISTS public.index_contracts_on_organization_id_and_external_id;
 DROP INDEX IF EXISTS public.index_contracts_on_organization_id;
 DROP INDEX IF EXISTS public.index_contracts_on_live_external_id;
 DROP INDEX IF EXISTS public.index_contracts_on_customer_id;
+DROP INDEX IF EXISTS public.index_contracts_on_catalog_plan_id;
 DROP INDEX IF EXISTS public.index_contract_rate_cards_on_rate_card_id;
 DROP INDEX IF EXISTS public.index_contract_rate_cards_on_organization_id;
 DROP INDEX IF EXISTS public.index_contract_rate_cards_on_next_billing_at;
@@ -2674,7 +2678,9 @@ CREATE TABLE public.contracts (
     terminated_at timestamp without time zone,
     canceled_at timestamp without time zone,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    catalog_plan_id uuid,
+    CONSTRAINT contracts_check_single_plan CHECK ((num_nonnulls(plan_id, catalog_plan_id) <= 1))
 );
 
 
@@ -5392,12 +5398,14 @@ CREATE TABLE public.pending_vies_checks (
 CREATE TABLE public.plan_rate_cards (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     organization_id uuid NOT NULL,
-    plan_id uuid NOT NULL,
+    plan_id uuid,
     rate_card_id uuid NOT NULL,
     units numeric,
     deleted_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    catalog_plan_id uuid,
+    CONSTRAINT plan_rate_cards_check_exactly_one_plan CHECK ((num_nonnulls(plan_id, catalog_plan_id) = 1))
 );
 
 
@@ -8633,6 +8641,13 @@ CREATE INDEX index_contract_rate_cards_on_rate_card_id ON public.contract_rate_c
 
 
 --
+-- Name: index_contracts_on_catalog_plan_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_contracts_on_catalog_plan_id ON public.contracts USING btree (catalog_plan_id);
+
+
+--
 -- Name: index_contracts_on_customer_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10576,6 +10591,13 @@ CREATE UNIQUE INDEX index_pending_vies_checks_on_customer_id ON public.pending_v
 --
 
 CREATE INDEX index_pending_vies_checks_on_organization_id ON public.pending_vies_checks USING btree (organization_id);
+
+
+--
+-- Name: index_plan_rate_cards_on_catalog_plan_id_and_rate_card_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_plan_rate_cards_on_catalog_plan_id_and_rate_card_id ON public.plan_rate_cards USING btree (catalog_plan_id, rate_card_id) WHERE (deleted_at IS NULL);
 
 
 --
@@ -13318,6 +13340,14 @@ ALTER TABLE ONLY public.data_exports
 
 
 --
+-- Name: contracts fk_rails_7418f461c3; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.contracts
+    ADD CONSTRAINT fk_rails_7418f461c3 FOREIGN KEY (catalog_plan_id) REFERENCES public.catalog_plans(id);
+
+
+--
 -- Name: fees_taxes fk_rails_745b4ca7dd; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -14462,6 +14492,14 @@ ALTER TABLE ONLY public.customer_metadata
 
 
 --
+-- Name: plan_rate_cards fk_rails_e05bca64df; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.plan_rate_cards
+    ADD CONSTRAINT fk_rails_e05bca64df FOREIGN KEY (catalog_plan_id) REFERENCES public.catalog_plans(id);
+
+
+--
 -- Name: product_categories fk_rails_e13d306a35; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -14820,6 +14858,8 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260905170745'),
+('20260905170744'),
 ('20260904132835'),
 ('20260904083017'),
 ('20260902143604'),

--- a/spec/models/catalog_plan_spec.rb
+++ b/spec/models/catalog_plan_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe CatalogPlan do
   describe "associations" do
     it do
       expect(catalog_plan).to belong_to(:organization)
+      expect(catalog_plan).to have_many(:applied_rate_cards).class_name("PlanRateCard")
+      expect(catalog_plan).to have_many(:contracts)
     end
   end
 

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -54,6 +54,23 @@ RSpec.describe Contract do
     end
 
     describe "single plan" do
+      it "accepts a contract priced only through a catalog plan" do
+        customer = create(:customer)
+        contract = build(
+          :contract,
+          organization: customer.organization,
+          customer:,
+          plan: nil,
+          catalog_plan: create(:catalog_plan, organization: customer.organization)
+        )
+
+        expect(contract).to be_valid
+      end
+
+      it "accepts a plan-less contract" do
+        expect(build(:contract, plan: nil, catalog_plan: nil)).to be_valid
+      end
+
       it "rejects both a plan and a catalog plan" do
         customer = create(:customer)
         contract = build(

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Contract do
       expect(contract).to belong_to(:organization)
       expect(contract).to belong_to(:customer)
       expect(contract).to belong_to(:plan).optional
+      expect(contract).to belong_to(:catalog_plan).optional
       expect(contract).to have_many(:applied_rate_cards).class_name("ContractRateCard")
       expect(contract).to have_many(:billing_segments)
     end
@@ -50,6 +51,35 @@ RSpec.describe Contract do
 
       expect(contract).not_to be_valid
       expect(contract.errors.where(:ended_at, :must_be_after_started_at)).to be_present
+    end
+
+    describe "single plan" do
+      it "rejects both a plan and a catalog plan" do
+        customer = create(:customer)
+        contract = build(
+          :contract,
+          organization: customer.organization,
+          customer:,
+          plan: create(:plan, organization: customer.organization),
+          catalog_plan: create(:catalog_plan, organization: customer.organization)
+        )
+
+        expect(contract).not_to be_valid
+        expect(contract.errors.where(:base, :single_plan)).to be_present
+      end
+
+      it "rejects both parents at the database level even past model validation" do
+        customer = create(:customer)
+        contract = build(
+          :contract,
+          organization: customer.organization,
+          customer:,
+          plan: create(:plan, organization: customer.organization),
+          catalog_plan: create(:catalog_plan, organization: customer.organization)
+        )
+
+        expect { contract.save(validate: false) }.to raise_error(ActiveRecord::StatementInvalid)
+      end
     end
 
     describe "live external id uniqueness (database)" do
@@ -123,6 +153,11 @@ RSpec.describe Contract do
 
     it "uses the customer currency for a plan-less contract" do
       expect(build(:contract, organization:, customer:, plan: nil).currency).to eq("USD")
+    end
+
+    it "uses the catalog plan currency when priced through one" do
+      catalog_plan = create(:catalog_plan, organization:, currency: "GBP")
+      expect(build(:contract, organization:, customer:, plan: nil, catalog_plan:).currency).to eq("GBP")
     end
 
     it "falls back to the organization default when the customer has none" do

--- a/spec/models/plan_rate_card_spec.rb
+++ b/spec/models/plan_rate_card_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe PlanRateCard do
   describe "associations" do
     it do
       expect(plan_rate_card).to belong_to(:organization)
-      expect(plan_rate_card).to belong_to(:plan)
+      expect(plan_rate_card).to belong_to(:plan).optional
+      expect(plan_rate_card).to belong_to(:catalog_plan).optional
       expect(plan_rate_card).to belong_to(:rate_card)
       expect(plan_rate_card).to have_many(:rate_phases).order(:position)
       expect(plan_rate_card).to have_one(:product).through(:rate_card)
@@ -52,6 +53,50 @@ RSpec.describe PlanRateCard do
 
         expect(build(:plan_rate_card, units: 0)).to be_valid
         expect(build(:plan_rate_card, units: nil)).to be_valid
+      end
+    end
+
+    describe "exactly one plan" do
+      let(:catalog_plan) { create(:catalog_plan) }
+
+      it "accepts a catalog plan instead of a plan" do
+        expect(build(:plan_rate_card, plan: nil, catalog_plan:, organization: catalog_plan.organization)).to be_valid
+      end
+
+      it "rejects both a plan and a catalog plan" do
+        card = build(:plan_rate_card, catalog_plan:)
+
+        expect(card).not_to be_valid
+        expect(card.errors.where(:base, :exactly_one_plan_required)).to be_present
+      end
+
+      it "rejects neither" do
+        card = build(:plan_rate_card, plan: nil)
+
+        expect(card).not_to be_valid
+        expect(card.errors.where(:base, :exactly_one_plan_required)).to be_present
+      end
+
+      it "scopes rate card uniqueness to the catalog plan" do
+        existing = create(:plan_rate_card, plan: nil, catalog_plan:, organization: catalog_plan.organization)
+        duplicate = build(:plan_rate_card, plan: nil, catalog_plan:, organization: catalog_plan.organization, rate_card: existing.rate_card)
+        duplicate.valid?
+
+        expect(duplicate.errors.where(:rate_card_id, :taken)).to be_present
+      end
+    end
+
+    describe "database parent guard" do
+      it "rejects a row with neither plan even past model validation" do
+        card = build(:plan_rate_card, plan: nil)
+
+        expect { card.save(validate: false) }.to raise_error(ActiveRecord::StatementInvalid)
+      end
+
+      it "rejects a row with both plans even past model validation" do
+        card = build(:plan_rate_card, catalog_plan: create(:catalog_plan))
+
+        expect { card.save(validate: false) }.to raise_error(ActiveRecord::StatementInvalid)
       end
     end
   end

--- a/spec/models/plan_rate_card_spec.rb
+++ b/spec/models/plan_rate_card_spec.rb
@@ -84,6 +84,19 @@ RSpec.describe PlanRateCard do
 
         expect(duplicate.errors.where(:rate_card_id, :taken)).to be_present
       end
+
+      it "counts a soft-deleted plan through its id" do
+        card = create(:plan_rate_card)
+        card.plan.discard!
+
+        expect(card.reload).to be_valid
+      end
+
+      it "counts an unsaved catalog plan through the association" do
+        unsaved = build(:catalog_plan)
+
+        expect(build(:plan_rate_card, plan: nil, catalog_plan: unsaved, organization: unsaved.organization)).to be_valid
+      end
     end
 
     describe "database parent guard" do


### PR DESCRIPTION
## What this is

The storage + association **repoint**: `plan_rate_cards` and `contracts` can now price through a **catalog** plan, not only a legacy one.

## Changes

- **`plan_rate_cards`**: nullable `catalog_plan_id` + FK; `plan_id` relaxed to nullable; a `num_nonnulls(plan_id, catalog_plan_id) = 1` check (NOT VALID → validated) keeps "exactly one plan"; a mirrored `(catalog_plan_id, rate_card_id)` partial-unique index matches the legacy `(plan_id, rate_card_id)` one. Rate-card uniqueness scope now includes `catalog_plan_id`.
- **`contracts`**: nullable `catalog_plan_id` + FK; a `num_nonnulls(plan_id, catalog_plan_id) <= 1` check — legacy plan, catalog plan, or plan-less, **never both**. `Contract#currency` resolves through the catalog plan.
- **`CatalogPlan`**: reverse `has_many :applied_rate_cards` (PlanRateCard) and `has_many :contracts`.