### PR TITLE
refactor(fees): centralize amount calculations

### DIFF
--- a/app/services/fees/amounts_service.rb
+++ b/app/services/fees/amounts_service.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+module Fees
+  class AmountsService < BaseService
+    Result = BaseResult[:amount, :true_up_amount]
+    Amount = Data.define(
+      :amount_cents,
+      :precise_amount_cents,
+      :unit_amount_cents,
+      :precise_unit_amount,
+      :pricing_unit_usage
+    ) do
+      def with_deduction(deduction)
+        with(
+          amount_cents: [amount_cents - deduction, 0].max,
+          precise_amount_cents: [precise_amount_cents - deduction.to_d, 0.to_d].max
+        )
+      end
+    end
+    private_constant :Amount
+
+    Deduction = Data.define(:amount_cents, :billed_days, :period_days) do
+      def self.none
+        new(amount_cents: nil, billed_days: 1, period_days: 1)
+      end
+
+      def none?
+        amount_cents.nil?
+      end
+
+      def prorated_amount_cents
+        (amount_cents * billed_days.to_f / period_days).round
+      end
+    end
+
+    TrueUp = Data.define(:minimum_amount_cents, :billed_days, :period_days, :used_amount_cents, :used_precise_amount_cents) do
+      def self.none
+        new(minimum_amount_cents: nil)
+      end
+
+      def initialize(minimum_amount_cents:, billed_days: 1, period_days: 1, used_amount_cents: nil, used_precise_amount_cents: nil)
+        super
+      end
+
+      def none?
+        minimum_amount_cents.nil?
+      end
+
+      def prorated_minimum_amount_cents
+        minimum_amount_cents.fdiv(period_days) * billed_days
+      end
+    end
+
+    PricingUnit = Data.define(:pricing_unit, :conversion_rate) do
+      def self.none
+        new(pricing_unit: nil, conversion_rate: nil)
+      end
+
+      def self.from(applied_pricing_unit)
+        if applied_pricing_unit.nil?
+          none
+        else
+          new(pricing_unit: applied_pricing_unit.pricing_unit, conversion_rate: applied_pricing_unit.conversion_rate)
+        end
+      end
+
+      def none?
+        pricing_unit.nil?
+      end
+
+      def subunit_to_unit
+        pricing_unit.subunit_to_unit.to_d
+      end
+    end
+
+    def initialize(
+      currency:,
+      charge_model_result:,
+      applied_pricing_unit: PricingUnit.none,
+      deduction: Deduction.none,
+      true_up: TrueUp.none
+    )
+      unless charge_model_result.is_a?(ChargeModels::BaseService::Result) ||
+          charge_model_result.is_a?(Charges::ApplyPayInAdvanceChargeModelService::Result)
+        raise ArgumentError, "charge_model_result must be a ChargeModels::BaseService::Result or Charges::ApplyPayInAdvanceChargeModelService::Result"
+      end
+
+      @currency = currency
+      @charge_model_result = charge_model_result
+      @applied_pricing_unit = applied_pricing_unit
+      @deduction = deduction
+      @true_up = true_up
+      super
+    end
+
+    def call
+      # An empty model result means no base fee, not a zero-valued fee.
+      unless charge_model_result.amount.nil?
+        result.amount = if charge_model_result.is_a?(Charges::ApplyPayInAdvanceChargeModelService::Result)
+          advance_amount
+        elsif charge_model_result.units.negative? || charge_model_result.amount.negative?
+          build_amount(amount: 0.to_d, unit_amount: 0.to_d)
+        else
+          build_amount(amount: charge_model_result.amount, unit_amount: charge_model_result.unit_amount)
+        end
+        unless deduction.none?
+          result.amount = result.amount.with_deduction(deduction.prorated_amount_cents)
+        end
+      end
+
+      result.true_up_amount = true_up_amount
+      result
+    end
+
+    private
+
+    attr_reader :currency, :charge_model_result, :applied_pricing_unit, :deduction, :true_up
+
+    def advance_amount
+      if !applied_pricing_unit.none?
+        build_amount(
+          amount: charge_model_result.amount / applied_pricing_unit.subunit_to_unit,
+          unit_amount: charge_model_result.unit_amount
+        )
+      else
+        # Advance totals are already in minor units, with independently computed precision.
+        Amount.new(
+          amount_cents: charge_model_result.amount,
+          precise_amount_cents: charge_model_result.precise_amount,
+          unit_amount_cents: charge_model_result.unit_amount * currency.subunit_to_unit,
+          precise_unit_amount: charge_model_result.unit_amount,
+          pricing_unit_usage: nil
+        )
+      end
+    end
+
+    def true_up_amount
+      return if true_up.none?
+
+      minimum = true_up.prorated_minimum_amount_cents
+      usage = result.amount&.pricing_unit_usage || result.amount
+      used = true_up.used_amount_cents || usage.amount_cents
+      precise_used = true_up.used_precise_amount_cents || usage.precise_amount_cents
+      return if used >= minimum
+
+      difference = minimum - used
+      precise_difference = minimum - precise_used
+
+      if !applied_pricing_unit.none?
+        # Minimum and used totals are in pricing-unit cents, not fiat cents.
+        subunit = applied_pricing_unit.subunit_to_unit
+        build_amount(amount: difference / subunit, unit_amount: precise_difference / subunit)
+      else
+        # True-ups retain separate rounded and precise totals across grouped fees.
+        Amount.new(
+          amount_cents: difference.round,
+          precise_amount_cents: precise_difference,
+          unit_amount_cents: difference.round,
+          precise_unit_amount: precise_difference / currency.subunit_to_unit,
+          pricing_unit_usage: nil
+        )
+      end
+    end
+
+    def build_amount(amount:, unit_amount:)
+      attributes = if !applied_pricing_unit.none?
+        usage = PricingUnitUsage.build_from_fiat_amounts(amount:, unit_amount:, applied_pricing_unit:)
+        usage.to_fiat_currency_cents(currency).merge(pricing_unit_usage: usage)
+      else
+        {
+          amount_cents: amount.round(currency.exponent) * currency.subunit_to_unit,
+          precise_amount_cents: amount * currency.subunit_to_unit.to_d,
+          unit_amount_cents: unit_amount * currency.subunit_to_unit,
+          precise_unit_amount: unit_amount,
+          pricing_unit_usage: nil
+        }
+      end
+
+      Amount.new(
+        amount_cents: attributes.fetch(:amount_cents),
+        precise_amount_cents: attributes.fetch(:precise_amount_cents),
+        unit_amount_cents: attributes.fetch(:unit_amount_cents),
+        precise_unit_amount: attributes.fetch(:precise_unit_amount),
+        pricing_unit_usage: attributes.fetch(:pricing_unit_usage)
+      )
+    end
+  end
+end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -267,31 +267,15 @@ module Fees
         return adjustement_result.fee
       end
 
