### PR TITLE
feat(account-tree): Add usage_attribution_values table and model

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -85,6 +85,7 @@ class Customer < ApplicationRecord
   has_many :payment_methods, dependent: :destroy
   has_many :payment_requests, dependent: :destroy
   has_many :quantified_events
+  has_many :usage_attribution_values
   has_many :integration_customers,
     class_name: "IntegrationCustomers::BaseCustomer",
     dependent: :destroy

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -94,6 +94,7 @@ class Organization < ApplicationRecord
   has_many :subscription_feature_removals, class_name: "Entitlement::SubscriptionFeatureRemoval"
 
   has_many :usage_attribution_types
+  has_many :usage_attribution_values
 
   has_many :subscription_activities, class_name: "UsageMonitoring::SubscriptionActivity"
   has_many :alerts, class_name: "UsageMonitoring::Alert"

--- a/app/models/usage_attribution_type.rb
+++ b/app/models/usage_attribution_type.rb
@@ -11,8 +11,9 @@ class UsageAttributionType < ApplicationRecord
   }.freeze
 
   belongs_to :organization
-  belongs_to :parent, class_name: "UsageAttributionType", optional: true
+  belongs_to :parent, -> { with_discarded }, class_name: "UsageAttributionType", optional: true
   has_many :children, class_name: "UsageAttributionType", foreign_key: :parent_id, inverse_of: :parent
+  has_many :usage_attribution_values
 
   enum :role, ROLES, validate: true
 

--- a/app/models/usage_attribution_value.rb
+++ b/app/models/usage_attribution_value.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class UsageAttributionValue < ApplicationRecord
+  include Discard::Model
+
+  self.discard_column = :deleted_at
+
+  belongs_to :organization
+  belongs_to :usage_attribution_type, -> { with_discarded }
+  belongs_to :customer, -> { with_discarded }
+  belongs_to :parent, -> { with_discarded }, class_name: "UsageAttributionValue", optional: true
+  has_many :children, class_name: "UsageAttributionValue", foreign_key: :parent_id, inverse_of: :parent
+
+  validates :value, presence: true, length: {maximum: 255}, uniqueness: {scope: %i[customer_id usage_attribution_type_id]}
+
+  default_scope -> { kept }
+end
+
+# == Schema Information
+#
+# Table name: usage_attribution_values
+# Database name: primary
+#
+#  id                        :uuid             not null, primary key
+#  deleted_at                :datetime
+#  last_seen_at              :datetime
+#  value                     :string           not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  customer_id               :uuid             not null
+#  organization_id           :uuid             not null
+#  parent_id                 :uuid
+#  usage_attribution_type_id :uuid             not null
+#
+# Indexes
+#
+#  index_usage_attribution_values_on_customer_id                   (customer_id)
+#  index_usage_attribution_values_on_customer_id_and_last_seen_at  (customer_id,last_seen_at)
+#  index_usage_attribution_values_on_customer_type_and_value       (customer_id,usage_attribution_type_id,value) UNIQUE
+#  index_usage_attribution_values_on_organization_id               (organization_id)
+#  index_usage_attribution_values_on_parent_id                     (parent_id)
+#  index_usage_attribution_values_on_usage_attribution_type_id     (usage_attribution_type_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (parent_id => usage_attribution_values.id)
+#  fk_rails_...  (usage_attribution_type_id => usage_attribution_types.id)
+#

--- a/db/migrate/20260909103355_create_usage_attribution_values.rb
+++ b/db/migrate/20260909103355_create_usage_attribution_values.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateUsageAttributionValues < ActiveRecord::Migration[8.0]
+  def change
+    create_table :usage_attribution_values, id: :uuid do |t|
+      t.references :organization, type: :uuid, null: false, foreign_key: true, index: true
+      t.references :usage_attribution_type, type: :uuid, null: false, foreign_key: true, index: true
+      t.references :customer, type: :uuid, null: false, foreign_key: true, index: true
+      t.references :parent, type: :uuid, null: true, foreign_key: {to_table: :usage_attribution_values}, index: true
+
+      t.string :value, null: false
+      t.datetime :last_seen_at
+
+      t.datetime :deleted_at
+
+      t.timestamps
+
+      t.index %i[customer_id usage_attribution_type_id value],
+        unique: true,
+        name: "index_usage_attribution_values_on_customer_type_and_value"
+      t.index %i[customer_id last_seen_at]
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -61,6 +61,7 @@ ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_ra
 ALTER TABLE IF EXISTS ONLY public.rate_cards DROP CONSTRAINT IF EXISTS fk_rails_ddab7acbd0;
 ALTER TABLE IF EXISTS ONLY public.invites DROP CONSTRAINT IF EXISTS fk_rails_dd342449a6;
 ALTER TABLE IF EXISTS ONLY public.enriched_store_subscription_migrations DROP CONSTRAINT IF EXISTS fk_rails_dc444f5f29;
