### PR TITLE
perf(events): scope fee recovery per subscription

### DIFF
--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -126,7 +126,10 @@ namespace :events do
   #   lago exec api bundle exec rails events:recover_pay_in_advance_fees \
   #     ORGANIZATION_ID=<uuid> FROM=2026-08-22T00:00:00Z TO=2026-08-24T00:00:00Z [DRY_RUN=false]
   #
-  # FROM/TO bound the event ingestion time, as [FROM, TO). DRY_RUN defaults to true (report only).
+  # FROM/TO bound the event timestamp, as [FROM, TO), which is the period a pay-in-advance fee is
+  # billed against. An event ingested during an outage but timestamped outside the window is
+  # therefore out of scope; widen FROM to reach backdated ones.
+  # DRY_RUN defaults to true (report only).
   desc "Recover pay-in-advance fees for events that were never post-processed"
   task recover_pay_in_advance_fees: :environment do
     prefix = "events:recover_pay_in_advance_fees"
@@ -167,173 +170,193 @@ namespace :events do
 
     codes = charges_by_plan_and_code.keys.map(&:last).uniq
 
-    # Not narrowed on subscription external ids: that would bind one parameter per subscription, and
-    # the per-event lookup below discards those events anyway.
-    scope = organization.events.where(created_at: from...to, code: codes)
+    # The bounds mirror `Events::Common#subscription`: a subscription starting after the window, or
+    # terminated before it, cannot cover an event timestamped inside it.
+    subscriptions_scope = organization.subscriptions
+      .where(plan_id: charges_by_plan_and_code.keys.map(&:first).uniq)
+      .where(started_at: ..to)
+      .where("terminated_at IS NULL OR terminated_at >= ?", from)
 
     recovered = 0
     invoices_to_create = 0
     not_due = 0
     scanned = 0
+    processed = 0
     skipped = []
     tainted_subscriptions = Set.new
     started_at = Time.current
-    total = scope.count
+
+    total_subscriptions = subscriptions_scope.distinct.count(:external_id)
 
     puts "#{prefix} [#{mode}]"
-    puts "Organization: #{organization.id}"
-    puts "Ingested in:  [#{from.iso8601}, #{to.iso8601})"
-    puts "Candidates:   #{total} event(s) on #{codes.size} pay-in-advance metric code(s)"
+    puts "Organization:  #{organization.id}"
+    puts "Timestamped:   [#{from.iso8601}, #{to.iso8601})"
+    puts "Metrics:       #{codes.size} pay-in-advance metric code(s)"
+    puts "Subscriptions: #{total_subscriptions} external id(s) on a plan carrying one"
     puts "=" * 80
 
-    # Cursored on (created_at, id) so the scan follows index_events_on_organization_id_and_created_at.
-    # The default primary-key cursor would paginate on a random uuid, re-sorting the whole remaining
-    # window on every batch.
-    scope.in_batches(of: batch_size, cursor: [:created_at, :id], order: :asc, load: true) do |events_in_batch|
-      # Printed every batch so a long run is visibly progressing rather than possibly stuck.
-      scanned += events_in_batch.size
-      puts "  ... #{scanned}/#{total} scanned in #{(Time.current - started_at).round(1)}s, " \
-        "at #{events_in_batch.last.created_at.iso8601}, #{recovered} to recover, #{skipped.size} skipped"
+    last_external_id = nil
 
-      # `group_by` preserves the SQL order, so `covering.first` below is what
-      # `Events::Common#subscription` resolves to.
+    subscriptions_scope.in_batches(of: batch_size, cursor: [:external_id, :id], order: :asc) do |relation|
+      batch_external_ids = relation.pluck(:external_id).uniq
+      batch_external_ids.shift if batch_external_ids.first == last_external_id
+      last_external_id = batch_external_ids.last if batch_external_ids.any?
+
       subscriptions_by_external_id = organization.subscriptions
