### PR TITLE
feat(billing): extract contract segment producer

### DIFF
--- a/app/graphql/types/contract_applied_rate_cards/object.rb
+++ b/app/graphql/types/contract_applied_rate_cards/object.rb
@@ -18,7 +18,7 @@ module Types
       field :billing_anchor_date, GraphQL::Types::ISO8601Date, null: false
       field :effective_date, GraphQL::Types::ISO8601Date, null: false
       field :ended_date, GraphQL::Types::ISO8601Date, null: true
-      field :next_billing_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :next_billing_at, GraphQL::Types::ISO8601DateTime, null: true
 
       field :rate_phases, [Types::RatePhases::Object], null: false
       field :rate_phases_count, Integer, null: false

--- a/app/jobs/billing_segments/schedule_job.rb
+++ b/app/jobs/billing_segments/schedule_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module BillingSegments
+  class ScheduleJob < ApplicationJob
+    unique :until_executed, on_conflict: :log, lock_ttl: 12.hours
+
+    queue_as do
+      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_BILLING"])
+        :billing
+      else
+        :default
+      end
+    end
+
+    def perform(customer_id)
+      customer = Customer.find(customer_id)
+      BillingSegments::ScheduleService.call!(customer:)
+    end
+  end
+end

--- a/app/jobs/clock/create_billing_segments_job.rb
+++ b/app/jobs/clock/create_billing_segments_job.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Clock
+  class CreateBillingSegmentsJob < ClockJob
+    unique :until_executed, on_conflict: :log, lock_ttl: 10.minutes
+
+    BATCH_SIZE = 1_000
+
+    def perform(cursor = nil)
+      scope = ContractRateCard.due_for_billing(Time.current)
+      if cursor
+        scope = scope.where("contracts.customer_id > ?", cursor)
+      end
+
+      customer_ids = scope.order("contracts.customer_id").distinct.limit(BATCH_SIZE).pluck("contracts.customer_id")
+      customer_ids.each { |customer_id| BillingSegments::ScheduleJob.perform_later(customer_id) }
+
+      if customer_ids.size == BATCH_SIZE
+        self.class.perform_later(customer_ids.last)
+      end
+    end
+  end
+end

--- a/app/models/contract_rate_card.rb
+++ b/app/models/contract_rate_card.rb
@@ -16,7 +16,6 @@ class ContractRateCard < ApplicationRecord
   has_many :billing_segments
 
   validates :billing_anchor_date, presence: true
-  validates :next_billing_at, presence: true
   validates :effective_date, presence: true
   validates :units, numericality: {greater_than_or_equal_to: 0}, allow_nil: true
   validates :rate_card_id, uniqueness: {scope: :contract_id, conditions: -> { where(deleted_at: nil, ended_date: nil) }}
@@ -24,6 +23,12 @@ class ContractRateCard < ApplicationRecord
   validate :validate_effective_before_ended
 
   default_scope -> { kept }
+
+  # Ended attachments may still have a final segment to produce. A nil clock marks
+  # a fully scheduled attachment; pending and canceled contracts never produce rows.
+  scope :due_for_billing, ->(timestamp) {
+    joins(:contract).merge(Contract.active).where(next_billing_at: ..timestamp)
+  }
 
   # The window is day-grained and the end inclusive: the card still bills on
   # its ended_date, charges stop after it. Ended attachments are history;
@@ -68,7 +73,7 @@ end
 #  deleted_at          :datetime
 #  effective_date      :date             not null
 #  ended_date          :date
-#  next_billing_at     :datetime         not null
+#  next_billing_at     :datetime
 #  units               :decimal(, )
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
@@ -81,6 +86,7 @@ end
 #  index_active_contract_rate_cards_on_contract_and_card  (contract_id,rate_card_id) UNIQUE WHERE ((deleted_at IS NULL) AND (ended_date IS NULL))
 #  index_contract_rate_cards_on_contract_id               (contract_id)
 #  index_contract_rate_cards_on_deleted_at                (deleted_at)
+#  index_contract_rate_cards_on_due_billing               (next_billing_at) WHERE ((deleted_at IS NULL) AND (next_billing_at IS NOT NULL))
 #  index_contract_rate_cards_on_next_billing_at           (next_billing_at) WHERE ((deleted_at IS NULL) AND (ended_date IS NULL))
 #  index_contract_rate_cards_on_organization_id           (organization_id)
 #  index_contract_rate_cards_on_rate_card_id              (rate_card_id)