+ALTER TABLE IF EXISTS ONLY public.usage_attribution_values DROP CONSTRAINT IF EXISTS fk_rails_dc093a8283;
 ALTER TABLE IF EXISTS ONLY public.customers_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_db9140d0fd;
 ALTER TABLE IF EXISTS ONLY public.contract_rate_cards DROP CONSTRAINT IF EXISTS fk_rails_da12dd4c55;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_d9ffb8b4a1;
@@ -151,6 +152,7 @@ ALTER TABLE IF EXISTS ONLY public.pending_vies_checks DROP CONSTRAINT IF EXISTS 
 ALTER TABLE IF EXISTS ONLY public.entitlement_subscription_feature_removals DROP CONSTRAINT IF EXISTS fk_rails_95df3194c5;
 ALTER TABLE IF EXISTS ONLY public.customers DROP CONSTRAINT IF EXISTS fk_rails_94cc21031f;
 ALTER TABLE IF EXISTS ONLY public.rate_cards_taxes DROP CONSTRAINT IF EXISTS fk_rails_9457f0d2da;
+ALTER TABLE IF EXISTS ONLY public.usage_attribution_values DROP CONSTRAINT IF EXISTS fk_rails_92e94c6810;
 ALTER TABLE IF EXISTS ONLY public.data_export_parts DROP CONSTRAINT IF EXISTS fk_rails_9298b8fdad;
 ALTER TABLE IF EXISTS ONLY public.adjusted_fees DROP CONSTRAINT IF EXISTS fk_rails_91802dc891;
 ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXISTS fk_rails_90d93bd016;
@@ -209,6 +211,7 @@ ALTER TABLE IF EXISTS ONLY public.invoices_taxes DROP CONSTRAINT IF EXISTS fk_ra
 ALTER TABLE IF EXISTS ONLY public.adjusted_fees DROP CONSTRAINT IF EXISTS fk_rails_6d465e6b10;
 ALTER TABLE IF EXISTS ONLY public.rate_overrides DROP CONSTRAINT IF EXISTS fk_rails_6c8a54dfe1;
 ALTER TABLE IF EXISTS ONLY public.dunning_campaigns DROP CONSTRAINT IF EXISTS fk_rails_6c720a8ccd;
+ALTER TABLE IF EXISTS ONLY public.usage_attribution_values DROP CONSTRAINT IF EXISTS fk_rails_6b11e175f4;
 ALTER TABLE IF EXISTS ONLY public.products DROP CONSTRAINT IF EXISTS fk_rails_6a4ad694b3;
 ALTER TABLE IF EXISTS ONLY public.billing_entities_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_699cd1384f;
 ALTER TABLE IF EXISTS ONLY public.customers_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_68754484c0;
@@ -249,6 +252,7 @@ ALTER TABLE IF EXISTS ONLY public.product_filter_values DROP CONSTRAINT IF EXIST
 ALTER TABLE IF EXISTS ONLY public.applied_usage_thresholds DROP CONSTRAINT IF EXISTS fk_rails_52b72c9b0e;
 ALTER TABLE IF EXISTS ONLY public.password_resets DROP CONSTRAINT IF EXISTS fk_rails_526379cd99;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules DROP CONSTRAINT IF EXISTS fk_rails_52370612ae;
+ALTER TABLE IF EXISTS ONLY public.usage_attribution_values DROP CONSTRAINT IF EXISTS fk_rails_521c8108bf;
 ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_521b5240ed;
 ALTER TABLE IF EXISTS ONLY public.commitments DROP CONSTRAINT IF EXISTS fk_rails_51ac39a0c6;
 ALTER TABLE IF EXISTS ONLY public.products DROP CONSTRAINT IF EXISTS fk_rails_512c4da634;
@@ -442,6 +446,12 @@ DROP INDEX IF EXISTS public.index_usage_monitoring_alerts_on_subscription_extern
 DROP INDEX IF EXISTS public.index_usage_monitoring_alerts_on_organization_id;
 DROP INDEX IF EXISTS public.index_usage_monitoring_alerts_on_billable_metric_id;
 DROP INDEX IF EXISTS public.index_usage_monitoring_alert_thresholds_on_organization_id;
