### PR TITLE
feat(catalog): update a pending contract

### DIFF
--- a/app/controllers/api/v2/contracts_controller.rb
+++ b/app/controllers/api/v2/contracts_controller.rb
@@ -18,6 +18,21 @@ module Api
         end
       end
 
+      def update
+        contract = current_organization.contracts.live_by_external_id(params[:external_id])
+
+        result = ::Contracts::UpdateService.call(
+          contract:,
+          params: update_params.to_h.deep_symbolize_keys
+        )
+
+        if result.success?
+          render_contract(result.contract)
+        else
+          render_error_response(result)
+        end
+      end
+
       def index
         filters = params.permit(:plan_code, :external_customer_id, :external_id)
         # Accept both ?status=pending and ?status[]=pending — strong params
@@ -98,6 +113,19 @@ module Api
         params.require(:contract).permit(
           :external_customer_id,
           :external_id,
+          :name,
+          :plan_code,
+          :billing_time,
+          :billing_anchor_date,
+          :started_at,
+          :ended_at
+        )
+      end
+
+      # external_customer_id and external_id are set at creation and address the
+      # contract; the rest are the editable authoring fields.
+      def update_params
+        params.require(:contract).permit(
           :name,
           :plan_code,
           :billing_time,

--- a/app/graphql/mutations/contracts/update.rb
+++ b/app/graphql/mutations/contracts/update.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Contracts
+    class Update < BaseMutation
+      include RequiresProductCatalog
+      include AuthenticableApiUser
+      include RequiredOrganization
+
+      REQUIRED_PERMISSION = "contracts:update"
+
+      graphql_name "UpdateContract"
+      description "Updates a pending contract"
+
+      input_object_class Types::Contracts::UpdateInput
+      type Types::Contracts::Object
+
+      def resolve(external_id:, **args)
+        contract = current_organization.contracts.live_by_external_id(external_id)
+
+        result = ::Contracts::UpdateService.call(contract:, params: args)
+
+        result.success? ? result.contract : result_error(result)
+      end
+    end
+  end
+end

--- a/app/graphql/types/contracts/update_input.rb
+++ b/app/graphql/types/contracts/update_input.rb
@@ -9,8 +9,7 @@ module Types
       argument :external_id, String, required: true, description: "External id of the contract to update"
 
       argument :name, String, required: false
-      # Optional by design: a plan-less contract prices through directly
-      # attached rate cards. Changing it re-materialises the rate cards.
+      # Optional: a plan-less contract prices through directly attached cards.
       argument :plan_code, String, required: false
 
       argument :billing_anchor_date, GraphQL::Types::ISO8601Date, required: false

--- a/app/graphql/types/contracts/update_input.rb
+++ b/app/graphql/types/contracts/update_input.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Types
+  module Contracts
+    class UpdateInput < BaseInputObject
+      graphql_name "UpdateContractInput"
+      description "Update contract input arguments"
+
+      argument :external_id, String, required: true, description: "External id of the contract to update"
+
+      argument :name, String, required: false
+      # Optional by design: a plan-less contract prices through directly
+      # attached rate cards. Changing it re-materialises the rate cards.
+      argument :plan_code, String, required: false
+
+      argument :billing_anchor_date, GraphQL::Types::ISO8601Date, required: false
+      argument :billing_time, Types::Contracts::BillingTimeEnum, required: false
+      argument :ended_at, GraphQL::Types::ISO8601DateTime, required: false
+      argument :started_at, GraphQL::Types::ISO8601DateTime, required: false
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -38,6 +38,7 @@ module Types
     field :create_contract, mutation: Mutations::Contracts::Create
     field :destroy_charge, mutation: Mutations::Charges::Destroy
     field :update_charge, mutation: Mutations::Charges::Update
+    field :update_contract, mutation: Mutations::Contracts::Update
 
     field :create_charge_filter, mutation: Mutations::ChargeFilters::Create
     field :destroy_charge_filter, mutation: Mutations::ChargeFilters::Destroy

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -42,7 +42,14 @@ class Contract < ApplicationRecord
   scope :live, -> { where(status: LIVE_STATUSES) }
 
   def self.live_by_external_id(external_id)
-    live.order(started_at: :desc, created_at: :desc).find_by(external_id:)
+    # Prefer the pending (editable) contract when a replacement coexists with an
+    # active one: every consumer — update, rate-card authoring, the detail read
+    # — wants the editable target, and resolving to the active sibling would
+    # wrongly report it locked. The started_at/created_at tie-break keeps the
+    # pick deterministic within a status.
+    live.where(external_id:)
+      .order(Arel.sql("status = 'pending' DESC"), started_at: :desc, created_at: :desc)
+      .first
   end
 
   validates :external_id, presence: true
@@ -63,6 +70,14 @@ class Contract < ApplicationRecord
   # lifecycle concern priced by the billing engine, not an authoring edit.
   def editable?
     pending?
+  end
+
+  # The error code an authoring edit fails with once the contract is no longer
+  # editable (active, terminated or canceled). Mirrors
+  # ContractRateCard#edit_error_code so both authoring surfaces speak the same
+  # vocabulary; nil when the edit is allowed.
+  def edit_error_code
+    "contract_locked" unless editable?
   end
 
   # The currency fees bill in: the plan's when there is one, otherwise the

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -42,11 +42,9 @@ class Contract < ApplicationRecord
   scope :live, -> { where(status: LIVE_STATUSES) }
 
   def self.live_by_external_id(external_id)
-    # Prefer the pending (editable) contract when a replacement coexists with an
-    # active one: every consumer — update, rate-card authoring, the detail read
-    # — wants the editable target, and resolving to the active sibling would
-    # wrongly report it locked. The started_at/created_at tie-break keeps the
-    # pick deterministic within a status.
+    # Prefer the pending (editable) contract over an active sibling — the
+    # editable target every consumer wants; started_at/created_at then breaks
+    # ties deterministically within a status.
     live.where(external_id:)
       .order(Arel.sql("status = 'pending' DESC"), started_at: :desc, created_at: :desc)
       .first
@@ -72,10 +70,8 @@ class Contract < ApplicationRecord
     pending?
   end
 
-  # The error code an authoring edit fails with once the contract is no longer
-  # editable (active, terminated or canceled). Mirrors
-  # ContractRateCard#edit_error_code so both authoring surfaces speak the same
-  # vocabulary; nil when the edit is allowed.
+  # Error code for an edit blocked by the pending-only rule; nil when allowed.
+  # Mirrors ContractRateCard#edit_error_code.
   def edit_error_code
     "contract_locked" unless editable?
   end

--- a/app/services/contracts/update_service.rb
+++ b/app/services/contracts/update_service.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Contracts
+  # Edits a pending contract's authoring fields. Pending-only: once the
+  # agreement is active it is locked, the same rule rate-card edits follow.
+  # Changing the plan re-materialises its rate cards onto the contract. No
+  # billing side-effects — lifecycle transitions live in their own services.
+  class UpdateService < BaseService
+    include CustomerTimezone
+
+    Result = BaseResult[:contract]
+
+    def initialize(contract:, params:)
+      @contract = contract
+      @params = params.to_h.with_indifferent_access
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: "contract") unless contract
+      return result.single_validation_failure!(field: :contract, error_code: "contract_locked") unless contract.editable?
+
+      if params[:plan_code].present? && catalog_plan.nil?
+        return result.not_found_failure!(resource: "plan")
+      end
+
+      # Date columns: a malformed value would silently cast to nil instead of
+      # failing, so formats are rejected explicitly.
+      %i[billing_anchor_date started_at ended_at].each do |field|
+        if params[field].present? && !Utils::Datetime.valid_format?(params[field])
+          return result.single_validation_failure!(field:, error_code: "value_is_invalid")
+        end
+      end
+
+      # A window that already closed cannot be set: nothing would ever
+      # terminate it, leaving a zombie active contract.
+      if params[:ended_at].present? && ended_at_in_customer_timezone <= Time.current
+        return result.single_validation_failure!(field: :ended_at, error_code: "already_ended")
+      end
+
+      plan_changed = params.key?(:plan_code) && catalog_plan != contract.catalog_plan
+
+      ActiveRecord::Base.transaction do
+        contract.name = params[:name] if params.key?(:name)
+        contract.billing_time = params[:billing_time] if params[:billing_time].present?
+        contract.billing_anchor_date = params[:billing_anchor_date] if params.key?(:billing_anchor_date)
+        contract.started_at = started_at_in_customer_timezone if params[:started_at].present?
+        contract.ended_at = ended_at_in_customer_timezone if params.key?(:ended_at)
+        contract.catalog_plan = catalog_plan if params.key?(:plan_code)
+        contract.save!
+
+        # The materialised cards belong to the old plan; a plan change re-derives
+        # them from the new one (or leaves the contract plan-less).
+        if plan_changed
+          contract.applied_rate_cards.discard_all!
+          Contracts::MaterializeRateCardsService.call!(contract:) if contract.catalog_plan
+        end
+
+        result.contract = contract
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue BaseService::FailedResult => e
+      e.result
+    end
+
+    private
+
+    attr_reader :contract, :params
+
+    delegate :organization, :customer, to: :contract
+
+    def catalog_plan
+      return @catalog_plan if defined?(@catalog_plan)
+
+      @catalog_plan = params[:plan_code].present? ? organization.catalog_plans.find_by(code: params[:plan_code]) : nil
+    end
+
+    # Read through the CustomerTimezone suffix: a naive datetime means the
+    # customer's wall clock, and an explicit offset is respected. Nil when
+    # the param is absent.
+    def started_at
+      params[:started_at].presence
+    end
+
+    def ended_at
+      params[:ended_at].presence
+    end
+  end
+end

