### PR TITLE
refactor(catalog): stop reading pricing_type and transitional plan_id

### DIFF
--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -86,8 +86,6 @@ module Types
       end
 
       def period_end_date
-        return if object.plan.product_catalog?
-
         ::Subscriptions::DatesService.new_instance(object, object.billing_reference_time)
           .next_end_of_period
       end
@@ -127,11 +125,7 @@ module Types
         end
       end
 
-      # Billing periods derive from the plan interval, which product-catalog
-      # plans don't have: their rate cards each carry their own billing cycle.
       def dates_service
-        return if object.plan.product_catalog?
-
         @dates_service ||= ::Subscriptions::DatesService.new_instance(object, object.billing_reference_time, current_usage: true)
       end
     end

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -50,7 +50,6 @@ class Charge < ApplicationRecord
   validates :charge_model, :code, presence: true
 
   validate :validate_code_unique
-  validate :validate_plan_pricing_type
   validate :charge_model_allowance
   validate :validate_pay_in_advance
   validate :validate_regroup_paid_fees
@@ -196,13 +195,6 @@ class Charge < ApplicationRecord
     return unless accepts_target_wallet
 
     errors.add(:accepts_target_wallet, :feature_unavailable) unless organization.events_targeting_wallets_enabled?
-  end
-
-  # Model-level so no caller can bypass it: a catalog plan never carries chargeables.
-  def validate_plan_pricing_type
-    return unless plan&.product_catalog?
-
-    errors.add(:plan, :legacy_billing_disabled)
   end
 end
 

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -9,6 +9,12 @@ class Contract < ApplicationRecord
   include PaperTrailTraceable
   include Terminatable
 
+  # plan_id is superseded by catalog_plan_id (contracts only ever pointed at
+  # catalog plans). The column is dropped in a follow-up release; ignore it
+  # until then.
+  # TODO: drop the plan_id column, then remove this ignore.
+  self.ignored_columns += %w[plan_id]
+
   STATUSES = {
     pending: "pending",
     active: "active",
@@ -112,7 +118,6 @@ end
 #  customer_id         :uuid             not null
 #  external_id         :string           not null
 #  organization_id     :uuid             not null
-#  plan_id             :uuid
 #
 # Indexes
 #

--- a/app/models/fixed_charge.rb
+++ b/app/models/fixed_charge.rb
@@ -41,7 +41,6 @@ class FixedCharge < ApplicationRecord
   validates :properties, presence: true
 
   validate :validate_code_unique
-  validate :validate_plan_pricing_type
   validate :validate_pay_in_advance
   validate :validate_prorated
   validate :validate_properties
@@ -111,13 +110,6 @@ class FixedCharge < ApplicationRecord
 
     fixed_charge = plan.fixed_charges.parents.where(code:).first
     errors.add(:code, :taken) if fixed_charge && fixed_charge != self
-  end
-
-  # Model-level so no caller can bypass it: a catalog plan never carries chargeables.
-  def validate_plan_pricing_type
-    return unless plan&.product_catalog?
-
-    errors.add(:plan, :legacy_billing_disabled)
   end
 end
 

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -7,6 +7,12 @@ class Plan < ApplicationRecord
 
   self.discard_column = :deleted_at
 
+  # pricing_type is retired: product-catalog plans now live in the catalog_plans
+  # table, so every plans row is legacy. The column is dropped in a follow-up
+  # release; ignore it until then.
+  # TODO: drop the pricing_type column, then remove this ignore.
+  self.ignored_columns += %w[pricing_type]
+
   belongs_to :organization
   belongs_to :parent, class_name: "Plan", optional: true
 
@@ -47,22 +53,17 @@ class Plan < ApplicationRecord
     semiannual
   ].freeze
 
-  PRICING_TYPES = {legacy: "legacy", product_catalog: "product_catalog"}.freeze
-
-  enum :pricing_type, PRICING_TYPES, validate: true
   enum :interval, INTERVALS, validate: {allow_nil: true}
 
   monetize :amount_cents, allow_nil: true
 
   validates :name, :code, presence: true
   validates :amount_currency, inclusion: {in: currency_list}
