### PR TITLE
fix(plan-change): add missing support for invoice grouping

### DIFF
--- a/app/services/invoices/advance_charges_service.rb
+++ b/app/services/invoices/advance_charges_service.rb
@@ -94,12 +94,14 @@ module Invoices
     end
 
     # NOTE: The re-expanded subscription set (matched by external_id) can span several
-    #       purchase order numbers — e.g. a terminated and an active subscription sharing
-    #       an external_id after an upgrade. Each PO must produce its own invoice.
+    #       currencies, billing entities and purchase order numbers — e.g. a terminated and an
+    #       active subscription sharing an external_id after an upgrade. An invoice holds one of
+    #       each, so every (currency, billing entity, PO) must produce its own invoice.
     def create_group_invoices
-      subscriptions.group_by(&:purchase_order_number).values.filter_map do |subscriptions_group|
-        create_group_invoice(subscriptions_group)
-      end
+      subscriptions
+        .group_by { |sub| [sub.plan.amount_currency, sub.applicable_billing_entity_id, sub.purchase_order_number] }
+        .values
+        .filter_map { |subscriptions_group| create_group_invoice(subscriptions_group) }
     end
 
     def create_group_invoice(subscriptions_group)
@@ -142,10 +144,10 @@ module Invoices
       invoice_result = Invoices::CreateGeneratingService.call(
         customer:,
         invoice_type: :advance_charges,
-        currency:,
+        currency: subscriptions_group.first&.plan&.amount_currency || currency,
         datetime: billing_at, # this is an int we need to convert it
         skip_charges: true,
-        billing_entity: initial_subscriptions.first&.billing_entity || customer.billing_entity,
+        billing_entity: subscriptions_group.first&.billing_entity || customer.billing_entity,
         purchase_order_number: subscriptions_group.first&.purchase_order_number
       ) do |invoice|
         Invoices::CreateAdvanceChargesInvoiceSubscriptionService.call!(

--- a/app/services/subscriptions/activate_service.rb
+++ b/app/services/subscriptions/activate_service.rb
@@ -143,14 +143,38 @@ module Subscriptions
 
     def bill_rotation_subscriptions(billable_subscriptions, billing_at:, non_invoiceable_subscriptions: [subscription.previous_subscription])
       after_commit do
-        # NOTE: On upgrade/downgrade the previous and new subscriptions may carry different
-        #       purchase order numbers. Split them so each PO produces its own invoice.
-        billable_subscriptions.group_by(&:purchase_order_number).each_value do |subscriptions|
+        group_for_invoicing(billable_subscriptions).each do |subscriptions|
           BillSubscriptionJob.perform_later(subscriptions, billing_at.to_i, invoicing_reason: :upgrading)
         end
-        non_invoiceable_subscriptions.group_by(&:purchase_order_number).each_value do |subscriptions|
+        group_for_invoicing(non_invoiceable_subscriptions).each do |subscriptions|
           BillNonInvoiceableFeesJob.perform_later(subscriptions, billing_at)
         end
+      end
+    end
+
+    def group_for_invoicing(subscriptions)
+      default_payment_method = subscription.customer.default_payment_method
+
+      subscriptions.group_by do |sub|
+        [
+          payment_method_key(sub, default_payment_method),
+          sub.plan.amount_currency,
+          sub.applicable_billing_entity_id,
+          sub.purchase_order_number,
+          sub.consolidate_invoice ? nil : sub.id
+        ]
+      end.values
+    end
+
+    def payment_method_key(sub, default_payment_method)
+      if sub.payment_method_id.present?
+        [sub.payment_method_id, sub.payment_method_type]
+      elsif sub.payment_method_type == "manual"
+        [nil, "manual"]
+      elsif default_payment_method.present?
+        [default_payment_method.id, "provider"]
+      else
+        [nil, sub.payment_method_type]
       end
     end
 

--- a/spec/scenarios/subscriptions/upgrade_across_billing_entities_spec.rb
+++ b/spec/scenarios/subscriptions/upgrade_across_billing_entities_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Subscription Upgrade Across Billing Entities Scenario", transaction: false do
+  let(:organization) do
+    create(:organization, webhook_url: false, email_settings: [], billing_entities: [us_entity, eu_entity])
+  end
+
+  let(:us_entity) do
+    create(:billing_entity, document_numbering: "per_customer", document_number_prefix: "BEUS")
+  end
+
+  let(:eu_entity) do
+    create(:billing_entity, document_numbering: "per_customer", document_number_prefix: "BEEU")
+  end
+
+  let(:customer) { create(:customer, organization:, billing_entity: us_entity) }
+
+  let(:monthly_plan) do
+    create(:plan, organization:, interval: "monthly", amount_cents: 1000, pay_in_advance: true)
+  end
+
+  let(:yearly_plan) do
+    create(:plan, organization:, interval: "yearly", amount_cents: 12_000, pay_in_advance: true)
+  end
+
+  let(:subscription_at) { DateTime.new(2024, 6, 5, 10, 0) }
+  let(:upgrade_at) { DateTime.new(2024, 6, 20, 10, 0) }
+
+  def upgrade_subscription(params = {})
+    create_subscription(
+      {
+        external_customer_id: customer.external_id,
+        external_id: customer.external_id,
+        plan_code: yearly_plan.code,
+        billing_time: "anniversary"
+      }.merge(params)
+    )
+  end
+
+  # NOTE: the subscription is bound to `eu_entity` while the customer's own (default) entity is `us_entity`
+  before do
+    travel_to(subscription_at) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: monthly_plan.code,
+          billing_time: "anniversary",
+          subscription_at: subscription_at.iso8601,
+          billing_entity_code: eu_entity.code
+        }
+      )
+    end
+  end
+
+  it "bills the terminated and the upgraded subscription on their own billing entity's invoice" do
+    subscription = customer.subscriptions.sole
+    expect(subscription.billing_entity_id).to eq(eu_entity.id)
+
+    initial_invoice = subscription.invoices.sole
+    expect(initial_invoice.billing_entity_id).to eq(eu_entity.id)
+    expect(initial_invoice.number).to start_with("BEEU-")
+
+    # NOTE: The upgrade moves the subscription to `us_entity`, so the terminated subscription stays
+    #       on `eu_entity` while the new one bills under `us_entity`. An invoice holds a single
+    #       billing entity, so the rotation must be billed on two separate invoices.
+    travel_to(upgrade_at) do
+      upgrade_subscription(billing_entity_code: us_entity.code)
+    end
+
+    expect(subscription.reload).to be_terminated
+
+    new_subscription = customer.subscriptions.order(created_at: :asc).last
+    expect(new_subscription.plan.code).to eq(yearly_plan.code)
+    expect(new_subscription).to be_active
+    expect(new_subscription.billing_entity_id).to eq(us_entity.id)
+
+    expect(customer.invoices.count).to eq(3)
+
+    upgrade_invoice_eu = subscription.invoices.order(created_at: :asc).last
+    expect(upgrade_invoice_eu.billing_entity_id).to eq(eu_entity.id)
+    expect(upgrade_invoice_eu.number).to start_with("BEEU-")
+    expect(upgrade_invoice_eu.sequential_id).to eq(2)
+
+    upgrade_invoice_us = new_subscription.invoices.sole
+    expect(upgrade_invoice_us.billing_entity_id).to eq(us_entity.id)
+    expect(upgrade_invoice_us.number).to start_with("BEUS-")
+    # NOTE: numbering is gapless per (customer, billing entity), so the US sequence starts at 1
+    expect(upgrade_invoice_us.sequential_id).to eq(1)
+
+    # NOTE: no invoice ever mixes subscriptions from different billing entities
+    customer.invoices.find_each do |invoice|
+      expect(invoice.subscriptions.map(&:applicable_billing_entity_id).uniq).to eq([invoice.billing_entity_id])
+    end
+  end
+
+  it "keeps billing the rotation on a single invoice when the upgrade inherits the billing entity" do
+    subscription = customer.subscriptions.sole
+
+    travel_to(upgrade_at) do
+      upgrade_subscription
+    end
+
+    expect(subscription.reload).to be_terminated
+
+    new_subscription = customer.subscriptions.order(created_at: :asc).last
+    expect(new_subscription.billing_entity_id).to eq(eu_entity.id)
+
+    expect(customer.invoices.count).to eq(2)
+
+    upgrade_invoice = new_subscription.invoices.sole
+    expect(upgrade_invoice.billing_entity_id).to eq(eu_entity.id)
+    expect(upgrade_invoice.subscriptions).to contain_exactly(subscription, new_subscription)
+  end
+end