+      amount = Fees::AmountsService.call(
+        currency: selected_metered_item.currency,
+        charge_model_result: amount_result,
+        applied_pricing_unit: Fees::AmountsService::PricingUnit.from(selected_metered_item.applied_pricing_unit)
+      ).amount
+
       # Prevent trying to create a fee with negative units or amount.
       if amount_result.units.negative? || amount_result.amount.negative?
-        amount_result.amount = amount_result.unit_amount = BigDecimal(0)
         amount_result.full_units_number = amount_result.units = BigDecimal(0)
-      end
-
-      # NOTE: amount_result should be a BigDecimal, we need to round it
-      # to the currency decimals and transform it into currency cents
-      if selected_metered_item.applied_pricing_unit
-        pricing_unit_usage = PricingUnitUsage.build_from_fiat_amounts(
-          amount: amount_result.amount,
-          unit_amount: amount_result.unit_amount,
-          applied_pricing_unit: selected_metered_item.applied_pricing_unit
-        )
-
-        amount_cents, precise_amount_cents, unit_amount_cents, precise_unit_amount = pricing_unit_usage
-          .to_fiat_currency_cents(selected_metered_item.currency)
-          .values_at(:amount_cents, :precise_amount_cents, :unit_amount_cents, :precise_unit_amount)
-      else
-        pricing_unit_usage = nil
-        rounded_amount = amount_result.amount.round(selected_metered_item.currency.exponent)
-        amount_cents = rounded_amount * selected_metered_item.currency.subunit_to_unit
-        precise_amount_cents = amount_result.amount * selected_metered_item.currency.subunit_to_unit.to_d
-        unit_amount_cents = amount_result.unit_amount * selected_metered_item.currency.subunit_to_unit
-        precise_unit_amount = amount_result.unit_amount
       end
 
       units = if options.current_usage? && (selected_metered_item.pay_in_advance? || selected_metered_item.prorated?)
@@ -308,8 +292,11 @@ module Fees
         billing_entity_id: subscription.applicable_billing_entity_id,
         subscription:,
         charge: selected_metered_item.charge,
-        amount_cents:,
-        precise_amount_cents:,
+        amount_cents: amount.amount_cents,
+        precise_amount_cents: amount.precise_amount_cents,
+        unit_amount_cents: amount.unit_amount_cents,
+        precise_unit_amount: amount.precise_unit_amount,
+        pricing_unit_usage: amount.pricing_unit_usage,
         amount_currency: selected_metered_item.currency,
         fee_type: :charge,
         invoiceable_type: "Charge",
@@ -321,12 +308,9 @@ module Fees
         payment_status: :pending,
         taxes_amount_cents: 0,
         taxes_precise_amount_cents: 0.to_d,
-        unit_amount_cents:,
-        precise_unit_amount:,
         amount_details: amount_result.amount_details,
         grouped_by: amount_result.grouped_by || {},
-        charge_filter: selected_metered_item.charge_filter&.persisted? ? selected_metered_item.charge_filter : nil,
-        pricing_unit_usage:
+        charge_filter: selected_metered_item.charge_filter&.persisted? ? selected_metered_item.charge_filter : nil
       )
 
       unless selected_metered_item.invoiceable?

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -82,31 +82,19 @@ module Fees
 
       charge_model_result = apply_charge_model(aggregation_result:, properties:)
 
-      if charge.applied_pricing_unit
-        pricing_unit_usage = PricingUnitUsage.build_from_fiat_amounts(
-          amount: charge_model_result.amount / charge.pricing_unit.subunit_to_unit.to_d,
-          unit_amount: charge_model_result.unit_amount,
-          applied_pricing_unit: charge.applied_pricing_unit
-        )
-
-        amount_cents, precise_amount_cents, unit_amount_cents, precise_unit_amount = pricing_unit_usage
-          .to_fiat_currency_cents(subscription.plan.amount.currency)
-          .values_at(:amount_cents, :precise_amount_cents, :unit_amount_cents, :precise_unit_amount)
-      else
-        pricing_unit_usage = nil
-        amount_cents = charge_model_result.amount
-        precise_amount_cents = charge_model_result.precise_amount
-        unit_amount_cents = charge_model_result.unit_amount * subscription.plan.amount.currency.subunit_to_unit
-        precise_unit_amount = charge_model_result.unit_amount
-      end
+      amount = Fees::AmountsService.call(
+        currency: subscription.plan.amount.currency,
+        charge_model_result:,
+        applied_pricing_unit: Fees::AmountsService::PricingUnit.from(charge.applied_pricing_unit)
+      ).amount
 
       fee = Fee.new(
         subscription:,
         charge:,
         organization_id: customer.organization_id,
         billing_entity_id: customer.billing_entity_id,
-        amount_cents:,
-        precise_amount_cents:,
+        amount_cents: amount.amount_cents,
+        precise_amount_cents: amount.precise_amount_cents,
         amount_currency: subscription.plan.amount_currency,
         fee_type: :charge,
         invoiceable: charge,
@@ -121,11 +109,11 @@ module Fees
         pay_in_advance: true,
         taxes_amount_cents: 0,
         taxes_precise_amount_cents: 0.to_d,
-        unit_amount_cents:,
-        precise_unit_amount:,
+        unit_amount_cents: amount.unit_amount_cents,
+        precise_unit_amount: amount.precise_unit_amount,
         grouped_by: format_grouped_by,
         amount_details: charge_model_result.amount_details || {},
-        pricing_unit_usage:
+        pricing_unit_usage: amount.pricing_unit_usage
       )
 
       build_breakdowns_for_fee(fee:, presentation_breakdowns: remove_formated_grouped_by_keys(aggregation_result.pay_in_advance_breakdowns))