--- a/app/serializers/v2/contract_applied_rate_card_serializer.rb
+++ b/app/serializers/v2/contract_applied_rate_card_serializer.rb
@@ -11,7 +11,7 @@ module V2
         effective_date: model.effective_date.iso8601,
         ended_date: model.ended_date&.iso8601,
         billing_anchor_date: model.billing_anchor_date.iso8601,
-        next_billing_at: model.next_billing_at.iso8601,
+        next_billing_at: model.next_billing_at&.iso8601,
         # size counts the loaded collection when the caller preloaded it.
         rate_phases_count: model.rate_phases.size,
         created_at: model.created_at.iso8601,

--- a/app/services/billing_segments/schedule_service.rb
+++ b/app/services/billing_segments/schedule_service.rb
@@ -14,7 +14,7 @@ module BillingSegments
       result.billing_segments = []
 
       customer.with_advisory_lock!("billing_segments_schedule_customer_#{customer.id}") do
-        ActiveRecord::Base.transaction do
+        ActiveRecord::Base.transaction(requires_new: true) do
           due_rate_cards.each { |card| schedule(card) }
         end
       end

--- a/app/services/billing_segments/schedule_service.rb
+++ b/app/services/billing_segments/schedule_service.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+module BillingSegments
+  class ScheduleService < BaseService
+    Result = BaseResult[:billing_segments]
+
+    def initialize(customer:, timestamp: Time.current)
+      @customer = customer
+      @timestamp = timestamp
+      super
+    end
+
+    def call
+      result.billing_segments = []
+
+      customer.with_advisory_lock!("billing_segments_schedule_customer_#{customer.id}") do
+        ActiveRecord::Base.transaction do
+          due_rate_cards.each { |card| schedule(card) }
+        end
+      end
+
+      result
+    rescue BaseService::FailedResult => error
+      result.billing_segments = []
+      result.fail_with_error!(error)
+    rescue ActiveRecord::RecordInvalid => error
+      result.billing_segments = []
+      result.record_validation_failure!(record: error.record)
+    rescue ActiveRecord::StatementInvalid => error
+      if error.cause&.message&.include?("billing_segments_no_overlapping_periods")
+        result.billing_segments = []
+        result.single_validation_failure!(field: :billing_segment, error_code: "overlapping_periods")
+      else
+        raise
+      end
+    end
+
+    private
+
+    attr_reader :customer, :timestamp
+
+    def due_rate_cards
+      ContractRateCard.due_for_billing(timestamp)
+        .where(organization_id: customer.organization_id, contracts: {customer_id: customer.id})
+        .includes(:rate_phases, rate_card: :rates,
+          contract: [:customer, {catalog_plan: {applied_rate_cards: :rate_phases}}])
+        .order(:id)
+    end
+
+    def schedule(card)
+      schedule = Billing::RateCards::BuildScheduleService.call!(contract_rate_card: card).schedule
+      segments = segments_to_schedule(card, schedule)
+      persisted = card.billing_segments.where(started_at: segments.map(&:started_at)).index_by(&:started_at)
+
+      segments.each do |segment|
+        existing = persisted[segment.started_at]
+
+        if existing
+          validate_persisted_segment!(existing, segment)
+        else
+          result.billing_segments << create_segment(card, segment)
+        end
+      end
+
+      card.update!(next_billing_at: schedule.next_billing_at(after: timestamp))
+    end
+
+    def segments_to_schedule(card, schedule)
+      segments = schedule.segments_due_by(timestamp)
+
+      if card.billing_segments.exists?
+        segments
+      else
+        # The initial clock skips historical cycles on backdated contracts, but all
+        # priced slices of the first billable cycle must still be produced together.
+        first = segments.find { it.billing_at >= card.next_billing_at } || segments.last
+        segments.select { it.cycle_started_at >= first.cycle_started_at }
+      end
+    end
+
+    # Resume repeats the last cycle. A retry must preserve its original price snapshot.
+    def validate_persisted_segment!(existing, segment)
+      if existing.ended_at != BillingSegment.inclusive_end(segment.ended_at) ||
+          existing.cycle_started_at != segment.cycle_started_at
+        result.single_validation_failure!(field: :billing_segment, error_code: "overlapping_periods").raise_if_error!
+      end
+    end
+
+    def create_segment(card, segment)
+      BillingSegment.create!(
+        organization_id: card.organization_id,
+        contract: card.contract,
+        customer:,
+        contract_rate_card: card,
+        billing_at: segment.billing_at,
+        cycle_started_at: segment.cycle_started_at,
+        started_at: segment.started_at,
+        ended_at: BillingSegment.inclusive_end(segment.ended_at),
+        rate_card_rate: segment.rate,
+        rate_override: segment.rate_override,
+        pricing_unit: pricing_unit_for(card),
+        currency: card.rate_card.currency,
+        rate_properties: (segment.rate_override || segment.rate).properties,
+        proration_ratio: segment.proration_ratio
+      )
+    end
+
+    def pricing_unit_for(card)
+      code = card.rate_card.applied_pricing_unit_code
+
+      if code.present?
+        customer.organization.pricing_units.find_by!(code:)
+      end
+    end
+  end
+end

