### PR TITLE
fix(quotes): underscore charge override properties keys

### DIFF
--- a/app/services/orders/subscription_creation/execute_service.rb
+++ b/app/services/orders/subscription_creation/execute_service.rb
@@ -133,11 +133,16 @@ module Orders
       end
 
       # chargeModel is not forwarded: Charges::OverrideService cannot switch models and ignores it.
+      #
+      # The properties are written in the payload's own camelCase and land verbatim on the duplicated
+      # charge, which reads them in snake_case. Underscoring them here is what the business validator
+      # approved, and skipping it would leave the charge invalid: Plans::OverrideService ignores the
+      # override services' results, so it would drop from the plan and bill nothing at all.
       def charge_overrides(item, plan)
         Array(item.dig("overrides", "charges")).map do |override|
           {
             id: charge_id!(item, plan, override["billableMetricCode"]),
-            properties: override["properties"],
+            properties: Utils::ChargeProperties.underscore_keys(override["properties"]),
             min_amount_cents: override["minAmountCents"],
             invoice_display_name: override["invoiceDisplayName"]
           }.compact
@@ -149,7 +154,7 @@ module Orders
           {
             id: fixed_charge_id!(item, plan, override["addOnCode"]),
             units: override["units"],
-            properties: override["properties"],
+            properties: Utils::ChargeProperties.underscore_keys(override["properties"]),
             invoice_display_name: override["invoiceDisplayName"]
           }.compact
         end

--- a/app/services/orders/subscription_creation/execute_service.rb
+++ b/app/services/orders/subscription_creation/execute_service.rb
@@ -133,11 +133,6 @@ module Orders
       end
 
       # chargeModel is not forwarded: Charges::OverrideService cannot switch models and ignores it.