--- a/app/services/contracts/update_service.rb
+++ b/app/services/contracts/update_service.rb
@@ -18,7 +18,10 @@ module Contracts
 
     def call
       return result.not_found_failure!(resource: "contract") unless contract
-      return result.single_validation_failure!(field: :contract, error_code: "contract_locked") unless contract.editable?
+
+      if (error_code = contract.edit_error_code)
+        return result.single_validation_failure!(field: :contract, error_code:)
+      end
 
       if params[:plan_code].present? && catalog_plan.nil?
         return result.not_found_failure!(resource: "plan")
@@ -50,9 +53,13 @@ module Contracts
         contract.save!
 
         # The materialised cards belong to the old plan; a plan change re-derives
-        # them from the new one (or leaves the contract plan-less).
+        # them from the new one (or leaves the contract plan-less). Tear each
+        # card down through the destroy service so its soft-deletable phases and
+        # overrides are discarded too — a bare discard_all! would orphan them.
         if plan_changed
-          contract.applied_rate_cards.discard_all!
+          contract.applied_rate_cards.to_a.each do |card|
+            ContractRateCards::DestroyService.call!(contract_rate_card: card)
+          end
           Contracts::MaterializeRateCardsService.call!(contract:) if contract.catalog_plan
         end
 

--- a/app/services/contracts/update_service.rb
+++ b/app/services/contracts/update_service.rb
@@ -27,16 +27,14 @@ module Contracts
         return result.not_found_failure!(resource: "plan")
       end
 