--- a/app/services/fees/create_true_up_service.rb
+++ b/app/services/fees/create_true_up_service.rb
@@ -15,31 +15,33 @@ module Fees
 
     def call
       return result unless fee
-      return result if used_amount_cents >= prorated_min_amount_cents
+      amount = Fees::AmountsService.call(
+        currency: charge.plan.amount.currency,
+        charge_model_result: ChargeModels::BaseService::Result.new,
+        applied_pricing_unit: Fees::AmountsService::PricingUnit.from(charge.applied_pricing_unit),
+        true_up: Fees::AmountsService::TrueUp.new(
+          minimum_amount_cents: charge.min_amount_cents,
+          billed_days: subscription.date_diff_with_timezone(boundaries.charges_from_datetime.to_time, boundaries.charges_to_datetime.to_time),
+          period_days: boundaries.charges_duration,
+          used_amount_cents:,
+          used_precise_amount_cents:
+        )
+      ).true_up_amount
 
-      if charge.applied_pricing_unit
-        amount_cents, precise_amount_cents, unit_amount_cents, precise_unit_amount = pricing_unit_usage
-          .to_fiat_currency_cents(charge.plan.amount.currency)
-          .values_at(:amount_cents, :precise_amount_cents, :unit_amount_cents, :precise_unit_amount)
-      else
-        amount_cents = (prorated_min_amount_cents - used_amount_cents).round
-        precise_amount_cents = prorated_min_amount_cents - used_precise_amount_cents
-        unit_amount_cents = amount_cents
-        precise_unit_amount = precise_amount_cents / charge.plan.amount.currency.subunit_to_unit
-      end
+      return result unless amount
 
       true_up_fee = fee.dup
       true_up_fee.assign_attributes(
-        amount_cents:,
-        precise_amount_cents:,
+        amount_cents: amount.amount_cents,
+        precise_amount_cents: amount.precise_amount_cents,
+        unit_amount_cents: amount.unit_amount_cents,
+        precise_unit_amount: amount.precise_unit_amount,
+        pricing_unit_usage: amount.pricing_unit_usage,
         units: 1,
         total_aggregated_units: 1,
         events_count: 0,
         charge_filter_id: nil,
-        true_up_parent_fee: fee,
-        unit_amount_cents:,
-        precise_unit_amount:,
-        pricing_unit_usage:
+        true_up_parent_fee: fee
       )
 
       result.true_up_fee = true_up_fee
@@ -51,32 +53,5 @@ module Fees
     attr_reader :fee, :used_amount_cents, :used_precise_amount_cents, :boundaries
 
     delegate :charge, :subscription, to: :fee
-
-    def prorated_min_amount_cents
-      # NOTE: number of days between beginning of the period and the termination date
-      from_datetime = boundaries.charges_from_datetime.to_time
-      to_datetime = boundaries.charges_to_datetime.to_time
-      number_of_day_to_bill = subscription.date_diff_with_timezone(from_datetime, to_datetime)
-
-      charge.min_amount_cents.fdiv(boundaries.charges_duration) * number_of_day_to_bill
-    end
-
-    def pricing_unit_usage
-      return @pricing_unit_usage if defined?(@pricing_unit_usage)
-
-      unless charge.applied_pricing_unit
-        @pricing_unit_usage = nil
-        return
-      end
-
-      amount_cents = prorated_min_amount_cents - used_amount_cents
-      precise_amount_cents = prorated_min_amount_cents - used_precise_amount_cents
-
-      @pricing_unit_usage = PricingUnitUsage.build_from_fiat_amounts(
-        amount: amount_cents / charge.pricing_unit.subunit_to_unit.to_d,
-        unit_amount: precise_amount_cents / charge.pricing_unit.subunit_to_unit.to_d,
-        applied_pricing_unit: charge.applied_pricing_unit
-      )
-    end
   end
 end

--- a/app/services/fees/fixed_charge_service.rb
+++ b/app/services/fees/fixed_charge_service.rb
@@ -83,22 +83,7 @@ module Fees
 
       amount_result = apply_aggregation_and_charge_model
 
-      # Prevent trying to create a fee with negative units or amount.
-      if amount_result.units.negative? || amount_result.amount.negative?
-        amount_result.amount = amount_result.unit_amount = BigDecimal(0)
-        amount_result.full_units_number = amount_result.units = amount_result.total_aggregated_units = BigDecimal(0)
-      end
-
-      # TODO: add pricing units
-      pricing_unit_usage = nil
-      rounded_amount = amount_result.amount.round(currency.exponent)
-      amount_cents = rounded_amount * currency.subunit_to_unit
-      precise_amount_cents = amount_result.amount * currency.subunit_to_unit.to_d
-      unit_amount_cents = amount_result.unit_amount * currency.subunit_to_unit
-      precise_unit_amount = amount_result.unit_amount
-
-      units = amount_result.full_units_number
-
+      deduction = Fees::AmountsService::Deduction.none
       if first_prorated_paid_in_advance_charge_billed_in_prev_subscription?
         already_paid_fee = find_already_paid_fee_for_the_fixed_charge(boundaries)
         if already_paid_fee