+DROP INDEX IF EXISTS public.index_usage_attribution_values_on_usage_attribution_type_id;
+DROP INDEX IF EXISTS public.index_usage_attribution_values_on_parent_id;
+DROP INDEX IF EXISTS public.index_usage_attribution_values_on_organization_id;
+DROP INDEX IF EXISTS public.index_usage_attribution_values_on_customer_type_and_value;
+DROP INDEX IF EXISTS public.index_usage_attribution_values_on_customer_id_and_last_seen_at;
+DROP INDEX IF EXISTS public.index_usage_attribution_values_on_customer_id;
 DROP INDEX IF EXISTS public.index_usage_attribution_types_on_parent_id;
 DROP INDEX IF EXISTS public.index_usage_attribution_types_on_organization_id_and_key;
 DROP INDEX IF EXISTS public.index_usage_attribution_types_on_organization_id_and_code;
@@ -1065,6 +1075,7 @@ ALTER TABLE IF EXISTS ONLY public.usage_monitoring_triggered_alerts DROP CONSTRA
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_subscription_activities DROP CONSTRAINT IF EXISTS usage_monitoring_subscription_activities_pkey;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alerts DROP CONSTRAINT IF EXISTS usage_monitoring_alerts_pkey;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alert_thresholds DROP CONSTRAINT IF EXISTS usage_monitoring_alert_thresholds_pkey;
+ALTER TABLE IF EXISTS ONLY public.usage_attribution_values DROP CONSTRAINT IF EXISTS usage_attribution_values_pkey;
 ALTER TABLE IF EXISTS ONLY public.usage_attribution_types DROP CONSTRAINT IF EXISTS usage_attribution_types_pkey;
 ALTER TABLE IF EXISTS ONLY public.taxes DROP CONSTRAINT IF EXISTS taxes_pkey;
 ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS subscriptions_pkey;
@@ -1206,6 +1217,7 @@ DROP TABLE IF EXISTS public.user_devices;
 DROP SEQUENCE IF EXISTS public.usage_monitoring_subscription_activities_id_seq;
 DROP TABLE IF EXISTS public.usage_monitoring_subscription_activities;
 DROP TABLE IF EXISTS public.usage_monitoring_alerts;
+DROP TABLE IF EXISTS public.usage_attribution_values;
 DROP TABLE IF EXISTS public.usage_attribution_types;
 DROP TABLE IF EXISTS public.subscriptions_invoice_custom_sections;
 DROP TABLE IF EXISTS public.subscription_fixed_charge_units_overrides;
