### PR TITLE
feat(events): recover missing pay-in-advance fees

### DIFF
--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -115,4 +115,249 @@ namespace :events do
   ensure
     Karafka.producer.close if reprocess
   end
+
+  # Recovers pay-in-advance fees for events that were persisted but never post-processed, because
+  # Kafka or Redis was down when they were ingested. Only the fee is recovered.
+  #
+  # Beware: on an invoiceable charge the replay also finalizes an invoice dated at the event
+  # timestamp, emails it and starts a payment. The dry-run report says how many are affected.
+  #
+  # Usage:
+  #   lago exec api bundle exec rails events:recover_pay_in_advance_fees \
+  #     ORGANIZATION_ID=<uuid> FROM=2026-08-22T00:00:00Z TO=2026-08-24T00:00:00Z [DRY_RUN=false]
+  #
+  # FROM/TO bound the event ingestion time, as [FROM, TO). DRY_RUN defaults to true (report only).
+  desc "Recover pay-in-advance fees for events that were never post-processed"
+  task recover_pay_in_advance_fees: :environment do
+    Rails.logger.level = Logger::Severity::INFO
+
+    prefix = "events:recover_pay_in_advance_fees"
+    batch_size = (ENV["BATCH_SIZE"] || 1000).to_i
+    organization = Organization.find(ENV.fetch("ORGANIZATION_ID"))
+    dry_run = ENV.fetch("DRY_RUN", "true") != "false"
+    mode = dry_run ? "DRY RUN" : "LIVE"
+
+    # `Time.zone.parse` returns nil rather than raising on input it cannot make sense of, and a nil
+    # bound silently drops the predicate: the run would then replay the whole event history.
+    from = Time.zone.parse(ENV.fetch("FROM")) or raise(ArgumentError, "FROM is not a parsable datetime")
+    to = Time.zone.parse(ENV.fetch("TO")) or raise(ArgumentError, "TO is not a parsable datetime")
+    raise ArgumentError, "FROM must be earlier than TO" unless from < to
+    raise ArgumentError, "BATCH_SIZE must be positive" unless batch_size.positive?
+
+    if organization.clickhouse_events_store?
+      Rails.logger.info(
+        "#{prefix} - Organization #{organization.id} uses the Clickhouse events store: " \
+        "events are not persisted in Postgres, so there is nothing to recover."
+      )
+      next
+    end
+
+    # `Charge belongs_to :billable_metric, -> { with_discarded }`, so the join carries no
+    # `deleted_at` predicate: a charge whose metric was discarded would be reported as recoverable
+    # while the replay creates nothing, because `Events::Common#billable_metric` resolves nothing.
+    # Discarded *plans* are deliberately kept: `Plans::DestroyService` does not discard the charges,
+    # so those events are still recoverable.
+    charges_by_plan_and_code = Charge.pay_in_advance
+      .where(organization_id: organization.id)
+      .joins(:billable_metric)
+      .where(billable_metrics: {deleted_at: nil})
+      .includes(:billable_metric)
+      .group_by { |charge| [charge.plan_id, charge.billable_metric.code] }
+
+    if charges_by_plan_and_code.empty?
+      Rails.logger.info("#{prefix} - Organization #{organization.id} has no pay-in-advance charge.")
+      next
+    end
+
+    codes = charges_by_plan_and_code.keys.map(&:last).uniq
+
+    # Not narrowed on subscription external ids: that would bind one parameter per subscription, and
+    # the per-event lookup below discards those events anyway.
+    scope = organization.events.where(created_at: from...to, code: codes)
+
+    recovered = 0
+    invoices_to_create = 0
+    not_due = 0
+    skipped = []
+    tainted_subscriptions = Set.new
+
+    # Cursored on (created_at, id) so the scan follows index_events_on_organization_id_and_created_at.
+    # The default primary-key cursor would paginate on a random uuid, re-sorting the whole remaining
+    # window on every batch.
+    scope.in_batches(of: batch_size, cursor: [:created_at, :id], order: :asc, load: true) do |events_in_batch|
+      # `group_by` preserves the SQL order, so `covering.first` below is what
+      # `Events::Common#subscription` resolves to.
+      subscriptions_by_external_id = organization.subscriptions
+        .where(external_id: events_in_batch.map(&:external_subscription_id).uniq)
+        .order(Arel.sql("terminated_at DESC NULLS FIRST, started_at DESC"))
+        .group_by(&:external_id)
+
+      candidates = events_in_batch.filter_map do |event|
+        covering = subscriptions_by_external_id.fetch(event.external_subscription_id, []).select do |candidate|
+          # `started_at` is nil until activation, and NULLS FIRST sorts those first. SQL drops them
+          # because the comparison is NULL; the same has to happen here.
+          next false if candidate.started_at.nil?
+
+          candidate.started_at.floor(3) <= event.timestamp &&
+            (candidate.terminated_at.nil? || candidate.terminated_at.floor(3) >= event.timestamp)
+        end
+
+        # Two resolutions disagree in production and both matter: the gate in
+        # `Events::PostProcessService#subscriptions` excludes incomplete subscriptions and decides
+        # whether a fee is created at all, while `Events::Common#subscription` ignores status and
+        # decides which plan's charges the replay bills.
+        replayed = covering.first
+        eligible = covering.find { |candidate| !candidate.incomplete? }
+
+        if eligible.nil?
+          reason = if replayed
+            "its only subscriptions are incomplete, which `Events::PostProcessService` skips, " \
+              "so no fee was created at ingestion either"
+          else
+            "no subscription covers its timestamp; a replay would create no fee"
+          end
+          skipped << [event.transaction_id, event.external_subscription_id, reason]
+          next
+        end
+
+        if replayed != eligible
+          skipped << [event.transaction_id, event.external_subscription_id,
+            "the subscription the replay would bill (#{replayed.id}) is not the one post-processing " \
+            "would have used (#{eligible.id}); recover it by hand"]
+          next
+        end
+
+        charges = charges_by_plan_and_code[[eligible.plan_id, event.code]]
+        if charges.blank?
+          not_due += 1
+          next
+        end
+
+        # The replay bills whatever the plan carries now, so a charge added after the event was
+        # ingested would be billed for a period it did not cover.
+        if charges.any? { |charge| charge.created_at > event.created_at }
+          skipped << [event.transaction_id, event.external_subscription_id,
+            "its plan gained a pay-in-advance charge after the event was ingested, so a replay " \
+            "would bill more than the original would have"]
+          next
+        end
+
+        billable_metric = charges.first.billable_metric
+        unless billable_metric.count_agg? ||
+            billable_metric.custom_agg? ||
+            event.properties[billable_metric.field_name].present?
+          not_due += 1
+          next
+        end
+
+        subscription = eligible
+
+        [event, subscription, charges, billable_metric]
+      end
+      next if candidates.empty?
+
+      transaction_ids = candidates.map { |event, _, _, _| event.transaction_id }
+
+      # No invoice_id filter: `Fee.from_organization_pay_in_advance` scopes to `invoice_id: nil` and
+      # would miss fees already billed.
+      charged_ids_by_transaction_id = Fee
+        .where(
+          organization_id: organization.id,
+          pay_in_advance: true,
+          original_fee_id: nil,
+          pay_in_advance_event_transaction_id: transaction_ids
+        )
+        .pluck(:pay_in_advance_event_transaction_id, :charge_id)
+        .group_by(&:first)
+        .transform_values { |rows| rows.map(&:last) }
+
+      # Every index on `pay_in_advance_event_transaction_id` is partial on `deleted_at IS NULL`, so
+      # including discarded fees in the query above would make all of them unusable.
+      uncharged = transaction_ids - charged_ids_by_transaction_id.keys
+      discarded_transaction_ids = if uncharged.empty?
+        Set.new
+      else
+        Fee.with_discarded
+          .where.not(deleted_at: nil)
+          .where(
+            organization_id: organization.id,
+            pay_in_advance: true,
+            original_fee_id: nil,
+            pay_in_advance_event_transaction_id: uncharged
+          )
+          .distinct
+          .pluck(:pay_in_advance_event_transaction_id)
+          .to_set
+      end
+
+      candidates.each do |event, subscription, charges, billable_metric|
+        charged_ids = charged_ids_by_transaction_id[event.transaction_id]
+
+        if charged_ids.present?
+          missing = charges.map(&:id) - charged_ids
+          if missing.any?
+            skipped << [event.transaction_id, event.external_subscription_id,
+              "charges #{missing.join(", ")} have no fee while others do, and " \
+              "`Events::PayInAdvanceService` skips the whole event once any fee exists"]
+          end
+          next
+        end
+
+        # The guard indexes ignore discarded rows, so a fee that was voided on purpose would look
+        # exactly like a missing one.
+        if discarded_transaction_ids.include?(event.transaction_id)
+          skipped << [event.transaction_id, event.external_subscription_id,
+            "its fees are all discarded, so they were either voided on purpose or already " \
+            "regenerated; check before recovering it by hand"]
+          next
+        end
+
+        # `Events::PayInAdvanceService` enqueues one `Invoices::CreatePayInAdvanceChargeJob` per
+        # invoiceable charge, and each mints its own invoice, so the blast radius is a count of
+        # charges rather than of events.
+        invoiceable_charges = charges.count(&:invoiceable?)
+        recovered += 1
+        invoices_to_create += invoiceable_charges
+        tainted_subscriptions << subscription.id unless billable_metric.count_agg?
+
+        Rails.logger.info(
+          "#{prefix} [#{mode}] - #{event.transaction_id} " \
+          "subscription=#{event.external_subscription_id} code=#{event.code} " \
+          "invoiceable_charges=#{invoiceable_charges}"
+        )
+
+        Events::PayInAdvanceJob.perform_later(Events::CommonFactory.new_instance(source: event).as_json) unless dry_run
+      end
+    end
+
+    skipped.each do |transaction_id, external_subscription_id, reason|
+      Rails.logger.warn(
+        "#{prefix} - SKIPPED #{transaction_id} (subscription=#{external_subscription_id}): #{reason}."
+      )
+    end
+
+    if tainted_subscriptions.any?
+      Rails.logger.warn(
+        "#{prefix} - Recovered events on subscriptions #{tainted_subscriptions.to_a.join(", ")} use an " \
+        "aggregation other than count_agg, so their units chain through cached aggregations. Where " \
+        "those billing periods contain decrements, the fees created for the events that followed the " \
+        "gap were computed without the missing rows and may over-bill. This task does not fix " \
+        "already-created fees."
+      )
+    end
+
+    if invoices_to_create.positive?
+      Rails.logger.warn(
+        "#{prefix} [#{mode}] - the replay creates #{invoices_to_create} invoice(s), one per " \
+        "invoiceable charge. Each is finalized and dated at the event timestamp, emailed, pushed to " \
+        "the accounting integrations, and has a payment started for it."
+      )
+    end
+
+    Rails.logger.info(
+      "#{prefix} [#{mode}] - #{recovered} event(s) to recover, #{skipped.size} skipped, " \
+      "#{not_due} with no fee due."
+    )
+    Rails.logger.info("#{prefix} - Run again with DRY_RUN=false to re-enqueue.") if dry_run && recovered.positive?
+  end
 end