-      #
-      # The properties are written in the payload's own camelCase and land verbatim on the duplicated
-      # charge, which reads them in snake_case. Underscoring them here is what the business validator
-      # approved, and skipping it would leave the charge invalid: Plans::OverrideService ignores the
-      # override services' results, so it would drop from the plan and bill nothing at all.
       def charge_overrides(item, plan)
         Array(item.dig("overrides", "charges")).map do |override|
           {

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -161,8 +161,11 @@ module QuoteVersions
           quoted_charge_model != chargeable.charge_model
         end
 
+        # The quoted payload is written in its own camelCase while the charge models read their
+        # properties in snake_case, so the negotiated hash is underscored here and, identically, where
+        # the override is applied. See Orders::SubscriptionCreation::ExecuteService#charge_overrides.
         def validate_charge_properties(charge_override, charge, index, charge_index)
-          properties = charge_override["properties"]
+          properties = Utils::ChargeProperties.underscore_keys(charge_override["properties"])
           return if properties.nil?
 
           field = plan_field(index, "overrides.charges.#{charge_index}.properties")
@@ -226,7 +229,7 @@ module QuoteVersions
         # before saving, and FixedCharge requires them to be present, so an override drafted for
         # another model filters down to nothing and takes the fixed charge with it.
         def validate_fixed_charge_properties(fixed_charge_override, fixed_charge, index, fixed_charge_index)
-          properties = fixed_charge_override["properties"]
+          properties = Utils::ChargeProperties.underscore_keys(fixed_charge_override["properties"])
           return if properties.nil?
 
           field = plan_field(index, "overrides.fixedCharges.#{fixed_charge_index}.properties")

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -161,9 +161,6 @@ module QuoteVersions
           quoted_charge_model != chargeable.charge_model
         end
 
-        # The quoted payload is written in its own camelCase while the charge models read their
-        # properties in snake_case, so the negotiated hash is underscored here and, identically, where
-        # the override is applied. See Orders::SubscriptionCreation::ExecuteService#charge_overrides.
         def validate_charge_properties(charge_override, charge, index, charge_index)
           properties = Utils::ChargeProperties.underscore_keys(charge_override["properties"])
           return if properties.nil?

--- a/app/services/quote_versions/validators/subscription_creation/schema.rb
+++ b/app/services/quote_versions/validators/subscription_creation/schema.rb
@@ -250,7 +250,10 @@ module QuoteVersions
                             # NOTE: chargeModel is stored for the execution flow to consume,
                             # Charges::OverrideService cannot switch models yet. properties is
                             # deliberately only type-checked: its shape per charge model is
-                            # validated where the override is applied, not here.
+                            # validated where the override is applied, not here. Its keys are
+                            # submitted in the camelCase of the payload and underscored by
+                            # Utils::ChargeProperties wherever they are read, since the charge
+                            # models themselves know them in snake_case.
                             "chargeModel" => {
                               "type" => %w[string null],
                               "enum" => [*CHARGE_MODELS, nil],

--- a/app/services/utils/charge_properties.rb
+++ b/app/services/utils/charge_properties.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Utils
+  class ChargeProperties
+    # Charge properties are read in snake_case by the charge models and their validators, while the
+    # payloads carrying them are written in the camelCase of the GraphQL schema they were read from:
+    # a quote's billing_items is a free-form JSON scalar, so nothing converts it on the way in.
+    # Underscoring is idempotent, so a payload already written in snake_case normalizes to itself and
+    # both spellings are accepted.
+    PRESERVED_KEY = "custom_properties"
+
+    # Anything that is not an object is returned as it arrived, for the callers to reject the way
+    # they already do.
+    def self.underscore_keys(properties)
+      return properties unless properties.is_a?(Hash)
+
+      properties.to_h do |key, value|
+        normalized_key = key.to_s.underscore
+
+        # custom_properties carries the keys the customer defined for their own aggregation, so
+        # renaming them would change what that aggregation reads at billing time.
+        if normalized_key == PRESERVED_KEY
+          [normalized_key, value]
+        else
+          [normalized_key, underscore_value(value)]
+        end
+      end
+    end
+
+    def self.underscore_value(value)
+      case value
+      when Hash then underscore_keys(value)
+      when Array then value.map { underscore_value(it) }
+      else value
+      end
+    end
+    private_class_method :underscore_value
+  end
+end

--- a/spec/services/orders/subscription_creation/execute_service_spec.rb
+++ b/spec/services/orders/subscription_creation/execute_service_spec.rb
@@ -109,10 +109,6 @@ RSpec.describe Orders::SubscriptionCreation::ExecuteService, :premium do
         expect(overridden_plan.charges.sole.properties["amount"]).to eq("30")
       end
 
-      # The charge models know their properties in snake_case, so tiers negotiated in the camelCase
-      # of the payload have to reach the override plan underscored. Left as submitted they would fail
-      # Charge#validate_charge_model_properties, and Plans::OverrideService ignores that: the charge
-      # would silently drop off the plan and the subscription would bill nothing for it.
       context "when the negotiated tiers are written in the camelCase of the payload" do
         let(:charge) { create(:graduated_charge, plan:, billable_metric:) }
         let(:plan_overrides) do

--- a/spec/services/orders/subscription_creation/execute_service_spec.rb
+++ b/spec/services/orders/subscription_creation/execute_service_spec.rb
@@ -109,6 +109,41 @@ RSpec.describe Orders::SubscriptionCreation::ExecuteService, :premium do
         expect(overridden_plan.charges.sole.properties["amount"]).to eq("30")
       end
 
+      # The charge models know their properties in snake_case, so tiers negotiated in the camelCase
+      # of the payload have to reach the override plan underscored. Left as submitted they would fail
+      # Charge#validate_charge_model_properties, and Plans::OverrideService ignores that: the charge
+      # would silently drop off the plan and the subscription would bill nothing for it.
+      context "when the negotiated tiers are written in the camelCase of the payload" do
+        let(:charge) { create(:graduated_charge, plan:, billable_metric:) }
+        let(:plan_overrides) do
+          super().merge(
+            "charges" => [
+              super()["charges"].sole.merge(
+                "properties" => {
+                  "graduatedRanges" => [
+                    {"fromValue" => 0, "toValue" => 1000, "perUnitAmount" => "0.005", "flatAmount" => "0"},
+                    {"fromValue" => 1001, "toValue" => nil, "perUnitAmount" => "0.002", "flatAmount" => "0"}
+                  ]
+                }
+              )
+            ]
+          )
+        end
+
+        it "bills the negotiated tiers" do
+          execute_service.call
+
+          overridden_charge = customer.subscriptions.sole.plan.charges.sole
+          expect(overridden_charge.parent_id).to eq(charge.id)
+          expect(overridden_charge.properties["graduated_ranges"]).to eq(
+            [
+              {"from_value" => 0, "to_value" => 1000, "per_unit_amount" => "0.005", "flat_amount" => "0"},
+              {"from_value" => 1001, "to_value" => nil, "per_unit_amount" => "0.002", "flat_amount" => "0"}
+            ]
+          )
+        end
+      end
+
       context "when the override reprices the plan in another currency" do
         let(:plan_overrides) { super().merge("amountCurrency" => "USD") }
         let(:quote_version) do

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -374,6 +374,43 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       end
     end
 
+    context "when the negotiated tiers are written in the camelCase of the payload" do
+      let(:charge) { create(:graduated_charge, plan:, billable_metric:) }
+      let(:charge_override) do
+        super().merge(
+          "chargeModel" => nil,
+          "properties" => {
+            "graduatedRanges" => [
+              {"fromValue" => 0, "toValue" => 1000, "perUnitAmount" => "0.005", "flatAmount" => "0"},
+              {"fromValue" => 1001, "toValue" => nil, "perUnitAmount" => "0.002", "flatAmount" => "0"}
+            ]
+          }
+        )
+      end
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the negotiated tiers are written in the snake_case of the charge model" do
+      let(:charge) { create(:graduated_charge, plan:, billable_metric:) }
+      let(:charge_override) do
+        super().merge(
+          "chargeModel" => nil,
+          "properties" => {
+            "graduated_ranges" => [
+              {"from_value" => 0, "to_value" => nil, "per_unit_amount" => "0.005", "flat_amount" => "0"}
+            ]
+          }
+        )
+      end
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
     context "when the charge override carries no properties" do
       let(:charge_override) { super().except("properties") }
 
@@ -528,6 +565,24 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
 
     context "when the negotiated fixed charge properties are valid" do
       let(:fixed_charge_override) { super().merge("properties" => {"amount" => "42"}) }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the negotiated fixed charge tiers are written in the camelCase of the payload" do
+      let(:fixed_charge) { create(:fixed_charge, :graduated, plan:) }
+      let(:fixed_charge_override) do
+        super().merge(
+          "properties" => {
+            "graduatedRanges" => [
+              {"fromValue" => 0, "toValue" => 10, "perUnitAmount" => "5", "flatAmount" => "200"},
+              {"fromValue" => 11, "toValue" => nil, "perUnitAmount" => "1", "flatAmount" => "300"}
+            ]
+          }
+        )
+      end
 
       it "is valid" do
         expect(validator).to be_valid

--- a/spec/services/utils/charge_properties_spec.rb
+++ b/spec/services/utils/charge_properties_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Utils::ChargeProperties do
+  describe ".underscore_keys" do
+    it "underscores the keys of a camelCase payload" do
+      properties = {
+        "graduatedRanges" => [
+          {"fromValue" => 0, "toValue" => 1000, "perUnitAmount" => "0.005", "flatAmount" => "0"},
+          {"fromValue" => 1001, "toValue" => nil, "perUnitAmount" => "0.002", "flatAmount" => "0"}
+        ],
+        "pricingGroupKeys" => %w[regionName cloudProvider]
+      }
+
+      expect(described_class.underscore_keys(properties)).to eq(
+        {
+          "graduated_ranges" => [
+            {"from_value" => 0, "to_value" => 1000, "per_unit_amount" => "0.005", "flat_amount" => "0"},
+            {"from_value" => 1001, "to_value" => nil, "per_unit_amount" => "0.002", "flat_amount" => "0"}
+          ],
+          "pricing_group_keys" => %w[regionName cloudProvider]
+        }
+      )
+    end
+
+    it "leaves an already underscored payload untouched" do
+      properties = {
+        "graduated_ranges" => [{"from_value" => 0, "to_value" => nil, "per_unit_amount" => "1", "flat_amount" => "0"}]
+      }
+
+      expect(described_class.underscore_keys(properties)).to eq(properties)
+    end
+
+    it "stringifies symbol keys" do
+      expect(described_class.underscore_keys({freeUnits: 10, packageSize: 100}))
+        .to eq({"free_units" => 10, "package_size" => 100})
+    end
+
+    # The customer defined those keys for their own aggregation, renaming them would change what it
+    # reads at billing time.
+    it "keeps the keys the customer defined inside custom_properties" do
+      properties = {"customProperties" => {"myOwnKey" => {"nestedKey" => "value"}}}
+
+      expect(described_class.underscore_keys(properties))
+        .to eq({"custom_properties" => {"myOwnKey" => {"nestedKey" => "value"}}})
+    end
+
+    it "returns anything that is not an object as it arrived" do
+      expect(described_class.underscore_keys(nil)).to be_nil
+      expect(described_class.underscore_keys("graduatedRanges")).to eq("graduatedRanges")
+      expect(described_class.underscore_keys([{"fromValue" => 0}])).to eq([{"fromValue" => 0}])
+    end
+  end
+end

--- a/spec/services/utils/charge_properties_spec.rb
+++ b/spec/services/utils/charge_properties_spec.rb
@@ -37,8 +37,6 @@ RSpec.describe Utils::ChargeProperties do
         .to eq({"free_units" => 10, "package_size" => 100})
     end
 
-    # The customer defined those keys for their own aggregation, renaming them would change what it
-    # reads at billing time.
     it "keeps the keys the customer defined inside custom_properties" do
       properties = {"customProperties" => {"myOwnKey" => {"nestedKey" => "value"}}}
 


### PR DESCRIPTION
Saving tier changes on a quote subscription override failed with `missing_graduated_ranges`: `billing_items` is camelCase, but charge override `properties` reaches the charge models and `Charges::OverrideService`, which read snake_case.

`Utils::ChargeProperties.underscore_keys` now normalizes those properties where they are consumed (validator and execution), leaving `custom_properties` untouched. Storage stays as the frontend sent it, and both casings are accepted.

Without this an approved quote also dropped the charge from the override plan silently, billing nothing for it.

LAGO-1918