-  # Legacy plans price at the plan level; product-catalog plans price through
-  # their products, so the plan-level billing fields are optional for them.
   # A blank interval keeps the historical "value_is_invalid" error (the enum used
   # to reject nil as an out-of-range value) rather than a "value_is_mandatory" one.
-  validates :interval, presence: {message: "value_is_invalid"}, unless: :product_catalog?
-  validates :amount_cents, presence: true, unless: :product_catalog?
-  validates :pay_in_advance, inclusion: {in: [true, false]}, unless: :product_catalog?
+  validates :interval, presence: {message: "value_is_invalid"}
+  validates :amount_cents, presence: true
+  validates :pay_in_advance, inclusion: {in: [true, false]}
   validate :validate_code_unique
 
   default_scope -> { kept }
@@ -176,7 +177,6 @@ end
 #  name                       :string           not null
 #  pay_in_advance             :boolean          default(FALSE)
 #  pending_deletion           :boolean          default(FALSE), not null
-#  pricing_type               :enum             default("legacy"), not null
 #  trial_period               :float
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null

--- a/app/models/plan_rate_card.rb
+++ b/app/models/plan_rate_card.rb
@@ -6,6 +6,11 @@ class PlanRateCard < ApplicationRecord
 
   self.discard_column = :deleted_at
 
+  # plan_id is superseded by catalog_plan_id (rows only ever pointed at catalog
+  # plans). The column is dropped in a follow-up release; ignore it until then.
+  # TODO: drop the plan_id column, then remove this ignore.
+  self.ignored_columns += %w[plan_id]
+
   belongs_to :organization
   belongs_to :catalog_plan
   belongs_to :rate_card
@@ -36,7 +41,6 @@ end
 #  updated_at      :datetime         not null
 #  catalog_plan_id :uuid
 #  organization_id :uuid             not null
-#  plan_id         :uuid
 #  rate_card_id    :uuid             not null
 #
 # Indexes

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -233,10 +233,6 @@ class Subscription < ApplicationRecord
 
   def downgrade_plan_date
     return unless next_subscription
-    # Downgrades compare plan-level amounts and land at the end of the current
-    # period, neither of which product-catalog plans have: their price and their
-    # billing cycles live on the rate cards.
-    return if plan.product_catalog?
 
     if next_subscription.active? && downgraded?
       return next_subscription.started_at&.to_date

--- a/app/queries/plans_query.rb
+++ b/app/queries/plans_query.rb
@@ -2,7 +2,7 @@
 
 class PlansQuery < BaseQuery
   Result = BaseResult[:plans]
-  Filters = BaseFilters[:with_deleted, :include_pending_deletion, :pricing_type]
+  Filters = BaseFilters[:with_deleted, :include_pending_deletion]
 
   def call
     plans = base_scope.result
@@ -20,7 +20,6 @@ class PlansQuery < BaseQuery
 
   def base_scope
     scope = Plan.parents.where(organization:)
-    scope = scope.where(pricing_type: filters.pricing_type) if filters.pricing_type.present?
     scope.ransack(search_params)
   end
 

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -87,11 +87,7 @@ module V1
       ::V1::UsageThresholdSerializer.new(options[:usage_threshold]).serialize
     end
 
-    # Billing periods derive from the plan interval, which product-catalog
-    # plans don't have: their rate cards each carry their own billing cycle.
     def dates_service
-      return if model.plan.product_catalog?
-
       @dates_service ||= ::Subscriptions::DatesService.new_instance(model, model.billing_reference_time, current_usage: true)
     end
 

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -44,8 +44,6 @@ module Plans
         bill_charges_monthly: bill_charges_monthly(args),
         bill_fixed_charges_monthly: bill_fixed_charges_monthly(args)
       )
