### PR TITLE
feat(account-tree): add table and model setup for usage_attribution_types

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -93,6 +93,8 @@ class Organization < ApplicationRecord
   has_many :entitlement_values, class_name: "Entitlement::EntitlementValue"
   has_many :subscription_feature_removals, class_name: "Entitlement::SubscriptionFeatureRemoval"
 
+  has_many :usage_attribution_types
+
   has_many :subscription_activities, class_name: "UsageMonitoring::SubscriptionActivity"
   has_many :alerts, class_name: "UsageMonitoring::Alert"
   has_many :triggered_alerts, -> { triggered }, class_name: "UsageMonitoring::TriggeredAlert"

--- a/app/models/usage_attribution_type.rb
+++ b/app/models/usage_attribution_type.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+class UsageAttributionType < ApplicationRecord
+  include Discard::Model
+
+  self.discard_column = :deleted_at
+
+  ROLES = {
+    hierarchical: "hierarchical",
+    flat: "flat"
+  }.freeze
+
+  belongs_to :organization
+  belongs_to :parent, class_name: "UsageAttributionType", optional: true
+  has_many :children, class_name: "UsageAttributionType", foreign_key: :parent_id, inverse_of: :parent
+
+  enum :role, ROLES, validate: true
+
+  validates :code, presence: true, length: {maximum: 255}, uniqueness: {scope: :organization_id, conditions: -> { where(deleted_at: nil) }}
+  validates :name, length: {maximum: 255}
+  validates :attribution_key, presence: true, length: {maximum: 255}, uniqueness: {scope: :organization_id, conditions: -> { where(deleted_at: nil) }}
+
+  validate :validate_parent
+
+  default_scope -> { kept }
+
+  private
+
+  def validate_parent
+    return if parent.nil?
+
+    if flat?
+      errors.add(:parent_id, :forbidden_for_flat_role)
+      return
+    end
+
+    errors.add(:parent_id, :must_be_hierarchical) unless parent.hierarchical?
+    errors.add(:parent_id, :must_belong_to_same_organization) unless parent.organization_id == organization_id
+    errors.add(:parent_id, :cannot_form_a_cycle) if cycle_through?(parent)
+  end
+
+  def cycle_through?(node)
+    visited = []
+
+    while node && visited.exclude?(node)
+      return true if node.id == id
+
+      visited << node
+      node = node.parent
+    end
+
+    false
+  end
+end
+
+# == Schema Information
+#
+# Table name: usage_attribution_types
+# Database name: primary
+#
+#  id              :uuid             not null, primary key
+#  attribution_key :string           not null
+#  code            :string           not null
+#  deleted_at      :datetime
+#  name            :string
+#  role            :enum             not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#  parent_id       :uuid
+#
+# Indexes
+#
+#  index_usage_attribution_types_on_organization_id           (organization_id)
+#  index_usage_attribution_types_on_organization_id_and_code  (organization_id,code) UNIQUE WHERE (deleted_at IS NULL)
+#  index_usage_attribution_types_on_organization_id_and_key   (organization_id,attribution_key) UNIQUE WHERE (deleted_at IS NULL)
+#  index_usage_attribution_types_on_parent_id                 (parent_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (parent_id => usage_attribution_types.id)
+#

