### PR TITLE
feat(events): report progress while recovering fees

### DIFF
--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -129,8 +129,6 @@ namespace :events do
   # FROM/TO bound the event ingestion time, as [FROM, TO). DRY_RUN defaults to true (report only).
   desc "Recover pay-in-advance fees for events that were never post-processed"
   task recover_pay_in_advance_fees: :environment do
-    Rails.logger.level = Logger::Severity::INFO
-
     prefix = "events:recover_pay_in_advance_fees"
     batch_size = (ENV["BATCH_SIZE"] || 1000).to_i
     organization = Organization.find(ENV.fetch("ORGANIZATION_ID"))
@@ -145,10 +143,8 @@ namespace :events do
     raise ArgumentError, "BATCH_SIZE must be positive" unless batch_size.positive?
 
     if organization.clickhouse_events_store?
-      Rails.logger.info(
-        "#{prefix} - Organization #{organization.id} uses the Clickhouse events store: " \
+      puts "#{prefix} - Organization #{organization.id} uses the Clickhouse events store: " \
         "events are not persisted in Postgres, so there is nothing to recover."
-      )
       next
     end
 
@@ -165,7 +161,7 @@ namespace :events do
       .group_by { |charge| [charge.plan_id, charge.billable_metric.code] }
 
     if charges_by_plan_and_code.empty?
-      Rails.logger.info("#{prefix} - Organization #{organization.id} has no pay-in-advance charge.")
+      puts "#{prefix} - Organization #{organization.id} has no pay-in-advance charge."
       next
     end
 
@@ -178,13 +174,27 @@ namespace :events do
     recovered = 0
     invoices_to_create = 0
     not_due = 0
+    scanned = 0
     skipped = []
     tainted_subscriptions = Set.new
+    started_at = Time.current
+    total = scope.count
+
+    puts "#{prefix} [#{mode}]"
+    puts "Organization: #{organization.id}"
+    puts "Ingested in:  [#{from.iso8601}, #{to.iso8601})"
+    puts "Candidates:   #{total} event(s) on #{codes.size} pay-in-advance metric code(s)"
+    puts "=" * 80
 
     # Cursored on (created_at, id) so the scan follows index_events_on_organization_id_and_created_at.
     # The default primary-key cursor would paginate on a random uuid, re-sorting the whole remaining
     # window on every batch.
     scope.in_batches(of: batch_size, cursor: [:created_at, :id], order: :asc, load: true) do |events_in_batch|
+      # Printed every batch so a long run is visibly progressing rather than possibly stuck.
+      scanned += events_in_batch.size
+      puts "  ... #{scanned}/#{total} scanned in #{(Time.current - started_at).round(1)}s, " \
+        "at #{events_in_batch.last.created_at.iso8601}, #{recovered} to recover, #{skipped.size} skipped"
+
       # `group_by` preserves the SQL order, so `covering.first` below is what
       # `Events::Common#subscription` resolves to.
       subscriptions_by_external_id = organization.subscriptions
@@ -320,44 +330,40 @@ namespace :events do
         invoices_to_create += invoiceable_charges
         tainted_subscriptions << subscription.id unless billable_metric.count_agg?
 
-        Rails.logger.info(
-          "#{prefix} [#{mode}] - #{event.transaction_id} " \
-          "subscription=#{event.external_subscription_id} code=#{event.code} " \
-          "invoiceable_charges=#{invoiceable_charges}"
-        )
+        puts "  RECOVER #{event.transaction_id} subscription=#{event.external_subscription_id} " \
+          "code=#{event.code} invoiceable_charges=#{invoiceable_charges}"
 
         Events::PayInAdvanceJob.perform_later(Events::CommonFactory.new_instance(source: event).as_json) unless dry_run
       end
     end
 
     skipped.each do |transaction_id, external_subscription_id, reason|
-      Rails.logger.warn(
-        "#{prefix} - SKIPPED #{transaction_id} (subscription=#{external_subscription_id}): #{reason}."
-      )
+      puts "  SKIPPED #{transaction_id} (subscription=#{external_subscription_id}): #{reason}."
     end
 
+    puts "=" * 80
+    puts "#{recovered} event(s) to recover, #{skipped.size} skipped, #{not_due} with no fee due " \
+      "(#{scanned} scanned in #{(Time.current - started_at).round(1)}s)"
+
     if tainted_subscriptions.any?
-      Rails.logger.warn(
-        "#{prefix} - Recovered events on subscriptions #{tainted_subscriptions.to_a.join(", ")} use an " \
+      puts
+      puts "WARNING: recovered events on subscriptions #{tainted_subscriptions.to_a.join(", ")} use an " \
         "aggregation other than count_agg, so their units chain through cached aggregations. Where " \
         "those billing periods contain decrements, the fees created for the events that followed the " \
         "gap were computed without the missing rows and may over-bill. This task does not fix " \
         "already-created fees."
-      )
     end
 
     if invoices_to_create.positive?
-      Rails.logger.warn(
-        "#{prefix} [#{mode}] - the replay creates #{invoices_to_create} invoice(s), one per " \
-        "invoiceable charge. Each is finalized and dated at the event timestamp, emailed, pushed to " \
-        "the accounting integrations, and has a payment started for it."
-      )
+      puts
+      puts "WARNING: the replay creates #{invoices_to_create} invoice(s), one per invoiceable charge. " \
+        "Each is finalized and dated at the event timestamp, emailed, pushed to the accounting " \
+        "integrations, and has a payment started for it."
     end
 
