### PR TITLE
refactor (events): use metered items in aggregations

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -311,7 +311,11 @@ class Invoice < ApplicationRecord
 
     service.new(
       event_store_class: Events::Stores::StoreFactory.store_class(organization:),
-      charge: fee.charge,
+      metered_item: Fees::ChargeService::MeteredItem.from_charge(
+        charge: fee.charge,
+        boundaries: BillingPeriodBoundaries.from_fee(fee),
+        charge_filter: fee.charge_filter
+      ),
       context: Events::Stores::EventContext.from(subscription: fee.subscription),
       boundaries: {
         from_datetime: Time.zone.parse(fee.properties["charges_from_datetime"]),

--- a/app/services/billable_metrics/aggregation_factory.rb
+++ b/app/services/billable_metrics/aggregation_factory.rb
@@ -2,46 +2,46 @@
 
 module BillableMetrics
   class AggregationFactory
-    def self.new_instance(charge:, context:, current_usage: false, **attributes)
-      aggregator_class(charge, current_usage).new(
-        event_store_class: Events::Stores::StoreFactory.store_class(organization: charge.billable_metric.organization),
-        charge:,
+    def self.new_instance(metered_item:, context:, current_usage: false, **attributes)
+      aggregator_class(metered_item, current_usage).new(
+        event_store_class: Events::Stores::StoreFactory.store_class(organization: metered_item.billable_metric.organization),
+        metered_item:,
         context:,
         **attributes
       )
     end
 
-    def self.aggregator_class(charge, current_usage)
-      case charge.billable_metric.aggregation_type.to_sym
+    def self.aggregator_class(metered_item, current_usage)
+      case metered_item.billable_metric.aggregation_type.to_sym
       when :count_agg
         BillableMetrics::Aggregations::CountService
 
       when :latest_agg
-        raise(NotImplementedError) if charge.pay_in_advance? && !current_usage
+        raise(NotImplementedError) if metered_item.pay_in_advance? && !current_usage
 
         BillableMetrics::Aggregations::LatestService
 
       when :max_agg
-        raise(NotImplementedError) if charge.pay_in_advance? && !current_usage
+        raise(NotImplementedError) if metered_item.pay_in_advance? && !current_usage
 
         BillableMetrics::Aggregations::MaxService
 
       when :sum_agg
-        if charge.prorated?
+        if metered_item.prorated?
           BillableMetrics::ProratedAggregations::SumService
         else
           BillableMetrics::Aggregations::SumService
         end
 
       when :unique_count_agg
-        if charge.prorated?
+        if metered_item.prorated?
           BillableMetrics::ProratedAggregations::UniqueCountService
         else
           BillableMetrics::Aggregations::UniqueCountService
         end
 
       when :weighted_sum_agg
-        raise(NotImplementedError) if charge.pay_in_advance? && !current_usage
+        raise(NotImplementedError) if metered_item.pay_in_advance? && !current_usage
 
         BillableMetrics::Aggregations::WeightedSumService
 

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -48,10 +48,10 @@ module BillableMetrics
         result
       end
 
-      def initialize(event_store_class:, charge:, context:, boundaries:, filters: {}, bypass_aggregation: false)
+      def initialize(event_store_class:, metered_item:, context:, boundaries:, filters: {}, bypass_aggregation: false)
         super(nil)
         @event_store_class = event_store_class
-        @charge = charge
+        @metered_item = metered_item
         @context = context
 
         @filters = filters
@@ -73,14 +73,14 @@ module BillableMetrics
       def aggregate(options: {})
         if grouped_by.present?
           compute_grouped_by_aggregation(options:)
-          if charge.dynamic?
+          if metered_item.dynamic?
             compute_grouped_by_precise_total_amount_cents(options:)
           end
 
           result.aggregations.each { apply_rounding(it) }
         else
           compute_aggregation(options:)
-          if charge.dynamic?
+          if metered_item.dynamic?
             compute_precise_total_amount_cents(options:)
           end
 
@@ -132,7 +132,7 @@ module BillableMetrics
       protected
 
       attr_accessor :event_store_class,
-        :charge,
+        :metered_item,
         :context,
         :filters,
         :charge_filter,
@@ -144,7 +144,7 @@ module BillableMetrics
         :bypass_aggregation,
         :uniq_grouped_by_and_presentation_by
 
-      delegate :billable_metric, to: :charge
+      delegate :billable_metric, to: :metered_item
 
       delegate :customer, to: :context
 
@@ -231,7 +231,7 @@ module BillableMetrics
         query = CachedAggregation
           .where(organization_id: billable_metric.organization_id)
           .where(external_subscription_id: context.external_id)
-          .where(charge_id: charge.id)
+          .where(charge_id: metered_item.charge_id)
           .from_datetime(with_from_datetime)
           .to_datetime(with_to_datetime)
           .where(grouped_by: grouped_by.presence || {})

--- a/app/services/billable_metrics/aggregations/custom_service.rb
+++ b/app/services/billable_metrics/aggregations/custom_service.rb
@@ -82,7 +82,7 @@ module BillableMetrics
       def custom_properties
         return charge_filter.properties["custom_properties"] if charge_filter.present?
 
-        charge.properties["custom_properties"]
+        metered_item.properties["custom_properties"]
       end
 
       def current_state(grouped_by_values:)
@@ -97,7 +97,7 @@ module BillableMetrics
         query = CachedAggregation
           .where(organization_id: billable_metric.organization_id)
           .where(external_subscription_id: context.external_id)
-          .where(charge_id: charge.id)
+          .where(charge_id: metered_item.charge_id)
           .where("cached_aggregations.timestamp < ?", truncated_datetime)
           .where(grouped_by: grouped_by_values.presence || {})
           .order(timestamp: :desc, created_at: :desc)

--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -136,7 +136,7 @@ module BillableMetrics
         query = CachedAggregation
           .where(organization_id: billable_metric.organization_id)
           .where(external_subscription_id: context.external_id)
-          .where(charge_id: charge.id)
+          .where(charge_id: metered_item.charge_id)
           .where(timestamp: ...from_datetime)
           .order(timestamp: :desc, created_at: :desc)
 

--- a/app/services/charges/pay_in_advance_aggregation_service.rb
+++ b/app/services/charges/pay_in_advance_aggregation_service.rb
@@ -16,7 +16,7 @@ module Charges
 
     def call
       aggregator = BillableMetrics::AggregationFactory.new_instance(
-        metered_item: Fees::ChargeService::MeteredItem.from_charge(charge:, boundaries:, charge_filter:),
+        metered_item: Fees::ChargeService::MeteredItem.from_charge(charge:, boundaries:, charge_filter:, properties:),
         context: Events::Stores::EventContext.from(subscription:),
         boundaries: {
           from_datetime: boundaries.charges_from_datetime,

--- a/app/services/charges/pay_in_advance_aggregation_service.rb
+++ b/app/services/charges/pay_in_advance_aggregation_service.rb
@@ -16,7 +16,7 @@ module Charges
 
     def call
       aggregator = BillableMetrics::AggregationFactory.new_instance(
-        charge:,
+        metered_item: Fees::ChargeService::MeteredItem.from_charge(charge:, boundaries:, charge_filter:),
         context: Events::Stores::EventContext.from(subscription:),
         boundaries: {
           from_datetime: boundaries.charges_from_datetime,

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -433,7 +433,7 @@ module Fees
       aggregate = filtered_aggregations.include?(selected_metered_item.charge_filter&.id) unless filtered_aggregations.nil?
 
       BillableMetrics::AggregationFactory.new_instance(
-        charge: selected_metered_item.charge,
+        metered_item: selected_metered_item,
         current_usage: options.current_usage?,
         context: Events::Stores::EventContext.from(subscription:),
         boundaries: {

--- a/app/services/fees/charge_service/metered_item.rb
+++ b/app/services/fees/charge_service/metered_item.rb
@@ -15,6 +15,8 @@ module Fees
       end
 
       delegate :charge,
+        :charge_id,
+        :dynamic?,
         :charge_filter,
         :billable_metric,
         :organization_id,

--- a/app/services/fees/charge_service/sources/charge.rb
+++ b/app/services/fees/charge_service/sources/charge.rb
@@ -13,6 +13,7 @@ module Fees
         end
 
         delegate :billable_metric,
+          :dynamic?,
           :pay_in_advance?,
           :prorated?,
           :invoiceable?,
@@ -20,6 +21,8 @@ module Fees
           :organization_id,
           :presentation_group_keys_values,
           to: :charge
+
+        delegate :id, to: :charge, prefix: true
 
         def with_charge_filter(charge_filter, properties: nil)
           self.class.new(

--- a/app/services/fees/projection_service.rb
+++ b/app/services/fees/projection_service.rb
@@ -112,7 +112,18 @@ module Fees
       }
 
       aggregator = BillableMetrics::AggregationFactory.new_instance(
-        charge: charge,
+        metered_item: ChargeService::MeteredItem.from_charge(
+          charge:,
+          charge_filter:,
+          boundaries: BillingPeriodBoundaries.new(
+            from_datetime:,
+            to_datetime:,
+            charges_from_datetime: from_datetime,
+            charges_to_datetime: to_datetime,
+            charges_duration: charges_duration_in_days,
+            timestamp: first_fee.properties["timestamp"]
+          )
+        ),
         context: Events::Stores::EventContext.from(subscription:),
         boundaries: boundaries,
         filters: aggregation_filters,

--- a/spec/services/billable_metrics/aggregation_factory_spec.rb
+++ b/spec/services/billable_metrics/aggregation_factory_spec.rb
@@ -22,8 +22,21 @@ RSpec.describe BillableMetrics::AggregationFactory do
   end
 
   let(:current_usage) { false }
+  let(:metered_item) do
+    Fees::ChargeService::MeteredItem.from_charge(
+      charge:,
+      boundaries: BillingPeriodBoundaries.new(
+        from_datetime: boundaries[:charges_from_datetime],
+        to_datetime: boundaries[:charges_to_datetime],
+        charges_from_datetime: boundaries[:charges_from_datetime],
+        charges_to_datetime: boundaries[:charges_to_datetime],
+        charges_duration: nil,
+        timestamp: nil
+      )
+    )
+  end
 
-  let(:result) { factory.new_instance(charge:, current_usage:, context: Events::Stores::EventContext.from(subscription:), boundaries:) }
+  let(:result) { factory.new_instance(metered_item:, current_usage:, context: Events::Stores::EventContext.from(subscription:), boundaries:) }
 
   describe "#new_instance" do
     context "with count_agg aggregation" do

--- a/spec/services/billable_metrics/aggregations/base_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/base_service_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe BillableMetrics::Aggregations::BaseService do
     let(:aggregator) do
       described_class.new(
         event_store_class: Events::Stores::PostgresStore,
-        charge:,
+        metered_item:,
         context: Events::Stores::EventContext.from(subscription:),
         boundaries: {from_datetime: Time.current, to_datetime: Time.current},
         filters:
@@ -88,6 +88,19 @@ RSpec.describe BillableMetrics::Aggregations::BaseService do
 
     let(:subscription) { create(:subscription) }
     let(:charge) { create(:standard_charge, plan: subscription.plan) }
+    let(:metered_item) do
+      Fees::ChargeService::MeteredItem.from_charge(
+        charge:,
+        boundaries: BillingPeriodBoundaries.new(
+          from_datetime: Time.current,
+          to_datetime: Time.current,
+          charges_from_datetime: Time.current,
+          charges_to_datetime: Time.current,
+          charges_duration: 1,
+          timestamp: Time.current
+        )
+      )
+    end
     let(:filters) { {} }
 
     context "without grouped_by" do

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService do
   subject(:count_service) do
     described_class.new(
       event_store_class:,
-      charge:,
+      metered_item:,
       context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
@@ -18,6 +18,19 @@ RSpec.describe BillableMetrics::Aggregations::CountService do
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
+  let(:metered_item) do
+    Fees::ChargeService::MeteredItem.from_charge(
+      charge:,
+      boundaries: BillingPeriodBoundaries.new(
+        from_datetime:,
+        to_datetime:,
+        charges_from_datetime: from_datetime,
+        charges_to_datetime: to_datetime,
+        charges_duration: (to_datetime.to_date - from_datetime.to_date).to_i + 1,
+        timestamp: to_datetime
+      )
+    )
+  end
   let(:bypass_aggregation) { false }
   let(:filters) do
     {event: pay_in_advance_event, grouped_by:, presentation_by:, matching_filters:, ignored_filters:}

--- a/spec/services/billable_metrics/aggregations/custom_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/custom_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::Aggregations::CustomService do
   subject(:custom_service) do
     described_class.new(
       event_store_class:,
-      charge:,
+      metered_item:,
       context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
@@ -18,6 +18,19 @@ RSpec.describe BillableMetrics::Aggregations::CustomService do
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
+  let(:metered_item) do
+    Fees::ChargeService::MeteredItem.from_charge(
+      charge:,
+      boundaries: BillingPeriodBoundaries.new(
+        from_datetime:,
+        to_datetime:,
+        charges_from_datetime: from_datetime,
+        charges_to_datetime: to_datetime,
+        charges_duration: (to_datetime.to_date - from_datetime.to_date).to_i + 1,
+        timestamp: to_datetime
+      )
+    )
+  end
   let(:bypass_aggregation) { false }
   let(:filters) { {grouped_by:, matching_filters:, ignored_filters:, event:} }
 

--- a/spec/services/billable_metrics/aggregations/latest_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/latest_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::Aggregations::LatestService do
   subject(:latest_service) do
     described_class.new(
       event_store_class:,
-      charge:,
+      metered_item:,
       context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
@@ -18,6 +18,19 @@ RSpec.describe BillableMetrics::Aggregations::LatestService do
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
+  let(:metered_item) do
+    Fees::ChargeService::MeteredItem.from_charge(
+      charge:,
+      boundaries: BillingPeriodBoundaries.new(
+        from_datetime:,
+        to_datetime:,
+        charges_from_datetime: from_datetime,
+        charges_to_datetime: to_datetime,
+        charges_duration: (to_datetime.to_date - from_datetime.to_date).to_i + 1,
+        timestamp: to_datetime
+      )
+    )
+  end
   let(:bypass_aggregation) { false }
   let(:filters) { {grouped_by:, presentation_by:, matching_filters:, ignored_filters:} }
 

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService do
   subject(:max_service) do
     described_class.new(
       event_store_class:,
-      charge:,
+      metered_item:,
       context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
@@ -18,6 +18,19 @@ RSpec.describe BillableMetrics::Aggregations::MaxService do
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
+  let(:metered_item) do
+    Fees::ChargeService::MeteredItem.from_charge(
+      charge:,
+      boundaries: BillingPeriodBoundaries.new(
+        from_datetime:,
+        to_datetime:,
+        charges_from_datetime: from_datetime,
+        charges_to_datetime: to_datetime,
+        charges_duration: (to_datetime.to_date - from_datetime.to_date).to_i + 1,
+        timestamp: to_datetime
+      )
+    )
+  end
   let(:bypass_aggregation) { false }
   let(:filters) { {grouped_by:, presentation_by:, matching_filters:, ignored_filters:} }
 

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, transaction: false do
   subject(:sum_service) do
     described_class.new(
       event_store_class:,
-      charge:,
+      metered_item:,
       context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
@@ -18,6 +18,19 @@ RSpec.describe BillableMetrics::Aggregations::SumService, transaction: false do
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
+  let(:metered_item) do
+    Fees::ChargeService::MeteredItem.from_charge(
+      charge:,
+      boundaries: BillingPeriodBoundaries.new(
+        from_datetime:,
+        to_datetime:,
+        charges_from_datetime: from_datetime,
+        charges_to_datetime: to_datetime,
+        charges_duration: (to_datetime.to_date - from_datetime.to_date).to_i + 1,
+        timestamp: to_datetime
+      )
+    )
+  end
   let(:bypass_aggregation) { false }
   let(:filters) do
     {event: pay_in_advance_event, grouped_by:, presentation_by:, charge_filter:, matching_filters:, ignored_filters:}

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, transaction: f
   subject(:count_service) do
     described_class.new(
       event_store_class:,
-      charge:,
+      metered_item:,
       context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
@@ -18,6 +18,19 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, transaction: f
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
+  let(:metered_item) do
+    Fees::ChargeService::MeteredItem.from_charge(
+      charge:,
+      boundaries: BillingPeriodBoundaries.new(
+        from_datetime:,
+        to_datetime:,
+        charges_from_datetime: from_datetime,
+        charges_to_datetime: to_datetime,
+        charges_duration: (to_datetime.to_date - from_datetime.to_date).to_i + 1,
+        timestamp: to_datetime
+      )
+    )
+  end
   let(:bypass_aggregation) { false }
   let(:filters) do
     {event: pay_in_advance_event, grouped_by:, presentation_by:, charge_filter:, matching_filters:, ignored_filters:}

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, transaction: f
   subject(:aggregator) do
     described_class.new(
       event_store_class:,
-      charge:,
+      metered_item:,
       context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
@@ -19,6 +19,19 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, transaction: f
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
+  let(:metered_item) do
+    Fees::ChargeService::MeteredItem.from_charge(
+      charge:,
+      boundaries: BillingPeriodBoundaries.new(
+        from_datetime:,
+        to_datetime:,
+        charges_from_datetime: from_datetime,
+        charges_to_datetime: to_datetime,
+        charges_duration:,
+        timestamp: to_datetime
+      )
+    )
+  end
   let(:bypass_aggregation) { false }
   let(:filters) { {grouped_by:, presentation_by:, matching_filters:, ignored_filters:} }
 

--- a/spec/services/billable_metrics/breakdown/sum_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/sum_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::Breakdown::SumService, transaction: false do
   subject(:service) do
     described_class.new(
       event_store_class:,
-      charge:,
+      metered_item:,
       context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
@@ -21,6 +21,19 @@ RSpec.describe BillableMetrics::Breakdown::SumService, transaction: false do
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
+  let(:metered_item) do
+    Fees::ChargeService::MeteredItem.from_charge(
+      charge:,
+      boundaries: BillingPeriodBoundaries.new(
+        from_datetime:,
+        to_datetime:,
+        charges_from_datetime: from_datetime,
+        charges_to_datetime: to_datetime,
+        charges_duration: 31,
+        timestamp: to_datetime
+      )
+    )
+  end
 
   let(:subscription) do
     create(

--- a/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::Breakdown::UniqueCountService, transaction: fals
   subject(:service) do
     described_class.new(
       event_store_class:,
-      charge:,
+      metered_item:,
       context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
@@ -21,6 +21,19 @@ RSpec.describe BillableMetrics::Breakdown::UniqueCountService, transaction: fals
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
+  let(:metered_item) do
+    Fees::ChargeService::MeteredItem.from_charge(
+      charge:,
+      boundaries: BillingPeriodBoundaries.new(
+        from_datetime:,
+        to_datetime:,
+        charges_from_datetime: from_datetime,
+        charges_to_datetime: to_datetime,
+        charges_duration: (to_datetime - from_datetime).fdiv(1.day).round,
+        timestamp: to_datetime
+      )
+    )
+  end
 
   let(:organization) { create(:organization) }
 

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, transaction: f
   subject(:sum_service) do
     described_class.new(
       event_store_class:,
-      charge:,
+      metered_item:,
       context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
@@ -18,6 +18,19 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, transaction: f
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
+  let(:metered_item) do
+    Fees::ChargeService::MeteredItem.from_charge(
+      charge:,
+      boundaries: BillingPeriodBoundaries.new(
+        from_datetime:,
+        to_datetime:,
+        charges_from_datetime: from_datetime,
+        charges_to_datetime: to_datetime,
+        charges_duration: 31,
+        timestamp: to_datetime
+      )
+    )
+  end
   let(:filters) { {event: pay_in_advance_event, grouped_by:, presentation_by:, matching_filters:, ignored_filters:} }
 
   let(:subscription) { create(:subscription, started_at: Time.zone.parse("2022-12-01 00:00:00")) }
@@ -830,7 +843,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, transaction: f
       subject(:sum_service) do
         described_class.new(
           event_store_class:,
-          charge:,
+          metered_item:,
           context: Events::Stores::EventContext.from(subscription:),
           boundaries: {
             from_datetime:,
@@ -870,7 +883,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, transaction: f
       subject(:sum_service) do
         described_class.new(
           event_store_class:,
-          charge:,
+          metered_item:,
           context: Events::Stores::EventContext.from(subscription:),
           boundaries: {
             from_datetime:,

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transa
   subject(:unique_count_service) do
     described_class.new(
       event_store_class:,
-      charge:,
+      metered_item:,
       context: Events::Stores::EventContext.from(subscription:),
       boundaries: {
         from_datetime:,
@@ -18,6 +18,19 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transa
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
+  let(:metered_item) do
+    Fees::ChargeService::MeteredItem.from_charge(
+      charge:,
+      boundaries: BillingPeriodBoundaries.new(
+        from_datetime:,
+        to_datetime:,
+        charges_from_datetime: from_datetime,
+        charges_to_datetime: to_datetime,
+        charges_duration: 31,
+        timestamp: to_datetime
+      )
+    )
+  end
   let(:filters) { {event: pay_in_advance_event, grouped_by:, presentation_by:, matching_filters:, ignored_filters:} }
 
   let(:subscription) do
@@ -1048,7 +1061,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transa
       subject(:unique_count_service) do
         described_class.new(
           event_store_class:,
-          charge:,
+          metered_item:,
           context: Events::Stores::EventContext.from(subscription:),
           boundaries: {
             from_datetime:,
@@ -1086,7 +1099,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transa
       subject(:unique_count_service) do
         described_class.new(
           event_store_class:,
-          charge:,
+          metered_item:,
           context: Events::Stores::EventContext.from(subscription:),
           boundaries: {
             from_datetime:,

--- a/spec/services/charge_models/percentage_service_spec.rb
+++ b/spec/services/charge_models/percentage_service_spec.rb
@@ -252,11 +252,24 @@ RSpec.describe ChargeModels::PercentageService do
     let(:per_transaction_min_amount) { "1.75" }
 
     let(:subscription) { create(:subscription, organization:, plan:) }
+    let(:metered_item) do
+      Fees::ChargeService::MeteredItem.from_charge(
+        charge:,
+        boundaries: BillingPeriodBoundaries.new(
+          from_datetime: subscription.started_at,
+          to_datetime: subscription.started_at.end_of_month,
+          charges_from_datetime: subscription.started_at,
+          charges_to_datetime: subscription.started_at.end_of_month,
+          charges_duration: subscription.started_at.end_of_month.day - subscription.started_at.day + 1,
+          timestamp: subscription.started_at.end_of_month
+        )
+      )
+    end
 
     let(:aggregator) do
       BillableMetrics::Aggregations::SumService.new(
         event_store_class:,
-        charge:,
+        metered_item:,
         context: Events::Stores::EventContext.from(subscription:),
         boundaries: nil
       )

--- a/spec/services/charge_models/prorated_graduated_service_spec.rb
+++ b/spec/services/charge_models/prorated_graduated_service_spec.rb
@@ -14,6 +14,19 @@ RSpec.describe ChargeModels::ProratedGraduatedService do
   let(:organization) { create(:organization) }
   let(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, organization:, plan:) }
+  let(:metered_item) do
+    Fees::ChargeService::MeteredItem.from_charge(
+      charge:,
+      boundaries: BillingPeriodBoundaries.new(
+        from_datetime: subscription.started_at,
+        to_datetime: subscription.started_at.end_of_month,
+        charges_from_datetime: subscription.started_at,
+        charges_to_datetime: subscription.started_at.end_of_month,
+        charges_duration: subscription.started_at.end_of_month.day - subscription.started_at.day + 1,
+        timestamp: subscription.started_at.end_of_month
+      )
+    )
+  end
 
   let(:aggregation_result) { BillableMetrics::Aggregations::BaseService::Result.new }
   let(:billable_metric) { create(:sum_billable_metric, recurring: true) }
@@ -21,7 +34,7 @@ RSpec.describe ChargeModels::ProratedGraduatedService do
   let(:aggregator) do
     BillableMetrics::ProratedAggregations::SumService.new(
       event_store_class:,
-      charge:,
+      metered_item:,
       context: Events::Stores::EventContext.from(subscription:),
       boundaries: nil
     )

--- a/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
+++ b/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
@@ -9,6 +9,19 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService do
   let(:plan) { create(:plan, organization:) }
   let(:charge) { create(:standard_charge, :pay_in_advance, plan:) }
   let(:subscription) { create(:subscription, plan:) }
+  let(:metered_item) do
+    Fees::ChargeService::MeteredItem.from_charge(
+      charge:,
+      boundaries: BillingPeriodBoundaries.new(
+        from_datetime: subscription.started_at,
+        to_datetime: subscription.started_at.end_of_month,
+        charges_from_datetime: subscription.started_at,
+        charges_to_datetime: subscription.started_at.end_of_month,
+        charges_duration: subscription.started_at.end_of_month.day - subscription.started_at.day + 1,
+        timestamp: subscription.started_at.end_of_month
+      )
+    )
+  end
 
   let(:aggregation_result) do
     BillableMetrics::Aggregations::BaseService::Result.new.tap do |result|
@@ -25,7 +38,7 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService do
   let(:aggregator) do
     BillableMetrics::Aggregations::CountService.new(
       event_store_class: Events::Stores::PostgresStore,
-      charge:,
+      metered_item:,
       context: Events::Stores::EventContext.from(subscription:),
       boundaries: nil
     )
@@ -220,7 +233,7 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService do
       let(:aggregator) do
         BillableMetrics::Aggregations::SumService.new(
           event_store_class: Events::Stores::PostgresStore,
-          charge:,
+          metered_item:,
           context: Events::Stores::EventContext.from(subscription:),
           boundaries: nil
         )

--- a/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
 
   let(:agg_result) { BaseService::Result.new }
   let(:subscription_context) { have_attributes(external_id: subscription.external_id, organization: subscription.organization) }
+  let(:metered_item) { Fees::ChargeService::MeteredItem.from_charge(charge:, boundaries:, charge_filter:) }
 
   describe "#call" do
     describe "when count aggregation" do
@@ -47,7 +48,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
         expect(BillableMetrics::Aggregations::CountService).to have_received(:new)
           .with(
             event_store_class: Events::Stores::PostgresStore,
-            charge:,
+            metered_item:,
             context: subscription_context,
             boundaries: {
               from_datetime: boundaries.charges_from_datetime,
@@ -94,7 +95,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
           expect(BillableMetrics::Aggregations::CountService).to have_received(:new)
             .with(
               event_store_class: Events::Stores::PostgresStore,
-              charge:,
+              metered_item:,
               context: subscription_context,
               boundaries: {
                 from_datetime: boundaries.charges_from_datetime,
@@ -142,7 +143,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
           expect(BillableMetrics::Aggregations::CountService).to have_received(:new)
             .with(
               event_store_class: Events::Stores::PostgresStore,
-              charge:,
+              metered_item:,
               context: subscription_context,
               boundaries: {
                 from_datetime: boundaries.charges_from_datetime,
@@ -193,7 +194,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
             expect(BillableMetrics::Aggregations::CountService).to have_received(:new)
               .with(
                 event_store_class: Events::Stores::PostgresStore,
-                charge:,
+                metered_item:,
                 context: subscription_context,
                 boundaries: {
                   from_datetime: boundaries.charges_from_datetime,
@@ -239,7 +240,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
           expect(BillableMetrics::Aggregations::CountService).to have_received(:new)
             .with(
               event_store_class: Events::Stores::PostgresStore,
-              charge:,
+              metered_item:,
               context: subscription_context,
               boundaries: {
                 from_datetime: boundaries.charges_from_datetime,
@@ -287,7 +288,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
           expect(BillableMetrics::Aggregations::CountService).to have_received(:new)
             .with(
               event_store_class: Events::Stores::PostgresStore,
-              charge:,
+              metered_item:,
               context: subscription_context,
               boundaries: {
                 from_datetime: boundaries.charges_from_datetime,
@@ -331,7 +332,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
           expect(BillableMetrics::Aggregations::CountService).to have_received(:new)
             .with(
               event_store_class: Events::Stores::PostgresStore,
-              charge:,
+              metered_item:,
               context: subscription_context,
               boundaries: {
                 from_datetime: boundaries.charges_from_datetime,
@@ -370,7 +371,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
         expect(BillableMetrics::Aggregations::SumService).to have_received(:new)
           .with(
             event_store_class: Events::Stores::PostgresStore,
-            charge:,
+            metered_item:,
             context: subscription_context,
             boundaries: {
               from_datetime: boundaries.charges_from_datetime,
@@ -404,7 +405,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
         expect(BillableMetrics::Aggregations::UniqueCountService).to have_received(:new)
           .with(
             event_store_class: Events::Stores::PostgresStore,
-            charge:,
+            metered_item:,
             context: subscription_context,
             boundaries: {
               from_datetime: boundaries.charges_from_datetime,

--- a/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
@@ -34,9 +34,35 @@ RSpec.describe Charges::PayInAdvanceAggregationService do
 
   let(:agg_result) { BaseService::Result.new }
   let(:subscription_context) { have_attributes(external_id: subscription.external_id, organization: subscription.organization) }
-  let(:metered_item) { Fees::ChargeService::MeteredItem.from_charge(charge:, boundaries:, charge_filter:) }
+  let(:metered_item) { Fees::ChargeService::MeteredItem.from_charge(charge:, boundaries:, charge_filter:, properties:) }
 
   describe "#call" do
+    context "with custom aggregation and an unsaved default filter" do
+      let(:billable_metric) { create(:custom_billable_metric, organization:) }
+      let(:charge_filter) { ChargeFilter.new(charge:) }
+      let(:properties) { charge.properties }
+      let(:charge) do
+        create(:standard_charge, billable_metric:, pay_in_advance: true,
+          properties: {"amount" => "100", "custom_properties" => {"multiplier" => "2"}})
+      end
+      let(:custom_service) { instance_double(BillableMetrics::Aggregations::CustomService, aggregate: agg_result) }
+
+      it "passes the resolved charge properties to the custom aggregation service" do
+        create(:charge_filter, charge:)
+        allow(BillableMetrics::Aggregations::CustomService).to receive(:new).and_return(custom_service)
+
+        agg_service.call
+
+        expect(BillableMetrics::Aggregations::CustomService).to have_received(:new).with(
+          event_store_class: Events::Stores::PostgresStore,
+          metered_item: have_attributes(properties: charge.properties),
+          context: subscription_context,
+          boundaries: anything,
+          filters: hash_excluding(:charge_filter)
+        )
+      end
+    end
+
     describe "when count aggregation" do
       let(:count_service) { instance_double(BillableMetrics::Aggregations::CountService, aggregate: agg_result) }
 

--- a/spec/services/fees/charge_service/metered_item_spec.rb
+++ b/spec/services/fees/charge_service/metered_item_spec.rb
@@ -35,12 +35,22 @@ RSpec.describe Fees::ChargeService::MeteredItem do
       expect(metered_item.properties).to eq(charge.properties)
       expect(metered_item.pricing_structure).to be_a(ChargeModels::PricingStructure)
       expect(metered_item).to have_attributes(
+        charge_id: charge.id,
+        dynamic?: false,
         charge_filter: nil,
         pay_in_advance?: false,
         prorated?: false,
         invoiceable?: true,
         applied_pricing_unit: nil
       )
+    end
+  end
+
+  describe "#dynamic?" do
+    it "reflects the backing charge's pricing model" do
+      charge.charge_model = "dynamic"
+
+      expect(metered_item).to be_dynamic
     end
   end
 

--- a/spec/services/fees/projection_service_spec.rb
+++ b/spec/services/fees/projection_service_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Fees::ProjectionService do
         allow(BillableMetrics::AggregationFactory).to receive(:new_instance).and_return(aggregator)
         service.call
         expect(BillableMetrics::AggregationFactory).to have_received(:new_instance).with(
-          charge: charge,
+          metered_item: have_attributes(charge:, charge_filter: nil),
           context: have_attributes(external_id: subscription.external_id, organization: subscription.organization),
           boundaries: {
             from_datetime: match_datetime(from_datetime),
@@ -201,7 +201,7 @@ RSpec.describe Fees::ProjectionService do
 
     context "with charge filter" do
       let(:charge_filter) do
-        create(:charge_filter, properties: {"amount" => "1000"})
+        create(:charge_filter, charge:, properties: {"amount" => "1000"})
       end
 
       let(:filter_service_result) do
@@ -223,7 +223,7 @@ RSpec.describe Fees::ProjectionService do
         allow(BillableMetrics::AggregationFactory).to receive(:new_instance).and_return(aggregator)
         service.call
         expect(BillableMetrics::AggregationFactory).to have_received(:new_instance).with(
-          charge: charge,
+          metered_item: have_attributes(charge:, charge_filter:),
           context: have_attributes(external_id: subscription.external_id, organization: subscription.organization),
           boundaries: {
             from_datetime: match_datetime(from_datetime),


### PR DESCRIPTION
## Context

Aggregation services depend directly on charges even though fee computation already uses metered items.

## Description

Pass metered items through the aggregation factory and services. Update fee, projection, and invoice breakdown callers and their specs. Expose charge_id and dynamic pricing through the charge source while preserving the explicit event context.