-      # Date columns: a malformed value would silently cast to nil instead of
-      # failing, so formats are rejected explicitly.
+      # Reject malformed dates explicitly — they would otherwise cast to nil.
       %i[billing_anchor_date started_at ended_at].each do |field|
         if params[field].present? && !Utils::Datetime.valid_format?(params[field])
           return result.single_validation_failure!(field:, error_code: "value_is_invalid")
         end
       end
 
-      # A window that already closed cannot be set: nothing would ever
-      # terminate it, leaving a zombie active contract.
+      # A window that already closed would never terminate — reject it.
       if params[:ended_at].present? && ended_at_in_customer_timezone <= Time.current
         return result.single_validation_failure!(field: :ended_at, error_code: "already_ended")
       end
@@ -52,10 +50,9 @@ module Contracts
         contract.catalog_plan = catalog_plan if params.key?(:plan_code)
         contract.save!
 
-        # The materialised cards belong to the old plan; a plan change re-derives
-        # them from the new one (or leaves the contract plan-less). Tear each
-        # card down through the destroy service so its soft-deletable phases and
-        # overrides are discarded too — a bare discard_all! would orphan them.
+        # Replace the old plan's materialised cards. The destroy service also
+        # discards each card's soft-deletable phases and overrides, which a bare
+        # discard_all! would orphan.
         if plan_changed
           contract.applied_rate_cards.to_a.each do |card|
             ContractRateCards::DestroyService.call!(contract_rate_card: card)
