### PR TITLE
refactor(catalog): drop stale pricing_type/plan_id ignores

### DIFF
--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -9,12 +9,6 @@ class Contract < ApplicationRecord
   include PaperTrailTraceable
   include Terminatable
 
-  # plan_id is superseded by catalog_plan_id (contracts only ever pointed at
-  # catalog plans). The column is dropped in a follow-up release; ignore it
-  # until then.
-  # TODO: drop the plan_id column, then remove this ignore.
-  self.ignored_columns += %w[plan_id]
-
   STATUSES = {
     pending: "pending",
     active: "active",

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -7,12 +7,6 @@ class Plan < ApplicationRecord
 
   self.discard_column = :deleted_at
 
-  # pricing_type is retired: product-catalog plans now live in the catalog_plans
-  # table, so every plans row is legacy. The column is dropped in a follow-up
-  # release; ignore it until then.
-  # TODO: drop the pricing_type column, then remove this ignore.
-  self.ignored_columns += %w[pricing_type]
-
   belongs_to :organization
   belongs_to :parent, class_name: "Plan", optional: true
 

--- a/app/models/plan_rate_card.rb
+++ b/app/models/plan_rate_card.rb
@@ -6,11 +6,6 @@ class PlanRateCard < ApplicationRecord
 
   self.discard_column = :deleted_at
 
-  # plan_id is superseded by catalog_plan_id (rows only ever pointed at catalog
-  # plans). The column is dropped in a follow-up release; ignore it until then.
-  # TODO: drop the plan_id column, then remove this ignore.
-  self.ignored_columns += %w[plan_id]
-
   belongs_to :organization
   belongs_to :catalog_plan
   belongs_to :rate_card


### PR DESCRIPTION
## Context

- #6335 (Step 1) removed the readers and added `ignored_columns` for `pricing_type`/`plan_id`.
- #6337 (Step 2) dropped the columns but **kept** `ignored_columns` for deploy safety.
- Step 3 (this PR): now that the columns are gone and deployed, the `ignored_columns` entries reference nothing — remove them + their `# TODO: … then remove this ignore` comments.

## Description

Delete the `self.ignored_columns += %w[...]` blocks from `Plan` (`pricing_type`), `Contract` and `PlanRateCard` (`plan_id`). Pure code cleanup — no migration, no behavior change.