--- a/db/migrate/20260908112310_create_usage_attribution_types.rb
+++ b/db/migrate/20260908112310_create_usage_attribution_types.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class CreateUsageAttributionTypes < ActiveRecord::Migration[8.0]
+  def change
+    create_enum :usage_attribution_type_role, %w[hierarchical flat]
+
+    create_table :usage_attribution_types, id: :uuid do |t|
+      t.references :organization, type: :uuid, null: false, foreign_key: true, index: true
+      t.references :parent, type: :uuid, null: true, foreign_key: {to_table: :usage_attribution_types}, index: true
+
+      t.string :code, null: false
+      t.string :name
+      t.string :attribution_key, null: false
+      t.enum :role, enum_type: :usage_attribution_type_role, null: false
+
+      t.datetime :deleted_at
+
+      t.timestamps
+
+      t.index %i[organization_id code],
+        unique: true,
+        where: "deleted_at IS NULL",
+        name: "index_usage_attribution_types_on_organization_id_and_code"
+      t.index %i[organization_id attribution_key],
+        unique: true,
+        where: "deleted_at IS NULL",
+        name: "index_usage_attribution_types_on_organization_id_and_key"
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -21,6 +21,7 @@ ALTER TABLE IF EXISTS ONLY public.wallet_targets DROP CONSTRAINT IF EXISTS fk_ra
 ALTER TABLE IF EXISTS ONLY public.product_filter_values DROP CONSTRAINT IF EXISTS fk_rails_f99eb07174;
 ALTER TABLE IF EXISTS ONLY public.fees_taxes DROP CONSTRAINT IF EXISTS fk_rails_f98413d404;
 ALTER TABLE IF EXISTS ONLY public.order_forms DROP CONSTRAINT IF EXISTS fk_rails_f94f882198;
+ALTER TABLE IF EXISTS ONLY public.usage_attribution_types DROP CONSTRAINT IF EXISTS fk_rails_f7f094fe3a;
 ALTER TABLE IF EXISTS ONLY public.billing_entities DROP CONSTRAINT IF EXISTS fk_rails_f66617edcb;
 ALTER TABLE IF EXISTS ONLY public.payment_receipts DROP CONSTRAINT IF EXISTS fk_rails_f53ff93138;
 ALTER TABLE IF EXISTS ONLY public.quantified_events DROP CONSTRAINT IF EXISTS fk_rails_f510acb495;
@@ -334,6 +335,7 @@ ALTER TABLE IF EXISTS ONLY public.rate_phases DROP CONSTRAINT IF EXISTS fk_rails
 ALTER TABLE IF EXISTS ONLY public.billing_entities_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_19c47827ba;
 ALTER TABLE IF EXISTS ONLY public.catalog_plans DROP CONSTRAINT IF EXISTS fk_rails_19759667f5;
 ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk_rails_195153290d;
+ALTER TABLE IF EXISTS ONLY public.usage_attribution_types DROP CONSTRAINT IF EXISTS fk_rails_18b43f689c;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_189f2a3949;
 ALTER TABLE IF EXISTS ONLY public.quote_owners DROP CONSTRAINT IF EXISTS fk_rails_1811b32fcd;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlements DROP CONSTRAINT IF EXISTS fk_rails_173327f0dc;
@@ -440,6 +442,10 @@ DROP INDEX IF EXISTS public.index_usage_monitoring_alerts_on_subscription_extern
 DROP INDEX IF EXISTS public.index_usage_monitoring_alerts_on_organization_id;
 DROP INDEX IF EXISTS public.index_usage_monitoring_alerts_on_billable_metric_id;
 DROP INDEX IF EXISTS public.index_usage_monitoring_alert_thresholds_on_organization_id;
+DROP INDEX IF EXISTS public.index_usage_attribution_types_on_parent_id;
+DROP INDEX IF EXISTS public.index_usage_attribution_types_on_organization_id_and_key;
+DROP INDEX IF EXISTS public.index_usage_attribution_types_on_organization_id_and_code;
+DROP INDEX IF EXISTS public.index_usage_attribution_types_on_organization_id;
 DROP INDEX IF EXISTS public.index_unique_transaction_id;
 DROP INDEX IF EXISTS public.index_unique_terminating_invoice_subscription;
 DROP INDEX IF EXISTS public.index_unique_starting_invoice_subscription;
@@ -1059,6 +1065,7 @@ ALTER TABLE IF EXISTS ONLY public.usage_monitoring_triggered_alerts DROP CONSTRA
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_subscription_activities DROP CONSTRAINT IF EXISTS usage_monitoring_subscription_activities_pkey;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alerts DROP CONSTRAINT IF EXISTS usage_monitoring_alerts_pkey;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alert_thresholds DROP CONSTRAINT IF EXISTS usage_monitoring_alert_thresholds_pkey;
+ALTER TABLE IF EXISTS ONLY public.usage_attribution_types DROP CONSTRAINT IF EXISTS usage_attribution_types_pkey;
 ALTER TABLE IF EXISTS ONLY public.taxes DROP CONSTRAINT IF EXISTS taxes_pkey;
 ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS subscriptions_pkey;
 ALTER TABLE IF EXISTS ONLY public.subscriptions_invoice_custom_sections DROP CONSTRAINT IF EXISTS subscriptions_invoice_custom_sections_pkey;