-        .where(external_id: events_in_batch.map(&:external_subscription_id).uniq)
+        .where(external_id: batch_external_ids)
         .order(Arel.sql("terminated_at DESC NULLS FIRST, started_at DESC"))
         .group_by(&:external_id)
 
-      candidates = events_in_batch.filter_map do |event|
-        covering = subscriptions_by_external_id.fetch(event.external_subscription_id, []).select do |candidate|
-          # `started_at` is nil until activation, and NULLS FIRST sorts those first. SQL drops them
-          # because the comparison is NULL; the same has to happen here.
-          next false if candidate.started_at.nil?
+      batch_external_ids.each do |external_id|
+        processed += 1
 
-          candidate.started_at.floor(3) <= event.timestamp &&
-            (candidate.terminated_at.nil? || candidate.terminated_at.floor(3) >= event.timestamp)
+        if (processed % 250).zero? || processed == total_subscriptions
+          puts "  ... #{processed}/#{total_subscriptions} subscription(s), #{scanned} event(s) scanned " \
+            "in #{(Time.current - started_at).round(1)}s, #{recovered} to recover, #{skipped.size} skipped"
         end
 
-        # Two resolutions disagree in production and both matter: the gate in
-        # `Events::PostProcessService#subscriptions` excludes incomplete subscriptions and decides
-        # whether a fee is created at all, while `Events::Common#subscription` ignores status and
-        # decides which plan's charges the replay bills.
-        replayed = covering.first
-        eligible = covering.find { |candidate| !candidate.incomplete? }
+        # Ordered as `Events::Common#subscription` does, so `covering.first` below is what it resolves.
+        subscriptions = subscriptions_by_external_id.fetch(external_id, [])
 
-        if eligible.nil?
-          reason = if replayed
-            "its only subscriptions are incomplete, which `Events::PostProcessService` skips, " \
-              "so no fee was created at ingestion either"
+        events = organization.events.where(external_subscription_id: external_id, code: codes, timestamp: from...to)
+
+        events.in_batches(of: batch_size, cursor: [:timestamp, :id], order: :asc, load: true) do |events_in_batch|
+          scanned += events_in_batch.size
+
+          candidates = events_in_batch.filter_map do |event|
+            covering = subscriptions.select do |candidate|
+              # `started_at` is nil until activation, and NULLS FIRST sorts those first. SQL drops them
+              # because the comparison is NULL; the same has to happen here.
+              next false if candidate.started_at.nil?
+
+              candidate.started_at.floor(3) <= event.timestamp &&
+                (candidate.terminated_at.nil? || candidate.terminated_at.floor(3) >= event.timestamp)
+            end
+
+            # Two resolutions disagree in production and both matter: the gate in
+            # `Events::PostProcessService#subscriptions` excludes incomplete subscriptions and decides
+            # whether a fee is created at all, while `Events::Common#subscription` ignores status and
+            # decides which plan's charges the replay bills.
+            replayed = covering.first
+            eligible = covering.find { |candidate| !candidate.incomplete? }
+
+            if eligible.nil?
+              reason = if replayed
+                "its only subscriptions are incomplete, which `Events::PostProcessService` skips, " \
+                  "so no fee was created at ingestion either"
+              else
+                "no subscription covers its timestamp; a replay would create no fee"
+              end
+              skipped << [event.transaction_id, event.external_subscription_id, reason]
+              next
+            end
+
+            if replayed != eligible
+              skipped << [event.transaction_id, event.external_subscription_id,
+                "the subscription the replay would bill (#{replayed.id}) is not the one post-processing " \
+                "would have used (#{eligible.id}); recover it by hand"]
+              next
+            end
+
+            charges = charges_by_plan_and_code[[eligible.plan_id, event.code]]
+            if charges.blank?
+              not_due += 1
+              next
+            end
+
+            # The replay bills whatever the plan carries now, so a charge added after the event was
+            # ingested would be billed for a period it did not cover.
+            if charges.any? { |charge| charge.created_at > event.created_at }
+              skipped << [event.transaction_id, event.external_subscription_id,
+                "its plan gained a pay-in-advance charge after the event was ingested, so a replay " \
+                "would bill more than the original would have"]
+              next
+            end
+
+            billable_metric = charges.first.billable_metric
+            unless billable_metric.count_agg? ||
+                billable_metric.custom_agg? ||
+                event.properties[billable_metric.field_name].present?
+              not_due += 1
+              next
+            end
+
+            subscription = eligible
+
+            [event, subscription, charges, billable_metric]
+          end
+          next if candidates.empty?
+
+          transaction_ids = candidates.map { |event, _, _, _| event.transaction_id }
+
+          # No invoice_id filter: `Fee.from_organization_pay_in_advance` scopes to `invoice_id: nil` and
+          # would miss fees already billed.
+          charged_ids_by_transaction_id = Fee
+            .where(
+              organization_id: organization.id,
+              pay_in_advance: true,
+              original_fee_id: nil,
+              pay_in_advance_event_transaction_id: transaction_ids
+            )
+            .pluck(:pay_in_advance_event_transaction_id, :charge_id)
+            .group_by(&:first)
+            .transform_values { |rows| rows.map(&:last) }
+
+          # Every index on `pay_in_advance_event_transaction_id` is partial on `deleted_at IS NULL`, so
+          # including discarded fees in the query above would make all of them unusable.
+          uncharged = transaction_ids - charged_ids_by_transaction_id.keys
+          discarded_transaction_ids = if uncharged.empty?
+            Set.new
           else