@@ -107,18 +92,25 @@ module Fees
           # the proration is started, despite from-to boundaries are taking into account the whole
           already_paid_fee_prorated_days = ((already_paid_fee.properties["fixed_charges_to_datetime"].to_time -
                                              already_paid_fee.properties["timestamp"].to_time) / 1.day.in_seconds).ceil
-          # if previous fee was prorated for x days out of n, current is prorated for y days out of n,
-          # we need to find coefficient of proration for current period:
-          # prorated_for_current_period = already_paid_fee.amount_cents / x * y
-          # we devide by prev proration length to find price of one day, and mutiply by the current period length
-          prorated_for_current_period = (already_paid_fee.amount_cents * current_period_duration_days.to_f / already_paid_fee_prorated_days).round
-          amount_cents -= prorated_for_current_period
-          precise_amount_cents -= prorated_for_current_period.to_d
-
-          amount_cents = 0 if amount_cents < 0
-          precise_amount_cents = 0.0 if precise_amount_cents < 0
+          deduction = Fees::AmountsService::Deduction.new(
+            amount_cents: already_paid_fee.amount_cents,
+            billed_days: current_period_duration_days,
+            period_days: already_paid_fee_prorated_days
+          )
         end
       end
+
+      amount = Fees::AmountsService.call(
+        currency:,
+        charge_model_result: amount_result,
+        deduction:
+      ).amount
+
+      # Prevent trying to create a fee with negative units or amount.
+      if amount_result.units.negative? || amount_result.amount.negative?
+        amount_result.full_units_number = amount_result.units = amount_result.total_aggregated_units = BigDecimal(0)
+      end
+      units = amount_result.full_units_number
 
       new_fee = Fee.new(
         invoice:,
@@ -126,8 +118,11 @@ module Fees
         billing_entity_id: subscription.applicable_billing_entity_id,
         subscription:,
         fixed_charge:,
-        amount_cents:,
-        precise_amount_cents:,
+        amount_cents: amount.amount_cents,
+        precise_amount_cents: amount.precise_amount_cents,
+        unit_amount_cents: amount.unit_amount_cents,
+        precise_unit_amount: amount.precise_unit_amount,
+        pricing_unit_usage: amount.pricing_unit_usage,
         amount_currency: currency,
         fee_type: :fixed_charge,
         invoiceable_type: "FixedCharge",
@@ -138,10 +133,7 @@ module Fees
         payment_status: :pending,
         taxes_amount_cents: 0,
         taxes_precise_amount_cents: 0.to_d,
-        unit_amount_cents:,
-        precise_unit_amount:,
         amount_details: amount_result.amount_details,
-        pricing_unit_usage:,
         pay_in_advance: fixed_charge.pay_in_advance?
       )
 