@@ -1199,6 +1206,7 @@ DROP TABLE IF EXISTS public.user_devices;
 DROP SEQUENCE IF EXISTS public.usage_monitoring_subscription_activities_id_seq;
 DROP TABLE IF EXISTS public.usage_monitoring_subscription_activities;
 DROP TABLE IF EXISTS public.usage_monitoring_alerts;
+DROP TABLE IF EXISTS public.usage_attribution_types;
 DROP TABLE IF EXISTS public.subscriptions_invoice_custom_sections;
 DROP TABLE IF EXISTS public.subscription_fixed_charge_units_overrides;
 DROP TABLE IF EXISTS public.subscription_activation_rules;
@@ -1372,6 +1380,7 @@ DROP FUNCTION IF EXISTS public.ensure_role_consistency();
 DROP TYPE IF EXISTS public.usage_monitoring_triggered_alert_kinds;
 DROP TYPE IF EXISTS public.usage_monitoring_alert_types;
 DROP TYPE IF EXISTS public.usage_monitoring_alert_direction;
+DROP TYPE IF EXISTS public.usage_attribution_type_role;
 DROP TYPE IF EXISTS public.tax_status;
 DROP TYPE IF EXISTS public.subscription_on_termination_invoice;
 DROP TYPE IF EXISTS public.subscription_on_termination_credit_note;
@@ -1950,6 +1959,16 @@ CREATE TYPE public.tax_status AS ENUM (
     'pending',
     'succeeded',
     'failed'
+);
+
+
+--
+-- Name: usage_attribution_type_role; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.usage_attribution_type_role AS ENUM (
+    'hierarchical',
+    'flat'
 );
 
 