-            "no subscription covers its timestamp; a replay would create no fee"
+            Fee.with_discarded
+              .where.not(deleted_at: nil)
+              .where(
+                organization_id: organization.id,
+                pay_in_advance: true,
+                original_fee_id: nil,
+                pay_in_advance_event_transaction_id: uncharged
+              )
+              .distinct
+              .pluck(:pay_in_advance_event_transaction_id)
+              .to_set
           end
-          skipped << [event.transaction_id, event.external_subscription_id, reason]
-          next
-        end
 
-        if replayed != eligible
-          skipped << [event.transaction_id, event.external_subscription_id,
-            "the subscription the replay would bill (#{replayed.id}) is not the one post-processing " \
-            "would have used (#{eligible.id}); recover it by hand"]
-          next
-        end
+          candidates.each do |event, subscription, charges, billable_metric|
+            charged_ids = charged_ids_by_transaction_id[event.transaction_id]
 
-        charges = charges_by_plan_and_code[[eligible.plan_id, event.code]]
-        if charges.blank?
-          not_due += 1
-          next
-        end
+            if charged_ids.present?
+              missing = charges.map(&:id) - charged_ids
+              if missing.any?
+                skipped << [event.transaction_id, event.external_subscription_id,
+                  "charges #{missing.join(", ")} have no fee while others do, and " \
+                  "`Events::PayInAdvanceService` skips the whole event once any fee exists"]
+              end
+              next
+            end
 
-        # The replay bills whatever the plan carries now, so a charge added after the event was
-        # ingested would be billed for a period it did not cover.
-        if charges.any? { |charge| charge.created_at > event.created_at }
-          skipped << [event.transaction_id, event.external_subscription_id,
-            "its plan gained a pay-in-advance charge after the event was ingested, so a replay " \
-            "would bill more than the original would have"]
-          next
-        end
+            # The guard indexes ignore discarded rows, so a fee that was voided on purpose would look
+            # exactly like a missing one.
+            if discarded_transaction_ids.include?(event.transaction_id)
+              skipped << [event.transaction_id, event.external_subscription_id,
+                "its fees are all discarded, so they were either voided on purpose or already " \
+                "regenerated; check before recovering it by hand"]
+              next
+            end
 
