### PR TITLE
feat(catalog): rename the pricing tables to catalog_plan

### DIFF
--- a/app/controllers/api/v2/contracts_controller.rb
+++ b/app/controllers/api/v2/contracts_controller.rb
@@ -36,7 +36,7 @@ module Api
         )
 
         if result.success?
-          contracts = result.contracts.includes(:plan, :customer)
+          contracts = result.contracts.includes(:catalog_plan, :customer)
 
           # One grouped query instead of one COUNT per row in the serializer.
           applied_rate_cards_counts = ContractRateCard.current_and_scheduled

--- a/app/controllers/api/v2/plan_rate_cards/rate_phases_controller.rb
+++ b/app/controllers/api/v2/plan_rate_cards/rate_phases_controller.rb
@@ -60,8 +60,8 @@ module Api
 
         def plan_rate_card
           @plan_rate_card ||= begin
-            plan = current_organization.plans.parents.find_by(code: params[:plan_code])
-            plan&.applied_rate_cards&.joins(:rate_card)&.find_by(rate_cards: {code: params[:applied_rate_card_code]})
+            catalog_plan = current_organization.catalog_plans.find_by(code: params[:plan_code])
+            catalog_plan&.applied_rate_cards&.joins(:rate_card)&.find_by(rate_cards: {code: params[:applied_rate_card_code]})
           end
         end
 

--- a/app/controllers/api/v2/plan_rate_cards_controller.rb
+++ b/app/controllers/api/v2/plan_rate_cards_controller.rb
@@ -7,7 +7,7 @@ module Api
 
       def create
         result = ::PlanRateCards::CreateService.call(
-          plan: find_plan,
+          catalog_plan: find_catalog_plan,
           params: create_params.to_h.deep_symbolize_keys
         )
 
@@ -52,7 +52,7 @@ module Api
       end
 
       def index