--- a/clock.rb
+++ b/clock.rb
@@ -24,6 +24,12 @@ module Clockwork
       .perform_later
   end
 
+  every(5.minutes, "schedule:create_billing_segments") do
+    Clock::CreateBillingSegmentsJob
+      .set(sentry: {"slug" => "lago_create_billing_segments", "cron" => "*/5 * * * *"})
+      .perform_later
+  end
+
   every(5.minutes, "schedule:refresh_draft_invoices") do
     Clock::RefreshDraftInvoicesJob
       .set(sentry: {"slug" => "lago_refresh_draft_invoices", "cron" => "*/5 * * * *"})

--- a/db/migrate/20260908183723_allow_completed_contract_rate_card_clocks.rb
+++ b/db/migrate/20260908183723_allow_completed_contract_rate_card_clocks.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AllowCompletedContractRateCardClocks < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :contract_rate_cards, :next_billing_at, true
+  end
+end

--- a/db/migrate/20260908183833_index_due_contract_rate_cards.rb
+++ b/db/migrate/20260908183833_index_due_contract_rate_cards.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class IndexDueContractRateCards < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :contract_rate_cards, :next_billing_at,
+      where: "deleted_at IS NULL AND next_billing_at IS NOT NULL",
+      name: "index_contract_rate_cards_on_due_billing", algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -867,6 +867,7 @@ DROP INDEX IF EXISTS public.index_contracts_on_catalog_plan_id;
 DROP INDEX IF EXISTS public.index_contract_rate_cards_on_rate_card_id;
 DROP INDEX IF EXISTS public.index_contract_rate_cards_on_organization_id;
 DROP INDEX IF EXISTS public.index_contract_rate_cards_on_next_billing_at;
+DROP INDEX IF EXISTS public.index_contract_rate_cards_on_due_billing;
 DROP INDEX IF EXISTS public.index_contract_rate_cards_on_deleted_at;
 DROP INDEX IF EXISTS public.index_contract_rate_cards_on_contract_id;
 DROP INDEX IF EXISTS public.index_commitments_taxes_on_tax_id;