-        billable_metric = charges.first.billable_metric
-        unless billable_metric.count_agg? ||
-            billable_metric.custom_agg? ||
-            event.properties[billable_metric.field_name].present?
-          not_due += 1
-          next
-        end
+            # `Events::PayInAdvanceService` enqueues one `Invoices::CreatePayInAdvanceChargeJob` per
+            # invoiceable charge, and each mints its own invoice, so the blast radius is a count of
+            # charges rather than of events.
+            invoiceable_charges = charges.count(&:invoiceable?)
+            recovered += 1
+            invoices_to_create += invoiceable_charges
+            tainted_subscriptions << subscription.id unless billable_metric.count_agg?
 
-        subscription = eligible
+            puts "  RECOVER #{event.transaction_id} subscription=#{event.external_subscription_id} " \
+              "code=#{event.code} invoiceable_charges=#{invoiceable_charges}"
 
-        [event, subscription, charges, billable_metric]
-      end
-      next if candidates.empty?
-
-      transaction_ids = candidates.map { |event, _, _, _| event.transaction_id }
-
-      # No invoice_id filter: `Fee.from_organization_pay_in_advance` scopes to `invoice_id: nil` and
-      # would miss fees already billed.
-      charged_ids_by_transaction_id = Fee
-        .where(
-          organization_id: organization.id,
-          pay_in_advance: true,
-          original_fee_id: nil,
-          pay_in_advance_event_transaction_id: transaction_ids
-        )
-        .pluck(:pay_in_advance_event_transaction_id, :charge_id)
-        .group_by(&:first)
-        .transform_values { |rows| rows.map(&:last) }
-
-      # Every index on `pay_in_advance_event_transaction_id` is partial on `deleted_at IS NULL`, so
-      # including discarded fees in the query above would make all of them unusable.
-      uncharged = transaction_ids - charged_ids_by_transaction_id.keys
-      discarded_transaction_ids = if uncharged.empty?
-        Set.new
-      else
-        Fee.with_discarded
-          .where.not(deleted_at: nil)
-          .where(
-            organization_id: organization.id,
-            pay_in_advance: true,
-            original_fee_id: nil,
-            pay_in_advance_event_transaction_id: uncharged
-          )
-          .distinct
-          .pluck(:pay_in_advance_event_transaction_id)
-          .to_set
-      end
-
-      candidates.each do |event, subscription, charges, billable_metric|
-        charged_ids = charged_ids_by_transaction_id[event.transaction_id]
-
-        if charged_ids.present?
-          missing = charges.map(&:id) - charged_ids
-          if missing.any?
-            skipped << [event.transaction_id, event.external_subscription_id,
-              "charges #{missing.join(", ")} have no fee while others do, and " \
-              "`Events::PayInAdvanceService` skips the whole event once any fee exists"]
+            Events::PayInAdvanceJob.perform_later(Events::CommonFactory.new_instance(source: event).as_json) unless dry_run
           end
-          next
         end
-
-        # The guard indexes ignore discarded rows, so a fee that was voided on purpose would look
-        # exactly like a missing one.
-        if discarded_transaction_ids.include?(event.transaction_id)
-          skipped << [event.transaction_id, event.external_subscription_id,
-            "its fees are all discarded, so they were either voided on purpose or already " \
-            "regenerated; check before recovering it by hand"]
-          next
-        end
-
-        # `Events::PayInAdvanceService` enqueues one `Invoices::CreatePayInAdvanceChargeJob` per
-        # invoiceable charge, and each mints its own invoice, so the blast radius is a count of
-        # charges rather than of events.
-        invoiceable_charges = charges.count(&:invoiceable?)
-        recovered += 1
-        invoices_to_create += invoiceable_charges
-        tainted_subscriptions << subscription.id unless billable_metric.count_agg?
-
-        puts "  RECOVER #{event.transaction_id} subscription=#{event.external_subscription_id} " \
-          "code=#{event.code} invoiceable_charges=#{invoiceable_charges}"
-
-        Events::PayInAdvanceJob.perform_later(Events::CommonFactory.new_instance(source: event).as_json) unless dry_run
       end
     end
 