-      # The pricing type is an organization-level choice, not a per-plan one.
-      plan.pricing_type = "product_catalog" if plan.organization&.product_catalog_enabled?
 
       chargeables_validation_result = Plans::ChargeablesValidationService.call(
         organization: plan.organization,

--- a/app/services/plans/override_service.rb
+++ b/app/services/plans/override_service.rb
@@ -16,7 +16,7 @@ module Plans
       return result.forbidden_failure! unless License.premium?
 
       # Per-customer pricing on the catalog is a ContractRateCard.
-      if plan.product_catalog? || plan.organization.product_catalog_enabled?
+      if plan.organization.product_catalog_enabled?
         return result.single_validation_failure!(field: :plan_overrides, error_code: "legacy_billing_disabled")
       end
 

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -22,7 +22,7 @@ module Plans
     def call
       return result.not_found_failure!(resource: "plan") unless plan
 
-      if plan.product_catalog? || plan.organization.product_catalog_enabled?
+      if plan.organization.product_catalog_enabled?
         legacy_field = Plans::CreateService::LEGACY_PRICING_FIELDS.find { params.key?(it) }
         if legacy_field
           return result.single_validation_failure!(field: legacy_field, error_code: "legacy_billing_disabled")

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -35,7 +35,7 @@ module Subscriptions
       )
       return result.forbidden_failure! if !License.premium? && params.key?(:plan_overrides)
 
-      if params.key?(:plan_overrides) && (plan.product_catalog? || plan.organization.product_catalog_enabled?)
+      if params.key?(:plan_overrides) && plan.organization.product_catalog_enabled?
         return result.single_validation_failure!(field: :plan_overrides, error_code: "legacy_billing_disabled")
       end
 

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -56,7 +56,7 @@ module Subscriptions
 
       return result.forbidden_failure! if !License.premium? && params.key?(:plan_overrides)
 
-      if params.key?(:plan_overrides) && (subscription.plan.product_catalog? || subscription.plan.organization.product_catalog_enabled?)
+      if params.key?(:plan_overrides) && subscription.plan.organization.product_catalog_enabled?
         return result.single_validation_failure!(field: :plan_overrides, error_code: "legacy_billing_disabled")
       end
 

--- a/spec/factories/plans.rb
+++ b/spec/factories/plans.rb
@@ -15,12 +15,5 @@ FactoryBot.define do
     trait :pay_in_advance do
       pay_in_advance { true }
     end
-
-    trait :product_catalog do
-      pricing_type { "product_catalog" }
-      interval { nil }
-      amount_cents { nil }
-      pay_in_advance { nil }
-    end
   end
 end

--- a/spec/graphql/resolvers/plan_resolver_spec.rb
+++ b/spec/graphql/resolvers/plan_resolver_spec.rb
@@ -340,29 +340,6 @@ RSpec.describe Resolvers::PlanResolver do
     end
   end
 