@@ -5884,6 +5903,24 @@ CREATE TABLE public.subscriptions_invoice_custom_sections (
 
 
 --
+-- Name: usage_attribution_types; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.usage_attribution_types (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    parent_id uuid,
+    code character varying NOT NULL,
+    name character varying,
+    attribution_key character varying NOT NULL,
+    role public.usage_attribution_type_role NOT NULL,
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: usage_monitoring_alerts; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -7115,6 +7152,14 @@ ALTER TABLE ONLY public.subscriptions
 
 ALTER TABLE ONLY public.taxes
     ADD CONSTRAINT taxes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: usage_attribution_types usage_attribution_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.usage_attribution_types
+    ADD CONSTRAINT usage_attribution_types_pkey PRIMARY KEY (id);
 
 
 --
@@ -11499,6 +11544,34 @@ CREATE UNIQUE INDEX index_unique_transaction_id ON public.events USING btree (or
 
 
 --
+-- Name: index_usage_attribution_types_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_usage_attribution_types_on_organization_id ON public.usage_attribution_types USING btree (organization_id);
+
+
+--
+-- Name: index_usage_attribution_types_on_organization_id_and_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_usage_attribution_types_on_organization_id_and_code ON public.usage_attribution_types USING btree (organization_id, code) WHERE (deleted_at IS NULL);
+
+
+--
+-- Name: index_usage_attribution_types_on_organization_id_and_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_usage_attribution_types_on_organization_id_and_key ON public.usage_attribution_types USING btree (organization_id, attribution_key) WHERE (deleted_at IS NULL);
+
+
+--
+-- Name: index_usage_attribution_types_on_parent_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_usage_attribution_types_on_parent_id ON public.usage_attribution_types USING btree (parent_id);
+
+
+--
 -- Name: index_usage_monitoring_alert_thresholds_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12181,6 +12254,14 @@ ALTER TABLE ONLY public.quote_owners
 
 ALTER TABLE ONLY public.coupon_targets
     ADD CONSTRAINT fk_rails_189f2a3949 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: usage_attribution_types fk_rails_18b43f689c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.usage_attribution_types
+    ADD CONSTRAINT fk_rails_18b43f689c FOREIGN KEY (parent_id) REFERENCES public.usage_attribution_types(id);
 
 
 --
@@ -14688,6 +14769,14 @@ ALTER TABLE ONLY public.billing_entities
 
 
 --
+-- Name: usage_attribution_types fk_rails_f7f094fe3a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.usage_attribution_types
+    ADD CONSTRAINT fk_rails_f7f094fe3a FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: order_forms fk_rails_f94f882198; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -14797,6 +14886,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260908160340'),
 ('20260908154406'),
 ('20260908154307'),
+('20260908112310'),
 ('20260905223042'),
 ('20260905223041'),
 ('20260904173416'),

--- a/spec/factories/usage_attribution_types.rb
+++ b/spec/factories/usage_attribution_types.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :usage_attribution_type do
+    organization
+    sequence(:code) { |n| "usage-attribution-type-#{n}" }
+    name { "User" }
+    sequence(:attribution_key) { |n| "attribution_key_#{n}" }
+    role { "hierarchical" }
+
+    factory :flat_usage_attribution_type do
+      name { "Model" }
+      role { "flat" }
+    end
+  end
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -60,6 +60,8 @@ RSpec.describe Organization do
       expect(subject).to have_many(:entitlement_values).class_name("Entitlement::EntitlementValue")
       expect(subject).to have_many(:subscription_feature_removals).class_name("Entitlement::SubscriptionFeatureRemoval")
 
+      expect(subject).to have_many(:usage_attribution_types)
+
       expect(subject).to have_one(:applied_dunning_campaign).conditions(applied_to_organization: true)
       expect(subject).to have_one(:enriched_store_migration)
       expect(subject).to have_many(:pending_vies_checks)

--- a/spec/models/usage_attribution_type_spec.rb
+++ b/spec/models/usage_attribution_type_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UsageAttributionType do
+  subject(:usage_attribution_type) { build(:usage_attribution_type) }
+
+  describe "enums" do
+    it do
+      expect(subject).to define_enum_for(:role)
+        .backed_by_column_of_type(:enum)
+        .validating
+        .with_values(hierarchical: "hierarchical", flat: "flat")
+    end
+  end
+
+  describe "associations" do
+    it do
+      expect(usage_attribution_type).to belong_to(:organization)
+      expect(usage_attribution_type).to belong_to(:parent).class_name("UsageAttributionType").optional
+      expect(usage_attribution_type).to have_many(:children).class_name("UsageAttributionType").with_foreign_key(:parent_id).inverse_of(:parent)
+    end
+  end
+
+  describe "validations" do
+    it do
+      expect(usage_attribution_type).to validate_presence_of(:code)
+      expect(usage_attribution_type).to validate_presence_of(:attribution_key)
+      expect(usage_attribution_type).to validate_length_of(:code).is_at_most(255)
+      expect(usage_attribution_type).to validate_length_of(:name).is_at_most(255)
+      expect(usage_attribution_type).to validate_length_of(:attribution_key).is_at_most(255)
+    end
+
+    describe "code uniqueness" do
+      let(:organization) { create(:organization) }
+
+      it "rejects a duplicate code within the organization" do
+        create(:usage_attribution_type, organization:, code: "user")
+        duplicate = build(:usage_attribution_type, organization:, code: "user")
+
+        expect(duplicate).not_to be_valid
+        expect(duplicate.errors.where(:code, :taken)).to be_present
+      end
+
+      it "allows the same code in another organization" do
+        create(:usage_attribution_type, organization:, code: "user")
+
+        expect(build(:usage_attribution_type, organization: create(:organization), code: "user")).to be_valid
+      end
+
+      it "frees the code once the holder is discarded" do
+        create(:usage_attribution_type, organization:, code: "user").discard!
+
+        expect(build(:usage_attribution_type, organization:, code: "user")).to be_valid
+      end
+    end
+
+    describe "attribution_key uniqueness" do
+      let(:organization) { create(:organization) }
+
+      it "rejects two types resolving from the same event property" do
+        create(:usage_attribution_type, organization:, attribution_key: "user_id")
+        duplicate = build(:usage_attribution_type, organization:, attribution_key: "user_id")
+
+        expect(duplicate).not_to be_valid
+        expect(duplicate.errors.where(:attribution_key, :taken)).to be_present
+      end
+
+      it "allows the same attribution_key in another organization" do
+        create(:usage_attribution_type, organization:, attribution_key: "user_id")
+
+        expect(build(:usage_attribution_type, organization: create(:organization), attribution_key: "user_id")).to be_valid
+      end
+
+      it "frees the attribution_key once the holder is discarded" do
+        create(:usage_attribution_type, organization:, attribution_key: "user_id").discard!
+
+        expect(build(:usage_attribution_type, organization:, attribution_key: "user_id")).to be_valid
+      end
+    end
+
+    describe "parent_id validation" do
+      let(:organization) { create(:organization) }
+      let(:department) { create(:usage_attribution_type, organization:, code: "department") }
+
+      it "accepts a hierarchical parent from the same organization" do
+        expect(build(:usage_attribution_type, organization:, parent: department)).to be_valid
+      end
+
+      it "accepts no parent at all" do
+        expect(build(:usage_attribution_type, organization:, parent: nil)).to be_valid
+        expect(build(:flat_usage_attribution_type, organization:, parent: nil)).to be_valid
+      end
+
+      it "rejects a parent on a flat type" do
+        flat = build(:flat_usage_attribution_type, organization:, parent: department)
+
+        expect(flat).not_to be_valid
+        expect(flat.errors.where(:parent_id, :forbidden_for_flat_role)).to be_present
+      end
+
+      it "rejects a flat parent" do
+        flat = create(:flat_usage_attribution_type, organization:)
+        child = build(:usage_attribution_type, organization:, parent: flat)
+
+        expect(child).not_to be_valid
+        expect(child.errors.where(:parent_id, :must_be_hierarchical)).to be_present
+      end
+
+      it "rejects a parent from another organization" do
+        foreign = create(:usage_attribution_type, organization: create(:organization))
+        child = build(:usage_attribution_type, organization:, parent: foreign)
+
+        expect(child).not_to be_valid
+        expect(child.errors.where(:parent_id, :must_belong_to_same_organization)).to be_present
+      end
+
+      it "rejects itself as parent" do
+        department.parent = department
+
+        expect(department).not_to be_valid
+        expect(department.errors.where(:parent_id, :cannot_form_a_cycle)).to be_present
+      end
+
+      it "rejects a cycle through an ancestor" do
+        team = create(:usage_attribution_type, organization:, code: "team", parent: department)
+        user = create(:usage_attribution_type, organization:, code: "user", parent: team)
+        department.parent = user
+
+        expect(department).not_to be_valid
+        expect(department.errors.where(:parent_id, :cannot_form_a_cycle)).to be_present
+      end
+    end
+  end
+
+  describe "soft deletion" do
+    it "hides discarded records behind the default scope" do
+      usage_attribution_type.save!
+      usage_attribution_type.discard!
+
+      expect(described_class.all).not_to include(usage_attribution_type)
+      expect(described_class.with_discarded).to include(usage_attribution_type)
+    end
+
+    it "enforces code uniqueness among kept rows at the database level" do
+      organization = create(:organization)
+      create(:usage_attribution_type, organization:, code: "user")
+      duplicate = build(:usage_attribution_type, organization:, code: "user")
+
+      expect { duplicate.save(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it "enforces attribution_key uniqueness among kept rows at the database level" do
+      organization = create(:organization)
+      create(:usage_attribution_type, organization:, attribution_key: "user_id")
+      duplicate = build(:usage_attribution_type, organization:, attribution_key: "user_id")
+
+      expect { duplicate.save(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
+end


### PR DESCRIPTION
## Context

First piece of the account tree config foundation: an organization declares
once which dimensions usage can be attributed to below a customer (user, team,
department, api_key, model). Instances are not declared here - they are
discovered lazily from events in a later step.

## Description

This PR adds new `usage_attribution_types` table and  `UsageAttributionType` model with required validations.