--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -186,13 +186,10 @@ namespace :events do
     tainted_subscriptions = Set.new
     started_at = Time.current
 
-    total_subscriptions = subscriptions_scope.distinct.count(:external_id)
-
     puts "#{prefix} [#{mode}]"
-    puts "Organization:  #{organization.id}"
-    puts "Timestamped:   [#{from.iso8601}, #{to.iso8601})"
-    puts "Metrics:       #{codes.size} pay-in-advance metric code(s)"
-    puts "Subscriptions: #{total_subscriptions} external id(s) on a plan carrying one"
+    puts "Organization: #{organization.id}"
+    puts "Timestamped:  [#{from.iso8601}, #{to.iso8601})"
+    puts "Metrics:      #{codes.size} pay-in-advance metric code(s)"
     puts "=" * 80
 
     last_external_id = nil
@@ -210,8 +207,8 @@ namespace :events do
       batch_external_ids.each do |external_id|
         processed += 1
 
-        if (processed % 250).zero? || processed == total_subscriptions
-          puts "  ... #{processed}/#{total_subscriptions} subscription(s), #{scanned} event(s) scanned " \
+        if (processed % 250).zero?
+          puts "  ... #{processed} subscription(s), #{scanned} event(s) scanned " \
             "in #{(Time.current - started_at).round(1)}s, #{recovered} to recover, #{skipped.size} skipped"
         end
 

--- a/spec/lib/tasks/events_rake_spec.rb
+++ b/spec/lib/tasks/events_rake_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "events:recover_pay_in_advance_fees" do # rubocop:disable RSpec/D
     create(:subscription, customer:, organization:, plan:, started_at: 10.days.ago)
   end
 
-  let(:ingested_at) { 3.days.ago.change(usec: 0) }
+  let(:occurred_at) { 3.days.ago.change(usec: 0) }
 
   let(:event) do
     create(
@@ -31,8 +31,8 @@ RSpec.describe "events:recover_pay_in_advance_fees" do # rubocop:disable RSpec/D
       subscription:,
       code: billable_metric.code,
       properties: {"item_id" => "12"},
-      timestamp: ingested_at,
-      created_at: ingested_at
+      timestamp: occurred_at,
+      created_at: occurred_at
     )
   end
 
@@ -160,6 +160,16 @@ RSpec.describe "events:recover_pay_in_advance_fees" do # rubocop:disable RSpec/D
     end
   end
 
+  context "when the aggregation is neither count nor custom" do
+    let(:billable_metric) do
+      create(:billable_metric, organization:, aggregation_type: "unique_count_agg", field_name: "item_id")
+    end
+
+    it "still recognises the event as due" do
+      expect { invoke }.to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+  end
+
   context "when the aggregation requires a field that the event does not carry" do
     let(:event) do
       create(
@@ -199,7 +209,7 @@ RSpec.describe "events:recover_pay_in_advance_fees" do # rubocop:disable RSpec/D
 
   # The window is documented as [FROM, TO), so an event ingested exactly at TO is out.
   context "when the event was ingested exactly at the upper bound" do
-    before { ENV["TO"] = ingested_at.iso8601 }
+    before { ENV["TO"] = occurred_at.iso8601 }
 
     it "does not enqueue anything" do
       expect { invoke }.not_to have_enqueued_job(Events::PayInAdvanceJob)
@@ -207,10 +217,30 @@ RSpec.describe "events:recover_pay_in_advance_fees" do # rubocop:disable RSpec/D
   end
 
   context "when the event was ingested exactly at the lower bound" do
-    before { ENV["FROM"] = ingested_at.iso8601 }
+    before { ENV["FROM"] = occurred_at.iso8601 }
 
     it "re-enqueues the event" do
       expect { invoke }.to have_enqueued_job(Events::PayInAdvanceJob)
+    end
+  end
+
+  # The window is the event timestamp, not its ingestion time, so a backdated event is out of scope
+  # even when it was ingested inside the window.
+  context "when the event was ingested in the window but timestamped before it" do
+    let(:event) do
+      create(
+        :event,
+        organization_id: organization.id,
+        subscription:,
+        code: billable_metric.code,
+        properties: {"item_id" => "12"},
+        timestamp: 8.days.ago,
+        created_at: occurred_at
+      )
+    end
+
+    it "does not enqueue anything" do
+      expect { invoke }.not_to have_enqueued_job(Events::PayInAdvanceJob)
     end
   end
 
@@ -295,23 +325,11 @@ RSpec.describe "events:recover_pay_in_advance_fees" do # rubocop:disable RSpec/D
   context "when the external id is shared with a later subscription" do
     let(:new_plan) { create(:plan, organization:) }
 
-    # Ingested during the outage window, but carrying a timestamp from before the upgrade.
-    let(:event) do
-      create(
-        :event,
-        organization_id: organization.id,
-        subscription:,
-        code: billable_metric.code,
-        properties: {"item_id" => "12"},
-        timestamp: 6.days.ago,
-        created_at: 3.days.ago
-      )
-    end
-
+    # The upgrade lands after the event, so only the terminated subscription covers its timestamp.
     before do
-      subscription.update!(terminated_at: 4.days.ago, status: :terminated)
+      subscription.update!(terminated_at: occurred_at + 1.hour, status: :terminated)
       create(:subscription, customer:, organization:, plan: new_plan, external_id: subscription.external_id,
-        started_at: 4.days.ago)
+        started_at: occurred_at + 1.hour)
     end
 
     it "re-enqueues the event against the subscription that covers its timestamp" do