--- a/spec/services/invoices/advance_charges_service_spec.rb
+++ b/spec/services/invoices/advance_charges_service_spec.rb
@@ -331,6 +331,63 @@ RSpec.describe Invoices::AdvanceChargesService do
       end
     end
 
+    context "when re-expanded subscriptions belong to different billing entities" do
+      let(:billable_metric) { create(:sum_billable_metric, :recurring, organization:) }
+      let(:other_billing_entity) { create(:billing_entity, organization:) }
+
+      let(:charge) do
+        create(
+          :charge,
+          plan:,
+          billable_metric:,
+          prorated: true,
+          pay_in_advance: true,
+          invoiceable: false,
+          regroup_paid_fees: "invoice",
+          properties: {amount: "1"}
+        )
+      end
+
+      let(:subscription) do
+        create(
+          :subscription,
+          plan:,
+          customer:,
+          subscription_at: started_at.to_date,
+          started_at:,
+          created_at: started_at
+        )
+      end
+
+      # Same external_id as `subscription` (an upgrade rotation), so the re-expansion
+      # by external_id pulls it in alongside `subscription` despite a different entity.
+      let(:subscription_2) do
+        create(
+          :subscription,
+          external_id: subscription.external_id,
+          customer:,
+          status: :terminated,
+          terminated_at: Time.current,
+          started_at: Time.current - 1.year,
+          plan:,
+          billing_entity: other_billing_entity
+        )
+      end
+
+      before do
+        create(:fee, :succeeded, organization_id: organization.id, succeeded_at: fee_boundaries[:charges_to_datetime] - 2.days, invoice_id: nil, subscription:, amount_cents: 100, taxes_amount_cents: 0, properties: fee_boundaries, charge:)
+        create(:fee, :succeeded, organization_id: organization.id, succeeded_at: fee_boundaries[:charges_to_datetime] - 2.days, invoice_id: nil, subscription: subscription_2, amount_cents: 200, taxes_amount_cents: 0, properties: fee_boundaries, charge:)
+      end
+
+      it "creates a separate advance-charges invoice per billing entity" do
+        expect { invoice_service.call }
+          .to change { Invoice.where(invoice_type: :advance_charges).count }.by(2)
+
+        invoices = Invoice.where(invoice_type: :advance_charges)
+        expect(invoices.map(&:billing_entity)).to match_array([customer.billing_entity, other_billing_entity])
+      end
+    end
+
     context "when re-expanded subscriptions share the same purchase order number" do
       let(:billable_metric) { create(:sum_billable_metric, :recurring, organization:) }
 