--- a/spec/lib/tasks/events_rake_spec.rb
+++ b/spec/lib/tasks/events_rake_spec.rb
@@ -1,0 +1,486 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+require "rake"
+
+RSpec.describe "events:recover_pay_in_advance_fees" do # rubocop:disable RSpec/DescribeClass
+  subject(:invoke) { task.invoke }
+
+  let(:task) { Rake::Task["events:recover_pay_in_advance_fees"] }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: "sum_agg", field_name: "item_id") }
+  let(:charge) do
+    create(:standard_charge, :pay_in_advance, plan:, billable_metric:, organization:,
+      invoiceable: false, created_at: 10.days.ago)
+  end
+
+  let(:subscription) do
+    create(:subscription, customer:, organization:, plan:, started_at: 10.days.ago)
+  end
+
+  let(:ingested_at) { 3.days.ago.change(usec: 0) }
+
+  let(:event) do
+    create(
+      :event,
+      organization_id: organization.id,
+      subscription:,
+      code: billable_metric.code,
+      properties: {"item_id" => "12"},
+      timestamp: ingested_at,
+      created_at: ingested_at
+    )
+  end
+
+  before do
+    Rake.application.rake_require("tasks/events")
+    Rake::Task.define_task(:environment)
+    task.reenable
+
+    charge
+    event
+
+    ENV["ORGANIZATION_ID"] = organization.id
+    ENV["FROM"] = 4.days.ago.iso8601
+    ENV["TO"] = 2.days.ago.iso8601
+    ENV["DRY_RUN"] = "false"
+  end
+
+  after do
+    %w[ORGANIZATION_ID FROM TO DRY_RUN].each { ENV.delete(it) }
+  end
+
+  it "re-enqueues the event for pay-in-advance processing" do
+    expect { invoke }.to have_enqueued_job(Events::PayInAdvanceJob)
+      .with(hash_including("transaction_id" => event.transaction_id, "id" => event.id))
+  end
+
+  # Restricted to the fee-creating chain so the `fee.created` webhook is not delivered here.
+  it "actually creates the missing fee once the job runs" do
+    perform_enqueued_jobs(only: [Events::PayInAdvanceJob, Fees::CreatePayInAdvanceJob]) { invoke }
+
+    fee = Fee.find_by(pay_in_advance_event_transaction_id: event.transaction_id)
+    expect(fee).to have_attributes(charge_id: charge.id, subscription_id: subscription.id, units: 12)
+  end
+
+  context "when running in dry run mode" do
+    before { ENV["DRY_RUN"] = "true" }
+
+    it "does not enqueue anything" do
+      expect { invoke }.not_to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+  end
+
+  # Reporting only is the default, so an operator who forgets DRY_RUN cannot bill anyone.
+  context "when DRY_RUN is not set at all" do
+    before { ENV.delete("DRY_RUN") }
+
+    it "does not enqueue anything" do
+      expect { invoke }.not_to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+  end
+
+  context "when BATCH_SIZE is not a positive number" do
+    before { ENV["BATCH_SIZE"] = "oops" }
+
+    after { ENV.delete("BATCH_SIZE") }
+
+    it "raises instead of silently scanning nothing" do
+      expect { invoke }.to raise_error(ArgumentError, /BATCH_SIZE must be positive/)
+    end
+  end
+
+  context "when the fee already exists without an invoice" do
+    before do
+      create(
+        :charge_fee,
+        charge:,
+        subscription:,
+        organization:,
+        invoice: nil,
+        pay_in_advance: true,
+        pay_in_advance_event_id: event.id,
+        pay_in_advance_event_transaction_id: event.transaction_id
+      )
+    end
+
+    it "does not enqueue anything" do
+      expect { invoke }.not_to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+  end
+
+  # Regression: `Fee.from_organization_pay_in_advance` filters on `invoice_id: nil`, so the guard
+  # inside `Events::PayInAdvanceService` cannot see this fee. The task must not rely on it.
+  context "when the fee already exists and is attached to an invoice" do
+    before do
+      create(
+        :charge_fee,
+        charge:,
+        subscription:,
+        organization:,
+        invoice: create(:invoice, organization:, customer:),
+        pay_in_advance: true,
+        pay_in_advance_event_id: event.id,
+        pay_in_advance_event_transaction_id: event.transaction_id
+      )
+    end
+
+    it "does not enqueue anything" do
+      expect { invoke }.not_to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+  end
+
+  context "when the only fee was voided" do
+    before do
+      create(
+        :charge_fee,
+        charge:,
+        subscription:,
+        organization:,
+        invoice: nil,
+        pay_in_advance: true,
+        pay_in_advance_event_transaction_id: event.transaction_id
+      ).discard!
+    end
+
+    it "does not enqueue anything" do
+      expect { invoke }.not_to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+  end
+
+  context "when the charge is not pay in advance" do
+    let(:charge) { create(:standard_charge, plan:, billable_metric:, organization:, created_at: 10.days.ago) }
+
+    it "does not enqueue anything" do
+      expect { invoke }.not_to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+  end
+
+  context "when the aggregation requires a field that the event does not carry" do
+    let(:event) do
+      create(
+        :event,
+        organization_id: organization.id,
+        subscription:,
+        code: billable_metric.code,
+        properties: {},
+        timestamp: 3.days.ago,
+        created_at: 3.days.ago
+      )
+    end
+
+    it "does not enqueue anything" do
+      expect { invoke }.not_to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+  end
+
+  context "when the aggregation needs no field" do
+    let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: "count_agg") }
+    let(:event) do
+      create(
+        :event,
+        organization_id: organization.id,
+        subscription:,
+        code: billable_metric.code,
+        properties: {},
+        timestamp: 3.days.ago,
+        created_at: 3.days.ago
+      )
+    end
+
+    it "re-enqueues the event" do
+      expect { invoke }.to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+  end
+
+  # The window is documented as [FROM, TO), so an event ingested exactly at TO is out.
+  context "when the event was ingested exactly at the upper bound" do
+    before { ENV["TO"] = ingested_at.iso8601 }
+
+    it "does not enqueue anything" do
+      expect { invoke }.not_to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+  end
+
+  context "when the event was ingested exactly at the lower bound" do
+    before { ENV["FROM"] = ingested_at.iso8601 }
+
+    it "re-enqueues the event" do
+      expect { invoke }.to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+  end
+
+  context "when a bound is not a parsable datetime" do
+    before { ENV["FROM"] = "yesterday" }
+
+    it "raises instead of widening the window" do
+      expect { invoke }.to raise_error(ArgumentError, /FROM is not a parsable datetime/)
+    end
+  end
+
+  context "when the bounds are inverted" do
+    before { ENV["FROM"] = 1.day.ago.iso8601 }
+
+    it "raises" do
+      expect { invoke }.to raise_error(ArgumentError, /FROM must be earlier than TO/)
+    end
+  end
+
+  context "when the subscription was terminated before the event" do
+    let(:subscription) do
+      create(:subscription, customer:, organization:, plan:, started_at: 10.days.ago,
+        terminated_at: 5.days.ago, status: :terminated)
+    end
+
+    it "does not enqueue anything" do
+      expect { invoke }.not_to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+  end
+
+  # `Events::PostProcessService#subscriptions` excludes incomplete subscriptions, so no fee was
+  # created at ingestion time either and there is nothing to recover.
+  context "when the subscription is still incomplete" do
+    let(:subscription) do
+      create(:subscription, customer:, organization:, plan:, started_at: 10.days.ago, status: :incomplete)
+    end
+
+    it "does not enqueue anything" do
+      expect { invoke }.not_to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+
+    it "reports why, rather than dropping the event silently" do
+      allow(Rails.logger).to receive(:warn).and_call_original
+      invoke
+
+      expect(Rails.logger).to have_received(:warn).with(/its only subscriptions are incomplete/)
+    end
+  end
+
+  context "when the plan gained a pay-in-advance charge after the event" do
+    before { create(:standard_charge, :pay_in_advance, plan:, billable_metric:, organization:, invoiceable: false) }
+
+    it "skips the event rather than billing a charge that did not exist" do
+      expect { invoke }.not_to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+
+    it "reports why" do
+      allow(Rails.logger).to receive(:warn).and_call_original
+      invoke
+
+      expect(Rails.logger).to have_received(:warn).with(/gained a pay-in-advance charge/)
+    end
+  end
+
+  # The gate excludes incomplete subscriptions but `Events::Common#subscription` does not, so the
+  # replay would bill a different plan than post-processing would have.
+  context "when an incomplete subscription would be billed instead" do
+    let(:other_plan) { create(:plan, organization:) }
+
+    before do
+      create(:standard_charge, :pay_in_advance, plan: other_plan, billable_metric:, organization:,
+        created_at: 10.days.ago)
+      create(:subscription, customer:, organization:, plan: other_plan,
+        external_id: subscription.external_id, started_at: 10.days.ago, status: :incomplete)
+    end
+
+    it "skips the event rather than billing the wrong plan" do
+      expect { invoke }.not_to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+
+    it "reports the disagreement" do
+      allow(Rails.logger).to receive(:warn).and_call_original
+      invoke
+
+      expect(Rails.logger).to have_received(:warn).with(/is not the one post-processing would have used/)
+    end
+  end
+
+  # An upgrade leaves several subscriptions sharing one external_id, and the event must be matched
+  # against the one covering its timestamp, not the currently active one.
+  context "when the external id is shared with a later subscription" do
+    let(:new_plan) { create(:plan, organization:) }
+
+    # Ingested during the outage window, but carrying a timestamp from before the upgrade.
+    let(:event) do
+      create(
+        :event,
+        organization_id: organization.id,
+        subscription:,
+        code: billable_metric.code,
+        properties: {"item_id" => "12"},
+        timestamp: 6.days.ago,
+        created_at: 3.days.ago
+      )
+    end
+
+    before do
+      subscription.update!(terminated_at: 4.days.ago, status: :terminated)
+      create(:subscription, customer:, organization:, plan: new_plan, external_id: subscription.external_id,
+        started_at: 4.days.ago)
+    end
+
+    it "re-enqueues the event against the subscription that covers its timestamp" do
+      expect { invoke }.to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+
+    context "when only the later subscription carries the pay-in-advance charge" do
+      let(:charge) do
+        create(:standard_charge, :pay_in_advance, plan: new_plan, billable_metric:, organization:,
+          invoiceable: false, created_at: 10.days.ago)
+      end
+
+      it "does not enqueue anything" do
+        expect { invoke }.not_to have_enqueued_job(Events::PayInAdvanceJob)
+      end
+    end
+  end
+
+  context "when an active and a terminated subscription both cover the timestamp" do
+    let(:other_plan) { create(:plan, organization:) }
+
+    before do
+      create(:subscription, customer:, organization:, plan: other_plan, external_id: subscription.external_id,
+        started_at: 10.days.ago, terminated_at: 1.day.ago, status: :terminated)
+    end
+
+    it "prefers the active subscription, whose plan carries the charge" do
+      expect { invoke }.to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+  end
+
+  # `started_at` is nil until activation and NULLS FIRST sorts such a subscription first, so an
+  # unguarded in-memory comparison raises before anything is reported.
+  context "when a pending subscription shares the external id" do
+    before do
+      create(:subscription, :pending, customer:, organization:, plan:,
+        external_id: subscription.external_id)
+    end
+
+    it "re-enqueues the event against the activated subscription" do
+      expect { invoke }.to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+  end
+
+  # The charge associations are declared `with_discarded`, so the joins carry no `deleted_at`
+  # predicate and a discarded metric has to be excluded explicitly. `Events::PayInAdvanceService`
+  # would resolve no billable metric and create nothing.
+  context "when the billable metric is discarded" do
+    before { billable_metric.discard! }
+
+    it "does not enqueue anything" do
+      expect { invoke }.not_to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+  end
+
+  # `Plans::DestroyService` discards the plan but not its charges, and `Charge belongs_to :plan,
+  # -> { with_discarded }`, so the replay still resolves the charge and creates the fee.
+  context "when the plan is discarded" do
+    before { plan.discard! }
+
+    it "re-enqueues the event" do
+      expect { invoke }.to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+  end
+
+  context "when the charge is invoiceable" do
+    let(:charge) do
+      create(:standard_charge, :pay_in_advance, plan:, billable_metric:, organization:, created_at: 10.days.ago)
+    end
+
+    it "re-enqueues the event" do
+      expect { invoke }.to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+
+    it "warns that the replay finalizes invoices and starts payments" do
+      allow(Rails.logger).to receive(:warn).and_call_original
+      invoke
+
+      expect(Rails.logger).to have_received(:warn).with(/creates 1 invoice\(s\)/)
+    end
+
+    # One `Invoices::CreatePayInAdvanceChargeJob` per invoiceable charge, each minting its own
+    # invoice, so the count is of charges and not of events.
+    context "when the plan carries two invoiceable charges for the metric" do
+      before do
+        create(:standard_charge, :pay_in_advance, plan:, billable_metric:, organization:,
+          created_at: 10.days.ago)
+      end
+
+      it "counts one invoice per invoiceable charge" do
+        allow(Rails.logger).to receive(:warn).and_call_original
+        invoke
+
+        expect(Rails.logger).to have_received(:warn).with(/creates 2 invoice\(s\)/)
+      end
+    end
+  end
+
+  context "when only some of the charges have a fee" do
+    let(:other_charge) do
+      create(:standard_charge, :pay_in_advance, plan:, billable_metric:, organization:,
+        invoiceable: false, created_at: 10.days.ago)
+    end
+
+    before do
+      create(
+        :charge_fee,
+        charge: other_charge,
+        subscription:,
+        organization:,
+        invoice: nil,
+        pay_in_advance: true,
+        pay_in_advance_event_transaction_id: event.transaction_id
+      )
+    end
+
+    it "skips the event rather than enqueueing a partial replay" do
+      expect { invoke }.not_to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+  end
+
+  context "when the events span several batches" do
+    let(:other_events) do
+      [2, 1].map do |days|
+        create(
+          :event,
+          organization_id: organization.id,
+          subscription:,
+          code: billable_metric.code,
+          properties: {"item_id" => "12"},
+          timestamp: days.days.ago.change(usec: 0),
+          created_at: days.days.ago.change(usec: 0)
+        )
+      end
+    end
+
+    before do
+      ENV["BATCH_SIZE"] = "1"
+      ENV["TO"] = 1.minute.ago.iso8601
+      other_events
+    end
+
+    after { ENV.delete("BATCH_SIZE") }
+
+    it "walks every batch exactly once, oldest first" do
+      invoke
+
+      enqueued = ActiveJob::Base.queue_adapter.enqueued_jobs
+        .select { it[:job] == Events::PayInAdvanceJob }
+        .map { it[:args].first["transaction_id"] }
+
+      expect(enqueued).to eq([event, *other_events].map(&:transaction_id))
+    end
+  end
+
+  context "when the organization uses the Clickhouse events store" do
+    let(:organization) { create(:organization, clickhouse_events_store: true) }
+
+    it "does not enqueue anything" do
+      expect { invoke }.not_to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+  end
+end


### PR DESCRIPTION
Part of ING-606

## Context

`Events::CreateService` commits the event row, then enqueues `Events::PostProcessJob`. The two are not transactional and the rescue clauses cover only ActiveRecord errors, so when Kafka or Redis is down the row is committed and the job never runs: the event counts in usage but no pay-in-advance fee is created. Reposting the same `transaction_id` returns `value_already_exist` forever, and nothing replays post-processing over persisted Postgres events.

## Description

- Add `events:recover_pay_in_advance_fees`, reporting only unless `DRY_RUN=false`.
- Scope detection to one organization and a `created_at` window, keyed on `(transaction_id, charge_id)` like the fee duplication guard indexes.
- Re-enqueue `Events::PayInAdvanceJob` per recoverable event, oldest first.
- Report, rather than replay, events with no subscription covering their timestamp, a voided fee, or only partly billed charges.
- Do not repair fees created after the gap: those were priced without the missing cached aggregations.

Detection cannot reuse `already_processed?`: its scope filters `invoice_id: nil` and misses invoiced fees. Replay enters at `PayInAdvanceJob` because `PostProcessJob` raises `RecordNotUnique` in `Events::EnrichService` under `postgres_enriched_events`, and `PostProcessService` swallows that as success without creating the fee.