@@ -85,9 +82,7 @@ module Contracts
       @catalog_plan = params[:plan_code].present? ? organization.catalog_plans.find_by(code: params[:plan_code]) : nil
     end
 
-    # Read through the CustomerTimezone suffix: a naive datetime means the
-    # customer's wall clock, and an explicit offset is respected. Nil when
-    # the param is absent.
+    # Raw source values for the CustomerTimezone *_in_customer_timezone readers.
     def started_at
       params[:started_at].presence
     end

--- a/app/services/contracts/update_service.rb
+++ b/app/services/contracts/update_service.rb
@@ -27,9 +27,14 @@ module Contracts
         return result.not_found_failure!(resource: "plan")
       end
 
-      # Reject malformed dates explicitly — they would otherwise cast to nil.
+      # Reject malformed dates, but let an explicit null clear the field. A bare
+      # present? check would treat false or "" as absent, silently clearing the
+      # column instead of rejecting the bad value.
       %i[billing_anchor_date started_at ended_at].each do |field|
-        if params[field].present? && !Utils::Datetime.valid_format?(params[field])
+        next unless params.key?(field)
+        next if params[field].nil?
+
+        unless Utils::Datetime.valid_format?(params[field])
           return result.single_validation_failure!(field:, error_code: "value_is_invalid")
         end
       end

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -41,6 +41,7 @@ charges:
 contracts:
   view:
   create:
+  update:
 coupons:
   view:
     - finance

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,7 @@ Rails.application.routes.draw do
       end
       # The constraint mirrors v1: without it, an external id containing a
       # dot is truncated at the format separator.
-      resources :contracts, only: %i[index show create], param: :external_id, constraints: {external_id: /[^\/]+/} do
+      resources :contracts, only: %i[index show create update], param: :external_id, constraints: {external_id: /[^\/]+/} do
         resources :applied_rate_cards, param: :code, code: /.*/, only: %i[index create show update destroy], controller: "contract_rate_cards" do
           scope module: :contract_rate_cards do
             resources :rate_phases, param: :code, code: /.*/, only: %i[index create update destroy]

