### PR TITLE
perf(payments): add indexes for payments list filters

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -772,6 +772,7 @@ end
 #  index_invoices_on_customer_billing_entity_sequential            (customer_id,billing_entity_id,sequential_id) UNIQUE
 #  index_invoices_on_number                                        (number)
 #  index_invoices_on_organization_id_and_customer_id               (customer_id,organization_id)
+#  index_invoices_on_organization_id_lower_number                  (organization_id, lower((number)::text))
 #  index_invoices_on_organization_id_lower_purchase_order_number   (organization_id, lower((purchase_order_number)::text))
 #  index_invoices_on_organization_id_number_gin_trgm_ops           (organization_id,number) USING gin
 #  index_invoices_on_organization_id_search_terms_gin_trgm_ops     (organization_id,search_terms) USING gin

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -168,6 +168,7 @@ end
 #  index_payments_by_cursor                                        (organization_id,created_at DESC,id)
 #  index_payments_on_customer_id                                   (customer_id)
 #  index_payments_on_invoice_id                                    (invoice_id)
+#  index_payments_on_org_pending_processing_created_at             (organization_id,payable_payment_status,created_at DESC,id) WHERE (payable_payment_status = ANY (ARRAY['pending'::payment_payable_payment_status, 'processing'::payment_payable_payment_status]))
 #  index_payments_on_organization_id                               (organization_id)
 #  index_payments_on_organization_id_reference_gin_trgm_ops        (organization_id,reference) USING gin
 #  index_payments_on_payable_id_and_payable_type                   (payable_id,payable_type) UNIQUE WHERE ((payable_payment_status = ANY (ARRAY['pending'::payment_payable_payment_status, 'processing'::payment_payable_payment_status])) AND (payment_type = 'provider'::payment_type))

--- a/app/models/payment_receipt.rb
+++ b/app/models/payment_receipt.rb
@@ -38,9 +38,10 @@ end
 #
 # Indexes
 #
-#  index_payment_receipts_on_billing_entity_id  (billing_entity_id)
-#  index_payment_receipts_on_organization_id    (organization_id)
-#  index_payment_receipts_on_payment_id         (payment_id) UNIQUE
+#  index_payment_receipts_on_billing_entity_id             (billing_entity_id)
+#  index_payment_receipts_on_organization_id               (organization_id)
+#  index_payment_receipts_on_organization_id_lower_number  (organization_id, lower((number)::text))
+#  index_payment_receipts_on_payment_id                    (payment_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/db/migrate/20260909090000_add_payment_receipts_organization_lower_number_index.rb
+++ b/db/migrate/20260909090000_add_payment_receipts_organization_lower_number_index.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddPaymentReceiptsOrganizationLowerNumberIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    # Supports the exact, case-insensitive receipt_number filter of the payments
+    # list for large organizations. Same shape as
+    # index_invoices_on_organization_id_lower_purchase_order_number.
+    add_index :payment_receipts, "organization_id, lower(number)",
+      name: "index_payment_receipts_on_organization_id_lower_number",
+      algorithm: :concurrently,
+      using: :btree,
+      if_not_exists: true
+  end
+end

--- a/db/migrate/20260909090100_add_invoices_organization_lower_number_index.rb
+++ b/db/migrate/20260909090100_add_invoices_organization_lower_number_index.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddInvoicesOrganizationLowerNumberIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    # Supports the exact, case-insensitive invoice_number filter of the payments
+    # list for large organizations. index_invoices_on_number is case-sensitive and
+    # not organization-scoped; the trgm index only serves ILIKE.
+    add_index :invoices, "organization_id, lower(number)",
+      name: "index_invoices_on_organization_id_lower_number",
+      algorithm: :concurrently,
+      using: :btree,
+      if_not_exists: true
+  end
+end