@@ -2653,7 +2654,7 @@ CREATE TABLE public.contract_rate_cards (
     contract_id uuid NOT NULL,
     rate_card_id uuid NOT NULL,
     billing_anchor_date date NOT NULL,
-    next_billing_at timestamp without time zone NOT NULL,
+    next_billing_at timestamp without time zone,
     effective_date date NOT NULL,
     ended_date date,
     units numeric,
@@ -8618,6 +8619,13 @@ CREATE INDEX index_contract_rate_cards_on_contract_id ON public.contract_rate_ca
 --
 
 CREATE INDEX index_contract_rate_cards_on_deleted_at ON public.contract_rate_cards USING btree (deleted_at);
+
+
+--
+-- Name: index_contract_rate_cards_on_due_billing; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_contract_rate_cards_on_due_billing ON public.contract_rate_cards USING btree (next_billing_at) WHERE ((deleted_at IS NULL) AND (next_billing_at IS NOT NULL));
 
 
 --
@@ -14904,6 +14912,8 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260908183833'),
+('20260908183723'),
 ('20260908180522'),
 ('20260905223042'),
 ('20260905223041'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -1528,7 +1528,7 @@ type ContractAppliedRateCard {
   effectiveDate: ISO8601Date!
   endedDate: ISO8601Date
   id: ID!
-  nextBillingAt: ISO8601DateTime!
+  nextBillingAt: ISO8601DateTime
   product: Product!
   rateCard: RateCard!
   ratePhases: [RatePhase!]!

--- a/schema.json
+++ b/schema.json
@@ -9192,13 +9192,9 @@
               "description": null,
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ISO8601DateTime",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/graphql/resolvers/contract_resolver_spec.rb
+++ b/spec/graphql/resolvers/contract_resolver_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Resolvers::ContractResolver do
           id externalId status billingTime
           customer { id }
           plan { id code name currency }
-          appliedRateCards { id rateCard { id } effectiveDate }
+          appliedRateCards { id rateCard { id } effectiveDate nextBillingAt }
           appliedRateCardsCount
         }
       }
@@ -61,5 +61,12 @@ RSpec.describe Resolvers::ContractResolver do
     it "returns a not found error" do
       expect_graphql_error(result: execution, message: "Resource not found")
     end
+  end
+
+  it "returns an exhausted billing clock as null" do
+    create(:contract_rate_card, organization:, contract:, next_billing_at: nil)
+
+    expect(execution["errors"]).to be_nil
+    expect(execution["data"]["contract"]["appliedRateCards"].sole["nextBillingAt"]).to be_nil
   end
 end

--- a/spec/jobs/billing_segments/schedule_job_spec.rb
+++ b/spec/jobs/billing_segments/schedule_job_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BillingSegments::ScheduleJob do
+  it "schedules the customer's due segments" do
+    customer = create(:customer)
+    allow(BillingSegments::ScheduleService).to receive(:call!)
+
+    described_class.perform_now(customer.id)
+
+    expect(BillingSegments::ScheduleService).to have_received(:call!).with(customer:)
+  end
+end

--- a/spec/jobs/clock/create_billing_segments_job_spec.rb
+++ b/spec/jobs/clock/create_billing_segments_job_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Clock::CreateBillingSegmentsJob do
+  it "enqueues one job per due customer, even across multiple cards and contracts" do
+    customer = create(:customer)
+    2.times do
+      contract = create(:contract, customer:)
+      create(:contract_rate_card, organization: customer.organization, contract:, next_billing_at: 1.hour.ago)
+    end
+    create(:contract_rate_card, next_billing_at: 1.hour.from_now)
+    create(:contract_rate_card, contract: create(:contract, :pending), next_billing_at: 1.hour.ago)
+
+    described_class.perform_now
+
+    expect(BillingSegments::ScheduleJob).to have_been_enqueued.once.with(customer.id)
+    expect(described_class).not_to have_been_enqueued
+  end
+
+  it "continues after the last customer of a full batch" do
+    stub_const("Clock::CreateBillingSegmentsJob::BATCH_SIZE", 1)
+    customers = Array.new(2) do
+      card = create(:contract_rate_card, next_billing_at: 1.hour.ago)
+      card.contract.customer
+    end.sort_by(&:id)
+
+    described_class.perform_now
+    described_class.perform_now(customers.first.id)
+    described_class.perform_now(customers.last.id)
+
+    customers.each do |customer|
+      expect(BillingSegments::ScheduleJob).to have_been_enqueued.once.with(customer.id)
+      expect(described_class).to have_been_enqueued.once.with(customer.id)
+    end
+    expect(described_class).to have_been_enqueued.exactly(2).times
+  end
+
+  it "does not enqueue jobs when no cards are due" do
+    described_class.perform_now
+
+    expect(BillingSegments::ScheduleJob).not_to have_been_enqueued
+    expect(described_class).not_to have_been_enqueued
+  end
+end

--- a/spec/models/contract_rate_card_spec.rb
+++ b/spec/models/contract_rate_card_spec.rb
@@ -19,6 +19,23 @@ RSpec.describe ContractRateCard do
   end
 
   describe "Scopes" do
+    describe ".due_for_billing" do
+      it "selects due active cards, including ended attachments with final billing outstanding" do
+        due = create(:contract_rate_card, next_billing_at: 1.hour.ago)
+        ended = create(:contract_rate_card, effective_date: 2.days.ago.to_date,
+          ended_date: 1.day.ago.to_date, next_billing_at: 1.hour.ago)
+        create(:contract_rate_card, next_billing_at: 1.hour.from_now)
+        create(:contract_rate_card, next_billing_at: nil)
+        create(:contract_rate_card, next_billing_at: 1.hour.ago).discard!
+        %i[pending canceled terminated].each do |status|
+          contract = create(:contract, status:)
+          create(:contract_rate_card, organization: contract.organization, contract:, next_billing_at: 1.hour.ago)
+        end
+
+        expect(described_class.due_for_billing(Time.current)).to match_array([due, ended])
+      end
+    end
+
     describe ".current_and_scheduled" do
       it "keeps open and upcoming attachments, hides ended ones" do
         open_card = create(:contract_rate_card)
@@ -58,7 +75,7 @@ RSpec.describe ContractRateCard do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:billing_anchor_date) }
-    it { is_expected.to validate_presence_of(:next_billing_at) }
+    it { is_expected.to allow_value(nil).for(:next_billing_at) }
     it { is_expected.to validate_presence_of(:effective_date) }
     it { is_expected.to validate_numericality_of(:units).is_greater_than_or_equal_to(0).allow_nil }
 