-    Rails.logger.info(
-      "#{prefix} [#{mode}] - #{recovered} event(s) to recover, #{skipped.size} skipped, " \
-      "#{not_due} with no fee due."
-    )
-    Rails.logger.info("#{prefix} - Run again with DRY_RUN=false to re-enqueue.") if dry_run && recovered.positive?
+    if dry_run && recovered.positive?
+      puts
+      puts "Run again with DRY_RUN=false to re-enqueue."
+    end
   end
 end

--- a/spec/lib/tasks/events_rake_spec.rb
+++ b/spec/lib/tasks/events_rake_spec.rb
@@ -253,10 +253,7 @@ RSpec.describe "events:recover_pay_in_advance_fees" do # rubocop:disable RSpec/D
     end
 
     it "reports why, rather than dropping the event silently" do
-      allow(Rails.logger).to receive(:warn).and_call_original
-      invoke
-
-      expect(Rails.logger).to have_received(:warn).with(/its only subscriptions are incomplete/)
+      expect { invoke }.to output(/its only subscriptions are incomplete/).to_stdout
     end
   end
 
@@ -268,10 +265,7 @@ RSpec.describe "events:recover_pay_in_advance_fees" do # rubocop:disable RSpec/D
     end
 
     it "reports why" do
-      allow(Rails.logger).to receive(:warn).and_call_original
-      invoke
-
-      expect(Rails.logger).to have_received(:warn).with(/gained a pay-in-advance charge/)
+      expect { invoke }.to output(/gained a pay-in-advance charge/).to_stdout
     end
   end
 
@@ -292,10 +286,7 @@ RSpec.describe "events:recover_pay_in_advance_fees" do # rubocop:disable RSpec/D
     end
 
     it "reports the disagreement" do
-      allow(Rails.logger).to receive(:warn).and_call_original
-      invoke
-
-      expect(Rails.logger).to have_received(:warn).with(/is not the one post-processing would have used/)
+      expect { invoke }.to output(/is not the one post-processing would have used/).to_stdout
     end
   end
 
@@ -396,10 +387,7 @@ RSpec.describe "events:recover_pay_in_advance_fees" do # rubocop:disable RSpec/D
     end
 
     it "warns that the replay finalizes invoices and starts payments" do
-      allow(Rails.logger).to receive(:warn).and_call_original
-      invoke
-
-      expect(Rails.logger).to have_received(:warn).with(/creates 1 invoice\(s\)/)
+      expect { invoke }.to output(/creates 1 invoice\(s\)/).to_stdout
     end
 
     # One `Invoices::CreatePayInAdvanceChargeJob` per invoiceable charge, each minting its own
@@ -411,10 +399,7 @@ RSpec.describe "events:recover_pay_in_advance_fees" do # rubocop:disable RSpec/D
       end
 
       it "counts one invoice per invoiceable charge" do
-        allow(Rails.logger).to receive(:warn).and_call_original
-        invoke
-
-        expect(Rails.logger).to have_received(:warn).with(/creates 2 invoice\(s\)/)
+        expect { invoke }.to output(/creates 2 invoice\(s\)/).to_stdout
       end
     end
   end
@@ -440,6 +425,10 @@ RSpec.describe "events:recover_pay_in_advance_fees" do # rubocop:disable RSpec/D
     it "skips the event rather than enqueueing a partial replay" do
       expect { invoke }.not_to have_enqueued_job(Events::PayInAdvanceJob)
     end
+  end
+
+  it "reports its progress so a long run is visibly advancing" do
+    expect { invoke }.to output(/1\/1 scanned in \d+(\.\d+)?s/).to_stdout
   end
 
   context "when the events span several batches" do


### PR DESCRIPTION
> Follow-up of #6314, which added the task.

## Context

`events:recover_pay_in_advance_fees` scans an ingestion-time window that can hold a lot of events, and printed nothing until it finished, so a slow run was indistinguishable from a stalled one. Its findings also went through `Rails.logger`, which only reaches stdout in production when `RAILS_LOG_TO_STDOUT` is set — and the report is the whole point of the task.

## Description

- Print the report on stdout rather than logging it, so it is visible regardless of `RAILS_LOG_TO_STDOUT`.
- Emit a line per batch with events scanned out of the total, elapsed time, the cursor position in the window, and the running counts.
- Open the run with the organization, the window and the candidate count, so the scope is visible before anything is enqueued.

```
events:recover_pay_in_advance_fees [DRY RUN]
Organization: b83c3993-e6ff-4567-b8da-3768a6102eb4
Ingested in:  [2026-08-27T14:34:24Z, 2026-09-06T14:34:24Z)
Candidates:   6 event(s) on 1 pay-in-advance metric code(s)
================================================================================
  ... 2/6 scanned in 0.0s, at 2026-08-29T14:34:24Z, 0 to recover, 0 skipped
  RECOVER tr_08adfd32 subscription=48c81d23 code=tleva9n1pk invoiceable_charges=0
  ... 4/6 scanned in 0.0s, at 2026-08-31T14:34:24Z, 2 to recover, 0 skipped
  SKIPPED tr_6d4414f4 (subscription=48c81d23): no subscription covers its timestamp.
================================================================================
5 event(s) to recover, 1 skipped, 0 with no fee due (6 scanned in 0.0s)
```