--- a/db/migrate/20260909090200_add_payments_pending_processing_index.rb
+++ b/db/migrate/20260909090200_add_payments_pending_processing_index.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AddPaymentsPendingProcessingIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    # Supports the payment_status filter of the payments list for its rare values
+    # (pending, processing) on large organizations, ordered like the list itself.
+    # Partial on purpose: the planner cannot pick it for the dominant values, which
+    # the (organization_id, created_at DESC, id) cursor index already serves.
+    # Four columns like index_invoices_by_cursor: the trailing (created_at DESC, id)
+    # is the list ordering, so the page is read without a sort.
+    safety_assured do
+      add_index :payments,
+        [:organization_id, :payable_payment_status, :created_at, :id],
+        order: {created_at: :desc, id: :asc},
+        where: "payable_payment_status IN ('pending', 'processing')",
+        name: "index_payments_on_org_pending_processing_created_at",
+        algorithm: :concurrently,
+        if_not_exists: true
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -597,6 +597,7 @@ DROP INDEX IF EXISTS public.index_payments_on_payable_id_and_payable_type_and_er
 DROP INDEX IF EXISTS public.index_payments_on_payable_id_and_payable_type;
 DROP INDEX IF EXISTS public.index_payments_on_organization_id_reference_gin_trgm_ops;
 DROP INDEX IF EXISTS public.index_payments_on_organization_id;
+DROP INDEX IF EXISTS public.index_payments_on_org_pending_processing_created_at;
 DROP INDEX IF EXISTS public.index_payments_on_invoice_id;
 DROP INDEX IF EXISTS public.index_payments_on_customer_id;
 DROP INDEX IF EXISTS public.index_payments_by_cursor;
@@ -604,6 +605,7 @@ DROP INDEX IF EXISTS public.index_payment_requests_on_organization_id;
 DROP INDEX IF EXISTS public.index_payment_requests_on_dunning_campaign_id;
 DROP INDEX IF EXISTS public.index_payment_requests_on_customer_id;
 DROP INDEX IF EXISTS public.index_payment_receipts_on_payment_id;
+DROP INDEX IF EXISTS public.index_payment_receipts_on_organization_id_lower_number;
 DROP INDEX IF EXISTS public.index_payment_receipts_on_organization_id;
 DROP INDEX IF EXISTS public.index_payment_receipts_on_billing_entity_id;
 DROP INDEX IF EXISTS public.index_payment_providers_on_organization_id;
@@ -666,6 +668,7 @@ DROP INDEX IF EXISTS public.index_invoices_on_payment_due_date;
 DROP INDEX IF EXISTS public.index_invoices_on_organization_id_search_terms_gin_trgm_ops;
 DROP INDEX IF EXISTS public.index_invoices_on_organization_id_number_gin_trgm_ops;
 DROP INDEX IF EXISTS public.index_invoices_on_organization_id_lower_purchase_order_number;
+DROP INDEX IF EXISTS public.index_invoices_on_organization_id_lower_number;
 DROP INDEX IF EXISTS public.index_invoices_on_organization_id_and_customer_id;
 DROP INDEX IF EXISTS public.index_invoices_on_number;
 DROP INDEX IF EXISTS public.index_invoices_on_customer_billing_entity_sequential;
@@ -10028,6 +10031,13 @@ CREATE INDEX index_invoices_on_organization_id_and_customer_id ON public.invoice
 
 
 --
+-- Name: index_invoices_on_organization_id_lower_number; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_invoices_on_organization_id_lower_number ON public.invoices USING btree (organization_id, lower((number)::text));
+
+
+--
 -- Name: index_invoices_on_organization_id_lower_purchase_order_number; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10462,6 +10472,13 @@ CREATE INDEX index_payment_receipts_on_organization_id ON public.payment_receipt
 
 
 --