-        return not_found_error(resource: "plan") unless find_plan
+        return not_found_error(resource: "plan") unless find_catalog_plan
 
         result = ::PlanRateCardsQuery.call(
           organization: current_organization,
@@ -66,7 +66,7 @@ module Api
         if result.success?
           render(
             json: ::CollectionSerializer.new(
-              result.plan_rate_cards.includes(:plan, :rate_card, :rate_phases),
+              result.plan_rate_cards.includes(:catalog_plan, :rate_card, :rate_phases),
               ::V1::PlanRateCardSerializer,
               collection_name: "applied_rate_cards",
               meta: pagination_metadata(result.plan_rate_cards)
@@ -79,15 +79,15 @@ module Api
 
       private
 
-      def find_plan
-        current_organization.plans.parents.find_by(code: params[:plan_code])
+      def find_catalog_plan
+        current_organization.catalog_plans.find_by(code: params[:plan_code])
       end
 
       def find_plan_rate_card
-        plan = find_plan
-        return nil unless plan
+        catalog_plan = find_catalog_plan
+        return nil unless catalog_plan
 
-        plan.applied_rate_cards.joins(:rate_card).find_by(rate_cards: {code: params[:code]})
+        catalog_plan.applied_rate_cards.joins(:rate_card).find_by(rate_cards: {code: params[:code]})
       end
 
       def create_params

--- a/app/graphql/mutations/plan_applied_rate_cards/create.rb
+++ b/app/graphql/mutations/plan_applied_rate_cards/create.rb
@@ -16,9 +16,11 @@ module Mutations
       type Types::PlanAppliedRateCards::Object
 
       def resolve(**args)
-        plan = current_organization.plans.parents.find_by(id: args[:plan_id])
+        # The public argument stays `plan_id`; internally these plans live in
+        # the catalog_plans table.
+        catalog_plan = current_organization.catalog_plans.find_by(id: args[:plan_id])
 
-        result = ::PlanRateCards::CreateService.call(plan:, params: args.except(:plan_id))
+        result = ::PlanRateCards::CreateService.call(catalog_plan:, params: args.except(:plan_id))
 
         result.success? ? result.plan_rate_card : result_error(result)
       end

--- a/app/graphql/resolvers/plans_resolver.rb
+++ b/app/graphql/resolvers/plans_resolver.rb
@@ -11,19 +11,17 @@ module Resolvers
 
     argument :limit, Integer, required: false
     argument :page, Integer, required: false
-    argument :product_category_id, ID, required: false
     argument :search_term, String, required: false
     argument :with_deleted, Boolean, required: false
 
     type Types::Plans::Object.collection_type, null: false
 
-    def resolve(page: nil, limit: nil, search_term: nil, with_deleted: nil, product_category_id: nil)
+    def resolve(page: nil, limit: nil, search_term: nil, with_deleted: nil)
       result = PlansQuery.call(
         organization: current_organization,
         search_term:,
         filters: {
-          with_deleted:,
-          product_category_id:
+          with_deleted:
         },
         pagination: {
           page:,

--- a/app/graphql/sources/attached_to_subscriptions.rb
+++ b/app/graphql/sources/attached_to_subscriptions.rb
@@ -2,14 +2,11 @@
 
 module Sources
   # Batches RateCard#attached_to_subscriptions?: a card bills someone through
-  # a direct contract attachment or through a plan that has contracts. The
-  # Subscription check stays for catalog plans subscribed through v1 before
-  # contracts existed.
+  # a direct contract attachment or through a catalog plan that has contracts.
   class AttachedToSubscriptions < GraphQL::Dataloader::Source
     def fetch(ids)
       attached = ContractRateCard.where(rate_card_id: ids).distinct.pluck(:rate_card_id) |
-        PlanRateCard.where(rate_card_id: ids, plan_id: Contract.select(:plan_id)).distinct.pluck(:rate_card_id) |
-        PlanRateCard.where(rate_card_id: ids, plan_id: Subscription.select(:plan_id)).distinct.pluck(:rate_card_id)
+        PlanRateCard.where(rate_card_id: ids, catalog_plan_id: Contract.select(:catalog_plan_id)).distinct.pluck(:rate_card_id)
 
       ids.map { attached.include?(it) }
     end

--- a/app/graphql/types/contracts/object.rb
+++ b/app/graphql/types/contracts/object.rb
@@ -24,9 +24,9 @@ module Types
 
       field :customer, Types::Customers::Object, null: false
       # Nullable by design: a plan-less contract prices through directly
-      # attached rate cards. Exposed as `plan`; the record lives in
-      # catalog_plans.
-      field :plan, Types::Plans::Object, null: true
+      # attached rate cards. Exposed as `plan`, but the record lives in
+      # catalog_plans, so it carries the CatalogPlan type.
+      field :plan, Types::CatalogPlans::Object, null: true
 
       field :applied_rate_cards, [Types::ContractAppliedRateCards::Object], null: false
       field :applied_rate_cards_count, Integer, null: false

--- a/app/graphql/types/contracts/object.rb
+++ b/app/graphql/types/contracts/object.rb
@@ -6,7 +6,7 @@ module Types
       graphql_name "Contract"
       description "The agreement a customer signed: an optional plan, a validity window and the billing anchor"
 
-      dataload_association :customer, :plan
+      dataload_association :customer
 
       field :external_id, String, null: false
       field :id, ID, null: false
@@ -24,7 +24,8 @@ module Types
 
       field :customer, Types::Customers::Object, null: false
       # Nullable by design: a plan-less contract prices through directly
-      # attached rate cards.
+      # attached rate cards. Exposed as `plan`; the record lives in
+      # catalog_plans.
       field :plan, Types::Plans::Object, null: true
 
       field :applied_rate_cards, [Types::ContractAppliedRateCards::Object], null: false
@@ -36,6 +37,10 @@ module Types
       # Ended attachments are history, not cards the contract currently
       # carries. Batched across the collection so a list of contracts does not
       # fire one query per contract; both fields read the same loaded set.
+      def plan
+        dataloader.with(Sources::ActiveRecordAssociation, :catalog_plan).load(object)
+      end
+
       def applied_rate_cards
         dataloader.with(Sources::ContractCurrentRateCards).load(object.id)
       end

--- a/app/models/catalog_plan.rb
+++ b/app/models/catalog_plan.rb
@@ -12,6 +12,9 @@ class CatalogPlan < ApplicationRecord
 
   belongs_to :organization
 
+  has_many :applied_rate_cards, class_name: "PlanRateCard"
+  has_many :contracts
+
   has_many :coupon_targets
   has_many :coupons, through: :coupon_targets
   has_many :applied_taxes, class_name: "Plan::AppliedTax", dependent: :destroy
@@ -24,6 +27,12 @@ class CatalogPlan < ApplicationRecord
   validates :currency, presence: true, inclusion: {in: currency_list, allow_nil: true}
 
   default_scope -> { kept }
+
+  # A catalog plan is subscribed through contracts; any attachment freezes its
+  # pricing (its rate cards can no longer be edited).
+  def attached_to_contracts?
+    contracts.exists?
+  end
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[name code]

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -23,10 +23,10 @@ class Contract < ApplicationRecord
 
   belongs_to :organization
   # with_discarded: a terminated contract must still resolve its customer and
-  # plan after they are discarded — history, serializers and invoices read
-  # through these associations.
+  # catalog plan after they are discarded — history, serializers and invoices
+  # read through these associations.
   belongs_to :customer, -> { with_discarded }
-  belongs_to :plan, -> { with_discarded }, optional: true
+  belongs_to :catalog_plan, -> { with_discarded }, optional: true
 
   has_many :applied_rate_cards, class_name: "ContractRateCard"
   has_many :billing_segments
@@ -68,7 +68,7 @@ class Contract < ApplicationRecord
   # The currency fees bill in: the plan's when there is one, otherwise the
   # customer's (a plan-less contract), falling back to the organization default.
   def currency
-    plan&.amount_currency || customer.currency || organization.default_currency
+    catalog_plan&.currency || customer.currency || organization.default_currency
   end
 
   # The billing lifecycle a rate card inherits when attached: it starts on the
@@ -108,6 +108,7 @@ end
 #  terminated_at       :datetime
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  catalog_plan_id     :uuid
 #  customer_id         :uuid             not null
 #  external_id         :string           not null
 #  organization_id     :uuid             not null
@@ -115,6 +116,7 @@ end
 #
 # Indexes
 #
+#  index_contracts_on_catalog_plan_id                  (catalog_plan_id)
 #  index_contracts_on_customer_id                      (customer_id)
 #  index_contracts_on_live_external_id                 (organization_id,external_id,status) UNIQUE WHERE (status = ANY (ARRAY['pending'::contract_status, 'active'::contract_status]))
 #  index_contracts_on_organization_id                  (organization_id)
@@ -123,6 +125,7 @@ end
 #
 # Foreign Keys
 #
+#  fk_rails_...  (catalog_plan_id => catalog_plans.id)
 #  fk_rails_...  (customer_id => customers.id)
 #  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (plan_id => plans.id)

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -28,8 +28,6 @@ class Plan < ApplicationRecord
   has_many :coupons, through: :coupon_targets
   has_many :invoices, through: :subscriptions
   has_many :usage_thresholds
-  has_many :applied_rate_cards, class_name: "PlanRateCard"
-  has_many :products, through: :applied_rate_cards
 
   has_many :applied_taxes, class_name: "Plan::AppliedTax", dependent: :destroy
   has_many :taxes, through: :applied_taxes

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -22,7 +22,6 @@ class Plan < ApplicationRecord
   has_many :fixed_charges, dependent: :destroy
   has_many :add_ons, through: :fixed_charges
   has_many :subscriptions
-  has_many :contracts
   has_many :customers, through: :subscriptions
   has_many :children, class_name: "Plan", foreign_key: :parent_id, dependent: :destroy
   has_many :coupon_targets
@@ -91,10 +90,10 @@ class Plan < ApplicationRecord
     !pay_in_advance
   end
 
-  # A catalog plan is subscribed through contracts, a legacy plan through
-  # subscriptions; either attachment freezes the plan.
+  # A legacy plan is frozen once it has subscriptions. Catalog plans live in
+  # their own table and freeze on contracts (CatalogPlan#attached_to_contracts?).
   def attached_to_subscriptions?
-    subscriptions.exists? || contracts.exists?
+    subscriptions.exists?
   end
 
   def has_trial?

--- a/app/models/plan_rate_card.rb
+++ b/app/models/plan_rate_card.rb
@@ -7,20 +7,20 @@ class PlanRateCard < ApplicationRecord
   self.discard_column = :deleted_at
 
   belongs_to :organization
-  belongs_to :plan
+  belongs_to :catalog_plan
   belongs_to :rate_card
 
   has_one :product, through: :rate_card
 
   has_many :rate_phases, -> { order(:position) }
 
-  validates :rate_card_id, uniqueness: {scope: :plan_id, conditions: -> { where(deleted_at: nil) }}
+  validates :rate_card_id, uniqueness: {scope: :catalog_plan_id, conditions: -> { where(deleted_at: nil) }}
   validates :units, numericality: {greater_than_or_equal_to: 0}, allow_nil: true
 
   default_scope -> { kept }
 
   def edit_error_code
-    "plan_locked" if plan.attached_to_subscriptions?
+    "plan_locked" if catalog_plan.attached_to_contracts?
   end
 end
 
@@ -34,20 +34,23 @@ end
 #  units           :decimal(, )
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  catalog_plan_id :uuid
 #  organization_id :uuid             not null
-#  plan_id         :uuid             not null
+#  plan_id         :uuid
 #  rate_card_id    :uuid             not null
 #
 # Indexes
 #
-#  index_plan_rate_cards_on_deleted_at                (deleted_at)
-#  index_plan_rate_cards_on_organization_id           (organization_id)
-#  index_plan_rate_cards_on_plan_id                   (plan_id)
-#  index_plan_rate_cards_on_plan_id_and_rate_card_id  (plan_id,rate_card_id) UNIQUE WHERE (deleted_at IS NULL)
-#  index_plan_rate_cards_on_rate_card_id              (rate_card_id)
+#  index_plan_rate_cards_on_catalog_plan_id_and_rate_card_id  (catalog_plan_id,rate_card_id) UNIQUE WHERE (deleted_at IS NULL)
+#  index_plan_rate_cards_on_deleted_at                        (deleted_at)
+#  index_plan_rate_cards_on_organization_id                   (organization_id)
+#  index_plan_rate_cards_on_plan_id                           (plan_id)
+#  index_plan_rate_cards_on_plan_id_and_rate_card_id          (plan_id,rate_card_id) UNIQUE WHERE (deleted_at IS NULL)
+#  index_plan_rate_cards_on_rate_card_id                      (rate_card_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (catalog_plan_id => catalog_plans.id)
 #  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (plan_id => plans.id)
 #  fk_rails_...  (rate_card_id => rate_cards.id)

--- a/app/models/rate_card.rb
+++ b/app/models/rate_card.rb
@@ -88,15 +88,13 @@ class RateCard < ApplicationRecord
     %w[name code]
   end
 
-  # The card bills someone once it belongs to a plan that has contracts or is
-  # attached directly to a contract. From that point the billed timeline
+  # The card bills someone once it belongs to a catalog plan that has contracts
+  # or is attached directly to a contract. From that point the billed timeline
   # freezes — card fields, active and past rates — and price changes go
-  # through appended rates. The Subscription check stays for catalog plans
-  # subscribed through v1 before contracts existed.
+  # through appended rates.
   def attached_to_subscriptions?
     contract_applied_rate_cards.exists? ||
-      Contract.where(plan_id: plan_applied_rate_cards.select(:plan_id)).exists? ||
-      Subscription.where(plan_id: plan_applied_rate_cards.select(:plan_id)).exists?
+      Contract.where(catalog_plan_id: plan_applied_rate_cards.select(:catalog_plan_id)).exists?
   end
 
   # The active rate is the latest effective rate; later rates are pending and

--- a/app/queries/catalog_plans_query.rb
+++ b/app/queries/catalog_plans_query.rb
@@ -7,6 +7,9 @@ class CatalogPlansQuery < BaseQuery
     catalog_plans = base_scope.result
     catalog_plans = paginate(catalog_plans)
     catalog_plans = apply_consistent_ordering(catalog_plans)
+    # The serializer reads applied_rate_cards.size per plan; preload so the
+    # collection resolves the counts in one query instead of one per plan.
+    catalog_plans = catalog_plans.includes(:applied_rate_cards)
 
     result.catalog_plans = catalog_plans
     result

--- a/app/queries/contracts_query.rb
+++ b/app/queries/contracts_query.rb
@@ -29,7 +29,7 @@ class ContractsQuery < BaseQuery
   end
 
   def with_plan_code(scope)
-    scope.where(plan_id: organization.plans.where(code: filters.plan_code).select(:id))
+    scope.where(catalog_plan_id: organization.catalog_plans.where(code: filters.plan_code).select(:id))
   end
 
   def with_external_id(scope)

--- a/app/queries/plan_rate_cards_query.rb
+++ b/app/queries/plan_rate_cards_query.rb
@@ -22,10 +22,10 @@ class PlanRateCardsQuery < BaseQuery
   end
 
   def with_plan(scope)
-    scope.where(plan_id: filters.plan_id)
+    scope.where(catalog_plan_id: filters.plan_id)
   end
 
   def with_plan_code(scope)
-    scope.joins(:plan).where(plans: {code: filters.plan_code})
+    scope.joins(:catalog_plan).where(catalog_plans: {code: filters.plan_code})
   end
 end

--- a/app/queries/plans_query.rb
+++ b/app/queries/plans_query.rb
@@ -2,7 +2,7 @@
 
 class PlansQuery < BaseQuery
   Result = BaseResult[:plans]
-  Filters = BaseFilters[:with_deleted, :include_pending_deletion, :product_category_id, :pricing_type]
+  Filters = BaseFilters[:with_deleted, :include_pending_deletion, :pricing_type]
 
   def call
     plans = base_scope.result
@@ -21,19 +21,7 @@ class PlansQuery < BaseQuery
   def base_scope
     scope = Plan.parents.where(organization:)
     scope = scope.where(pricing_type: filters.pricing_type) if filters.pricing_type.present?
-    scope = with_product_category(scope)
     scope.ransack(search_params)
-  end
-
-  def with_product_category(scope)
-    return scope if filters.product_category_id.blank?
-
-    scope.where(
-      id: PlanRateCard
-        .joins(rate_card: :product)
-        .where(products: {product_category_id: filters.product_category_id})
-        .select(:plan_id)
-    )
   end
 
   def search_params

--- a/app/serializers/v1/plan_rate_card_serializer.rb
+++ b/app/serializers/v1/plan_rate_card_serializer.rb
@@ -5,7 +5,7 @@ module V1
     def serialize
       {
         lago_id: model.id,
-        plan_code: model.plan.code,
+        plan_code: model.catalog_plan.code,
         rate_card_code: model.rate_card.code,
         units: model.units,
         rate_phases_count: model.rate_phases.size,

--- a/app/serializers/v2/catalog_plan_serializer.rb
+++ b/app/serializers/v2/catalog_plan_serializer.rb
@@ -10,8 +10,7 @@ module V2
         code: model.code,
         description: model.description,
         currency: model.currency,
-        # Rate cards attach to catalog plans in a later slice; until then it is always 0.
-        applied_rate_cards_count: 0,
+        applied_rate_cards_count: model.applied_rate_cards.size,
         created_at: model.created_at.iso8601
       }
     end

--- a/app/serializers/v2/contract_serializer.rb
+++ b/app/serializers/v2/contract_serializer.rb
@@ -13,7 +13,7 @@ module V2
         lago_customer_id: model.customer_id,
         external_customer_id: model.customer.external_id,
         name: model.name,
-        plan_code: model.plan&.code,
+        plan_code: model.catalog_plan&.code,
         status: model.status,
         billing_time: model.billing_time,
         billing_anchor_date: model.billing_anchor_date&.iso8601,

--- a/app/services/catalog_plans/update_service.rb
+++ b/app/services/catalog_plans/update_service.rb
@@ -19,6 +19,13 @@ module CatalogPlans
     def call
       return result.not_found_failure!(resource: "plan") unless catalog_plan
 
+      # The currency is fixed once rate cards price against it: fees bill in the
+      # card currency and the invoice in the plan currency, so a change would
+      # desync already-attached cards.
+      if params.key?(:currency) && params[:currency] != catalog_plan.currency && catalog_plan.applied_rate_cards.exists?
+        return result.single_validation_failure!(field: :currency, error_code: "not_editable_with_applied_rate_cards")
+      end
+
       catalog_plan.name = params[:name] if params.key?(:name)
       catalog_plan.code = params[:code] if params.key?(:code)
       catalog_plan.description = params[:description] if params.key?(:description)

--- a/app/services/catalog_plans/update_service.rb
+++ b/app/services/catalog_plans/update_service.rb
@@ -19,10 +19,12 @@ module CatalogPlans
     def call
       return result.not_found_failure!(resource: "plan") unless catalog_plan
 
-      # The currency is fixed once rate cards price against it: fees bill in the
-      # card currency and the invoice in the plan currency, so a change would
-      # desync already-attached cards.
-      if params.key?(:currency) && params[:currency] != catalog_plan.currency && catalog_plan.applied_rate_cards.exists?
+      # The currency is fixed once anything prices against the plan — plan-level
+      # rate cards, or a contract (whose fees bill in the card currency and
+      # invoice in the plan currency). Changing it would desync already-attached
+      # cards from the currency they were validated against.
+      currency_change = params.key?(:currency) && params[:currency] != catalog_plan.currency
+      if currency_change && (catalog_plan.applied_rate_cards.exists? || catalog_plan.attached_to_contracts?)
         return result.single_validation_failure!(field: :currency, error_code: "not_editable_with_applied_rate_cards")
       end
 

--- a/app/services/contracts/create_service.rb
+++ b/app/services/contracts/create_service.rb
@@ -19,12 +19,8 @@ module Contracts
     def call
       return result.not_found_failure!(resource: "customer") unless customer
 
-      if params[:plan_code].present? && plan.nil?
+      if params[:plan_code].present? && catalog_plan.nil?
         return result.not_found_failure!(resource: "plan")
-      end
-
-      if plan && !plan.product_catalog?
-        return result.single_validation_failure!(field: :plan, error_code: "not_a_product_catalog_plan")
       end
 
       # Date columns: a malformed value would silently cast to nil instead of
@@ -54,7 +50,7 @@ module Contracts
       ActiveRecord::Base.transaction do
         contract = organization.contracts.create!(
           customer:,
-          plan:,
+          catalog_plan:,
           external_id: params[:external_id],
           name: params[:name],
           billing_time: params[:billing_time].presence || "calendar",
@@ -64,7 +60,7 @@ module Contracts
           status: started_at.future? ? :pending : :active
         )
 
-        Contracts::MaterializeRateCardsService.call!(contract:) if contract.plan
+        Contracts::MaterializeRateCardsService.call!(contract:) if contract.catalog_plan
 
         result.contract = contract
       end
@@ -91,8 +87,8 @@ module Contracts
       @customer ||= organization.customers.find_by(external_id: params[:external_customer_id])
     end
 
-    def plan
-      @plan ||= organization.plans.parents.find_by(code: params[:plan_code])
+    def catalog_plan
+      @catalog_plan ||= organization.catalog_plans.find_by(code: params[:plan_code])
     end
 
     # Read through the CustomerTimezone suffix: a datetime without an offset

--- a/app/services/contracts/materialize_rate_cards_service.rb
+++ b/app/services/contracts/materialize_rate_cards_service.rb
@@ -15,11 +15,11 @@ module Contracts
     end
 
     def call
-      return result unless contract.plan
+      return result unless contract.catalog_plan
 
       materialized = []
       ActiveRecord::Base.transaction do
-        contract.plan.applied_rate_cards.find_each do |plan_rate_card|
+        contract.catalog_plan.applied_rate_cards.find_each do |plan_rate_card|
           materialized << contract.applied_rate_cards.create!(
             organization: contract.organization,
             rate_card: plan_rate_card.rate_card,

--- a/app/services/plan_rate_cards/create_service.rb
+++ b/app/services/plan_rate_cards/create_service.rb
@@ -4,24 +4,19 @@ module PlanRateCards
   class CreateService < BaseService
     Result = BaseResult[:plan_rate_card]
 
-    def initialize(plan:, params:)
-      @plan = plan
+    def initialize(catalog_plan:, params:)
+      @catalog_plan = catalog_plan
       @params = params.to_h.with_indifferent_access
       super
     end
 
     def call
-      return result.not_found_failure!(resource: "plan") unless plan
+      return result.not_found_failure!(resource: "plan") unless catalog_plan
 
-      # A plan with subscriptions is immutable: pricing changes go through a new
-      # plan and a subscription migration.
-      if plan.attached_to_subscriptions?
+      # A plan with contracts is immutable: pricing changes go through a new
+      # plan and a contract migration.
+      if catalog_plan.attached_to_contracts?
         return result.single_validation_failure!(field: :plan, error_code: "plan_locked")
-      end
-
-      # On a legacy plan the config would be silently ignored by the v1 engine.
-      unless plan.product_catalog?
-        return result.single_validation_failure!(field: :plan, error_code: "legacy_plan")
       end
 
       rate_card = organization.rate_cards.find_by(code: params[:rate_card_code])
@@ -30,18 +25,18 @@ module PlanRateCards
       # Fees are billed in the card currency and the invoice in the plan
       # currency; a mismatch must fail at configuration time, not on the
       # first invoice.
-      if rate_card.currency != plan.amount_currency
+      if rate_card.currency != catalog_plan.currency
         return result.single_validation_failure!(field: :currency, error_code: "currency_does_not_match")
       end
 
-      plan.with_lock do
+      catalog_plan.with_lock do
         # One card per pricing slice: a plan may hold several cards of the same
         # item only when they cover different filter slices (default + EU, ...).
         if slice_already_priced?(rate_card)
           return result.single_validation_failure!(field: :rate_card, error_code: slice_error_code(rate_card))
         end
 
-        plan_rate_card = plan.applied_rate_cards.create!(
+        plan_rate_card = catalog_plan.applied_rate_cards.create!(
           organization:,
           rate_card:,
           units: params[:units]
@@ -70,7 +65,7 @@ module PlanRateCards
 
     private
 
-    attr_reader :plan, :params
+    attr_reader :catalog_plan, :params
 
     def slice_error_code(rate_card)
       if rate_card.product_filter_id
@@ -81,7 +76,7 @@ module PlanRateCards
     end
 
     def slice_already_priced?(rate_card)
-      plan.applied_rate_cards.joins(:rate_card).exists?(
+      catalog_plan.applied_rate_cards.joins(:rate_card).exists?(
         rate_cards: {
           product_id: rate_card.product_id,
           product_filter_id: rate_card.product_filter_id
@@ -90,7 +85,7 @@ module PlanRateCards
     end
 
     def organization
-      plan.organization
+      catalog_plan.organization
     end
   end
 end

--- a/app/services/plan_rate_cards/destroy_service.rb
+++ b/app/services/plan_rate_cards/destroy_service.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module PlanRateCards
-  # Removes a rate card from a plan. A plan with subscriptions is immutable:
-  # pricing changes go through a new plan and a subscription migration.
+  # Removes a rate card from a plan. A plan with contracts is immutable:
+  # pricing changes go through a new plan and a contract migration.
   class DestroyService < BaseService
     Result = BaseResult[:plan_rate_card]
 
@@ -14,7 +14,7 @@ module PlanRateCards
     def call
       return result.not_found_failure!(resource: "applied_rate_card") unless plan_rate_card
 
-      if plan_rate_card.plan.attached_to_subscriptions?
+      if plan_rate_card.catalog_plan.attached_to_contracts?
         return result.single_validation_failure!(field: :plan, error_code: "plan_locked")
       end
 

--- a/app/services/plan_rate_cards/update_service.rb
+++ b/app/services/plan_rate_cards/update_service.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module PlanRateCards
-  # Edits a plan's rate card entry. A plan with subscriptions is immutable:
-  # pricing changes go through a new plan and a subscription migration.
+  # Edits a plan's rate card entry. A plan with contracts is immutable:
+  # pricing changes go through a new plan and a contract migration.
   class UpdateService < BaseService
     Result = BaseResult[:plan_rate_card]
 
@@ -15,7 +15,7 @@ module PlanRateCards
     def call
       return result.not_found_failure!(resource: "applied_rate_card") unless plan_rate_card
 
-      if plan_rate_card.plan.attached_to_subscriptions?
+      if plan_rate_card.catalog_plan.attached_to_contracts?
         return result.single_validation_failure!(field: :plan, error_code: "plan_locked")
       end
 

--- a/app/services/plans/destroy_service.rb
+++ b/app/services/plans/destroy_service.rb
@@ -34,13 +34,6 @@ module Plans
       plan.entitlements.update_all(deleted_at: Time.current)
       # rubocop:enable Rails/SkipsModelValidations
 
-      # A kept attachment keeps its rate card frozen.
-      plan.applied_rate_cards.find_each do |entry|
-        RateOverride.where(id: entry.rate_phases.filter_map(&:rate_override_id)).discard_all!
-        entry.rate_phases.discard_all!
-      end
-      plan.applied_rate_cards.discard_all!
-
       plan.pending_deletion = false
       plan.discard!
 

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -22,11 +22,6 @@ module Plans
     def call
       return result.not_found_failure!(resource: "plan") unless plan
 
-      if params.key?(:amount_currency) && params[:amount_currency] != plan.amount_currency &&
-          plan.applied_rate_cards.exists?
-        return result.single_validation_failure!(field: :amount_currency, error_code: "not_editable_with_applied_rate_cards")
-      end
-
       if plan.product_catalog? || plan.organization.product_catalog_enabled?
         legacy_field = Plans::CreateService::LEGACY_PRICING_FIELDS.find { params.key?(it) }
         if legacy_field

--- a/db/migrate/20260905223041_add_catalog_plan_to_pricing_tables.rb
+++ b/db/migrate/20260905223041_add_catalog_plan_to_pricing_tables.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class AddCatalogPlanToPricingTables < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    # plan_rate_cards and contracts only ever pointed at product-catalog plans,
+    # which now live in catalog_plans. Repoint them there. The old plan_id stays
+    # as a dead nullable column, dropped in a follow-up once no row uses it.
+
+    # The composite unique index mirrors the legacy (plan_id, rate_card_id) one
+    # and serves catalog_plan_id FK lookups (leftmost), so no standalone index.
+    add_reference :plan_rate_cards, :catalog_plan, type: :uuid, null: true, index: false
+    add_foreign_key :plan_rate_cards, :catalog_plans, validate: false
+    add_index :plan_rate_cards, %i[catalog_plan_id rate_card_id],
+      unique: true,
+      where: "deleted_at IS NULL",
+      name: "index_plan_rate_cards_on_catalog_plan_id_and_rate_card_id",
+      algorithm: :concurrently
+    # New rows carry catalog_plan_id, not plan_id.
+    change_column_null :plan_rate_cards, :plan_id, true
+
+    add_reference :contracts, :catalog_plan, type: :uuid, null: true, index: {algorithm: :concurrently}
+    add_foreign_key :contracts, :catalog_plans, validate: false
+  end
+
+  def down
+    remove_foreign_key :contracts, :catalog_plans
+    remove_reference :contracts, :catalog_plan
+
+    change_column_null :plan_rate_cards, :plan_id, false
+    remove_index :plan_rate_cards, name: "index_plan_rate_cards_on_catalog_plan_id_and_rate_card_id"
+    remove_foreign_key :plan_rate_cards, :catalog_plans
+    remove_reference :plan_rate_cards, :catalog_plan
+  end
+end

--- a/db/migrate/20260905223042_validate_catalog_plan_pricing_foreign_keys.rb
+++ b/db/migrate/20260905223042_validate_catalog_plan_pricing_foreign_keys.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ValidateCatalogPlanPricingForeignKeys < ActiveRecord::Migration[8.0]
+  def up
+    validate_foreign_key :plan_rate_cards, :catalog_plans
+    validate_foreign_key :contracts, :catalog_plans
+  end
+
+  def down
+  end
+end

--- a/db/seeds/30_product_catalog.rb
+++ b/db/seeds/30_product_catalog.rb
@@ -98,14 +98,18 @@ unless ProductCategory.exists?(organization:, code: "cloud_platform")
     }
   )
 
-  # Seed a catalog plan for the offer. Rate cards attach to catalog plans in a
-  # later slice, so the plan is seeded on its own for now.
+  # Assign the rate card to a catalog plan so the catalog is wired into an offer.
   # CreateService takes the attributes as a single positional hash (it mirrors
   # the controller's permitted params), so pass them wrapped, not as keywords.
-  CatalogPlans::CreateService.call!({
+  catalog_plan = CatalogPlans::CreateService.call!({
     organization_id: organization.id,
     name: "Growth",
     code: "growth",
     currency: "USD"
-  })
+  }).catalog_plan
+
+  PlanRateCards::CreateService.call!(
+    catalog_plan:,
+    params: {rate_card_code: rate_card.code}
+  )
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -53,6 +53,7 @@ ALTER TABLE IF EXISTS ONLY public.usage_monitoring_triggered_alerts DROP CONSTRA
 ALTER TABLE IF EXISTS ONLY public.rate_cards_taxes DROP CONSTRAINT IF EXISTS fk_rails_e2dbfbb01e;
 ALTER TABLE IF EXISTS ONLY public.integration_collection_mappings DROP CONSTRAINT IF EXISTS fk_rails_e148d17c1f;
 ALTER TABLE IF EXISTS ONLY public.product_categories DROP CONSTRAINT IF EXISTS fk_rails_e13d306a35;
+ALTER TABLE IF EXISTS ONLY public.plan_rate_cards DROP CONSTRAINT IF EXISTS fk_rails_e05bca64df;
 ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk_rails_dfac602b2c;
 ALTER TABLE IF EXISTS ONLY public.credit_note_items DROP CONSTRAINT IF EXISTS fk_rails_dea748e529;
 ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS fk_rails_de7694c307;
@@ -198,6 +199,7 @@ ALTER TABLE IF EXISTS ONLY public.integrations DROP CONSTRAINT IF EXISTS fk_rail
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_75577c354e;
 ALTER TABLE IF EXISTS ONLY public.fixed_charge_events DROP CONSTRAINT IF EXISTS fk_rails_752665cc51;
 ALTER TABLE IF EXISTS ONLY public.fees_taxes DROP CONSTRAINT IF EXISTS fk_rails_745b4ca7dd;
+ALTER TABLE IF EXISTS ONLY public.contracts DROP CONSTRAINT IF EXISTS fk_rails_7418f461c3;
 ALTER TABLE IF EXISTS ONLY public.data_exports DROP CONSTRAINT IF EXISTS fk_rails_73d83e23b6;
 ALTER TABLE IF EXISTS ONLY public.invoice_connections DROP CONSTRAINT IF EXISTS fk_rails_7286421039;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alert_thresholds DROP CONSTRAINT IF EXISTS fk_rails_710f37148d;
@@ -580,6 +582,7 @@ DROP INDEX IF EXISTS public.index_plan_rate_cards_on_plan_id_and_rate_card_id;
 DROP INDEX IF EXISTS public.index_plan_rate_cards_on_plan_id;
 DROP INDEX IF EXISTS public.index_plan_rate_cards_on_organization_id;
 DROP INDEX IF EXISTS public.index_plan_rate_cards_on_deleted_at;
+DROP INDEX IF EXISTS public.index_plan_rate_cards_on_catalog_plan_id_and_rate_card_id;
 DROP INDEX IF EXISTS public.index_pending_vies_checks_on_organization_id;
 DROP INDEX IF EXISTS public.index_pending_vies_checks_on_customer_id;
 DROP INDEX IF EXISTS public.index_pending_vies_checks_on_billing_entity_id;
@@ -860,6 +863,7 @@ DROP INDEX IF EXISTS public.index_contracts_on_organization_id_and_external_id;
 DROP INDEX IF EXISTS public.index_contracts_on_organization_id;
 DROP INDEX IF EXISTS public.index_contracts_on_live_external_id;
 DROP INDEX IF EXISTS public.index_contracts_on_customer_id;
+DROP INDEX IF EXISTS public.index_contracts_on_catalog_plan_id;
 DROP INDEX IF EXISTS public.index_contract_rate_cards_on_rate_card_id;
 DROP INDEX IF EXISTS public.index_contract_rate_cards_on_organization_id;
 DROP INDEX IF EXISTS public.index_contract_rate_cards_on_next_billing_at;
@@ -2681,7 +2685,8 @@ CREATE TABLE public.contracts (
     terminated_at timestamp without time zone,
     canceled_at timestamp without time zone,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    catalog_plan_id uuid
 );
 
 
@@ -5404,12 +5409,13 @@ CREATE TABLE public.pending_vies_checks (
 CREATE TABLE public.plan_rate_cards (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     organization_id uuid NOT NULL,
-    plan_id uuid NOT NULL,
+    plan_id uuid,
     rate_card_id uuid NOT NULL,
     units numeric,
     deleted_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    catalog_plan_id uuid
 );
 
 
@@ -8652,6 +8658,13 @@ CREATE INDEX index_contract_rate_cards_on_rate_card_id ON public.contract_rate_c
 
 
 --
+-- Name: index_contracts_on_catalog_plan_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_contracts_on_catalog_plan_id ON public.contracts USING btree (catalog_plan_id);
+
+
+--
 -- Name: index_contracts_on_customer_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10609,6 +10622,13 @@ CREATE UNIQUE INDEX index_pending_vies_checks_on_customer_id ON public.pending_v
 --
 
 CREATE INDEX index_pending_vies_checks_on_organization_id ON public.pending_vies_checks USING btree (organization_id);
+
+
+--
+-- Name: index_plan_rate_cards_on_catalog_plan_id_and_rate_card_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_plan_rate_cards_on_catalog_plan_id_and_rate_card_id ON public.plan_rate_cards USING btree (catalog_plan_id, rate_card_id) WHERE (deleted_at IS NULL);
 
 
 --
@@ -13366,6 +13386,14 @@ ALTER TABLE ONLY public.data_exports
 
 
 --
+-- Name: contracts fk_rails_7418f461c3; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.contracts
+    ADD CONSTRAINT fk_rails_7418f461c3 FOREIGN KEY (catalog_plan_id) REFERENCES public.catalog_plans(id);
+
+
+--
 -- Name: fees_taxes fk_rails_745b4ca7dd; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -14526,6 +14554,14 @@ ALTER TABLE ONLY public.customer_metadata
 
 
 --
+-- Name: plan_rate_cards fk_rails_e05bca64df; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.plan_rate_cards
+    ADD CONSTRAINT fk_rails_e05bca64df FOREIGN KEY (catalog_plan_id) REFERENCES public.catalog_plans(id);
+
+
+--
 -- Name: product_categories fk_rails_e13d306a35; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -14884,6 +14920,8 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260905223042'),
+('20260905223041'),
 ('20260904173416'),
 ('20260904173415'),
 ('20260904132835'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -1497,7 +1497,7 @@ type Contract {
   externalId: String!
   id: ID!
   name: String
-  plan: Plan
+  plan: CatalogPlan
   startedAt: ISO8601DateTime
   status: ContractStatusEnum!
   terminatedAt: ISO8601DateTime

--- a/schema.graphql
+++ b/schema.graphql
@@ -12222,7 +12222,7 @@ type Query {
   """
   Query plans of an organization
   """
-  plans(limit: Int, page: Int, productCategoryId: ID, searchTerm: String, withDeleted: Boolean): PlanCollection!
+  plans(limit: Int, page: Int, searchTerm: String, withDeleted: Boolean): PlanCollection!
 
   """
   Query the pricing unit

--- a/schema.json
+++ b/schema.json
@@ -66037,18 +66037,6 @@
                   "deprecationReason": null
                 },
                 {
-                  "name": "productCategoryId",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
                   "name": "searchTerm",
                   "description": null,
                   "type": {

--- a/schema.json
+++ b/schema.json
@@ -8987,7 +8987,7 @@
               "args": [],
               "type": {
                 "kind": "OBJECT",
-                "name": "Plan",
+                "name": "CatalogPlan",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/spec/factories/contracts.rb
+++ b/spec/factories/contracts.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :contract do
     customer
     organization { customer&.organization || association(:organization) }
-    plan { nil }
+    catalog_plan { nil }
     status { :active }
     external_id { SecureRandom.uuid }
     billing_time { :calendar }

--- a/spec/factories/plan_rate_cards.rb
+++ b/spec/factories/plan_rate_cards.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :plan_rate_card do
     organization
-    plan { association(:plan, organization:) }
+    catalog_plan { association(:catalog_plan, organization:) }
     rate_card { association(:rate_card, organization:) }
     units { nil }
   end

--- a/spec/graphql/mutations/catalog_plans/update_spec.rb
+++ b/spec/graphql/mutations/catalog_plans/update_spec.rb
@@ -31,6 +31,19 @@ RSpec.describe Mutations::CatalogPlans::Update do
 
   it_behaves_like "requires permission", "plans:update"
 
+  context "when the plan holds rate card attachments" do
+    let(:catalog_plan) { create(:catalog_plan, organization:, currency: "EUR") }
+    let(:input) { {id: catalog_plan.id, currency: "USD"} }
+
+    before { create(:plan_rate_card, organization:, catalog_plan:) }
+
+    it "reports the frozen currency under the input field name" do
+      error = result.dig("errors", 0, "extensions", "details")
+
+      expect(error["currency"]).to eq(["not_editable_with_applied_rate_cards"])
+    end
+  end
+
   it "updates the plan" do
     expect(result["data"]["updateCatalogPlan"]["name"]).to eq("Renamed")
     expect(catalog_plan.reload.name).to eq("Renamed")

--- a/spec/graphql/mutations/contracts/create_spec.rb
+++ b/spec/graphql/mutations/contracts/create_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe Mutations::Contracts::Create do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, :product_catalog, organization:) }
+  let(:catalog_plan) { create(:catalog_plan, organization:) }
 
   let(:input) do
     {
       externalCustomerId: customer.external_id,
       externalId: "contract-1",
-      planCode: plan.code
+      planCode: catalog_plan.code
     }
   end
 
@@ -45,7 +45,7 @@ RSpec.describe Mutations::Contracts::Create do
   it_behaves_like "requires permission", "contracts:create"
 
   it "creates a contract and materializes the plan's rate cards" do
-    create(:plan_rate_card, organization:, plan:, rate_card: create(:rate_card, organization:))
+    create(:plan_rate_card, organization:, catalog_plan:, rate_card: create(:rate_card, organization:))
 
     result_data = execution["data"]["createContract"]
 
@@ -53,7 +53,7 @@ RSpec.describe Mutations::Contracts::Create do
     expect(result_data["externalId"]).to eq("contract-1")
     expect(result_data["status"]).to eq("active")
     expect(result_data["billingTime"]).to eq("calendar")
-    expect(result_data["plan"]["id"]).to eq(plan.id)
+    expect(result_data["plan"]["id"]).to eq(catalog_plan.id)
     expect(result_data["appliedRateCardsCount"]).to eq(1)
   end
 

--- a/spec/graphql/mutations/plan_applied_rate_cards/create_spec.rb
+++ b/spec/graphql/mutations/plan_applied_rate_cards/create_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe Mutations::PlanAppliedRateCards::Create do
     )
   end
 
-  let(:input) { {planId: plan.id, rateCardCode: rate_card.code, units: 10.0} }
+  let(:input) { {planId: catalog_plan.id, rateCardCode: rate_card.code, units: 10.0} }
 
   let(:required_permission) { "plans:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:plan) { create(:plan, :product_catalog, organization:) }
+  let(:catalog_plan) { create(:catalog_plan, organization:) }
   let(:rate_card) { create(:rate_card, organization:) }
 
   let(:mutation) do
@@ -51,7 +51,7 @@ RSpec.describe Mutations::PlanAppliedRateCards::Create do
   context "with nested rate phases" do
     let(:input) do
       {
-        planId: plan.id,
+        planId: catalog_plan.id,
         rateCardCode: rate_card.code,
         ratePhases: [
           {code: "launch", position: 1, name: "Launch", billingIntervalCycleCount: 3},
@@ -67,7 +67,7 @@ RSpec.describe Mutations::PlanAppliedRateCards::Create do
     end
 
     context "when the list is explicitly empty" do
-      let(:input) { {planId: plan.id, rateCardCode: rate_card.code, ratePhases: []} }
+      let(:input) { {planId: catalog_plan.id, rateCardCode: rate_card.code, ratePhases: []} }
 
       it "returns an error" do
         expect_graphql_error(result: execution, message: :unprocessable_entity)

--- a/spec/graphql/resolvers/contract_resolver_spec.rb
+++ b/spec/graphql/resolvers/contract_resolver_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Resolvers::ContractResolver do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
-  let(:catalog_plan) { create(:catalog_plan, organization:) }
+  let(:catalog_plan) { create(:catalog_plan, organization:, code: "premium", currency: "EUR") }
   let(:contract) { create(:contract, organization:, customer:, catalog_plan:) }
 
   let(:query) do
@@ -26,7 +26,7 @@ RSpec.describe Resolvers::ContractResolver do
         contract(id: $contractId) {
           id externalId status billingTime
           customer { id }
-          plan { id }
+          plan { id code name currency }
           appliedRateCards { id rateCard { id } effectiveDate }
           appliedRateCardsCount
         }
@@ -45,7 +45,12 @@ RSpec.describe Resolvers::ContractResolver do
 
     expect(response["id"]).to eq(contract.id)
     expect(response["customer"]["id"]).to eq(customer.id)
-    expect(response["plan"]["id"]).to eq(catalog_plan.id)
+    expect(response["plan"]).to eq(
+      "id" => catalog_plan.id,
+      "code" => "premium",
+      "name" => catalog_plan.name,
+      "currency" => "EUR"
+    )
     expect(response["appliedRateCards"].sole["id"]).to eq(card.id)
     expect(response["appliedRateCardsCount"]).to eq(1)
   end

--- a/spec/graphql/resolvers/contract_resolver_spec.rb
+++ b/spec/graphql/resolvers/contract_resolver_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe Resolvers::ContractResolver do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, :product_catalog, organization:) }
-  let(:contract) { create(:contract, organization:, customer:, plan:) }
+  let(:catalog_plan) { create(:catalog_plan, organization:) }
+  let(:contract) { create(:contract, organization:, customer:, catalog_plan:) }
 
   let(:query) do
     <<~GQL
@@ -45,7 +45,7 @@ RSpec.describe Resolvers::ContractResolver do
 
     expect(response["id"]).to eq(contract.id)
     expect(response["customer"]["id"]).to eq(customer.id)
-    expect(response["plan"]["id"]).to eq(plan.id)
+    expect(response["plan"]["id"]).to eq(catalog_plan.id)
     expect(response["appliedRateCards"].sole["id"]).to eq(card.id)
     expect(response["appliedRateCardsCount"]).to eq(1)
   end

--- a/spec/graphql/resolvers/plan_applied_rate_cards_resolver_spec.rb
+++ b/spec/graphql/resolvers/plan_applied_rate_cards_resolver_spec.rb
@@ -9,15 +9,15 @@ RSpec.describe Resolvers::PlanAppliedRateCardsResolver do
       current_organization: organization,
       permissions: required_permission,
       query:,
-      variables: {planId: plan.id}
+      variables: {planId: catalog_plan.id}
     )
   end
 
   let(:required_permission) { "plans:view" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization:) }
-  let!(:plan_rate_card) { create(:plan_rate_card, organization:, plan:) }
+  let(:catalog_plan) { create(:catalog_plan, organization:) }
+  let!(:plan_rate_card) { create(:plan_rate_card, organization:, catalog_plan:) }
 
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/plans_resolver_spec.rb
+++ b/spec/graphql/resolvers/plans_resolver_spec.rb
@@ -77,40 +77,4 @@ RSpec.describe Resolvers::PlansResolver do
       expect(plans_response["metadata"]["totalCount"]).to eq(2)
     end
   end
-
-  context "when filtering by product_category_id" do
-    let(:product_category) { create(:product_category, organization:) }
-    let(:other_plan) { create(:plan, organization:) }
-    let(:query) do
-      <<~GQL
-        query($productCategoryId: ID!) {
-          plans(limit: 5, productCategoryId: $productCategoryId) {
-            collection { id }
-            metadata { totalCount }
-          }
-        }
-      GQL
-    end
-
-    before do
-      other_plan
-      item = create(:product, organization:, product_category:)
-      rate_card = create(:rate_card, organization:, product: item)
-      create(:plan_rate_card, organization:, plan:, rate_card:)
-    end
-
-    it "returns only the plans linked to the product_category" do
-      result = execute_graphql(
-        current_user: membership.user,
-        current_organization: organization,
-        permissions: required_permission,
-        query:,
-        variables: {productCategoryId: product_category.id}
-      )
-
-      plans_response = result["data"]["plans"]
-      expect(plans_response["collection"].map { |p| p["id"] }).to eq([plan.id])
-      expect(plans_response["metadata"]["totalCount"]).to eq(1)
-    end
-  end
 end

--- a/spec/graphql/sources/attached_to_subscriptions_spec.rb
+++ b/spec/graphql/sources/attached_to_subscriptions_spec.rb
@@ -9,26 +9,21 @@ RSpec.describe Sources::AttachedToSubscriptions do
   let(:product) { create(:product, organization:) }
 
   describe "#fetch" do
-    it "flags cards billed directly or through a subscribed plan" do
+    it "flags cards billed directly or through a plan that has contracts" do
       direct = create(:rate_card, organization:, product:)
       create(:contract_rate_card, organization:, rate_card: direct)
 
-      through_plan = create(:rate_card, organization:, product:)
-      plan = create(:plan, organization:)
-      create(:plan_rate_card, organization:, plan:, rate_card: through_plan)
-      create(:subscription, organization:, plan:)
-
       through_contracted_plan = create(:rate_card, organization:, product:)
-      contracted_plan = create(:plan, organization:)
-      create(:plan_rate_card, organization:, plan: contracted_plan, rate_card: through_contracted_plan)
-      create(:contract, organization:, plan: contracted_plan)
+      contracted_plan = create(:catalog_plan, organization:)
+      create(:plan_rate_card, organization:, catalog_plan: contracted_plan, rate_card: through_contracted_plan)
+      create(:contract, organization:, catalog_plan: contracted_plan)
 
-      plan_without_subscription = create(:rate_card, organization:, product:)
-      create(:plan_rate_card, organization:, rate_card: plan_without_subscription)
+      plan_without_contract = create(:rate_card, organization:, product:)
+      create(:plan_rate_card, organization:, rate_card: plan_without_contract)
 
-      result = source.fetch([direct.id, through_plan.id, through_contracted_plan.id, plan_without_subscription.id])
+      result = source.fetch([direct.id, through_contracted_plan.id, plan_without_contract.id])
 
-      expect(result).to eq([true, true, true, false])
+      expect(result).to eq([true, true, false])
     end
   end
 end

--- a/spec/models/catalog_plan_spec.rb
+++ b/spec/models/catalog_plan_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe CatalogPlan do
   describe "associations" do
     it do
       expect(catalog_plan).to belong_to(:organization)
+      expect(catalog_plan).to have_many(:applied_rate_cards).class_name("PlanRateCard")
+      expect(catalog_plan).to have_many(:contracts)
       expect(catalog_plan).to have_many(:coupon_targets)
       expect(catalog_plan).to have_many(:coupons).through(:coupon_targets)
       expect(catalog_plan).to have_many(:applied_taxes).class_name("Plan::AppliedTax").dependent(:destroy)
@@ -50,6 +52,16 @@ RSpec.describe CatalogPlan do
 
         expect(build(:catalog_plan, organization:, code: "dup")).to be_valid
       end
+    end
+  end
+
+  describe "#attached_to_contracts?" do
+    it "is true once a contract references the catalog plan" do
+      catalog_plan = create(:catalog_plan)
+      expect(catalog_plan.attached_to_contracts?).to be(false)
+
+      create(:contract, organization: catalog_plan.organization, catalog_plan:)
+      expect(catalog_plan.attached_to_contracts?).to be(true)
     end
   end
 

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -24,21 +24,21 @@ RSpec.describe Contract do
     it do
       expect(contract).to belong_to(:organization)
       expect(contract).to belong_to(:customer)
-      expect(contract).to belong_to(:plan).optional
+      expect(contract).to belong_to(:catalog_plan).optional
       expect(contract).to have_many(:applied_rate_cards).class_name("ContractRateCard")
       expect(contract).to have_many(:billing_segments)
     end
 
-    it "resolves a discarded customer and plan" do
+    it "resolves a discarded customer and catalog plan" do
       customer = create(:customer)
-      plan = create(:plan, organization: customer.organization)
-      contract = create(:contract, customer:, plan:, organization: customer.organization)
+      catalog_plan = create(:catalog_plan, organization: customer.organization)
+      contract = create(:contract, customer:, catalog_plan:, organization: customer.organization)
 
       customer.discard!
-      plan.discard!
+      catalog_plan.discard!
 
       expect(contract.reload.customer).to eq(customer)
-      expect(contract.plan).to eq(plan)
+      expect(contract.catalog_plan).to eq(catalog_plan)
     end
   end
 
@@ -117,17 +117,17 @@ RSpec.describe Contract do
     let(:customer) { create(:customer, organization:, currency: "USD") }
 
     it "prefers the plan currency over the customer currency" do
-      plan = create(:plan, organization:, amount_currency: "EUR")
-      expect(build(:contract, organization:, customer:, plan:).currency).to eq("EUR")
+      catalog_plan = create(:catalog_plan, organization:, currency: "EUR")
+      expect(build(:contract, organization:, customer:, catalog_plan:).currency).to eq("EUR")
     end
 
     it "uses the customer currency for a plan-less contract" do
-      expect(build(:contract, organization:, customer:, plan: nil).currency).to eq("USD")
+      expect(build(:contract, organization:, customer:, catalog_plan: nil).currency).to eq("USD")
     end
 
     it "falls back to the organization default when the customer has none" do
       no_currency = create(:customer, organization:, currency: nil)
-      contract = build(:contract, organization:, customer: no_currency, plan: nil)
+      contract = build(:contract, organization:, customer: no_currency, catalog_plan: nil)
 
       expect(contract.currency).to eq(organization.default_currency)
     end

--- a/spec/models/plan_rate_card_spec.rb
+++ b/spec/models/plan_rate_card_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe PlanRateCard do
   describe "associations" do
     it do
       expect(plan_rate_card).to belong_to(:organization)
-      expect(plan_rate_card).to belong_to(:plan)
+      expect(plan_rate_card).to belong_to(:catalog_plan)
       expect(plan_rate_card).to belong_to(:rate_card)
       expect(plan_rate_card).to have_many(:rate_phases).order(:position)
       expect(plan_rate_card).to have_one(:product).through(:rate_card)
@@ -18,26 +18,26 @@ RSpec.describe PlanRateCard do
   end
 
   describe "validations" do
-    describe "uniqueness of (plan, rate_card)" do
-      it "rejects a duplicate plan / rate_card pair" do
+    describe "uniqueness of (catalog_plan, rate_card)" do
+      it "rejects a duplicate catalog_plan / rate_card pair" do
         existing = create(:plan_rate_card)
         duplicate = build(
           :plan_rate_card,
           organization: existing.organization,
-          plan: existing.plan,
+          catalog_plan: existing.catalog_plan,
           rate_card: existing.rate_card
         )
         duplicate.valid?
         expect(duplicate.errors.where(:rate_card_id, :taken)).to be_present
       end
 
-      it "allows a different rate_card on the same plan" do
+      it "allows a different rate_card on the same catalog_plan" do
         existing = create(:plan_rate_card)
         other_card = create(:rate_card, organization: existing.organization)
         sibling = build(
           :plan_rate_card,
           organization: existing.organization,
-          plan: existing.plan,
+          catalog_plan: existing.catalog_plan,
           rate_card: other_card
         )
         expect(sibling).to be_valid
@@ -57,13 +57,13 @@ RSpec.describe PlanRateCard do
   end
 
   describe "#edit_error_code" do
-    it "is nil while the plan has no subscriptions" do
+    it "is nil while the plan has no contracts" do
       expect(create(:plan_rate_card).edit_error_code).to be_nil
     end
 
-    it "is plan_locked once the plan has subscriptions" do
+    it "is plan_locked once the plan has contracts" do
       card = create(:plan_rate_card)
-      create(:subscription, plan: card.plan)
+      create(:contract, organization: card.organization, catalog_plan: card.catalog_plan)
 
       expect(card.edit_error_code).to eq("plan_locked")
     end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe Plan do
     expect(subject).to have_many(:fixed_charges).dependent(:destroy)
     expect(subject).to have_many(:add_ons).through(:fixed_charges)
     expect(subject).to have_many(:subscriptions)
-    expect(subject).to have_many(:contracts)
     expect(subject).to have_many(:customers).through(:subscriptions)
     expect(subject).to have_many(:children).class_name("Plan").dependent(:destroy)
     expect(subject).to have_many(:coupon_targets)

--- a/spec/models/rate_card_spec.rb
+++ b/spec/models/rate_card_spec.rb
@@ -188,29 +188,21 @@ RSpec.describe RateCard do
       expect(rate_card.attached_to_subscriptions?).to be(false)
     end
 
-    it "is false when on a plan without subscriptions" do
+    it "is false when on a catalog plan without contracts" do
       create(:plan_rate_card, organization: rate_card.organization, rate_card:)
 
       expect(rate_card.attached_to_subscriptions?).to be(false)
     end
 
-    it "is true when on a plan that has subscriptions" do
-      plan = create(:plan, organization: rate_card.organization)
-      create(:plan_rate_card, organization: rate_card.organization, plan:, rate_card:)
-      create(:subscription, plan:, organization: rate_card.organization)
+    it "is true when on a catalog plan that has contracts" do
+      catalog_plan = create(:catalog_plan, organization: rate_card.organization)
+      create(:plan_rate_card, organization: rate_card.organization, catalog_plan:, rate_card:)
+      create(:contract, catalog_plan:, organization: rate_card.organization)
 
       expect(rate_card.attached_to_subscriptions?).to be(true)
     end
 
-    it "is true when on a plan that has contracts" do
-      plan = create(:plan, organization: rate_card.organization)
-      create(:plan_rate_card, organization: rate_card.organization, plan:, rate_card:)
-      create(:contract, plan:, organization: rate_card.organization)
-
-      expect(rate_card.attached_to_subscriptions?).to be(true)
-    end
-
-    it "is true when attached directly to a subscription" do
+    it "is true when attached directly to a contract" do
       create(:contract_rate_card, organization: rate_card.organization, rate_card:)
 
       expect(rate_card.attached_to_subscriptions?).to be(true)

--- a/spec/queries/catalog_plans_query_spec.rb
+++ b/spec/queries/catalog_plans_query_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe CatalogPlansQuery do
     expect(result.catalog_plans).to match_array([catalog_plan])
   end
 
+  it "preloads applied_rate_cards so the collection avoids a count per plan" do
+    create(:plan_rate_card, organization:, catalog_plan:)
+
+    expect(result.catalog_plans.first.association(:applied_rate_cards)).to be_loaded
+  end
+
   context "with a search term" do
     let(:search_term) { "grow" }
 

--- a/spec/queries/contracts_query_spec.rb
+++ b/spec/queries/contracts_query_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe ContractsQuery do
 
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, :product_catalog, organization:) }
+  let(:catalog_plan) { create(:catalog_plan, organization:) }
   let(:filters) { {} }
 
-  let!(:contract) { create(:contract, organization:, customer:, plan:) }
+  let!(:contract) { create(:contract, organization:, customer:, catalog_plan:) }
   let!(:other_contract) { create(:contract, organization:) }
 
   before { create(:contract) }
@@ -28,7 +28,7 @@ RSpec.describe ContractsQuery do
   end
 
   context "when filtering by plan_code" do
-    let(:filters) { {plan_code: plan.code} }
+    let(:filters) { {plan_code: catalog_plan.code} }
 
     it "returns the plan's contracts" do
       expect(result.contracts).to contain_exactly(contract)

--- a/spec/queries/plan_rate_cards_query_spec.rb
+++ b/spec/queries/plan_rate_cards_query_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe PlanRateCardsQuery, type: :query do
   let(:pagination) { nil }
   let(:filters) { {} }
 
-  let(:plan) { create(:plan, organization:) }
-  let!(:plan_rate_card) { create(:plan_rate_card, organization:, plan:) }
+  let(:catalog_plan) { create(:catalog_plan, organization:) }
+  let!(:plan_rate_card) { create(:plan_rate_card, organization:, catalog_plan:) }
   let!(:other_plan_rate_card) { create(:plan_rate_card, organization:) }
 
   it "returns all plan products of the organization" do
@@ -19,7 +19,7 @@ RSpec.describe PlanRateCardsQuery, type: :query do
   end
 
   context "when filtering by plan_id" do
-    let(:filters) { {plan_id: plan.id} }
+    let(:filters) { {plan_id: catalog_plan.id} }
 
     it "returns only the plan's products" do
       expect(result.plan_rate_cards).to eq([plan_rate_card])
@@ -27,7 +27,7 @@ RSpec.describe PlanRateCardsQuery, type: :query do
   end
 
   context "when filtering by plan_code" do
-    let(:filters) { {plan_code: plan.code} }
+    let(:filters) { {plan_code: catalog_plan.code} }
 
     it "returns only the plan's products" do
       expect(result.plan_rate_cards).to eq([plan_rate_card])

--- a/spec/queries/plans_query_spec.rb
+++ b/spec/queries/plans_query_spec.rb
@@ -89,20 +89,4 @@ RSpec.describe PlansQuery do
       expect(returned_ids).not_to include(plan_third.id)
     end
   end
-
-  context "when filtering by product_category_id" do
-    let(:product_category) { create(:product_category, organization:) }
-    let(:filters) { {product_category_id: product_category.id} }
-
-    before do
-      item = create(:product, organization:, product_category:)
-      rate_card = create(:rate_card, organization:, product: item)
-      create(:plan_rate_card, organization:, plan: plan_first, rate_card:)
-    end
-
-    it "returns only the plans linked to the product_category" do
-      expect(result).to be_success
-      expect(returned_ids).to eq([plan_first.id])
-    end
-  end
 end

--- a/spec/requests/api/v2/contracts_controller_spec.rb
+++ b/spec/requests/api/v2/contracts_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Api::V2::ContractsController do
   let(:organization) { create(:organization, feature_flags: ["product_catalog"]) }
   let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, :product_catalog, organization:) }
+  let(:catalog_plan) { create(:catalog_plan, organization:) }
 
   describe "POST /api/v2/contracts" do
     subject { post_with_token(organization, "/api/v2/contracts", {contract: create_params}) }
@@ -14,7 +14,7 @@ RSpec.describe Api::V2::ContractsController do
       {
         external_customer_id: customer.external_id,
         external_id: "contract-1",
-        plan_code: plan.code
+        plan_code: catalog_plan.code
       }
     end
 
@@ -22,13 +22,13 @@ RSpec.describe Api::V2::ContractsController do
 
     it "creates the contract and returns it with its materialized rate cards" do
       rate_card = create(:rate_card, organization:)
-      create(:plan_rate_card, organization:, plan:, rate_card:, units: 2)
+      create(:plan_rate_card, organization:, catalog_plan:, rate_card:, units: 2)
 
       subject
 
       expect(response).to have_http_status(:success)
       expect(json[:contract][:external_id]).to eq("contract-1")
-      expect(json[:contract][:plan_code]).to eq(plan.code)
+      expect(json[:contract][:plan_code]).to eq(catalog_plan.code)
       expect(json[:contract][:status]).to eq("active")
       expect(json[:contract][:applied_rate_cards_count]).to eq(1)
       expect(json[:contract][:applied_rate_cards].sole[:rate_card_code]).to eq(rate_card.code)
@@ -71,7 +71,7 @@ RSpec.describe Api::V2::ContractsController do
   describe "GET /api/v2/contracts" do
     subject { get_with_token(organization, "/api/v2/contracts") }
 
-    let!(:contract) { create(:contract, organization:, customer:, plan:) }
+    let!(:contract) { create(:contract, organization:, customer:, catalog_plan:) }
 
     include_examples "requires API permission", "contract", "read"
 
@@ -114,7 +114,7 @@ RSpec.describe Api::V2::ContractsController do
   describe "GET /api/v2/contracts/:external_id" do
     subject { get_with_token(organization, "/api/v2/contracts/#{contract.external_id}") }
 
-    let!(:contract) { create(:contract, organization:, customer:, plan:) }
+    let!(:contract) { create(:contract, organization:, customer:, catalog_plan:) }
 
     include_examples "requires API permission", "contract", "read"
 

--- a/spec/requests/api/v2/plan_rate_cards/rate_phases_controller_spec.rb
+++ b/spec/requests/api/v2/plan_rate_cards/rate_phases_controller_spec.rb
@@ -4,12 +4,12 @@ require "rails_helper"
 
 RSpec.describe Api::V2::PlanRateCards::RatePhasesController do
   let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
+  let(:catalog_plan) { create(:catalog_plan, organization:) }
   let(:rate_card) { create(:rate_card, organization:) }
-  let!(:plan_rate_card) { create(:plan_rate_card, organization:, plan:, rate_card:) }
+  let!(:plan_rate_card) { create(:plan_rate_card, organization:, catalog_plan:, rate_card:) }
 
   describe "GET /api/v2/plans/:plan_code/applied_rate_cards/:rate_card_code/rate_phases" do
-    subject { get_with_token(organization, "/api/v2/plans/#{plan.code}/applied_rate_cards/#{rate_card.code}/rate_phases") }
+    subject { get_with_token(organization, "/api/v2/plans/#{catalog_plan.code}/applied_rate_cards/#{rate_card.code}/rate_phases") }
 
     let!(:rate_phase) { create(:rate_phase, organization:, plan_rate_card:, position: 1) }
 
@@ -24,7 +24,7 @@ RSpec.describe Api::V2::PlanRateCards::RatePhasesController do
     end
 
     context "when the plan rate card does not exist" do
-      subject { get_with_token(organization, "/api/v2/plans/#{plan.code}/applied_rate_cards/unknown/rate_phases") }
+      subject { get_with_token(organization, "/api/v2/plans/#{catalog_plan.code}/applied_rate_cards/unknown/rate_phases") }
 
       it "returns a not found error" do
         subject
@@ -36,7 +36,7 @@ RSpec.describe Api::V2::PlanRateCards::RatePhasesController do
 
   describe "POST /api/v2/plans/:plan_code/applied_rate_cards/:rate_card_code/rate_phases" do
     subject do
-      post_with_token(organization, "/api/v2/plans/#{plan.code}/applied_rate_cards/#{rate_card.code}/rate_phases", {rate_phase: phase_params})
+      post_with_token(organization, "/api/v2/plans/#{catalog_plan.code}/applied_rate_cards/#{rate_card.code}/rate_phases", {rate_phase: phase_params})
     end
 
     let!(:terminal) { create(:rate_phase, organization:, plan_rate_card:, position: 1, billing_interval_cycle_count: nil) }
@@ -89,7 +89,7 @@ RSpec.describe Api::V2::PlanRateCards::RatePhasesController do
     subject do
       put_with_token(
         organization,
-        "/api/v2/plans/#{plan.code}/applied_rate_cards/#{rate_card.code}/rate_phases/#{rate_phase.code}",
+        "/api/v2/plans/#{catalog_plan.code}/applied_rate_cards/#{rate_card.code}/rate_phases/#{rate_phase.code}",
         {rate_phase: {name: "Renamed"}}
       )
     end
@@ -109,7 +109,7 @@ RSpec.describe Api::V2::PlanRateCards::RatePhasesController do
       subject do
         put_with_token(
           organization,
-          "/api/v2/plans/#{plan.code}/applied_rate_cards/#{rate_card.code}/rate_phases/#{rate_phase.code}",
+          "/api/v2/plans/#{catalog_plan.code}/applied_rate_cards/#{rate_card.code}/rate_phases/#{rate_phase.code}",
           {rate_phase: {name: "Renamed", position: 4}}
         )
       end
@@ -126,7 +126,7 @@ RSpec.describe Api::V2::PlanRateCards::RatePhasesController do
       subject do
         put_with_token(
           organization,
-          "/api/v2/plans/#{plan.code}/applied_rate_cards/#{rate_card.code}/rate_phases/#{rate_phase.code}",
+          "/api/v2/plans/#{catalog_plan.code}/applied_rate_cards/#{rate_card.code}/rate_phases/#{rate_phase.code}",
           {rate_phase: {rate_override: nil}}
         )
       end
@@ -149,7 +149,7 @@ RSpec.describe Api::V2::PlanRateCards::RatePhasesController do
       subject do
         put_with_token(
           organization,
-          "/api/v2/plans/#{plan.code}/applied_rate_cards/#{rate_card.code}/rate_phases/#{rate_phase.code}",
+          "/api/v2/plans/#{catalog_plan.code}/applied_rate_cards/#{rate_card.code}/rate_phases/#{rate_phase.code}",
           {rate_phase: {rate_override: {}}}
         )
       end
@@ -170,7 +170,7 @@ RSpec.describe Api::V2::PlanRateCards::RatePhasesController do
       subject do
         put_with_token(
           organization,
-          "/api/v2/plans/#{plan.code}/applied_rate_cards/#{rate_card.code}/rate_phases/#{rate_phase.code}",
+          "/api/v2/plans/#{catalog_plan.code}/applied_rate_cards/#{rate_card.code}/rate_phases/#{rate_phase.code}",
           {}
         )
       end
@@ -186,7 +186,7 @@ RSpec.describe Api::V2::PlanRateCards::RatePhasesController do
       subject do
         put_with_token(
           organization,
-          "/api/v2/plans/#{plan.code}/applied_rate_cards/#{rate_card.code}/rate_phases/#{rate_phase.code}",
+          "/api/v2/plans/#{catalog_plan.code}/applied_rate_cards/#{rate_card.code}/rate_phases/#{rate_phase.code}",
           {rate_phase: {rate_override: {rate_model: "standard", rate_properties: {amount: "0.02"}, billing_timing: "advance"}}}
         )
       end
@@ -204,7 +204,7 @@ RSpec.describe Api::V2::PlanRateCards::RatePhasesController do
       subject do
         put_with_token(
           organization,
-          "/api/v2/plans/#{plan.code}/applied_rate_cards/#{rate_card.code}/rate_phases/unknown",
+          "/api/v2/plans/#{catalog_plan.code}/applied_rate_cards/#{rate_card.code}/rate_phases/unknown",
           {rate_phase: {name: "Renamed"}}
         )
       end
@@ -219,7 +219,7 @@ RSpec.describe Api::V2::PlanRateCards::RatePhasesController do
 
   describe "DELETE /api/v2/plans/:plan_code/applied_rate_cards/:rate_card_code/rate_phases/:code" do
     subject do
-      delete_with_token(organization, "/api/v2/plans/#{plan.code}/applied_rate_cards/#{rate_card.code}/rate_phases/#{terminal.code}")
+      delete_with_token(organization, "/api/v2/plans/#{catalog_plan.code}/applied_rate_cards/#{rate_card.code}/rate_phases/#{terminal.code}")
     end
 
     let!(:launch) { create(:rate_phase, organization:, plan_rate_card:, position: 1, billing_interval_cycle_count: 3) }

--- a/spec/requests/api/v2/plan_rate_cards_controller_spec.rb
+++ b/spec/requests/api/v2/plan_rate_cards_controller_spec.rb
@@ -4,13 +4,13 @@ require "rails_helper"
 
 RSpec.describe Api::V2::PlanRateCardsController do
   let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, :product_catalog, organization:) }
+  let(:catalog_plan) { create(:catalog_plan, organization:) }
   let(:rate_card) { create(:rate_card, organization:) }
 
   describe "POST /api/v2/plans/:plan_code/applied_rate_cards" do
     subject { post_with_token(organization, "/api/v2/plans/#{plan_code}/applied_rate_cards", {applied_rate_card: create_params}) }
 
-    let(:plan_code) { plan.code }
+    let(:plan_code) { catalog_plan.code }
     let(:create_params) do
       {rate_card_code: rate_card.code, units: "10"}
     end
@@ -22,7 +22,7 @@ RSpec.describe Api::V2::PlanRateCardsController do
 
       expect(response).to have_http_status(:success)
       expect(json[:applied_rate_card][:lago_id]).to be_present
-      expect(json[:applied_rate_card][:plan_code]).to eq(plan.code)
+      expect(json[:applied_rate_card][:plan_code]).to eq(catalog_plan.code)
       expect(json[:applied_rate_card][:rate_card_code]).to eq(rate_card.code)
       expect(json[:applied_rate_card][:rate_phases_count]).to eq(1)
     end
@@ -51,8 +51,8 @@ RSpec.describe Api::V2::PlanRateCardsController do
   describe "GET /api/v2/plans/:plan_code/applied_rate_cards" do
     subject { get_with_token(organization, "/api/v2/plans/#{plan_code}/applied_rate_cards") }
 
-    let(:plan_code) { plan.code }
-    let!(:plan_rate_card) { create(:plan_rate_card, organization:, plan:) }
+    let(:plan_code) { catalog_plan.code }
+    let!(:plan_rate_card) { create(:plan_rate_card, organization:, catalog_plan:) }
 
     before { create(:plan_rate_card, organization:) }
 
@@ -78,7 +78,7 @@ RSpec.describe Api::V2::PlanRateCardsController do
 
   context "with a nested rate_phases sequence" do
     subject do
-      post_with_token(organization, "/api/v2/plans/#{plan.code}/applied_rate_cards", {applied_rate_card: {
+      post_with_token(organization, "/api/v2/plans/#{catalog_plan.code}/applied_rate_cards", {applied_rate_card: {
         rate_card_code: rate_card.code,
         units: "1",
         rate_phases: [
@@ -98,7 +98,7 @@ RSpec.describe Api::V2::PlanRateCardsController do
 
     context "when the list is explicitly empty" do
       subject do
-        post_with_token(organization, "/api/v2/plans/#{plan.code}/applied_rate_cards", {applied_rate_card: {
+        post_with_token(organization, "/api/v2/plans/#{catalog_plan.code}/applied_rate_cards", {applied_rate_card: {
           rate_card_code: rate_card.code, rate_phases: []
         }})
       end
@@ -113,9 +113,9 @@ RSpec.describe Api::V2::PlanRateCardsController do
   end
 
   describe "GET /api/v2/plans/:plan_code/applied_rate_cards/:code" do
-    subject { get_with_token(organization, "/api/v2/plans/#{plan.code}/applied_rate_cards/#{plan_rate_card.rate_card.code}") }
+    subject { get_with_token(organization, "/api/v2/plans/#{catalog_plan.code}/applied_rate_cards/#{plan_rate_card.rate_card.code}") }
 
-    let(:plan_rate_card) { create(:plan_rate_card, organization:, plan:) }
+    let(:plan_rate_card) { create(:plan_rate_card, organization:, catalog_plan:) }
 
     include_examples "requires API permission", "plan_rate_card", "read"
 
@@ -127,7 +127,7 @@ RSpec.describe Api::V2::PlanRateCardsController do
     end
 
     context "when it does not exist" do
-      subject { get_with_token(organization, "/api/v2/plans/#{plan.code}/applied_rate_cards/unknown") }
+      subject { get_with_token(organization, "/api/v2/plans/#{catalog_plan.code}/applied_rate_cards/unknown") }
 
       it "returns a not found error" do
         subject
@@ -138,9 +138,9 @@ RSpec.describe Api::V2::PlanRateCardsController do
   end
 
   describe "PUT /api/v2/plans/:plan_code/applied_rate_cards/:code" do
-    subject { put_with_token(organization, "/api/v2/plans/#{plan.code}/applied_rate_cards/#{plan_rate_card.rate_card.code}", {applied_rate_card: {units: "12"}}) }
+    subject { put_with_token(organization, "/api/v2/plans/#{catalog_plan.code}/applied_rate_cards/#{plan_rate_card.rate_card.code}", {applied_rate_card: {units: "12"}}) }
 
-    let(:plan_rate_card) { create(:plan_rate_card, organization:, plan:, units: 5) }
+    let(:plan_rate_card) { create(:plan_rate_card, organization:, catalog_plan:, units: 5) }
 
     include_examples "requires API permission", "plan_rate_card", "write"
 
@@ -151,8 +151,8 @@ RSpec.describe Api::V2::PlanRateCardsController do
       expect(json[:applied_rate_card][:units]).to eq("12.0")
     end
 
-    context "when the plan has subscriptions" do
-      before { create(:subscription, plan:, organization:) }
+    context "when the plan has contracts" do
+      before { create(:contract, catalog_plan:, organization:) }
 
       it "returns a validation error" do
         subject
@@ -162,7 +162,7 @@ RSpec.describe Api::V2::PlanRateCardsController do
     end
 
     context "when it does not exist" do
-      subject { put_with_token(organization, "/api/v2/plans/#{plan.code}/applied_rate_cards/unknown", {applied_rate_card: {units: "12"}}) }
+      subject { put_with_token(organization, "/api/v2/plans/#{catalog_plan.code}/applied_rate_cards/unknown", {applied_rate_card: {units: "12"}}) }
 
       it "returns a not found error" do
         subject
@@ -173,9 +173,9 @@ RSpec.describe Api::V2::PlanRateCardsController do
   end
 
   describe "DELETE /api/v2/plans/:plan_code/applied_rate_cards/:code" do
-    subject { delete_with_token(organization, "/api/v2/plans/#{plan.code}/applied_rate_cards/#{plan_rate_card.rate_card.code}") }
+    subject { delete_with_token(organization, "/api/v2/plans/#{catalog_plan.code}/applied_rate_cards/#{plan_rate_card.rate_card.code}") }
 
-    let(:plan_rate_card) { create(:plan_rate_card, organization:, plan:) }
+    let(:plan_rate_card) { create(:plan_rate_card, organization:, catalog_plan:) }
 
     include_examples "requires API permission", "plan_rate_card", "write"
 
@@ -183,11 +183,11 @@ RSpec.describe Api::V2::PlanRateCardsController do
       subject
 
       expect(response).to have_http_status(:success)
-      expect(plan.reload.applied_rate_cards).to be_empty
+      expect(catalog_plan.reload.applied_rate_cards).to be_empty
     end
 
-    context "when the plan has subscriptions" do
-      before { create(:subscription, plan:, organization:) }
+    context "when the plan has contracts" do
+      before { create(:contract, catalog_plan:, organization:) }
 
       it "returns a validation error" do
         subject

--- a/spec/requests/api/v2/plans_controller_spec.rb
+++ b/spec/requests/api/v2/plans_controller_spec.rb
@@ -145,14 +145,13 @@ RSpec.describe Api::V2::PlansController do
     end
   end
 
-  # A plan created through this surface is a CatalogPlan, while the nested
-  # applied_rate_cards routes still resolve their parent as a legacy Plan. Until
-  # a later slice repoints the pricing tables onto CatalogPlan, attaching a rate
-  # card to a plan born here cleanly reports the parent as not found.
+  # A plan created through this surface is a CatalogPlan, and the nested
+  # applied_rate_cards routes resolve their parent from catalog_plans too, so
+  # the create-then-attach flow works end to end.
   describe "attaching a rate card to a catalog plan" do
-    let(:rate_card) { create(:rate_card, organization:) }
+    let(:rate_card) { create(:rate_card, organization:, currency: "USD") }
 
-    it "does not find the parent plan yet" do
+    it "attaches the rate card to the plan created here" do
       post_with_token(organization, "/api/v2/plans", {plan: {name: "Growth", code: "growth", currency: "USD"}})
       expect(response).to have_http_status(:success)
 
@@ -162,7 +161,9 @@ RSpec.describe Api::V2::PlansController do
         {applied_rate_card: {rate_card_code: rate_card.code}}
       )
 
-      expect(response).to be_not_found_error("plan")
+      expect(response).to have_http_status(:success)
+      expect(json[:applied_rate_card][:plan_code]).to eq("growth")
+      expect(json[:applied_rate_card][:rate_card_code]).to eq(rate_card.code)
     end
   end
 end

--- a/spec/requests/api/v2/plans_controller_spec.rb
+++ b/spec/requests/api/v2/plans_controller_spec.rb
@@ -108,12 +108,14 @@ RSpec.describe Api::V2::PlansController do
 
     it "lists the organization catalog plans" do
       create(:catalog_plan)
+      create_list(:plan_rate_card, 2, organization:, catalog_plan:)
 
       subject
 
       expect(response).to have_http_status(:success)
       expect(json[:plans].map { it[:lago_id] }).to eq([catalog_plan.id])
       expect(json[:plans].first[:currency]).to eq(catalog_plan.currency)
+      expect(json[:plans].first[:applied_rate_cards_count]).to eq(2)
       expect(json[:plans].first).not_to have_key(:interval)
       expect(json[:meta][:total_count]).to eq(1)
     end

--- a/spec/serializers/v2/catalog_plan_serializer_spec.rb
+++ b/spec/serializers/v2/catalog_plan_serializer_spec.rb
@@ -20,4 +20,10 @@ RSpec.describe V2::CatalogPlanSerializer do
       "created_at" => catalog_plan.created_at.iso8601
     )
   end
+
+  it "counts the plan's applied rate cards" do
+    create(:plan_rate_card, organization: catalog_plan.organization, catalog_plan:)
+
+    expect(result["plan"]["applied_rate_cards_count"]).to eq(1)
+  end
 end

--- a/spec/services/catalog_plans/update_service_spec.rb
+++ b/spec/services/catalog_plans/update_service_spec.rb
@@ -52,4 +52,23 @@ RSpec.describe CatalogPlans::UpdateService do
       expect(Utils::ActivityLog).not_to have_produced("plan.updated")
     end
   end
+
+  context "when changing the currency of a plan holding applied rate cards" do
+    let(:catalog_plan) { create(:catalog_plan, currency: "EUR") }
+    let(:params) { {currency: "USD"} }
+
+    before { create(:plan_rate_card, organization: catalog_plan.organization, catalog_plan:) }
+
+    it "rejects the change" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:currency]).to eq(["not_editable_with_applied_rate_cards"])
+    end
+
+    it "still allows editing other attributes" do
+      result = described_class.call(catalog_plan:, params: {name: "Renamed"})
+
+      expect(result).to be_success
+      expect(result.catalog_plan.reload.name).to eq("Renamed")
+    end
+  end
 end

--- a/spec/services/catalog_plans/update_service_spec.rb
+++ b/spec/services/catalog_plans/update_service_spec.rb
@@ -71,4 +71,21 @@ RSpec.describe CatalogPlans::UpdateService do
       expect(result.catalog_plan.reload.name).to eq("Renamed")
     end
   end
+
+  context "when changing the currency of a plan attached to a contract with direct rate cards" do
+    let(:catalog_plan) { create(:catalog_plan, currency: "EUR") }
+    let(:params) { {currency: "USD"} }
+
+    before do
+      customer = create(:customer, organization: catalog_plan.organization)
+      contract = create(:contract, organization: catalog_plan.organization, customer:, catalog_plan:)
+      create(:contract_rate_card, organization: catalog_plan.organization, contract:)
+    end
+
+    it "rejects the change even without plan-level rate cards" do
+      expect(catalog_plan.applied_rate_cards).to be_empty
+      expect(result).not_to be_success
+      expect(result.error.messages[:currency]).to eq(["not_editable_with_applied_rate_cards"])
+    end
+  end
 end

--- a/spec/services/contract_rate_cards/create_service_spec.rb
+++ b/spec/services/contract_rate_cards/create_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe ContractRateCards::CreateService do
 
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:, currency: "EUR") }
-  let(:plan) { nil }
-  let(:contract) { create(:contract, :pending, organization:, customer:, plan:) }
+  let(:catalog_plan) { nil }
+  let(:contract) { create(:contract, :pending, organization:, customer:, catalog_plan:) }
   let(:rate_card) { create(:rate_card, organization:, currency: "EUR") }
   let(:params) { {rate_card_code: rate_card.code, units: "10"} }
 
@@ -57,7 +57,7 @@ RSpec.describe ContractRateCards::CreateService do
   end
 
   context "when the contract is locked (active)" do
-    let(:contract) { create(:contract, organization:, customer:, plan:) }
+    let(:contract) { create(:contract, organization:, customer:, catalog_plan:) }
 
     it "fails with a contract_locked error" do
       expect(result).not_to be_success
@@ -84,7 +84,7 @@ RSpec.describe ContractRateCards::CreateService do
   end
 
   context "when the contract prices through a plan" do
-    let(:plan) { create(:plan, :product_catalog, organization:, amount_currency: "EUR") }
+    let(:catalog_plan) { create(:catalog_plan, organization:, currency: "EUR") }
 
     it "matches the currency against the plan" do
       expect(result).to be_success

--- a/spec/services/contracts/create_service_spec.rb
+++ b/spec/services/contracts/create_service_spec.rb
@@ -7,26 +7,26 @@ RSpec.describe Contracts::CreateService do
 
   let(:organization) { create(:organization, feature_flags: ["product_catalog"]) }
   let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, :product_catalog, organization:) }
+  let(:catalog_plan) { create(:catalog_plan, organization:) }
 
   let(:params) do
     {
       external_customer_id: customer.external_id,
       external_id: "contract-1",
-      plan_code: plan.code
+      plan_code: catalog_plan.code
     }
   end
 
   it "creates an active contract on the plan and materializes its rate cards" do
     rate_card = create(:rate_card, organization:)
-    create(:plan_rate_card, organization:, plan:, rate_card:, units: 5)
+    create(:plan_rate_card, organization:, catalog_plan:, rate_card:, units: 5)
 
     expect { result }.to change(Contract, :count).by(1).and change(ContractRateCard, :count).by(1)
 
     contract = result.contract
     expect(contract).to have_attributes(
       customer:,
-      plan:,
+      catalog_plan:,
       external_id: "contract-1",
       status: "active",
       billing_time: "calendar"
@@ -41,7 +41,7 @@ RSpec.describe Contracts::CreateService do
     it "creates a plan-less contract with no rate cards" do
       expect { result }.to change(Contract, :count).by(1)
 
-      expect(result.contract.plan).to be_nil
+      expect(result.contract.catalog_plan).to be_nil
       expect(result.contract.applied_rate_cards).to be_empty
     end
   end
@@ -80,7 +80,7 @@ RSpec.describe Contracts::CreateService do
 
     it "reads the customer's wall clock, not the application's" do
       rate_card = create(:rate_card, organization:)
-      create(:plan_rate_card, organization:, plan:, rate_card:)
+      create(:plan_rate_card, organization:, catalog_plan:, rate_card:)
 
       contract = result.contract
       expect(contract.started_at).to eq(Time.zone.parse("2026-10-01T07:00:00Z"))
@@ -131,15 +131,6 @@ RSpec.describe Contracts::CreateService do
     it "returns a not found failure" do
       expect(result).not_to be_success
       expect(result.error.resource).to eq("plan")
-    end
-  end
-
-  context "when the plan is a legacy plan" do
-    let(:plan) { create(:plan, organization:) }
-
-    it "returns a validation failure" do
-      expect(result).not_to be_success
-      expect(result.error.messages[:plan]).to eq(["not_a_product_catalog_plan"])
     end
   end
 

--- a/spec/services/contracts/materialize_rate_cards_service_spec.rb
+++ b/spec/services/contracts/materialize_rate_cards_service_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe Contracts::MaterializeRateCardsService do
 
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, :product_catalog, organization:) }
-  let(:contract) { create(:contract, organization:, customer:, plan:, started_at: Time.zone.parse("2026-10-01")) }
+  let(:catalog_plan) { create(:catalog_plan, organization:) }
+  let(:contract) { create(:contract, organization:, customer:, catalog_plan:, started_at: Time.zone.parse("2026-10-01")) }
 
   let(:rate_card) { create(:rate_card, organization:) }
 
   before do
-    create(:plan_rate_card, organization:, plan:, rate_card:, units: 5)
+    create(:plan_rate_card, organization:, catalog_plan:, rate_card:, units: 5)
   end
 
   it "materializes one contract rate card per plan rate card" do
@@ -33,7 +33,7 @@ RSpec.describe Contracts::MaterializeRateCardsService do
         :contract,
         organization:,
         customer:,
-        plan:,
+        catalog_plan:,
         started_at: Time.zone.parse("2026-10-15"),
         billing_anchor_date: Date.new(2026, 10, 1)
       )
@@ -48,7 +48,7 @@ RSpec.describe Contracts::MaterializeRateCardsService do
 
   context "when the customer's day differs from UTC at the start instant" do
     let(:customer) { create(:customer, organization:, timezone: "America/Los_Angeles") }
-    let(:contract) { create(:contract, organization:, customer:, plan:, started_at: Time.zone.parse("2026-10-01T02:00:00Z")) }
+    let(:contract) { create(:contract, organization:, customer:, catalog_plan:, started_at: Time.zone.parse("2026-10-01T02:00:00Z")) }
 
     it "materializes on the customer-local day" do
       result
@@ -60,7 +60,7 @@ RSpec.describe Contracts::MaterializeRateCardsService do
   end
 
   it "does not copy the plan entry's phases: pricing resolves by reference" do
-    plan_rate_card = plan.applied_rate_cards.sole
+    plan_rate_card = catalog_plan.applied_rate_cards.sole
     create(:rate_phase, organization:, plan_rate_card:, position: 1)
 
     expect { result }.not_to change(RatePhase, :count)
@@ -68,7 +68,7 @@ RSpec.describe Contracts::MaterializeRateCardsService do
   end
 
   context "when the contract has no plan" do
-    let(:contract) { create(:contract, organization:, customer:, plan: nil) }
+    let(:contract) { create(:contract, organization:, customer:, catalog_plan: nil) }
 
     it "materializes nothing" do
       expect { result }.not_to change(ContractRateCard, :count)

--- a/spec/services/plan_rate_cards/create_service_spec.rb
+++ b/spec/services/plan_rate_cards/create_service_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 RSpec.describe PlanRateCards::CreateService do
-  subject(:result) { described_class.call(plan:, params:) }
+  subject(:result) { described_class.call(catalog_plan:, params:) }
 
   let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, :product_catalog, organization:) }
+  let(:catalog_plan) { create(:catalog_plan, organization:) }
   let(:rate_card) { create(:rate_card, organization:) }
 
   let(:params) { {rate_card_code: rate_card.code, units: "10"} }
@@ -15,7 +15,7 @@ RSpec.describe PlanRateCards::CreateService do
     expect { result }.to change(PlanRateCard, :count).by(1)
 
     plan_rate_card = result.plan_rate_card
-    expect(plan_rate_card.plan).to eq(plan)
+    expect(plan_rate_card.catalog_plan).to eq(catalog_plan)
     expect(plan_rate_card.rate_card).to eq(rate_card)
     expect(plan_rate_card.units).to eq(10)
   end
@@ -30,7 +30,7 @@ RSpec.describe PlanRateCards::CreateService do
   end
 
   context "when the plan already prices the whole item" do
-    before { create(:plan_rate_card, organization:, plan:, rate_card: create(:rate_card, organization:, product: rate_card.product)) }
+    before { create(:plan_rate_card, organization:, catalog_plan:, rate_card: create(:rate_card, organization:, product: rate_card.product)) }
 
     it "returns a validation failure" do
       expect(result).not_to be_success
@@ -43,7 +43,7 @@ RSpec.describe PlanRateCards::CreateService do
     let(:filter) { create(:product_filter, organization:, product:) }
     let(:rate_card) { create(:rate_card, organization:, product:, product_filter: filter) }
 
-    before { create(:plan_rate_card, organization:, plan:, rate_card: create(:rate_card, organization:, product:, product_filter: filter)) }
+    before { create(:plan_rate_card, organization:, catalog_plan:, rate_card: create(:rate_card, organization:, product:, product_filter: filter)) }
 
     it "returns a validation failure" do
       expect(result).not_to be_success
@@ -55,7 +55,7 @@ RSpec.describe PlanRateCards::CreateService do
     before do
       filter = create(:product_filter, organization:, product: rate_card.product)
       scoped_card = create(:rate_card, organization:, product: rate_card.product, product_filter: filter)
-      create(:plan_rate_card, organization:, plan:, rate_card: scoped_card)
+      create(:plan_rate_card, organization:, catalog_plan:, rate_card: scoped_card)
     end
 
     it "creates the entry" do
@@ -71,15 +71,6 @@ RSpec.describe PlanRateCards::CreateService do
 
       expect(result).not_to be_success
       expect(result.error.messages[:currency]).to eq(["currency_does_not_match"])
-    end
-  end
-
-  context "when the plan is a legacy plan" do
-    let(:plan) { create(:plan, organization:) }
-
-    it "rejects the attachment" do
-      expect(result).not_to be_success
-      expect(result.error.messages[:plan]).to eq(["legacy_plan"])
     end
   end
 
@@ -130,7 +121,7 @@ RSpec.describe PlanRateCards::CreateService do
   end
 
   context "when the plan is missing" do
-    let(:plan) { nil }
+    let(:catalog_plan) { nil }
 
     it "returns a not found failure" do
       expect(result).not_to be_success
@@ -147,8 +138,8 @@ RSpec.describe PlanRateCards::CreateService do
     end
   end
 
-  context "when the plan has subscriptions" do
-    before { create(:subscription, plan:, organization:) }
+  context "when the plan has contracts" do
+    before { create(:contract, catalog_plan:, organization:) }
 
     it "forbids adding a rate card" do
       expect(result).not_to be_success

--- a/spec/services/plan_rate_cards/destroy_service_spec.rb
+++ b/spec/services/plan_rate_cards/destroy_service_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe PlanRateCards::DestroyService do
   subject(:result) { described_class.call(plan_rate_card:) }
 
   let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
-  let(:plan_rate_card) { create(:plan_rate_card, organization:, plan:) }
+  let(:catalog_plan) { create(:catalog_plan, organization:) }
+  let(:plan_rate_card) { create(:plan_rate_card, organization:, catalog_plan:) }
 
   it "soft deletes the entry" do
     expect(result).to be_success
     expect(result.plan_rate_card).to be_discarded
-    expect(plan.reload.applied_rate_cards).to be_empty
+    expect(catalog_plan.reload.applied_rate_cards).to be_empty
   end
 
   it "discards the entry's phases and their overrides" do
@@ -25,8 +25,8 @@ RSpec.describe PlanRateCards::DestroyService do
     expect(rate_override.reload).to be_discarded
   end
 
-  context "when the plan has subscriptions" do
-    before { create(:subscription, plan:, organization:) }
+  context "when the plan has contracts" do
+    before { create(:contract, catalog_plan:, organization:) }
 
     it "forbids the deletion" do
       expect(result).not_to be_success

--- a/spec/services/plan_rate_cards/update_service_spec.rb
+++ b/spec/services/plan_rate_cards/update_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe PlanRateCards::UpdateService do
   subject(:result) { described_class.call(plan_rate_card:, params:) }
 
   let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
-  let(:plan_rate_card) { create(:plan_rate_card, organization:, plan:, units: 5) }
+  let(:catalog_plan) { create(:catalog_plan, organization:) }
+  let(:plan_rate_card) { create(:plan_rate_card, organization:, catalog_plan:, units: 5) }
 
   let(:params) { {units: "12"} }
 
@@ -16,8 +16,8 @@ RSpec.describe PlanRateCards::UpdateService do
     expect(result.plan_rate_card.units).to eq(12)
   end
 
-  context "when the plan has subscriptions" do
-    before { create(:subscription, plan:, organization:) }
+  context "when the plan has contracts" do
+    before { create(:contract, catalog_plan:, organization:) }
 
     it "forbids the update" do
       expect(result).not_to be_success

--- a/spec/services/plans/destroy_service_spec.rb
+++ b/spec/services/plans/destroy_service_spec.rb
@@ -13,26 +13,6 @@ RSpec.describe Plans::DestroyService do
     plan
   end
 
-  describe "catalog plan attachments" do
-    it "discards the applied rate cards, their phases and overrides" do
-      organization = create(:organization, feature_flags: ["product_catalog"])
-      plan = create(:plan, :product_catalog, organization:, pending_deletion: true)
-      product = create(:product, organization:)
-      rate_card = create(:rate_card, organization:, product:, currency: plan.amount_currency)
-      entry = plan.applied_rate_cards.create!(organization:, rate_card:, units: 1)
-      override = create(:rate_override, organization:)
-      phase = create(:rate_phase, organization:, plan_rate_card: entry, position: 1, rate_override: override)
-
-      result = described_class.call(plan:)
-
-      expect(result).to be_success
-      expect(entry.reload).to be_discarded
-      expect(phase.reload).to be_discarded
-      expect(override.reload).to be_discarded
-      expect(rate_card.reload).not_to be_attached_to_plan_or_subscription
-    end
-  end
-
   describe "#call" do
     it "soft deletes the plan" do
       freeze_time do

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -1835,32 +1835,4 @@ RSpec.describe Plans::UpdateService do
       end
     end
   end
-
-  context "when the plan has applied rate cards" do
-    let(:plan) { create(:plan, organization:, amount_currency: "EUR") }
-
-    before { create(:plan_rate_card, organization:, plan:) }
-
-    context "when changing the amount_currency" do
-      let(:update_args) { {amount_currency: "USD"} }
-
-      it "returns a validation failure" do
-        result = plans_service.call
-
-        expect(result).not_to be_success
-        expect(result.error.messages[:amount_currency]).to eq(["not_editable_with_applied_rate_cards"])
-      end
-    end
-
-    context "when resending the unchanged amount_currency" do
-      let(:update_args) { {amount_currency: "EUR", name: "After"} }
-
-      it "is allowed" do
-        result = plans_service.call
-
-        expect(result).to be_success
-        expect(result.plan.name).to eq("After")
-      end
-    end
-  end
 end

--- a/spec/services/rate_card_rates/create_service_spec.rb
+++ b/spec/services/rate_card_rates/create_service_spec.rb
@@ -174,11 +174,11 @@ RSpec.describe RateCardRates::CreateService do
     end
   end
 
-  context "when the card is on a plan that has subscriptions" do
+  context "when the card is on a plan that has contracts" do
     before do
-      plan = create(:plan, organization:)
-      create(:plan_rate_card, organization:, plan:, rate_card:)
-      create(:subscription, plan:, organization:)
+      catalog_plan = create(:catalog_plan, organization:)
+      create(:plan_rate_card, organization:, catalog_plan:, rate_card:)
+      create(:contract, catalog_plan:, organization:)
     end
 
     it "appends the rate" do

--- a/spec/services/rate_phases/create_service_spec.rb
+++ b/spec/services/rate_phases/create_service_spec.rb
@@ -103,8 +103,8 @@ RSpec.describe RatePhases::CreateService do
     end
   end
 
-  context "when the plan has subscriptions" do
-    before { create(:subscription, plan: plan_rate_card.plan, organization:) }
+  context "when the plan has contracts" do
+    before { create(:contract, catalog_plan: plan_rate_card.catalog_plan, organization: plan_rate_card.organization) }
 
     it "returns a validation failure" do
       expect(result).not_to be_success

--- a/spec/services/rate_phases/destroy_service_spec.rb
+++ b/spec/services/rate_phases/destroy_service_spec.rb
@@ -75,10 +75,10 @@ RSpec.describe RatePhases::DestroyService do
     end
   end
 
-  context "when the plan has subscriptions" do
+  context "when the plan has contracts" do
     let(:rate_phase) { ramp }
 
-    before { create(:subscription, plan: plan_rate_card.plan, organization:) }
+    before { create(:contract, catalog_plan: plan_rate_card.catalog_plan, organization: plan_rate_card.organization) }
 
     it "returns a validation failure" do
       expect(result).not_to be_success

--- a/spec/services/rate_phases/replace_service_spec.rb
+++ b/spec/services/rate_phases/replace_service_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe RatePhases::ReplaceService do
   subject(:result) { described_class.call(plan_rate_card:, phases_params:) }
 
   let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:) }
+  let(:catalog_plan) { create(:catalog_plan, organization:) }
   let(:rate_card) { create(:rate_card, organization:) }
-  let(:plan_rate_card) { create(:plan_rate_card, organization:, plan:, rate_card:) }
+  let(:plan_rate_card) { create(:plan_rate_card, organization:, catalog_plan:, rate_card:) }
 
   let(:phases_params) do
     [
@@ -141,8 +141,8 @@ RSpec.describe RatePhases::ReplaceService do
     end
   end
 
-  context "when the plan is attached to a subscription" do
-    before { create(:subscription, plan:, organization:) }
+  context "when the plan is attached to a contract" do
+    before { create(:contract, catalog_plan:, organization:) }
 
     it "returns a plan_locked failure" do
       expect(result).not_to be_success

--- a/spec/services/rate_phases/update_service_spec.rb
+++ b/spec/services/rate_phases/update_service_spec.rb
@@ -113,8 +113,8 @@ RSpec.describe RatePhases::UpdateService do
     end
   end
 
-  context "when the plan has subscriptions" do
-    before { create(:subscription, plan: plan_rate_card.plan, organization:) }
+  context "when the plan has contracts" do
+    before { create(:contract, catalog_plan: plan_rate_card.catalog_plan, organization: plan_rate_card.organization) }
 
     it "returns a validation failure" do
       expect(result).not_to be_success


### PR DESCRIPTION
## Context

`plan_rate_cards` and `contracts` only ever pointed at product-catalog plans, which now live in `catalog_plans`. Their `plan_id` referenced the shared `plans` table, so both tables must be repointed. This is a **rename, not a dual parent**: a legacy plan is subscribed through `subscriptions`, never through a contract or a rate card.

## Description

- Two-step migration adds `catalog_plan_id` to both tables (concurrent index, NOT VALID FK then validated), relaxes the old `plan_rate_cards.plan_id` NOT NULL. `plan_id` stays a dead column, dropped in a follow-up.
- `PlanRateCard`/`Contract` drop `belongs_to :plan` for `belongs_to :catalog_plan`; `CatalogPlan` gains `applied_rate_cards` + `contracts` and `attached_to_contracts?`.
- Every internal reader repointed (services, queries, controllers, serializers, GraphQL) while **the public surface stays `plan`/`plan_code`/`plan_id`** — `catalog_plan` is the DB/model name only.
- Rate-card locking moves off subscriptions onto contracts; Part 1's deferrals are restored (real `applied_rate_cards_count`, currency lock, seed rate-card wiring) across REST and GraphQL.

Legacy `Plan` rate-card code paths (`Plan#applied_rate_cards` and its consumers, plus `PlansQuery#with_product_category` / the GraphQL `productCategoryId` argument) are now dead after the rename and retired in this PR.