### PR TITLE
fix(seeds): pass catalog plan attributes as a positional hash

### DIFF
--- a/db/seeds/30_product_catalog.rb
+++ b/db/seeds/30_product_catalog.rb
@@ -100,10 +100,10 @@ unless ProductCategory.exists?(organization:, code: "cloud_platform")
 
   # Seed a catalog plan for the offer. Rate cards attach to catalog plans in a
   # later slice, so the plan is seeded on its own for now.
-  CatalogPlans::CreateService.call!(
+  CatalogPlans::CreateService.call!({
     organization_id: organization.id,
     name: "Growth",
     code: "growth",
     currency: "USD"
-  )
+  })
 end


### PR DESCRIPTION
Pass the product catalog seed attributes as an explicit positional hash to CatalogPlans::CreateService. Its initializer requires that hash, so the current keyword-only call raises ArgumentError and stops database seeding before frontend end-to-end tests can start.
