### PR TITLE
feat(catalog): expose catalogPlan and catalogPlans on GraphQL

### DIFF
--- a/app/graphql/resolvers/catalog_plan_resolver.rb
+++ b/app/graphql/resolvers/catalog_plan_resolver.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class CatalogPlanResolver < Resolvers::BaseResolver
+    include RequiresProductCatalog
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    REQUIRED_PERMISSION = "plans:view"
+
+    description "Query a single catalog plan of an organization"
+
+    argument :id, ID, required: true, description: "Uniq ID of the catalog plan"
+
+    type Types::CatalogPlans::Object, null: true
+
+    def resolve(id: nil)
+      current_organization.catalog_plans.find(id)
+    rescue ActiveRecord::RecordNotFound
+      not_found_error(resource: "plan")
+    end
+  end
+end

--- a/app/graphql/resolvers/catalog_plans_resolver.rb
+++ b/app/graphql/resolvers/catalog_plans_resolver.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class CatalogPlansResolver < Resolvers::BaseResolver
+    include RequiresProductCatalog
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    REQUIRED_PERMISSION = "plans:view"
+
+    description "Query catalog plans of an organization"
+
+    argument :limit, Integer, required: false
+    argument :page, Integer, required: false
+    argument :search_term, String, required: false
+
+    type Types::CatalogPlans::Object.collection_type, null: false
+
+    def resolve(page: nil, limit: nil, search_term: nil)
+      result = CatalogPlansQuery.call(
+        organization: current_organization,
+        search_term:,
+        pagination: {
+          page:,
+          limit:
+        }
+      )
+
+      result.catalog_plans
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -27,6 +27,8 @@ module Types
     field :billing_entities, resolver: Resolvers::BillingEntitiesResolver
     field :billing_entity, resolver: Resolvers::BillingEntityResolver
     field :billing_entity_taxes, resolver: Resolvers::BillingEntityTaxesResolver
+    field :catalog_plan, resolver: Resolvers::CatalogPlanResolver
+    field :catalog_plans, resolver: Resolvers::CatalogPlansResolver
     field :contract, resolver: Resolvers::ContractResolver
     field :contracts, resolver: Resolvers::ContractsResolver
     field :coupon, resolver: Resolvers::CouponResolver

--- a/schema.graphql
+++ b/schema.graphql
@@ -1207,6 +1207,21 @@ type CatalogPlan {
   updatedAt: ISO8601DateTime!
 }
 