--- a/schema.graphql
+++ b/schema.graphql
@@ -9737,6 +9737,16 @@ type Mutation {
   ): ChargeFilter
 
   """
+  Updates a pending contract
+  """
+  updateContract(
+    """
+    Parameters for UpdateContract
+    """
+    input: UpdateContractInput!
+  ): Contract
+
+  """
   Update an existing coupon
   """
   updateCoupon(
@@ -10724,6 +10734,7 @@ enum PermissionEnum {
   charges_delete
   charges_update
   contracts_create
+  contracts_update
   contracts_view
   coupons_attach
   coupons_create
@@ -10862,6 +10873,7 @@ type Permissions {
   chargesDelete: Boolean!
   chargesUpdate: Boolean!
   contractsCreate: Boolean!
+  contractsUpdate: Boolean!
   contractsView: Boolean!
   couponsAttach: Boolean!
   couponsCreate: Boolean!
@@ -14752,6 +14764,28 @@ input UpdateCatalogPlanInput {
   id: ID!
   invoiceDisplayName: String
   name: String
+}
+
+"""
+Update contract input arguments
+"""
+input UpdateContractInput {
+  billingAnchorDate: ISO8601Date
+  billingTime: ContractBillingTimeEnum
+
+  """
+  A unique identifier for the client performing the mutation.
+  """
+  clientMutationId: String
+  endedAt: ISO8601DateTime
+
+  """
+  External id of the contract to update
+  """
+  externalId: String!
+  name: String
+  planCode: String
+  startedAt: ISO8601DateTime
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -47060,6 +47060,35 @@
               "deprecationReason": null
             },
             {
+              "name": "updateContract",
+              "description": "Updates a pending contract",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for UpdateContract",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "UpdateContractInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Contract",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "updateCoupon",
               "description": "Update an existing coupon",
               "args": [
@@ -52151,6 +52180,12 @@
               "deprecationReason": null
             },
             {
+              "name": "contracts_update",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "coupons_view",
               "description": null,
               "isDeprecated": false,
@@ -53150,6 +53185,22 @@
             },
             {
               "name": "contractsCreate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "contractsUpdate",
               "description": null,
               "args": [],
               "type": {
@@ -78226,6 +78277,117 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "UpdateContractInput",
+          "description": "Update contract input arguments",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "externalId",
+              "description": "External id of the contract to update",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "planCode",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "billingAnchorDate",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "billingTime",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "ContractBillingTimeEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "endedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/mutations/contracts/update_spec.rb
+++ b/spec/graphql/mutations/contracts/update_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Mutations::Contracts::Update do
+  subject(:execution) do
+    execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query: mutation,
+      variables: {input:}
+    )
+  end
+
+  let(:required_permission) { "contracts:update" }
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:catalog_plan) { create(:catalog_plan, organization:) }
+  let(:contract) { create(:contract, :pending, organization:, customer:, catalog_plan:) }
+
+  let(:input) { {externalId: contract.external_id, name: "Renamed"} }
+
+  let(:mutation) do
+    <<-GQL
+      mutation($input: UpdateContractInput!) {
+        updateContract(input: $input) {
+          id externalId name
+          plan { id }
+          appliedRateCards { id }
+        }
+      }
+    GQL
+  end
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "contracts:update"
+
+  it "updates the contract" do
+    result_data = execution["data"]["updateContract"]
+
+    expect(result_data["externalId"]).to eq(contract.external_id)
+    expect(result_data["name"]).to eq("Renamed")
+  end
+
+  context "when changing the plan" do
+    let(:other_plan) { create(:catalog_plan, organization:) }
+    let(:input) { {externalId: contract.external_id, planCode: other_plan.code} }
+
+    it "re-materializes the rate cards from the new plan" do
+      create(:plan_rate_card, organization:, catalog_plan: other_plan, rate_card: create(:rate_card, organization:))
+
+      result_data = execution["data"]["updateContract"]
+
+      expect(result_data["plan"]["id"]).to eq(other_plan.id)
+      expect(result_data["appliedRateCards"].size).to eq(1)
+    end
+  end
+
+  context "when the contract is already active" do
+    let(:contract) { create(:contract, organization:, customer:, catalog_plan:) }
+
+    it "returns a validation error" do
+      expect_unprocessable_entity(execution)
+    end
+  end
+end

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -112,6 +112,14 @@ RSpec.describe Contract do
     end
   end
 
+  describe "#edit_error_code" do
+    it "is nil while pending and contract_locked once no longer editable" do
+      expect(build(:contract, :pending).edit_error_code).to be_nil
+      expect(build(:contract, status: :active).edit_error_code).to eq("contract_locked")
+      expect(build(:contract, :terminated).edit_error_code).to eq("contract_locked")
+    end
+  end
+
   describe "#currency" do
     let(:organization) { create(:organization) }
     let(:customer) { create(:customer, organization:, currency: "USD") }
@@ -178,6 +186,14 @@ RSpec.describe Contract do
         create(:contract, :terminated, organization:, external_id: "gone")
 
         expect(organization.contracts.live_by_external_id("gone")).to be_nil
+      end
+
+      it "prefers the pending replacement over its active sibling" do
+        active = create(:contract, organization:, external_id: "reused", started_at: 1.month.ago)
+        pending = create(:contract, :pending, organization:, external_id: "reused")
+
+        expect(organization.contracts.live_by_external_id("reused")).to eq(pending)
+        expect(active.reload.status).to eq("active")
       end
     end
   end

--- a/spec/requests/api/v2/contracts_controller_spec.rb
+++ b/spec/requests/api/v2/contracts_controller_spec.rb
@@ -183,4 +183,58 @@ RSpec.describe Api::V2::ContractsController do
       end
     end
   end
+
+  describe "PUT /api/v2/contracts/:external_id" do
+    subject { put_with_token(organization, "/api/v2/contracts/#{contract.external_id}", {contract: update_params}) }
+
+    let(:contract) { create(:contract, :pending, organization:, customer:, catalog_plan:) }
+    let(:update_params) { {name: "Renamed"} }
+
+    include_examples "requires API permission", "contract", "write"
+
+    it "updates the contract and returns it" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:contract][:external_id]).to eq(contract.external_id)
+      expect(json[:contract][:name]).to eq("Renamed")
+    end
+
+    context "when changing the plan" do
+      let(:other_plan) { create(:catalog_plan, organization:) }
+      let(:update_params) { {plan_code: other_plan.code} }
+
+      it "re-materializes the rate cards from the new plan" do
+        rate_card = create(:rate_card, organization:)
+        create(:plan_rate_card, organization:, catalog_plan: other_plan, rate_card:, units: 4)
+
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:contract][:plan_code]).to eq(other_plan.code)
+        expect(json[:contract][:applied_rate_cards].sole[:rate_card_code]).to eq(rate_card.code)
+      end
+    end
+
+    context "when the contract is already active" do
+      let(:contract) { create(:contract, organization:, customer:, catalog_plan:) }
+
+      it "returns an unprocessable entity error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json[:error_details][:contract]).to eq(["contract_locked"])
+      end
+    end
+
+    context "when it does not exist" do
+      subject { put_with_token(organization, "/api/v2/contracts/unknown", {contract: update_params}) }
+
+      it "returns a not found error" do
+        subject
+
+        expect(response).to be_not_found_error("contract")
+      end
+    end
+  end
 end