--- a/spec/services/fees/amounts_service_spec.rb
+++ b/spec/services/fees/amounts_service_spec.rb
@@ -1,0 +1,524 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Fees::AmountsService do
+  subject(:result) { described_class.call(currency:, charge_model_result:, **options) }
+
+  let(:currency) { Money::Currency.new("USD") }
+  let(:charge_model_result) { model_result }
+  let(:model_result) do
+    ChargeModels::BaseService::Result.new.tap do |model_result|
+      model_result.amount = model_result.unit_amount = value
+      model_result.units = units
+    end
+  end
+  let(:value) { "0.3333".to_d }
+  let(:units) { 1.to_d }
+  let(:options) { {} }
+
+  describe "option values" do
+    [described_class::Deduction, described_class::TrueUp, described_class::PricingUnit].each do |type|
+      it "represents absent #{type.name.demodulize} with an immutable none value" do
+        expect(type.none).to be_none
+        expect(type.none).to be_frozen
+      end
+    end
+
+    it "distinguishes zero monetary values from absence" do
+      expect(described_class::Deduction.new(amount_cents: 0, billed_days: 1, period_days: 1)).not_to be_none
+      expect(described_class::TrueUp.new(minimum_amount_cents: 0)).not_to be_none
+      expect(described_class::PricingUnit.new(pricing_unit: build(:pricing_unit), conversion_rate: 0.to_d)).not_to be_none
+    end
+
+    it "normalizes absent pricing units" do
+      expect(described_class::PricingUnit.from(nil)).to be_none
+    end
+
+    it "copies actual pricing-unit options" do
+      actual = build(:applied_pricing_unit, conversion_rate: 0.25)
+      options = described_class::PricingUnit.from(actual)
+
+      expect(options).to have_attributes(pricing_unit: actual.pricing_unit, conversion_rate: actual.conversion_rate)
+      expect(options).not_to be_none
+      expect(options).to be_frozen
+    end
+
+    it "rounds the prorated deduction to integer cents" do
+      deduction = described_class::Deduction.new(amount_cents: 100, billed_days: 2, period_days: 3)
+
+      expect(deduction.prorated_amount_cents).to eq(67)
+    end
+
+    it "preserves fractional cents in the prorated minimum" do
+      true_up = described_class::TrueUp.new(minimum_amount_cents: 100, billed_days: 2, period_days: 3)
+
+      expect(true_up.prorated_minimum_amount_cents).to eq(100.fdiv(3) * 2)
+    end
+
+    it "exposes the pricing unit's decimal subunit factor" do
+      options = described_class::PricingUnit.from(build(:applied_pricing_unit))
+
+      expect(options.subunit_to_unit).to eq(100.to_d)
+      expect(options.subunit_to_unit).to be_a(BigDecimal)
+    end
+  end
+
+  describe "#call" do
+    [nil, BaseResult.new, {amount: 1, unit_amount: 1, units: 1}].each do |invalid_result|
+      context "with a #{invalid_result.class} charge model result" do
+        let(:charge_model_result) { invalid_result }
+
+        it "rejects results that are not charge model results" do
+          expect { result }.to raise_error(
+            ArgumentError,
+            "charge_model_result must be a ChargeModels::BaseService::Result or Charges::ApplyPayInAdvanceChargeModelService::Result"
+          )
+        end
+      end
+    end
+
+    context "with a charge model result subclass" do
+      let(:charge_model_result) do
+        Class.new(ChargeModels::BaseService::Result).new.tap do |model_result|
+          model_result.amount = model_result.unit_amount = value
+          model_result.units = units
+        end
+      end
+
+      it "accepts the result without mutating it" do
+        expect(result).to be_success
+        expect(result.amount).to have_attributes(amount_cents: 33, precise_amount_cents: 33.33.to_d)
+        expect(charge_model_result).to have_attributes(amount: value, unit_amount: value, units:)
+      end
+    end
+
+    context "with a pay-in-advance result" do
+      let(:charge_model_result) do
+        Charges::ApplyPayInAdvanceChargeModelService::Result.new.tap do |advance_result|
+          advance_result.amount = value
+          advance_result.precise_amount = precise_value
+          advance_result.unit_amount = unit_value
+          advance_result.units = units
+        end
+      end
+      let(:value) { 101.to_d }
+      let(:precise_value) { "100.8".to_d }
+      let(:unit_value) { "0.336".to_d }
+
+      it "retains minor-unit totals and separate precision without scaling or rounding again" do
+        expect(result).to be_success
+        expect(result.amount).to be_frozen
+        expect(result.amount).to have_attributes(
+          amount_cents: 101, precise_amount_cents: precise_value,
+          unit_amount_cents: 33.6.to_d, precise_unit_amount: unit_value, pricing_unit_usage: nil
+        )
+        expect(Fee.new(unit_amount_cents: result.amount.unit_amount_cents).unit_amount_cents).to eq(33)
+        expect(charge_model_result).to have_attributes(amount: value, precise_amount: precise_value, unit_amount: unit_value, units:)
+        expect(result.true_up_amount).to be_nil
+      end
+
+      [
+        ["0", "0.4", "0", "0"],
+        ["101", "100.8", "0.336", "0"],
+        ["101", "100.8", "-0.336", "-3"],
+        ["-101", "-100.8", "-0.336", "3"]
+      ].each do |total, precise, unit, usage|
+        context "with total #{total} and units #{usage}" do
+          let(:value) { total.to_d }
+          let(:precise_value) { precise.to_d }
+          let(:unit_value) { unit.to_d }
+          let(:units) { usage.to_d }
+
+          it "preserves zero and negative values without standard-model clamping" do
+            expect(result.amount).to have_attributes(
+              amount_cents: value, precise_amount_cents: precise_value,
+              unit_amount_cents: unit_value * 100, precise_unit_amount: unit_value, pricing_unit_usage: nil
+            )
+          end
+        end
+      end
+
+      context "with pricing units" do
+        let(:options) do
+          {applied_pricing_unit: described_class::PricingUnit.from(
+            build(:applied_pricing_unit, pricing_unitable: nil, conversion_rate: 0.25)
+          )}
+        end
+
+        [
+          ["USD", "101", "0.336", "25", "25.25", "8.25", "0.0825", 33],
+          ["JPY", "101", "0.336", "0", "0.2525", "0.0825", "0.0825", 33],
+          ["USD", "0", "0", "0", "0", "0", "0", 0],
+          ["USD", "-101", "-0.336", "-25", "-25.25", "-8.25", "-0.0825", -33]
+        ].each do |code, total, unit, rounded, precise, unit_cents, precise_unit, usage_unit_cents|
+          context "with #{total} pricing-unit cents in #{code}" do
+            let(:currency) { Money::Currency.new(code) }
+            let(:value) { total.to_d }
+            let(:unit_value) { unit.to_d }
+            let(:units) { -3.to_d }
+
+            it "converts the rounded total using pricing-unit subunits and retains unit truncation" do
+              expect(result.amount).to have_attributes(
+                amount_cents: rounded.to_d, precise_amount_cents: precise.to_d,
+                unit_amount_cents: unit_cents.to_d, precise_unit_amount: precise_unit.to_d
+              )
+              expect(result.amount.pricing_unit_usage).to be_new_record.and have_attributes(
+                amount_cents: value, precise_amount_cents: value,
+                unit_amount_cents: usage_unit_cents, precise_unit_amount: unit_value
+              )
+            end
+          end
+        end
+      end
+    end
+
+    context "with explicit absent options" do
+      let(:options) do
+        {
+          applied_pricing_unit: described_class::PricingUnit.none,
+          deduction: described_class::Deduction.none,
+          true_up: described_class::TrueUp.none
+        }
+      end
+
+      it "returns the base amount without deductions, pricing-unit usage, or a true-up" do
+        expect(result.amount).to have_attributes(amount_cents: 33, precise_amount_cents: 33.33.to_d, pricing_unit_usage: nil)
+        expect(result.true_up_amount).to be_nil
+      end
+    end
+
+    context "with an empty charge model result" do
+      let(:charge_model_result) { ChargeModels::BaseService::Result.new }
+
+      it "returns no amounts and leaves the empty result unchanged" do
+        expect(result).to be_success
+        expect(result.amount).to be_nil
+        expect(result.true_up_amount).to be_nil
+        expect(charge_model_result).to have_attributes(amount: nil, unit_amount: nil, units: nil)
+      end
+    end
+
+    [
+      ["USD", "0.3333", 33, "33.33", 33],
+      ["USD", "0.336", 34, "33.6", 33],
+      ["USD", "0.50125", 50, "50.125", 50],
+      ["JPY", "0.3333", 0, "0.3333", 0],
+      ["JPY", "0.336", 0, "0.336", 0],
+      ["JPY", "0.50125", 1, "0.50125", 0],
+      ["KWD", "0.3333", 333, "333.3", 333],
+      ["KWD", "0.336", 336, "336", 336],
+      ["KWD", "0.50125", 501, "501.25", 501]
+    ].each do |currency_code, input, rounded, precise, unit_cents|
+      context "with #{input} #{currency_code}" do
+        let(:currency) { Money::Currency.new(currency_code) }
+        let(:value) { input.to_d }
+
+        it "rounds the total but leaves unit cents for the fee's implicit truncation" do
+          expect(result).to be_success
+          expect(result.amount).to have_attributes(
+            amount_cents: rounded,
+            precise_amount_cents: precise.to_d,
+            unit_amount_cents: precise.to_d,
+            precise_unit_amount: value,
+            pricing_unit_usage: nil
+          )
+          expect(Fee.new(**result.amount.to_h)).to have_attributes(
+            amount_cents: rounded,
+            precise_amount_cents: precise.to_d,
+            unit_amount_cents: unit_cents,
+            precise_unit_amount: value
+          )
+          expect(result.true_up_amount).to be_nil
+        end
+      end
+    end
+
+    context "with distinct total and unit amounts" do
+      let(:units) { 3.to_d }
+
+      before { model_result.amount = "0.9999".to_d }
+
+      it "converts each model amount independently" do
+        expect(result.amount).to have_attributes(
+          amount_cents: 100, precise_amount_cents: 99.99.to_d, unit_amount_cents: 33.33.to_d, precise_unit_amount: value
+        )
+      end
+    end
+
+    context "with zero usage" do
+      let(:units) { 0.to_d }
+
+      it "retains the model's flat amount and unit price" do
+        expect(result.amount).to have_attributes(amount_cents: 33, unit_amount_cents: 33.33.to_d, precise_unit_amount: value)
+      end
+
+      context "with a zero amount" do
+        let(:value) { 0.to_d }
+
+        it "returns zero monetary fields" do
+          expect(result.amount).to have_attributes(
+            amount_cents: 0, precise_amount_cents: 0, unit_amount_cents: 0, precise_unit_amount: 0
+          )
+          expect(charge_model_result).to have_attributes(amount: 0, unit_amount: 0, units: 0)
+        end
+      end
+    end
+
+    context "with negative units" do
+      let(:units) { -1.to_d }
+
+      it "normalizes monetary fields without mutating the charge model result" do
+        expect(result.amount).to have_attributes(
+          amount_cents: 0, precise_amount_cents: 0, unit_amount_cents: 0, precise_unit_amount: 0
+        )
+        expect(charge_model_result).to have_attributes(amount: value, unit_amount: value, units: -1)
+      end
+    end
+
+    context "with a negative amount" do
+      let(:value) { -1.to_d }
+
+      it "normalizes monetary fields without mutating the charge model result" do
+        expect(result.amount).to have_attributes(
+          amount_cents: 0, precise_amount_cents: 0, unit_amount_cents: 0, precise_unit_amount: 0
+        )
+        expect(charge_model_result).to have_attributes(amount: value, unit_amount: value, units:)
+      end
+    end
+
+    context "with an already-paid fee" do
+      let(:value) { "1.006".to_d }
+      let(:options) { {deduction: described_class::Deduction.new(amount_cents: 100, billed_days: 2, period_days: 3)} }
+
+      it "prorates and rounds the deduction without changing the unit price" do
+        expect(result.amount).to have_attributes(
+          amount_cents: 34, precise_amount_cents: 33.6.to_d, unit_amount_cents: 100.6.to_d, precise_unit_amount: value
+        )
+      end
+
+      context "with zero already paid" do
+        let(:options) { {deduction: described_class::Deduction.new(amount_cents: 0, billed_days: 2, period_days: 3)} }
+
+        it "retains the full rounded and precise totals" do
+          expect(result.amount).to have_attributes(amount_cents: 101, precise_amount_cents: 100.6.to_d)
+        end
+      end
+
+      context "when the deduction exceeds the total" do
+        let(:value) { "0.5".to_d }
+
+        it "clamps both totals independently to zero" do
+          expect(result.amount).to have_attributes(
+            amount_cents: 0, precise_amount_cents: 0, unit_amount_cents: 50, precise_unit_amount: value
+          )
+        end
+      end
+
+      context "when only the precise total is below the deduction" do
+        let(:value) { "0.666".to_d }
+
+        it "does not leave a negative precise total" do
+          expect(result.amount).to have_attributes(amount_cents: 0, precise_amount_cents: 0)
+        end
+      end
+
+      context "when a precise remainder survives a zero rounded total" do
+        let(:value) { "0.674".to_d }
+
+        it "retains the precise remainder" do
+          expect(result.amount).to have_attributes(amount_cents: 0, precise_amount_cents: 0.4.to_d)
+        end
+      end
+    end
+
+    context "with a minimum" do
+      let(:options) { {true_up: described_class::TrueUp.new(minimum_amount_cents: 100)} }
+
+      it "calculates amount and true-up from separate rounded and precise totals" do
+        expect(result.amount.amount_cents).to eq(33)
+        expect(result.true_up_amount).to have_attributes(
+          amount_cents: 67, precise_amount_cents: 66.67.to_d, unit_amount_cents: 67, precise_unit_amount: 0.6667.to_d
+        )
+      end
+
+      context "with explicit grouped usage totals" do
+        let(:options) do
+          {true_up: described_class::TrueUp.new(minimum_amount_cents: 100, used_amount_cents: 66, used_precise_amount_cents: 66.66.to_d)}
+        end
+
+        it "uses grouped totals instead of the individual amount for the true-up" do
+          expect(result.amount.amount_cents).to eq(33)
+          expect(result.true_up_amount).to have_attributes(amount_cents: 34, precise_amount_cents: 33.34.to_d)
+        end
+      end
+
+      context "when rounded usage meets the minimum but precise usage does not" do
+        let(:value) { "0.996".to_d }
+
+        it "does not create a true-up" do
+          expect(result.true_up_amount).to be_nil
+        end
+      end
+
+      context "when usage exceeds the minimum" do
+        let(:value) { 2.to_d }
+
+        it "does not create a true-up" do
+          expect(result.true_up_amount).to be_nil
+        end
+      end
+
+      context "with a zero minimum" do
+        let(:options) { {true_up: described_class::TrueUp.new(minimum_amount_cents: 0)} }
+
+        it "does not create a true-up" do
+          expect(result.true_up_amount).to be_nil
+        end
+      end
+    end
+
+    context "with only grouped usage totals" do
+      let(:charge_model_result) { ChargeModels::BaseService::Result.new }
+      let(:options) do
+        {true_up: described_class::TrueUp.new(minimum_amount_cents: 100, used_amount_cents: 66, used_precise_amount_cents: 66.66.to_d)}
+      end
+
+      it "returns only a true-up, not a synthetic base amount" do
+        expect(result.amount).to be_nil
+        expect(result.true_up_amount).to have_attributes(
+          amount_cents: 34, precise_amount_cents: 33.34.to_d, unit_amount_cents: 34, precise_unit_amount: 0.3334.to_d
+        )
+        expect(charge_model_result).to have_attributes(amount: nil, unit_amount: nil, units: nil)
+      end
+
+      context "with a fractional prorated minimum" do
+        let(:options) do
+          {true_up: described_class::TrueUp.new(
+            minimum_amount_cents: 1000, billed_days: 15, period_days: 31, used_amount_cents: 200, used_precise_amount_cents: 200.to_d
+          )}
+        end
+
+        it "does not round the minimum before computing the difference" do
+          expect(result.true_up_amount).to have_attributes(
+            amount_cents: 284,
+            precise_amount_cents: "283.8709677419355".to_d,
+            unit_amount_cents: 284,
+            precise_unit_amount: "2.838709677419355".to_d
+          )
+        end
+      end
+
+      context "with a positive difference below half a cent" do
+        let(:options) do
+          {true_up: described_class::TrueUp.new(
+            minimum_amount_cents: 100, billed_days: 1, period_days: 16, used_amount_cents: 6, used_precise_amount_cents: 6.6.to_d
+          )}
+        end
+
+        it "retains a zero-rounded true-up and its negative precise difference" do
+          expect(result.true_up_amount.amount_cents).to eq(0)
+          expect(result.true_up_amount.precise_amount_cents).to eq("-0.35".to_d)
+        end
+      end
+
+      ["JPY", "KWD"].each do |currency_code|
+        context "with #{currency_code}" do
+          let(:currency) { Money::Currency.new(currency_code) }
+
+          it "uses the fiat subunit for the precise unit amount" do
+            expect(result.true_up_amount).to have_attributes(
+              amount_cents: 34, precise_amount_cents: 33.34.to_d,
+              unit_amount_cents: 34, precise_unit_amount: 33.34.to_d / currency.subunit_to_unit
+            )
+          end
+        end
+      end
+    end
+
+    context "with pricing units" do
+      let(:pricing_unit) { build(:pricing_unit) }
+      let(:applied_pricing_unit) do
+        described_class::PricingUnit.from(build(:applied_pricing_unit, pricing_unit:, pricing_unitable: nil, conversion_rate: 0.25))
+      end
+      let(:options) { {applied_pricing_unit:} }
+      let(:value) { "0.336".to_d }
+
+      it "preserves the pricing-unit rounding and implicit unit-cent truncation before fiat conversion" do
+        expect(result.amount).to have_attributes(
+          amount_cents: 9, precise_amount_cents: 8.5.to_d, unit_amount_cents: 8.25.to_d, precise_unit_amount: 0.0825.to_d
+        )
+        expect(result.amount.pricing_unit_usage).to be_new_record.and have_attributes(
+          amount_cents: 34, precise_amount_cents: 33.6.to_d, unit_amount_cents: 33, precise_unit_amount: value
+        )
+        expect(Fee.new(**result.amount.to_h).unit_amount_cents).to eq(8)
+      end
+
+      context "with zero units and a flat price" do
+        let(:units) { 0.to_d }
+
+        it "retains both pricing-unit and fiat unit amounts" do
+          expect(result.amount.precise_unit_amount).to eq(0.0825.to_d)
+          expect(result.amount.pricing_unit_usage.precise_unit_amount).to eq(value)
+        end
+      end
+
+      context "with a negative amount" do
+        let(:value) { -1.to_d }
+
+        it "normalizes pricing-unit and fiat monetary fields" do
+          expect(result.amount).to have_attributes(amount_cents: 0, precise_amount_cents: 0, unit_amount_cents: 0, precise_unit_amount: 0)
+          expect(result.amount.pricing_unit_usage).to have_attributes(
+            amount_cents: 0, precise_amount_cents: 0, unit_amount_cents: 0, precise_unit_amount: 0
+          )
+        end
+      end
+
+      context "with a minimum" do
+        let(:options) { {applied_pricing_unit:, true_up: described_class::TrueUp.new(minimum_amount_cents: 100)} }
+
+        it "compares the minimum to pricing-unit usage rather than fiat usage" do
+          expect(result.true_up_amount).to have_attributes(
+            amount_cents: 17, precise_amount_cents: 16.5.to_d, unit_amount_cents: 16.5.to_d, precise_unit_amount: 0.165.to_d
+          )
+          expect(result.true_up_amount.pricing_unit_usage).to have_attributes(
+            amount_cents: 66, precise_amount_cents: 66, unit_amount_cents: 66, precise_unit_amount: 0.664.to_d
+          )
+        end
+
+        context "when pricing-unit usage meets the minimum but fiat usage does not" do
+          let(:value) { 1.to_d }
+
+          it "does not create a true-up" do
+            expect(result.amount.amount_cents).to eq(25)
+            expect(result.true_up_amount).to be_nil
+          end
+        end
+      end
+
+      context "with grouped totals and a fractional minimum" do
+        let(:charge_model_result) { ChargeModels::BaseService::Result.new }
+        let(:options) do
+          {
+            applied_pricing_unit:,
+            true_up: described_class::TrueUp.new(
+              minimum_amount_cents: 1000, billed_days: 15, period_days: 31,
+              used_amount_cents: 200, used_precise_amount_cents: 200.6.to_d
+            )
+          }
+        end
+
+        it "converts rounded and precise differences separately using pricing-unit subunits" do
+          expect(result.amount).to be_nil
+          expect(result.true_up_amount).to have_attributes(
+            amount_cents: 71, precise_amount_cents: 71, unit_amount_cents: 70.75.to_d, precise_unit_amount: 0.7075.to_d
+          )
+          expect(result.true_up_amount.pricing_unit_usage).to have_attributes(
+            amount_cents: 284, precise_amount_cents: "283.8709677419355".to_d,
+            unit_amount_cents: 283, precise_unit_amount: "2.832709677419355".to_d
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

Preparation for Product Catalog v1 including shared fee computation and minimum true-ups. This PR does not complete the product-catalog billing integration.

## Context

Fee builders independently convert charge-model results into rounded totals, precise totals, unit amounts, and pricing-unit usage. Deductions and minimum true-ups add further monetary rules. Duplicating these calculations makes it easy for billing paths to diverge on fractional cents, currency precision, or conversion rates.

`Fees::AmountsService` establishes a shared calculation boundary. Existing fee services keep their orchestration responsibilities, while monetary calculations can be reused without requiring a Charge, FixedCharge, Subscription, or BillingSegment record inside the calculator.

## Description

Extract `Fees::AmountsService` and delegate monetary calculations from:

- `Fees::ChargeService`: standard charge-model amounts and pricing-unit conversion.
- `Fees::FixedChargeService`: base amounts and prorated deductions for amounts already paid.
- `Fees::CreateTrueUpService`: minimum shortfalls using separate rounded and precise usage totals.
- `Fees::CreatePayInAdvanceService`: advance results whose totals are already expressed in minor units, including pricing-unit conversion.

Callers still own aggregation, pricing-model execution, period selection, unit normalization, fee identity, persistence, taxes, and webhooks. The calculator returns `amount` and `true_up_amount`; it does not persist fees.

### PORO responsibilities

| PORO | Responsibility |
| --- | --- |
| `Amount` | Immutable output containing `amount_cents`, `precise_amount_cents`, `unit_amount_cents`, `precise_unit_amount`, and `pricing_unit_usage`. `with_deduction` returns a new amount with rounded and precise totals clamped independently, preserving unit prices. |
| `Deduction` | Groups the already-paid amount and billed/period days. Owns calculation and rounding of the prorated deduction. |
| `TrueUp` | Groups the minimum, billed/period days, and optional rounded/precise used totals. Owns minimum proration; grouped usage can override the individual base amount. |
| `PricingUnit` | Groups the pricing-unit model and conversion rate, adapts an existing applied pricing unit, and exposes the decimal subunit factor used in conversion. |

### Explicit empty states

`Deduction.none`, `TrueUp.none`, and `PricingUnit.none` supply typed empty states instead of optional nil inputs. Their `none?` predicates express absence explicitly. A zero deduction or zero minimum remains a real value, not an empty state.

`charge_model_result` is mandatory and checked against the two supported native result classes. True-up-only callers pass an empty `ChargeModels::BaseService::Result`; an absent amount means no base fee, not a synthetic zero-valued fee. There is no additional charge-model-result wrapper.

### Preserve existing monetary behavior

The extraction keeps currency-exponent rounding for standard totals, unrounded precise values, and implicit integer-column truncation for unit cents. For example, a unit price of `$0.336` remains `0.336` in the precise field while the fee stores `33` integer unit cents.

Advance totals are not scaled or rounded a second time. Existing differences between standard and advance negative/zero handling are retained. Pricing-unit conversion, fractional minimum proration, independent precise true-up differences, and already-paid deduction rules also remain intact. This is not an attempt to silently unify different billing policies.

## Future products and plans integration

The upcoming product-catalog `BillingSegments::ProcessService` can orchestrate segment billing and pass charge-model outputs into this same calculator. Segment snapshots can provide currency and conversion-rate inputs, while segment periods and minimums populate `TrueUp` or `Deduction` when applicable. The resulting amounts can then be assigned to product-backed fees without copying the monetary formulas into another billing engine.

Period generation, rate/override selection, filter routing, invoice grouping, and persistence remain the responsibility of that runtime. Mapping its minimum and pricing-unit semantics explicitly will be part of the integration; it must not assume every legacy and product rule is interchangeable.

This branch contains no billing-segment models, jobs, migrations, or ProcessService changes. The integration is future work, not a dependency required to use this refactor.