+-- Name: index_payment_receipts_on_organization_id_lower_number; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_payment_receipts_on_organization_id_lower_number ON public.payment_receipts USING btree (organization_id, lower((number)::text));
+
+
+--
 -- Name: index_payment_receipts_on_payment_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10508,6 +10525,13 @@ CREATE INDEX index_payments_on_customer_id ON public.payments USING btree (custo
 --
 
 CREATE INDEX index_payments_on_invoice_id ON public.payments USING btree (invoice_id);
+
+
+--
+-- Name: index_payments_on_org_pending_processing_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_payments_on_org_pending_processing_created_at ON public.payments USING btree (organization_id, payable_payment_status, created_at DESC, id) WHERE (payable_payment_status = ANY (ARRAY['pending'::public.payment_payable_payment_status, 'processing'::public.payment_payable_payment_status]));
 
 
 --
@@ -14904,6 +14928,9 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260909090200'),
+('20260909090100'),
+('20260909090000'),
 ('20260908180522'),
 ('20260905223042'),
 ('20260905223041'),


### PR DESCRIPTION
Adds the indexes the payments list filters (#6325) rely on for large organizations. Migration-only PR: no application code. Deploy this before #6325.

## Indexes

| table | index | serves |
|---|---|---|
| payment_receipts | `index_payment_receipts_on_organization_id_lower_number` on `(organization_id, lower(number))` | exact, case-insensitive `receipt_number` filter |
| invoices | `index_invoices_on_organization_id_lower_number` on `(organization_id, lower(number))` | exact, case-insensitive `invoice_number` filter (both payable paths) |
| payments | `index_payments_on_org_pending_processing_created_at` on `(organization_id, payable_payment_status, created_at DESC, id) WHERE payable_payment_status IN ('pending', 'processing')` | rare `payment_status` values, pre-sorted for the list. Partial on purpose: the planner cannot pick it for `succeeded`/`failed`, which the cursor index already serves |

Same shape as `index_invoices_on_organization_id_lower_purchase_order_number`. All builds use `algorithm: :concurrently`, `if_not_exists: true`, one migration per table.

## Build cost, synthetic dataset

Measured on a synthetic dataset of ~6.5M payments / 5.9M invoices / 3.5M receipts (see `script/perf/payments_filters/` on the filters branch). Figures are from that dataset, not from production.

| index | rows | build time (CONCURRENTLY, idle machine) | size |
|---|---|---|---|
| payment_receipts (organization_id, lower(number)) | 3.5M | 4.2 s | 107 MB |
| invoices (organization_id, lower(number)) | 5.9M | 12.7 s | 382 MB |
| payments partial pending/processing | 6.5M (135k indexed) | 3.8 s | 11 MB |

Rejected after measurement (details in the internal doc): a full `(organization_id, payable_payment_status, created_at DESC, id)` index (423 MB, the planner takes it for `succeeded` and the count regresses), `(organization_id, amount_cents)` (same regression on common ranges), and an expression index on the payment method jsonb (never used while the saved-method fallback branch exists).

## Deploying

- `config/database.yml` applies `LAGO_DATABASE_STATEMENT_TIMEOUT` to every session, including `db:migrate`. Run the migration with the statement timeout unset (or above the expected build time). A short `LAGO_DATABASE_LOCK_TIMEOUT` is fine: `CREATE INDEX CONCURRENTLY` takes a `ShareUpdateExclusiveLock` only.
- A concurrent build that is cancelled or fails leaves an `INVALID` index behind. Check after the deploy and drop/retry if any row comes back:
  ```sql
  SELECT indexrelid::regclass FROM pg_index WHERE NOT indisvalid;
  ```
- Rollback: `DROP INDEX CONCURRENTLY <name>`, no application change needed.
- After the filters PR ships, confirm the indexes are used: `SELECT indexrelname, idx_scan FROM pg_stat_user_indexes WHERE indexrelname LIKE '%lower_number%'`.

Performance analysis: internal document "Payments list filters: performance analysis" (Raffi; not public). All figures above come from the synthetic dataset built by `script/perf/payments_filters/generate.rb` on #6325.