--- a/spec/requests/api/v2/contracts_controller_spec.rb
+++ b/spec/requests/api/v2/contracts_controller_spec.rb
@@ -128,6 +128,15 @@ RSpec.describe Api::V2::ContractsController do
       expect(json[:contract][:applied_rate_cards].sole[:lago_id]).to eq(card.id)
     end
 
+    it "returns an exhausted billing clock as null" do
+      create(:contract_rate_card, organization:, contract:, next_billing_at: nil)
+
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:contract][:applied_rate_cards].sole[:next_billing_at]).to be_nil
+    end
+
     context "when the external id contains a dot" do
       let(:contract) { create(:contract, organization:, customer:, external_id: "contract.2026-01") }
 

--- a/spec/services/billing_segments/schedule_service_spec.rb
+++ b/spec/services/billing_segments/schedule_service_spec.rb
@@ -1,0 +1,320 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BillingSegments::ScheduleService do
+  subject(:result) { described_class.call(customer:, timestamp:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:, timezone: "UTC") }
+  let(:contract) { create(:contract, organization:, customer:, started_at: Time.utc(2026, 1, 1)) }
+  let(:product) { create(:product, :fixed, organization:) }
+  let(:rate_card) { create(:rate_card, organization:, product:, proration: true) }
+  let(:rate) do
+    create(:rate_card_rate, organization:, rate_card:, effective_from: Time.utc(2025, 1, 1),
+      rate_properties: {"amount" => "100"})
+  end
+  let(:card) do
+    create(:contract_rate_card, organization:, contract:, rate_card:,
+      effective_date: Date.new(2026, 1, 1), billing_anchor_date: Date.new(2026, 1, 1),
+      next_billing_at: Time.utc(2026, 2, 1))
+  end
+  let(:timestamp) { Time.utc(2026, 2, 1) }
+
+  around { |example| travel_to(timestamp) { example.run } }
+
+  before do
+    rate
+    card
+  end
+
+  it "persists the due segment and advances the billing clock" do
+    expect { result }.to change(BillingSegment, :count).by(1)
+
+    expect(result).to be_success
+    segment = result.billing_segments.sole
+    expect(segment).to have_attributes(
+      organization_id: organization.id, contract_id: contract.id, customer_id: customer.id,
+      contract_rate_card_id: card.id, rate_card_rate_id: rate.id,
+      rate_override_id: nil, currency: rate_card.currency, status: "pending",
+      started_at: Time.utc(2026, 1, 1), cycle_started_at: Time.utc(2026, 1, 1),
+      ended_at: BillingSegment.inclusive_end(Time.utc(2026, 2, 1)),
+      billing_at: timestamp, rate_properties: {"amount" => "100"}, proration_ratio: 1
+    )
+    expect(card.reload.next_billing_at).to eq(Time.utc(2026, 3, 1))
+  end
+
+  it "does not duplicate segments on repeated runs" do
+    result
+
+    retry_result = described_class.call(customer:, timestamp:)
+
+    expect(retry_result).to be_success
+    expect(retry_result.billing_segments).to eq([])
+    expect(BillingSegment.count).to eq(1)
+  end
+
+  it "resumes at the last cycle and adds only the newly due segment" do
+    result
+
+    next_result = described_class.call(customer:, timestamp: Time.utc(2026, 3, 1))
+
+    expect(next_result.billing_segments.map(&:started_at)).to eq([Time.utc(2026, 2, 1)])
+    expect(BillingSegment.count).to eq(2)
+  end
+
+  it "preserves an existing snapshot when replaying a stale clock" do
+    result
+    existing = BillingSegment.sole
+    existing.update!(rate_properties: {"amount" => "80"}, status: :done)
+    card.update!(next_billing_at: timestamp)
+
+    replay = described_class.call(customer:, timestamp:)
+
+    expect(replay).to be_success
+    expect(replay.billing_segments).to eq([])
+    expect(existing.reload).to have_attributes(rate_properties: {"amount" => "80"}, status: "done")
+    expect(card.reload.next_billing_at).to eq(Time.utc(2026, 3, 1))
+  end
+
+  it "scopes scheduling to this customer's organization and contracts" do
+    other = create(:contract_rate_card, next_billing_at: timestamp)
+
+    result
+
+    expect(result.billing_segments.map(&:contract_rate_card_id)).to eq([card.id])
+    expect(other.reload.next_billing_at).to eq(timestamp)
+  end
+
+  context "when the seeded billing date has not arrived" do
+    let(:timestamp) { Time.utc(2026, 1, 31, 23, 59, 59) }
+
+    it "does not bill a period early" do
+      expect { result }.not_to change(BillingSegment, :count)
+      expect(card.reload.next_billing_at).to eq(Time.utc(2026, 2, 1))
+    end
+  end
+
+  context "when processing is delayed" do
+    let(:timestamp) { Time.utc(2026, 4, 10) }
+
+    it "catches up all due periods and preserves their original billing dates" do
+      expect(result.billing_segments.map(&:billing_at))
+        .to eq([Time.utc(2026, 2, 1), Time.utc(2026, 3, 1), Time.utc(2026, 4, 1)])
+      expect(card.reload.next_billing_at).to eq(Time.utc(2026, 5, 1))
+    end
+
+    it "respects a backdated contract's seeded clock without billing its earlier history" do
+      card.update!(next_billing_at: Time.utc(2026, 4, 1))
+
+      expect(result.billing_segments.map(&:started_at)).to eq([Time.utc(2026, 3, 1)])
+    end
+  end
+
+  context "with a rate change inside the cycle" do
+    let(:timestamp) { Time.utc(2026, 1, 16) }
+    let(:new_rate) do
+      create(:rate_card_rate, organization:, rate_card:, effective_from: timestamp,
+        rate_properties: {"amount" => "200"})
+    end
+
+    before do
+      new_rate
+      card.update!(next_billing_at: timestamp)
+    end
+
+    it "produces the first slice when due and the remainder on the next run" do
+      first = result.billing_segments.sole
+      expect(first).to have_attributes(rate_card_rate_id: rate.id, billing_at: timestamp,
+        ended_at: BillingSegment.inclusive_end(timestamp), proration_ratio: BigDecimal("0.4838709677"))
+
+      next_result = described_class.call(customer:, timestamp: Time.utc(2026, 2, 1))
+      second = next_result.billing_segments.sole
+      expect(second).to have_attributes(started_at: timestamp, cycle_started_at: first.cycle_started_at,
+        rate_card_rate_id: new_rate.id, rate_properties: {"amount" => "200"})
+      expect(BillingSegment.count).to eq(2)
+    end
+
+    it "keeps all slices when the initial clock was seeded before the rate change" do
+      card.update!(next_billing_at: Time.utc(2026, 2, 1))
+
+      produced = described_class.call(customer:, timestamp: Time.utc(2026, 2, 1)).billing_segments
+
+      expect(produced.map(&:rate_card_rate_id)).to eq([rate.id, new_rate.id])
+    end
+  end
+
+  context "with advance billing" do
+    let(:rate_card) { create(:rate_card, :advance, organization:, product:, proration: true) }
+    let(:timestamp) { Time.utc(2026, 1, 1) }
+
+    before { card.update!(next_billing_at: timestamp) }
+
+    it "persists the whole priced segment at its opening boundary" do
+      expect(result.billing_segments.sole).to have_attributes(
+        billing_at: timestamp, started_at: timestamp,
+        ended_at: BillingSegment.inclusive_end(Time.utc(2026, 2, 1))
+      )
+      expect(card.reload.next_billing_at).to eq(Time.utc(2026, 2, 1))
+    end
+  end
+
+  context "with a contract phase override" do
+    let(:override) { create(:rate_override, organization:, rate_properties: {"amount" => "25"}) }
+
+    before do
+      create(:rate_phase, :contract_level, organization:, contract_rate_card: card, rate_override: override)
+    end
+
+    it "persists the resolved override and its properties" do
+      expect(result.billing_segments.sole).to have_attributes(rate_card_rate_id: rate.id,
+        rate_override_id: override.id, rate_properties: {"amount" => "25"})
+    end
+  end
+
+  context "with phases inherited from the catalog plan" do
+    let(:catalog_plan) { create(:catalog_plan, organization:) }
+    let(:override) { create(:rate_override, organization:, rate_properties: {"amount" => "50"}) }
+
+    before do
+      contract.update!(catalog_plan:)
+      plan_rate_card = create(:plan_rate_card, organization:, catalog_plan:, rate_card:)
+      create(:rate_phase, organization:, plan_rate_card:, rate_override: override)
+    end
+
+    it "persists the plan's resolved price" do
+      expect(result.billing_segments.sole).to have_attributes(
+        rate_override_id: override.id, rate_properties: {"amount" => "50"}
+      )
+    end
+  end
+
+  context "with customer-local boundaries across daylight saving time" do
+    let(:customer) { create(:customer, organization:, timezone: "America/New_York") }
+    let(:timestamp) { Time.utc(2026, 4, 1, 4) }
+
+    before do
+      card.update!(effective_date: Date.new(2026, 3, 1), billing_anchor_date: Date.new(2026, 3, 1),
+        next_billing_at: timestamp)
+    end
+
+    it "persists inclusive UTC boundaries without changing day-based proration" do
+      expect(result.billing_segments.sole).to have_attributes(
+        started_at: Time.utc(2026, 3, 1, 5), ended_at: BillingSegment.inclusive_end(timestamp),
+        billing_at: timestamp, proration_ratio: 1
+      )
+    end
+  end
+
+  context "with a pricing unit" do
+    let(:pricing_unit) { create(:pricing_unit, organization:) }
+    let(:rate_card) { create(:rate_card, organization:, applied_pricing_unit_code: pricing_unit.code) }
+    let(:rate) do
+      create(:rate_card_rate, organization:, rate_card:, effective_from: Time.utc(2025, 1, 1),
+        applied_pricing_unit_conversion_rate: 0.5)
+    end
+
+    it "stores the pricing unit alongside the currency" do
+      expect(result.billing_segments.sole).to have_attributes(pricing_unit_id: pricing_unit.id,
+        currency: rate_card.currency, pricing_unit_conversion_rate: 0.5)
+    end
+  end
+
+  context "when the attachment ends" do
+    before { card.update!(ended_date: Date.new(2026, 1, 20)) }
+
+    it "produces the final due segment and clears the exhausted clock" do
+      expect(result.billing_segments.sole).to have_attributes(
+        ended_at: BillingSegment.inclusive_end(Time.utc(2026, 1, 21)),
+        billing_at: Time.utc(2026, 1, 21)
+      )
+      expect(card.reload.next_billing_at).to be_nil
+      expect(described_class.call(customer:, timestamp:).billing_segments).to eq([])
+    end
+  end
+
+  context "when pricing starts in the future" do
+    let(:rate) { create(:rate_card_rate, organization:, rate_card:, effective_from: Time.utc(2026, 3, 1)) }
+
+    it "moves the clock to the next priced segment even when nothing is produced" do
+      expect(result).to be_success
+      expect(result.billing_segments).to eq([])
+      expect(card.reload.next_billing_at).to eq(Time.utc(2026, 4, 1))
+    end
+  end
+
+  context "when another card has an invalid schedule" do
+    before do
+      other_rate_card = create(:rate_card, organization:)
+      create(:contract_rate_card, organization:, contract:, rate_card: other_rate_card,
+        next_billing_at: timestamp, id: "ffffffff-ffff-ffff-ffff-ffffffffffff")
+    end
+
+    it "rolls back every segment and clock for the customer" do
+      expect { result }.not_to change(BillingSegment, :count)
+      expect(result).to be_failure
+      expect(result.error).to be_a(BaseService::NotFoundFailure)
+      expect(result.billing_segments).to eq([])
+      expect(card.reload.next_billing_at).to eq(timestamp)
+    end
+  end
+
+  context "with an overlapping persisted segment" do
+    before do
+      create(:billing_segment, organization:, contract:, customer:, contract_rate_card: card,
+        rate_card_rate: rate, cycle_started_at: Time.utc(2026, 1, 1), started_at: Time.utc(2026, 1, 15),
+        ended_at: BillingSegment.inclusive_end(timestamp))
+    end
+
+    it "fails without advancing the clock or returning rolled-back rows" do
+      expect { result }.not_to change(BillingSegment, :count)
+      expect(result).to be_failure
+      expect(result.error.messages).to eq(billing_segment: ["overlapping_periods"])
+      expect(result.billing_segments).to eq([])
+      expect(card.reload.next_billing_at).to eq(timestamp)
+    end
+
+    it "rejects a different window with the same starting boundary" do
+      BillingSegment.sole.update!(started_at: Time.utc(2026, 1, 1), ended_at: Time.utc(2026, 1, 20))
+
+      expect(result).to be_failure
+      expect(result.error.messages).to eq(billing_segment: ["overlapping_periods"])
+      expect(card.reload.next_billing_at).to eq(timestamp)
+    end
+  end
+
+  context "when updating the clock fails" do
+    before do
+      allow(Billing::RateCards::BuildScheduleService).to receive(:call!).and_wrap_original do |original, **arguments|
+        allow(arguments.fetch(:contract_rate_card)).to receive(:update!).and_raise(ActiveRecord::RecordInvalid.new(card))
+        original.call(**arguments)
+      end
+    end
+
+    it "rolls back the inserted segment" do
+      expect { result }.not_to change(BillingSegment, :count)
+      expect(result).to be_failure
+      expect(result.billing_segments).to eq([])
+      expect(card.reload.next_billing_at).to eq(timestamp)
+    end
+  end
+
+  context "with concurrent runs for the same customer", transaction: false do
+    it "serializes production and advances the clock only once" do
+      customer_id = customer.id
+      threads = Array.new(2) do
+        Thread.new do
+          ActiveRecord::Base.connection_pool.with_connection do
+            described_class.call(customer: Customer.find(customer_id), timestamp:)
+          end
+        end
+      end
+      results = threads.map(&:value)
+
+      expect(results).to all(be_success)
+      expect(results.flat_map(&:billing_segments).size).to eq(1)
+      expect(card.billing_segments.count).to eq(1)
+      expect(card.reload.next_billing_at).to eq(Time.utc(2026, 3, 1))
+    end
+  end
+end