--- a/spec/services/subscriptions/activate_service_spec.rb
+++ b/spec/services/subscriptions/activate_service_spec.rb
@@ -707,6 +707,80 @@ RSpec.describe Subscriptions::ActivateService do
           expect(BillNonInvoiceableFeesJob).to have_been_enqueued.with([subscription], anything)
         end
       end
+
+      context "when the previous and new subscriptions belong to different billing entities" do
+        let(:billing_entity) { create(:billing_entity, organization:) }
+
+        before do
+          previous_subscription.update!(billing_entity:)
+        end
+
+        it "splits the upgrade bill into one job per billing entity" do
+          result
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([previous_subscription], anything, invoicing_reason: :upgrading)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([subscription], anything, invoicing_reason: :upgrading)
+        end
+
+        it "splits BillNonInvoiceableFeesJob per billing entity" do
+          result
+
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued.with([previous_subscription], anything)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued.with([subscription], anything)
+        end
+
+        context "when the new subscription is explicitly bound to the same entity" do
+          before { subscription.update!(billing_entity:) }
+
+          it "keeps both subscriptions on the same invoice" do
+            result
+
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with([previous_subscription, subscription], anything, invoicing_reason: :upgrading)
+          end
+        end
+      end
+
+      context "when the previous and new subscriptions are billed in different currencies" do
+        let(:plan) { create(:plan, organization:, amount_cents: 100, amount_currency: "USD", pay_in_advance: true) }
+
+        it "splits the upgrade bill into one job per currency" do
+          result
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([previous_subscription], anything, invoicing_reason: :upgrading)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([subscription], anything, invoicing_reason: :upgrading)
+        end
+      end
+
+      context "when the previous and new subscriptions resolve to different payment methods" do
+        before { previous_subscription.update!(payment_method_type: :manual) }
+
+        it "splits the upgrade bill into one job per payment method" do
+          result
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([previous_subscription], anything, invoicing_reason: :upgrading)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([subscription], anything, invoicing_reason: :upgrading)
+        end
+      end
+
+      context "when the new subscription opted out of invoice consolidation" do
+        before { subscription.update!(consolidate_invoice: false) }
+
+        it "bills the opted-out subscription on its own invoice" do
+          result
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([subscription], anything, invoicing_reason: :upgrading)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([previous_subscription], anything, invoicing_reason: :upgrading)
+        end
+      end
     end
 
     context "when activation_rules gate the new subscription" do

--- a/spec/services/subscriptions/plan_upgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_upgrade_service_spec.rb
@@ -556,7 +556,9 @@ RSpec.describe Subscriptions::PlanUpgradeService do
           expect(subscription.reload.billing_entity_id).to eq(billing_entity.id)
           expect(new_subscription.billing_entity_id).to eq(other_entity.id)
           expect(BillSubscriptionJob).to have_been_enqueued
-            .with([subscription, new_subscription], kind_of(Integer), invoicing_reason: :upgrading)
+            .with([subscription], kind_of(Integer), invoicing_reason: :upgrading)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([new_subscription], kind_of(Integer), invoicing_reason: :upgrading)
         end
       end
     end


### PR DESCRIPTION
## Context

On plan upgrade and downgrade Lago is missing support for invoice grouping per billing entity, currency, payment method or purchase number.

## Description

Invoice grouping is currently present in `OrganizationBillingService` but we missed similar support in `ActivateService` which is responsible for handling plan upgrade and downgrade. This PR handles missing use-case.