-  context "when the plan uses the product catalog" do
-    let(:query) do
-      <<~GQL
-        query($planId: ID!) {
-          plan(id: $planId) { id amountCents interval payInAdvance }
-        }
-      GQL
-    end
-
-    let(:plan) do
-      create(:plan, organization:, pricing_type: "product_catalog", interval: nil, amount_cents: nil, pay_in_advance: nil)
-    end
-
-    it "returns the plan with null plan-level billing fields" do
-      expect(result["data"]["plan"]).to eq(
-        "id" => plan.id,
-        "amountCents" => nil,
-        "interval" => nil,
-        "payInAdvance" => nil
-      )
-    end
-  end
-
   context "when plan is not found" do
     it "returns an error" do
       result = execute_graphql(

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -5,16 +5,6 @@ require "rails_helper"
 RSpec.describe Charge do
   subject(:charge) { create(:standard_charge) }
 
-  describe "plan pricing type validation" do
-    it "rejects a charge on a product-catalog plan" do
-      plan = create(:plan, pricing_type: "product_catalog", interval: nil, amount_cents: nil, pay_in_advance: nil)
-      charge = build(:standard_charge, plan:, organization: plan.organization)
-
-      expect(charge).not_to be_valid
-      expect(charge.errors.where(:plan, :legacy_billing_disabled)).to be_present
-    end
-  end
-
   it_behaves_like "paper_trail traceable"
 
   it { is_expected.to validate_presence_of(:code) }

--- a/spec/models/fixed_charge_spec.rb
+++ b/spec/models/fixed_charge_spec.rb
@@ -5,16 +5,6 @@ require "rails_helper"
 RSpec.describe FixedCharge do
   subject { build(:fixed_charge) }
 
-  describe "plan pricing type validation" do
-    it "rejects a fixed charge on a product-catalog plan" do
-      plan = create(:plan, pricing_type: "product_catalog", interval: nil, amount_cents: nil, pay_in_advance: nil)
-      fixed_charge = build(:fixed_charge, plan:, organization: plan.organization)
-
-      expect(fixed_charge).not_to be_valid
-      expect(fixed_charge.errors.where(:plan, :legacy_billing_disabled)).to be_present
-    end
-  end
-
   it_behaves_like "paper_trail traceable"
 
   it { expect(described_class).to be_soft_deletable }

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -30,10 +30,6 @@ RSpec.describe Plan do
     expect(subject).to have_many(:entitlement_values).through(:entitlements).source(:values).class_name("Entitlement::EntitlementValue").dependent(:destroy)
 
     expect(subject).to define_enum_for(:interval).with_values(Plan::INTERVALS).validating(allowing_nil: true)
-    expect(subject).to define_enum_for(:pricing_type)
-      .with_values(Plan::PRICING_TYPES)
-      .backed_by_column_of_type(:enum)
-      .validating
   end
 
   describe "Clickhouse associations", clickhouse: true do
@@ -49,16 +45,6 @@ RSpec.describe Plan do
 
       plan.pay_in_advance = true
       expect(plan).to be_valid
-    end
-
-    context "with a product_catalog plan" do
-      subject(:plan) do
-        build(:plan, pricing_type: "product_catalog", interval: nil, amount_cents: nil, pay_in_advance: nil)
-      end
-
-      it "does not require the plan-level billing fields" do
-        expect(plan).to be_valid
-      end
     end
 
     context "with a legacy plan" do

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -835,25 +835,6 @@ RSpec.describe Subscription do
       end
     end
 
-    context "with a product-catalog plan" do
-      let(:plan) do
-        create(:plan, pricing_type: "product_catalog", interval: nil, amount_cents: nil, pay_in_advance: nil)
-      end
-      let(:subscription) { create(:subscription, plan:) }
-
-      it "returns nil rather than deriving a plan-level period" do
-        create(:subscription, previous_subscription: subscription, status: :pending)
-
-        expect(subscription.downgrade_plan_date).to be_nil
-      end
-
-      it "returns nil without comparing plan amounts when the next subscription is active" do
-        create(:subscription, previous_subscription: subscription, status: :active)
-
-        expect(subscription.downgrade_plan_date).to be_nil
-      end
-    end
-
     it "returns the date when the plan will be downgraded" do
       current_date = DateTime.parse("20 Jun 2022")
       create(:subscription, previous_subscription: subscription, status: :pending)

--- a/spec/requests/api/v1/legacy_billing_gate_spec.rb
+++ b/spec/requests/api/v1/legacy_billing_gate_spec.rb
@@ -4,27 +4,13 @@ require "rails_helper"
 
 RSpec.describe "v1 pricing endpoints on a product-catalog organization", type: :request do
   let(:organization) { create(:organization, feature_flags: ["product_catalog"]) }
-  let(:plan) { create(:plan, organization:, pricing_type: "product_catalog") }
+  let(:plan) { create(:plan, organization:) }
 
   it "rejects legacy pricing fields on plan creation" do
     post_with_token(organization, "/api/v1/plans", {plan: {name: "Legacy", code: "legacy", interval: "monthly", amount_cents: 100, amount_currency: "USD", pay_in_advance: false}})
 
     expect(response).to have_http_status(:unprocessable_content)
     expect(json[:error_details]).to eq({interval: %w[legacy_billing_disabled]})
-  end
-
-  it "creates a catalog plan from a payload without legacy pricing fields" do
-    post_with_token(organization, "/api/v1/plans", {plan: {name: "Catalog", code: "catalog", amount_currency: "USD"}})
-
-    expect(response).to have_http_status(:success)
-    expect(json[:plan][:code]).to eq("catalog")
-  end
-
-  it "tolerates blank legacy no-ops without persisting them" do
-    post_with_token(organization, "/api/v1/plans", {plan: {name: "Catalog", code: "catalog_blank", amount_currency: "USD", pay_in_advance: false, interval: ""}})
-
-    expect(response).to have_http_status(:success)
-    expect(organization.plans.find_by(code: "catalog_blank")).to have_attributes(pricing_type: "product_catalog", interval: nil)
   end
 
   it "rejects legacy pricing fields on plan update but accepts the others" do

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -286,19 +286,4 @@ RSpec.describe ::V1::SubscriptionSerializer do
       )
     end
   end