@@ -428,7 +446,25 @@ RSpec.describe "events:recover_pay_in_advance_fees" do # rubocop:disable RSpec/D
   end
 
   it "reports its progress so a long run is visibly advancing" do
-    expect { invoke }.to output(/1\/1 scanned in \d+(\.\d+)?s/).to_stdout
+    expect { invoke }.to output(/1 scanned in \d+(\.\d+)?s/).to_stdout
+  end
+
+  # Subscriptions are streamed in batches, and an external id shared by an upgrade can straddle a
+  # boundary; it must still be visited exactly once.
+  context "when the subscriptions span several batches" do
+    before do
+      ENV["BATCH_SIZE"] = "1"
+      subscription.update!(terminated_at: occurred_at + 1.hour, status: :terminated)
+      create(:subscription, customer:, organization:, plan:, external_id: subscription.external_id,
+        started_at: occurred_at + 1.hour)
+      3.times { create(:subscription, customer:, organization:, plan:, started_at: 10.days.ago) }
+    end
+
+    after { ENV.delete("BATCH_SIZE") }
+
+    it "enqueues the event exactly once" do
+      expect { invoke }.to have_enqueued_job(Events::PayInAdvanceJob).once
+    end
   end
 
   context "when the events span several batches" do


### PR DESCRIPTION
> Follow-up of #6314 and #6320.

## Context

`events:recover_pay_in_advance_fees` is very slow on an organization with a very large `events` table. It scanned the whole ingestion-time window for the organization, and no index carries the event code alongside the time, so every event ingested in the window was visited just to test its code. It also counted those candidates up front to show a total, walking the window twice before printing anything.

## Description

- Bound the window on the event `timestamp` rather than `created_at`, and walk one subscription external id at a time, so each lookup is served by an index leading on `external_subscription_id`. Cost now follows that subscription's events inside the window rather than everything the organization ingested.
- Drop the up-front count, so the header and progress appear immediately. Progress is reported per subscription, which gives back a total to measure against.

Timestamp is also the axis a pay-in-advance fee is billed against — its period comes from the event timestamp, and the cached aggregations it chains through are ordered by it — so replaying in timestamp order per subscription is closer to the original processing than ingestion order was.

## Behavior change to be aware of

- `FROM`/`TO` now bound the event timestamp. An event ingested during an outage but timestamped outside the window is no longer in scope; widen `FROM` to reach backdated ones.
