### PR TITLE
fix(catalog): pass seed plan attributes as a positional hash

### DIFF
--- a/db/seeds/30_product_catalog.rb
+++ b/db/seeds/30_product_catalog.rb
@@ -100,10 +100,12 @@ unless ProductCategory.exists?(organization:, code: "cloud_platform")
 
   # Seed a catalog plan for the offer. Rate cards attach to catalog plans in a
   # later slice, so the plan is seeded on its own for now.
-  CatalogPlans::CreateService.call!(
+  # CreateService takes the attributes as a single positional hash (it mirrors
+  # the controller's permitted params), so pass them wrapped, not as keywords.
+  CatalogPlans::CreateService.call!({
     organization_id: organization.id,
     name: "Growth",
     code: "growth",
     currency: "USD"
-  )
+  })
 end


### PR DESCRIPTION
## Context

The product-catalog seed (`db/seeds/30_product_catalog.rb`) calls `CatalogPlans::CreateService` with **keyword** arguments, but the service takes its attributes as a **single positional hash** (it mirrors the controller's permitted params: `initialize(args, send_webhook: true)`). `BaseService.call!` forwards to `new(*, **)`, so keywords reach `initialize` with zero positional args and Ruby 3 raises `ArgumentError: wrong number of arguments (given 0, expected 1)`.

## Fix

Wrap the attributes in an explicit hash so they arrive as the positional argument the service expects, with a comment noting the convention.