--- a/spec/services/contracts/update_service_spec.rb
+++ b/spec/services/contracts/update_service_spec.rb
@@ -87,6 +87,27 @@ RSpec.describe Contracts::UpdateService do
     end
   end
 
+  context "with a boolean date value" do
+    let(:contract) { create(:contract, :pending, organization:, customer:, catalog_plan:, ended_at: 1.month.from_now) }
+    let(:params) { {ended_at: false} }
+
+    it "rejects it instead of silently clearing the end date" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:ended_at]).to eq(["value_is_invalid"])
+      expect(contract.reload.ended_at).to be_present
+    end
+  end
+
+  context "when clearing a date with an explicit null" do
+    let(:contract) { create(:contract, :pending, organization:, customer:, catalog_plan:, ended_at: 1.month.from_now) }
+    let(:params) { {ended_at: nil} }
+
+    it "clears the end date" do
+      expect(result).to be_success
+      expect(contract.reload.ended_at).to be_nil
+    end
+  end
+
   context "when the end date is already in the past" do
     let(:params) { {ended_at: 1.day.ago.iso8601} }
 

--- a/spec/services/contracts/update_service_spec.rb
+++ b/spec/services/contracts/update_service_spec.rb
@@ -47,9 +47,11 @@ RSpec.describe Contracts::UpdateService do
     let(:new_rate_card) { create(:rate_card, organization:) }
     let(:other_plan) { create(:catalog_plan, organization:) }
     let(:params) { {plan_code: other_plan.code} }
+    let(:old_card) { create(:contract_rate_card, organization:, contract:, rate_card: create(:rate_card, organization:)) }
+    let(:old_phase) { create(:rate_phase, :contract_level, organization:, contract_rate_card: old_card) }
 
     before do
-      create(:contract_rate_card, organization:, contract:, rate_card: create(:rate_card, organization:))
+      old_phase
       create(:plan_rate_card, organization:, catalog_plan: other_plan, rate_card: new_rate_card, units: 3)
     end
 
@@ -57,6 +59,13 @@ RSpec.describe Contracts::UpdateService do
       expect(result).to be_success
       expect(contract.reload.catalog_plan).to eq(other_plan)
       expect(contract.applied_rate_cards.sole).to have_attributes(rate_card: new_rate_card, units: 3)
+    end
+
+    it "discards the replaced cards along with their phases" do
+      result
+
+      expect(old_card.reload).to be_discarded
+      expect(old_phase.reload).to be_discarded
     end
   end
 