-
-  context "when the plan uses the product catalog" do
-    let(:plan) { create(:plan, pricing_type: "product_catalog") }
-    let(:subscription) { create(:subscription, plan:, created_at: started_at, started_at:, ending_at:) }
-
-    it "serializes without plan-level billing period dates" do
-      result = JSON.parse(serializer.to_json)
-
-      expect(result["subscription"]).to include(
-        "plan_code" => plan.code,
-        "current_billing_period_started_at" => nil,
-        "current_billing_period_ending_at" => nil
-      )
-    end
-  end
 end

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -974,41 +974,4 @@ RSpec.describe Plans::CreateService do
       expect(result.error.messages[:interval]).to eq(["legacy_billing_disabled"])
     end
   end
-
-  context "when the organization uses the product catalog" do
-    let(:create_args) do
-      {
-        organization_id: organization.id,
-        name: "Catalog plan",
-        code: "catalog_plan",
-        amount_currency: "USD"
-      }
-    end
-
-    before { organization.enable_feature_flag!(:product_catalog) }
-
-    it "creates a product_catalog plan without plan-level billing fields" do
-      result = plans_service.call
-
-      expect(result).to be_success
-      expect(result.plan).to have_attributes(pricing_type: "product_catalog", interval: nil, amount_cents: nil)
-    end
-  end
-
-  describe "pricing type derivation" do
-    it "creates legacy plans for organizations without the catalog flag" do
-      result = described_class.call(create_args)
-
-      expect(result.plan.pricing_type).to eq("legacy")
-    end
-
-    it "creates catalog plans for catalog organizations, ignoring any submitted pricing_type" do
-      organization.update!(feature_flags: organization.feature_flags | ["product_catalog"])
-      result = described_class.call(
-        {organization_id: organization.id, name: "Catalog", code: "catalog", amount_currency: "USD", pricing_type: "legacy"}
-      )
-
-      expect(result.plan.pricing_type).to eq("product_catalog")
-    end
-  end
 end

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -152,8 +152,8 @@ RSpec.describe Plans::UpdateService do
       applied_tax
     end
 
-    context "when the plan is a catalog plan" do
-      let(:plan) { create(:plan, organization:, pricing_type: "product_catalog", interval: nil, amount_cents: nil, pay_in_advance: nil) }
+    context "when the organization uses the product catalog" do
+      before { organization.enable_feature_flag!(:product_catalog) }
 
       it "rejects legacy pricing fields and accepts the others" do
         result = described_class.call(plan:, params: {amount_cents: 100})


### PR DESCRIPTION
**Step 1 of a two-step column drop**: remove every reader + `ignored_columns` now; a follow-up release drops the columns. No migration in this PR.

## Context

With product-catalog plans now owned by the `catalog_plans` table and catalog organizations blocked from v1 legacy billing, the `plans` table is **pure v1** — every row is a legacy plan. So `Plan#product_catalog?` is always false, making the `pricing_type` discriminator and every guard it fed dead code; likewise the transitional `plan_id` on `plan_rate_cards`/`contracts` is fully superseded by `catalog_plan_id`.

## Description

- **Retire `pricing_type`**: remove the enum + the now-dead `product_catalog?` guards — the `charge`/`fixed_charge` `validate_plan_pricing_type` validations, the subscription downgrade + billing-period-date guards (model, v1 serializer, GraphQL), and the `plan.product_catalog?` disjunct in the legacy-billing gates (`plans`/`subscriptions` create/update/override — they keep their org-flag `product_catalog_enabled?` check). Plan-level billing fields (`interval`/`amount_cents`/`pay_in_advance`) are now unconditionally required.
- Drop the `pricing_type` filter from `PlansQuery` and the `pricing_type` assignment in `Plans::CreateService`.
- `ignored_columns`: `pricing_type` on `Plan`; `plan_id` on `PlanRateCard` and `Contract`.