@@ -5921,6 +5933,24 @@ CREATE TABLE public.usage_attribution_types (
 
 
 --
+-- Name: usage_attribution_values; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.usage_attribution_values (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    usage_attribution_type_id uuid NOT NULL,
+    customer_id uuid NOT NULL,
+    parent_id uuid,
+    value character varying NOT NULL,
+    last_seen_at timestamp(6) without time zone,
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: usage_monitoring_alerts; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -7160,6 +7190,14 @@ ALTER TABLE ONLY public.taxes
 
 ALTER TABLE ONLY public.usage_attribution_types
     ADD CONSTRAINT usage_attribution_types_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: usage_attribution_values usage_attribution_values_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.usage_attribution_values
+    ADD CONSTRAINT usage_attribution_values_pkey PRIMARY KEY (id);
 
 
 --
@@ -11572,6 +11610,48 @@ CREATE INDEX index_usage_attribution_types_on_parent_id ON public.usage_attribut
 
 
 --
+-- Name: index_usage_attribution_values_on_customer_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_usage_attribution_values_on_customer_id ON public.usage_attribution_values USING btree (customer_id);
+
+
+--
+-- Name: index_usage_attribution_values_on_customer_id_and_last_seen_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_usage_attribution_values_on_customer_id_and_last_seen_at ON public.usage_attribution_values USING btree (customer_id, last_seen_at);
+
+
+--
+-- Name: index_usage_attribution_values_on_customer_type_and_value; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_usage_attribution_values_on_customer_type_and_value ON public.usage_attribution_values USING btree (customer_id, usage_attribution_type_id, value);
+
+
+--
+-- Name: index_usage_attribution_values_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_usage_attribution_values_on_organization_id ON public.usage_attribution_values USING btree (organization_id);
+
+
+--
+-- Name: index_usage_attribution_values_on_parent_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_usage_attribution_values_on_parent_id ON public.usage_attribution_values USING btree (parent_id);
+
+
+--
+-- Name: index_usage_attribution_values_on_usage_attribution_type_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_usage_attribution_values_on_usage_attribution_type_id ON public.usage_attribution_values USING btree (usage_attribution_type_id);
+
+
+--
 -- Name: index_usage_monitoring_alert_thresholds_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12953,6 +13033,14 @@ ALTER TABLE ONLY public.credits
 
 
 --
+-- Name: usage_attribution_values fk_rails_521c8108bf; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.usage_attribution_values
+    ADD CONSTRAINT fk_rails_521c8108bf FOREIGN KEY (parent_id) REFERENCES public.usage_attribution_values(id);
+
+
+--
 -- Name: recurring_transaction_rules fk_rails_52370612ae; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -13270,6 +13358,14 @@ ALTER TABLE ONLY public.billing_entities_invoice_custom_sections
 
 ALTER TABLE ONLY public.products
     ADD CONSTRAINT fk_rails_6a4ad694b3 FOREIGN KEY (charge_id) REFERENCES public.charges(id);
+
+
+--
+-- Name: usage_attribution_values fk_rails_6b11e175f4; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.usage_attribution_values
+    ADD CONSTRAINT fk_rails_6b11e175f4 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -13734,6 +13830,14 @@ ALTER TABLE ONLY public.adjusted_fees
 
 ALTER TABLE ONLY public.data_export_parts
     ADD CONSTRAINT fk_rails_9298b8fdad FOREIGN KEY (data_export_id) REFERENCES public.data_exports(id);
+
+
+--
+-- Name: usage_attribution_values fk_rails_92e94c6810; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.usage_attribution_values
+    ADD CONSTRAINT fk_rails_92e94c6810 FOREIGN KEY (usage_attribution_type_id) REFERENCES public.usage_attribution_types(id);
 
 
 --
@@ -14457,6 +14561,14 @@ ALTER TABLE ONLY public.customers_invoice_custom_sections
 
 
 --
+-- Name: usage_attribution_values fk_rails_dc093a8283; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.usage_attribution_values
+    ADD CONSTRAINT fk_rails_dc093a8283 FOREIGN KEY (customer_id) REFERENCES public.customers(id);
+
+
+--
 -- Name: enriched_store_subscription_migrations fk_rails_dc444f5f29; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -14880,6 +14992,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260910095513'),
+('20260909103355'),
 ('20260908222044'),
 ('20260908211313'),
 ('20260908180522'),

--- a/spec/factories/usage_attribution_values.rb
+++ b/spec/factories/usage_attribution_values.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :usage_attribution_value do
+    customer
+    organization { customer.organization }
+    usage_attribution_type { association :usage_attribution_type, organization: }
+    sequence(:value) { |n| "usage-attribution-value-#{n}" }
+    last_seen_at { Time.current }
+  end
+end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Customer do
   it { is_expected.to have_many(:error_details).dependent(:destroy) }
   it { is_expected.to have_many(:order_forms) }
   it { is_expected.to have_many(:orders) }
+  it { is_expected.to have_many(:usage_attribution_values) }
 
   it { is_expected.to have_one(:netsuite_customer) }
   it { is_expected.to have_one(:anrok_customer) }

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe Organization do
       expect(subject).to have_many(:subscription_feature_removals).class_name("Entitlement::SubscriptionFeatureRemoval")
 
       expect(subject).to have_many(:usage_attribution_types)
+      expect(subject).to have_many(:usage_attribution_values)
 
       expect(subject).to have_one(:applied_dunning_campaign).conditions(applied_to_organization: true)
       expect(subject).to have_one(:enriched_store_migration)

--- a/spec/models/usage_attribution_type_spec.rb
+++ b/spec/models/usage_attribution_type_spec.rb
@@ -19,6 +19,18 @@ RSpec.describe UsageAttributionType do
       expect(usage_attribution_type).to belong_to(:organization)
       expect(usage_attribution_type).to belong_to(:parent).class_name("UsageAttributionType").optional
       expect(usage_attribution_type).to have_many(:children).class_name("UsageAttributionType").with_foreign_key(:parent_id).inverse_of(:parent)
+      expect(usage_attribution_type).to have_many(:usage_attribution_values)
+    end
+  end
+
+  describe "soft deleted associations" do
+    it "still resolves a discarded parent" do
+      organization = create(:organization)
+      parent = create(:usage_attribution_type, organization:)
+      child = create(:usage_attribution_type, organization:, parent:)
+      parent.discard!
+
+      expect(child.reload.parent).to eq(parent)
     end
   end
 

--- a/spec/models/usage_attribution_value_spec.rb
+++ b/spec/models/usage_attribution_value_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UsageAttributionValue do
+  subject(:usage_attribution_value) { build(:usage_attribution_value) }
+
+  describe "associations" do
+    it do
+      expect(usage_attribution_value).to belong_to(:organization)
+      expect(usage_attribution_value).to belong_to(:usage_attribution_type)
+      expect(usage_attribution_value).to belong_to(:customer)
+      expect(usage_attribution_value).to belong_to(:parent).class_name("UsageAttributionValue").optional
+      expect(usage_attribution_value).to have_many(:children).class_name("UsageAttributionValue").with_foreign_key(:parent_id).inverse_of(:parent)
+    end
+
+    it "still resolves a discarded parent" do
+      parent = create(:usage_attribution_value)
+      child = create(:usage_attribution_value, organization: parent.organization, customer: parent.customer, parent:)
+      parent.discard!
+
+      expect(child.reload.parent).to eq(parent)
+    end
+
+    it "still resolves a discarded type and customer" do
+      usage_attribution_value.save!
+      usage_attribution_value.usage_attribution_type.discard!
+      usage_attribution_value.customer.discard!
+
+      reloaded = usage_attribution_value.reload
+
+      expect(reloaded.usage_attribution_type).to be_present
+      expect(reloaded.customer).to be_present
+    end
+  end
+
+  describe "validations" do
+    it do
+      expect(usage_attribution_value).to validate_presence_of(:value)
+      expect(usage_attribution_value).to validate_length_of(:value).is_at_most(255)
+    end
+
+    describe "value uniqueness" do
+      let(:organization) { create(:organization) }
+      let(:customer) { create(:customer, organization:) }
+      let(:usage_attribution_type) { create(:usage_attribution_type, organization:) }
+
+      it "rejects the same value for the same customer and type" do
+        create(:usage_attribution_value, organization:, customer:, usage_attribution_type:, value: "alice")
+        duplicate = build(:usage_attribution_value, organization:, customer:, usage_attribution_type:, value: "alice")
+
+        expect(duplicate).not_to be_valid
+        expect(duplicate.errors.where(:value, :taken)).to be_present
+      end
+
+      it "allows the same value for another customer" do
+        create(:usage_attribution_value, organization:, customer:, usage_attribution_type:, value: "alice")
+        other_customer = create(:customer, organization:)
+
+        expect(build(:usage_attribution_value, organization:, customer: other_customer, usage_attribution_type:, value: "alice")).to be_valid
+      end
+
+      it "allows the same value under another type" do
+        create(:usage_attribution_value, organization:, customer:, usage_attribution_type:, value: "alice")
+        other_type = create(:usage_attribution_type, organization:)
+
+        expect(build(:usage_attribution_value, organization:, customer:, usage_attribution_type: other_type, value: "alice")).to be_valid
+      end
+
+      it "still rejects the value once the holder is discarded" do
+        create(:usage_attribution_value, organization:, customer:, usage_attribution_type:, value: "alice").discard!
+        returning = build(:usage_attribution_value, organization:, customer:, usage_attribution_type:, value: "alice")
+
+        expect(returning).not_to be_valid
+        expect(returning.errors.where(:value, :taken)).to be_present
+      end
+    end
+  end
+
+  describe "soft deletion" do
+    it "hides discarded records behind the default scope" do
+      usage_attribution_value.save!
+      usage_attribution_value.discard!
+
+      expect(described_class.all).not_to include(usage_attribution_value)
+      expect(described_class.with_discarded).to include(usage_attribution_value)
+    end
+
+    it "enforces value uniqueness at the database level even once discarded" do
+      existing = create(:usage_attribution_value)
+      existing.discard!
+      duplicate = build(
+        :usage_attribution_value,
+        organization: existing.organization,
+        customer: existing.customer,
+        usage_attribution_type: existing.usage_attribution_type,
+        value: existing.value
+      )
+
+      expect { duplicate.save(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Account tree feature allows tracking usage under custom types like teams or users.

## Description

This PR adds support for `usage_attribution_values` table and  `UsageAttributionValue` model with required validations. This resource is used to store concrete instance of the attribution type that is defined in the organization level