--- a/spec/services/billing_segments/schedule_service_spec.rb
+++ b/spec/services/billing_segments/schedule_service_spec.rb
@@ -317,4 +317,20 @@ RSpec.describe BillingSegments::ScheduleService do
       expect(card.reload.next_billing_at).to eq(Time.utc(2026, 3, 1))
     end
   end
+
+  context "with an existing transaction", transaction: false do
+    it "rolls back the customer's partial production even when the caller commits" do
+      other_rate_card = create(:rate_card, organization:)
+      create(:contract_rate_card, organization:, contract:, rate_card: other_rate_card,
+        next_billing_at: timestamp, id: "ffffffff-ffff-ffff-ffff-ffffffffffff")
+
+      ActiveRecord::Base.transaction do
+        expect(result).to be_failure
+      end
+
+      expect(BillingSegment.count).to eq(0)
+      expect(result.billing_segments).to eq([])
+      expect(card.reload.next_billing_at).to eq(timestamp)
+    end
+  end
 end


### PR DESCRIPTION
## Context

The contract date engine from #6267 calculates billable segments, but main has no producer to persist them. This extracts the producer responsibility from #5836 and adapts it to ContractRateCard and BillingSegment.

## Description

- Run a producer scan every five minutes, paging through distinct customers with due cards on active contracts and enqueueing one scheduling job per customer.
- Build schedules using the merged date engine. Persist pending segments with their original billing dates, cycle boundaries, resolved rate and override, currency, pricing unit, price properties and proration ratio.
- Serialize each customer's runs with an advisory lock. Insert segments and advance billing clocks in a transaction with its own savepoint when called from a lifecycle transaction. Replays preserve existing price snapshots; conflicting windows fail without advancing the clock.
- Respect the initial clock of backdated contracts while preserving all due slices of the first billable cycle. Resume subsequent runs from persisted history.
- Clear next_billing_at when a schedule is exhausted. Add a concurrent index covering due cards, including ended attachments with outstanding segments.