--- a/spec/services/contracts/update_service_spec.rb
+++ b/spec/services/contracts/update_service_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::UpdateService do
+  subject(:result) { described_class.call(contract:, params:) }
+
+  let(:organization) { create(:organization, feature_flags: ["product_catalog"]) }
+  let(:customer) { create(:customer, organization:) }
+  let(:catalog_plan) { create(:catalog_plan, organization:) }
+  let(:contract) { create(:contract, :pending, organization:, customer:, catalog_plan:) }
+
+  let(:params) { {name: "Renamed", billing_time: "anniversary"} }
+
+  it "updates the editable authoring fields" do
+    expect(result).to be_success
+    expect(contract.reload).to have_attributes(name: "Renamed", billing_time: "anniversary")
+  end
+
+  it "sets the window dates in the customer timezone" do
+    result = described_class.call(contract:, params: {started_at: "2026-11-01T00:00:00", ended_at: "2026-12-01T00:00:00"})
+
+    expect(result).to be_success
+    expect(contract.reload.started_at).to eq(Time.zone.parse("2026-11-01T00:00:00"))
+    expect(contract.ended_at).to eq(Time.zone.parse("2026-12-01T00:00:00"))
+  end
+
+  context "when the contract is already active" do
+    let(:contract) { create(:contract, organization:, customer:, catalog_plan:) }
+
+    it "rejects the edit as locked" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:contract]).to eq(["contract_locked"])
+    end
+  end
+
+  context "when the contract is missing" do
+    let(:contract) { nil }
+
+    it "returns a not found failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotFoundFailure)
+    end
+  end
+
+  context "when changing the plan" do
+    let(:new_rate_card) { create(:rate_card, organization:) }
+    let(:other_plan) { create(:catalog_plan, organization:) }
+    let(:params) { {plan_code: other_plan.code} }
+
+    before do
+      create(:contract_rate_card, organization:, contract:, rate_card: create(:rate_card, organization:))
+      create(:plan_rate_card, organization:, catalog_plan: other_plan, rate_card: new_rate_card, units: 3)
+    end
+
+    it "re-materializes the rate cards from the new plan" do
+      expect(result).to be_success
+      expect(contract.reload.catalog_plan).to eq(other_plan)
+      expect(contract.applied_rate_cards.sole).to have_attributes(rate_card: new_rate_card, units: 3)
+    end
+  end
+
+  context "when the plan code is unknown" do
+    let(:params) { {plan_code: "unknown"} }
+
+    it "returns a not found plan failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotFoundFailure)
+    end
+  end
+
+  context "with a malformed date" do
+    let(:params) { {started_at: "not-a-date"} }
+
+    it "rejects the value" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:started_at]).to eq(["value_is_invalid"])
+    end
+  end
+
+  context "when the end date is already in the past" do
+    let(:params) { {ended_at: 1.day.ago.iso8601} }
+
+    it "rejects the ended_at" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:ended_at]).to eq(["already_ended"])
+    end
+  end
+end


### PR DESCRIPTION
## Context

A contract is authored while **pending**: its window, plan and billing settings can still be corrected before it goes live. Once `active` the agreement is locked — the same rule its attached rate cards already follow. Until now only creation and reads were exposed (BIL-640).

## Description

Adds `Contracts::UpdateService`, exposed over both surfaces:

- **REST** — `PUT /api/v2/contracts/:external_id`
- **GraphQL** — `updateContract` mutation

Editable fields: `name`, `started_at`, `ended_at`, `billing_anchor_date`, `billing_time`, `plan_code`.

- Changing `plan_code` re-materialises the new plan's rate cards onto the contract (discards the old applied rate cards, re-runs `Contracts::MaterializeRateCardsService`); clearing it leaves a plan-less contract.
- Dates are read through the customer timezone, mirroring create; malformed formats are rejected explicitly and an already-past `ended_at` is refused.
- Editing a non-pending contract fails with `contract_locked`.

**No billing side-effects.** Out of scope: status/lifecycle mutations (`terminateContract` et al.) — those live in their own services.

## Testing

- `spec/services/contracts/update_service_spec.rb`
- `spec/requests/api/v2/contracts_controller_spec.rb` (PUT block)
- `spec/graphql/mutations/contracts/update_spec.rb`
- Schema dump (`schema.graphql`/`schema.json`) regenerated for the new mutation; `lago_api_schema_spec` green.