+"""
+CatalogPlanCollection type
+"""
+type CatalogPlanCollection {
+  """
+  A collection of paginated CatalogPlanCollection
+  """
+  collection: [CatalogPlan!]!
+
+  """
+  Pagination Metadata for navigating the Pagination
+  """
+  metadata: CollectionMetadata!
+}
+
 type Charge {
   appliedPricingUnit: AppliedPricingUnit
   billableMetric: BillableMetric!
@@ -11643,6 +11658,21 @@ type Query {
     """
     billingEntityId: ID!
   ): TaxCollection!
+
+  """
+  Query a single catalog plan of an organization
+  """
+  catalogPlan(
+    """
+    Uniq ID of the catalog plan
+    """
+    id: ID!
+  ): CatalogPlan
+
+  """
+  Query catalog plans of an organization
+  """
+  catalogPlans(limit: Int, page: Int, searchTerm: String): CatalogPlanCollection!
 
   """
   Query a single contract of an organization

--- a/schema.json
+++ b/schema.json
@@ -6517,6 +6517,57 @@
         },
         {
           "kind": "OBJECT",
+          "name": "CatalogPlanCollection",
+          "description": "CatalogPlanCollection type",
+          "fields": [
+            {
+              "name": "collection",
+              "description": "A collection of paginated CatalogPlanCollection",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CatalogPlan",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "metadata",
+              "description": "Pagination Metadata for navigating the Pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "Charge",
           "description": null,
           "fields": [
@@ -60573,6 +60624,88 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "TaxCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "catalogPlan",
+              "description": "Query a single catalog plan of an organization",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Uniq ID of the catalog plan",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CatalogPlan",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "catalogPlans",
+              "description": "Query catalog plans of an organization",
+              "args": [
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "searchTerm",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CatalogPlanCollection",
                   "ofType": null
                 }
               },

--- a/spec/graphql/resolvers/catalog_plan_resolver_spec.rb
+++ b/spec/graphql/resolvers/catalog_plan_resolver_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::CatalogPlanResolver do
+  subject(:result) do
+    execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query:,
+      variables: {catalogPlanId: catalog_plan.id}
+    )
+  end
+
+  let(:required_permission) { "plans:view" }
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:catalog_plan) { create(:catalog_plan, organization:, name: "Growth", code: "growth", currency: "EUR") }
+
+  let(:query) do
+    <<~GQL
+      query($catalogPlanId: ID!) {
+        catalogPlan(id: $catalogPlanId) {
+          id code name currency
+        }
+      }
+    GQL
+  end
+
+  before { organization.enable_feature_flag!(:product_catalog) }
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "plans:view"
+
+  it "returns the catalog plan" do
+    expect(result["data"]["catalogPlan"]).to include(
+      "id" => catalog_plan.id,
+      "code" => "growth",
+      "name" => "Growth",
+      "currency" => "EUR"
+    )
+  end
+
+  context "when the catalog plan belongs to another organization" do
+    let(:catalog_plan) { create(:catalog_plan) }
+
+    it "returns a not found error" do
+      expect_graphql_error(result:, message: "Resource not found")
+    end
+  end
+
+  context "when the organization is not on the product catalog" do
+    before { organization.update!(feature_flags: organization.feature_flags - ["product_catalog"]) }
+
+    it "returns a feature unavailable error" do
+      expect(result["errors"].first.dig("extensions", "code")).to eq("feature_unavailable")
+    end
+  end
+end

--- a/spec/graphql/resolvers/catalog_plans_resolver_spec.rb
+++ b/spec/graphql/resolvers/catalog_plans_resolver_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::CatalogPlansResolver do
+  subject(:result) do
+    execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query:,
+      variables:
+    )
+  end
+
+  let(:required_permission) { "plans:view" }
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:variables) { {} }
+  let!(:catalog_plan) { create(:catalog_plan, organization:, name: "Growth", code: "growth", currency: "EUR") }
+
+  let(:query) do
+    <<~GQL
+      query($searchTerm: String) {
+        catalogPlans(limit: 5, searchTerm: $searchTerm) {
+          collection { id code name currency }
+          metadata { currentPage totalCount }
+        }
+      }
+    GQL
+  end
+
+  before { organization.enable_feature_flag!(:product_catalog) }
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "plans:view"
+
+  it "returns the organization catalog plans" do
+    create(:catalog_plan)
+
+    collection = result["data"]["catalogPlans"]["collection"]
+
+    expect(collection.map { it["id"] }).to eq([catalog_plan.id])
+    expect(collection.first).to include("code" => "growth", "name" => "Growth", "currency" => "EUR")
+    expect(result["data"]["catalogPlans"]["metadata"]["totalCount"]).to eq(1)
+  end
+
+  context "with a search term" do
+    let(:variables) { {searchTerm: "grow"} }
+
+    before { create(:catalog_plan, organization:, name: "Other", code: "other") }
+
+    it "filters by name or code" do
+      collection = result["data"]["catalogPlans"]["collection"]
+
+      expect(collection.map { it["id"] }).to eq([catalog_plan.id])
+    end
+  end
+
+  context "when the organization is not on the product catalog" do
+    before { organization.update!(feature_flags: organization.feature_flags - ["product_catalog"]) }
+
+    it "returns a feature unavailable error" do
+      expect(result["errors"].first.dig("extensions", "code")).to eq("feature_unavailable")
+    end
+  end
+end


### PR DESCRIPTION
## Context

The v2 catalog plan surface already had the `CatalogPlan` GraphQL type plus `createCatalogPlan` / `updateCatalogPlan` mutations, but **no query resolvers** — the legacy `PlansResolver` never exposed a product-catalog view, so catalog plans could not be read through GraphQL. This closes that gap (the dedicated v2 plan surface).

## Description

Add two catalog-gated query resolvers backed by the `CatalogPlan` model, mirroring the legacy plan resolvers and the `RequiresProductCatalog` doctrine (same `Contract` vs `Subscription` split):

- **`catalogPlans`** (collection) — reuses `CatalogPlansQuery` (name/code search, pagination, `applied_rate_cards` counts preloaded), returns `CatalogPlanCollection`.
- **`catalogPlan`** (single) — scoped to `current_organization.catalog_plans`, returns a not-found `plan` error when missing.

Both require `plans:view` and the `product_catalog` feature flag; the legacy `Plan` type/resolvers are untouched.