REST and GraphQL now expose a completed card's next billing date as null; the generated GraphQL schemas are updated accordingly.

The producer writes pending segments. Invoice processing, credit notes and the lifecycle workflows that refresh clocks after changes to live contracts or rates remain separate work.

## Validation

- 69 distinct examples passed across focused runs in the API container using `lago exec api bundle exec rspec`: producer, jobs, card scope, contract materialization, GraphQL resolver and the REST contract show endpoint.
- Coverage includes advance/arrears, rate splits, plan/card overrides, DST, delayed runs, initial clocks, retries, two concurrent runs, overlap conflicts and transaction rollback.
- Both migrations applied successfully to the test database.
- RuboCop: 15 files inspected, no offenses. GraphQL schemas regenerated; diff whitespace check passed.

## Integration probe

A temporary adaptation of the #5836 consumer exercised real fee calculation, invoice finalization and credit-note creation. It found and fixed partial production surviving an outer transaction; the regression is included here.

The temporary suite ran 20 scenarios: 16 passed and four exposed remaining engine integration requirements:

- New rates can make segments due before the attachment's seeded clock; rate changes must refresh affected clocks.
- The old quantity-versioning flow stores an increment's original cycle start on a newer attachment, which the current resume validation rejects.
- Appending a rate inside an already billed advance window requires an adjustment policy; replaying the changed window produces an overlap conflict.
- The imported consumer computes fixed quantities and does not yet aggregate metered events for usage products.

The probe also needed temporary product-fee serialization and contract/segment linkage adapters. These consumer/lifecycle adaptations are not included in this PR. The PR remains a draft; the probe is not evidence that the complete engine is ready.
