### PR TITLE
feat(catalog): price a contract at creation

### DIFF
--- a/app/controllers/api/v2/contract_rate_cards_controller.rb
+++ b/app/controllers/api/v2/contract_rate_cards_controller.rb
@@ -5,6 +5,35 @@ module Api
     class ContractRateCardsController < Api::BaseController
       include Api::RequiresProductCatalog
 
+      # The permitted shape of one applied rate card, shared with the contract
+      # create surface that authors cards atomically at birth.
+      APPLIED_RATE_CARD_PARAMS = [
+        :rate_card_code, :units, :billing_anchor_date,
+        {rate_phases: [
+          :code,
+          :position,
+          :name,
+          :billing_interval_cycle_count,
+          {rate_override: [
+            :rate_model,
+            :min_amount_cents,
+            :billing_interval_count,
+            :billing_interval_unit,
+            :pricing_unit_conversion_rate,
+            # Structural card fields pass through so the override service can
+            # reject them explicitly instead of strong params dropping them.
+            :billing_timing,
+            :currency,
+            :proration,
+            :display_on_invoice,
+            :regroup_paid_fees,
+            :wallet_targetable,
+            :applied_pricing_unit_code,
+            {rate_properties: {}}
+          ]}
+        ]}
+      ].freeze
+
       def create
         return not_found_error(resource: "contract") unless find_contract
 
@@ -95,32 +124,7 @@ module Api
       end
 
       def create_params
-        params.require(:applied_rate_card).permit(
-          :rate_card_code, :units, :billing_anchor_date,
-          rate_phases: [
-            :code,
-            :position,
-            :name,
-            :billing_interval_cycle_count,
-            {rate_override: [
-              :rate_model,
-              :min_amount_cents,
-              :billing_interval_count,
-              :billing_interval_unit,
-              :pricing_unit_conversion_rate,
-              # Structural card fields pass through so the override service can
-              # reject them explicitly instead of strong params dropping them.
-              :billing_timing,
-              :currency,
-              :proration,
-              :display_on_invoice,
-              :regroup_paid_fees,
-              :wallet_targetable,
-              :applied_pricing_unit_code,
-              {rate_properties: {}}
-            ]}
-          ]
-        )
+        params.require(:applied_rate_card).permit(*APPLIED_RATE_CARD_PARAMS)
       end
 
       def update_params

--- a/app/controllers/api/v2/contracts_controller.rb
+++ b/app/controllers/api/v2/contracts_controller.rb
@@ -118,7 +118,10 @@ module Api
           :billing_time,
           :billing_anchor_date,
           :started_at,
-          :ended_at
+          :ended_at,
+          # Price the contract atomically at birth: each card carries the same
+          # shape the standalone attach surface permits.
+          applied_rate_cards: ContractRateCardsController::APPLIED_RATE_CARD_PARAMS
         )
       end
 

--- a/app/services/contract_rate_cards/create_service.rb
+++ b/app/services/contract_rate_cards/create_service.rb
@@ -8,16 +8,21 @@ module ContractRateCards
   class CreateService < BaseService
     Result = BaseResult[:contract_rate_card]
 
-    def initialize(contract:, params:)
+    def initialize(contract:, params:, initial: false)
       @contract = contract
       @params = params.to_h.with_indifferent_access
+      @initial = initial
       super
     end
 
     def call
       return result.not_found_failure!(resource: "contract") unless contract
 
-      unless contract.editable?
+      # initial: cards authored inside the contract's own create transaction,
+      # before the active lock applies — an immediate-start contract is born
+      # active, so it could never be priced otherwise. External attach passes
+      # initial: false and still rejects active contracts.
+      unless initial || contract.editable?
         return result.single_validation_failure!(field: :contract, error_code: "contract_locked")
       end
 
@@ -57,9 +62,9 @@ module ContractRateCards
         # create back. Omitted or null, the card starts on a single default
         # terminal phase.
         if params.key?(:rate_phases) && !params[:rate_phases].nil?
-          RatePhases::ReplaceService.call!(contract_rate_card:, phases_params: params[:rate_phases])
+          RatePhases::ReplaceService.call!(contract_rate_card:, phases_params: params[:rate_phases], initial:)
         else
-          RatePhases::CreateService.call!(contract_rate_card:, params: {code: "default", position: 1})
+          RatePhases::CreateService.call!(contract_rate_card:, params: {code: "default", position: 1}, initial:)
         end
 
         result.contract_rate_card = contract_rate_card
@@ -74,7 +79,7 @@ module ContractRateCards
 
     private
 
-    attr_reader :contract, :params
+    attr_reader :contract, :params, :initial
 
     def slice_error_code(rate_card)
       if rate_card.product_filter_id

--- a/app/services/contracts/create_service.rb
+++ b/app/services/contracts/create_service.rb
@@ -62,6 +62,15 @@ module Contracts
 
         Contracts::MaterializeRateCardsService.call!(contract:) if contract.catalog_plan
 
+        # Atomic initial pricing: cards authored here are born with the
+        # contract, bypassing the active lock only for this birth. An
+        # immediate-start plan-less contract would otherwise be unpriceable —
+        # active on creation with the attach door already closed. Any invalid
+        # card or phase rolls the whole create back.
+        Array.wrap(params[:applied_rate_cards]).each do |card_params|
+          ContractRateCards::CreateService.call!(contract:, params: card_params, initial: true)
+        end
+
         result.contract = contract
       end
 

--- a/app/services/rate_phases/create_service.rb
+++ b/app/services/rate_phases/create_service.rb
@@ -6,10 +6,11 @@ module RatePhases
   class CreateService < BaseService
     Result = BaseResult[:rate_phase]
 
-    def initialize(plan_rate_card: nil, contract_rate_card: nil, params: {})
+    def initialize(plan_rate_card: nil, contract_rate_card: nil, params: {}, initial: false)
       @plan_rate_card = plan_rate_card
       @contract_rate_card = contract_rate_card
       @params = params.to_h.with_indifferent_access
+      @initial = initial
       super
     end
 
@@ -28,7 +29,10 @@ module RatePhases
       # contract activating (or a plan gaining a subscription) concurrently
       # cannot slip past the edit check.
       applied_rate_card.with_lock do
-        if (blocked = applied_rate_card.edit_error_code)
+        # initial: the card is being authored inside its contract's create
+        # transaction, before the active lock applies. Every other caller edits
+        # a live card and must still pass the guard.
+        if !initial && (blocked = applied_rate_card.edit_error_code)
           return result.single_validation_failure!(field: :rate_phase, error_code: blocked)
         end
 
@@ -73,7 +77,7 @@ module RatePhases
 
     private
 
-    attr_reader :plan_rate_card, :contract_rate_card, :params
+    attr_reader :plan_rate_card, :contract_rate_card, :params, :initial
 
     def applied_rate_card
       plan_rate_card || contract_rate_card

--- a/app/services/rate_phases/replace_service.rb
+++ b/app/services/rate_phases/replace_service.rb
@@ -4,10 +4,11 @@ module RatePhases
   class ReplaceService < BaseService
     Result = BaseResult[:rate_phases]
 
-    def initialize(plan_rate_card: nil, contract_rate_card: nil, phases_params: [])
+    def initialize(plan_rate_card: nil, contract_rate_card: nil, phases_params: [], initial: false)
       @plan_rate_card = plan_rate_card
       @contract_rate_card = contract_rate_card
       @phases_params = Array.wrap(phases_params).map { |phase| phase.to_h.with_indifferent_access }
+      @initial = initial
       super
     end
 
@@ -21,7 +22,9 @@ module RatePhases
       # gaining a subscription) concurrently cannot slip past the guard
       # mid-replace.
       applied_rate_card.with_lock do
-        if (blocked = applied_rate_card.edit_error_code)
+        # initial: authored inside the contract's create transaction, before
+        # the active lock applies; every live-card caller still passes the guard.
+        if !initial && (blocked = applied_rate_card.edit_error_code)
           return result.single_validation_failure!(field: :rate_phases, error_code: blocked)
         end
 
@@ -50,7 +53,7 @@ module RatePhases
 
     private
 
-    attr_reader :plan_rate_card, :contract_rate_card, :phases_params
+    attr_reader :plan_rate_card, :contract_rate_card, :phases_params, :initial
 
     def applied_rate_card
       plan_rate_card || contract_rate_card

--- a/spec/requests/api/v2/contracts_controller_spec.rb
+++ b/spec/requests/api/v2/contracts_controller_spec.rb
@@ -46,6 +46,40 @@ RSpec.describe Api::V2::ContractsController do
       end
     end
 
+    context "with applied_rate_cards priced at creation" do
+      let(:customer) { create(:customer, organization:, currency: "EUR") }
+      let(:rate_card) { create(:rate_card, organization:, currency: "EUR") }
+      let(:create_params) do
+        {
+          external_customer_id: customer.external_id,
+          external_id: "contract-1",
+          applied_rate_cards: [{rate_card_code: rate_card.code, units: "10"}]
+        }
+      end
+
+      it "creates the active contract already priced" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:contract][:status]).to eq("active")
+        expect(json[:contract][:applied_rate_cards].sole[:rate_card_code]).to eq(rate_card.code)
+      end
+
+      it "still rejects a post-creation attach on the now-active contract" do
+        subject
+        expect(response).to have_http_status(:success)
+
+        post_with_token(
+          organization,
+          "/api/v2/contracts/contract-1/applied_rate_cards",
+          {applied_rate_card: {rate_card_code: create(:rate_card, organization:, currency: "EUR").code}}
+        )
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json.dig(:error_details, :contract)).to eq(["contract_locked"])
+      end
+    end
+
     context "when the customer does not exist" do
       let(:create_params) { super().merge(external_customer_id: "unknown") }
 

--- a/spec/services/contract_rate_cards/create_service_spec.rb
+++ b/spec/services/contract_rate_cards/create_service_spec.rb
@@ -63,6 +63,15 @@ RSpec.describe ContractRateCards::CreateService do
       expect(result).not_to be_success
       expect(result.error.messages[:contract]).to eq(["contract_locked"])
     end
+
+    context "when authored as an initial (birth) card" do
+      subject(:result) { described_class.call(contract:, params:, initial: true) }
+
+      it "bypasses the active lock" do
+        expect(result).to be_success
+        expect(result.contract_rate_card.rate_card).to eq(rate_card)
+      end
+    end
   end
 
   context "when the rate card does not exist" do

--- a/spec/services/contracts/create_service_spec.rb
+++ b/spec/services/contracts/create_service_spec.rb
@@ -46,6 +46,49 @@ RSpec.describe Contracts::CreateService do
     end
   end
 
+  context "with applied_rate_cards priced at creation" do
+    let(:customer) { create(:customer, organization:, currency: "EUR") }
+    let(:rate_card) { create(:rate_card, organization:, currency: "EUR") }
+    let(:params) do
+      {
+        external_customer_id: customer.external_id,
+        external_id: "contract-1",
+        applied_rate_cards: [
+          {rate_card_code: rate_card.code, units: "10", rate_phases: [{code: "ramp", position: 1}]}
+        ]
+      }
+    end
+
+    it "prices the immediate-start plan-less contract at birth" do
+      expect { result }.to change(Contract, :count).by(1).and change(ContractRateCard, :count).by(1)
+
+      contract = result.contract
+      expect(contract.status).to eq("active")
+      card = contract.applied_rate_cards.sole
+      expect(card).to have_attributes(rate_card:, units: 10)
+      expect(card.rate_phases.sole.code).to eq("ramp")
+    end
+
+    context "when a card is invalid" do
+      let(:params) { super().merge(applied_rate_cards: [{rate_card_code: "unknown"}]) }
+
+      it "rolls the whole create back" do
+        expect { result }.not_to change(Contract, :count)
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+      end
+    end
+
+    context "when the card currency does not match" do
+      let(:rate_card) { create(:rate_card, organization:, currency: "USD") }
+
+      it "rolls back with a currency error" do
+        expect { result }.not_to change(Contract, :count)
+        expect(result.error.messages[:currency]).to eq(["currency_does_not_match"])
+      end
+    end
+  end
+
   context "when the contract starts in the future" do
     let(:params) { super().merge(started_at: 1.month.from_now.iso8601) }
 


### PR DESCRIPTION
Closes BIL-641.

## Problem
An immediate-start contract is born `active`, and the standalone attach surface (BIL-624) rejects `active` contracts with `contract_locked`. A plan-less contract materialises no cards — so an **immediate-start plan-less contract had no way to be priced**: born active with zero cards, attach door already closed.

## Fix — atomic initial pricing (REST)
`POST /api/v2/contracts` now accepts a nested `applied_rate_cards` array (each with its `rate_phases`), authored **inside the create transaction**:

- An `initial:` flag threads `ContractRateCards::CreateService` → `RatePhases::CreateService` / `ReplaceService` past the active lock — **only** for this birth authoring. The lock is enforced defense-in-depth at all three layers, so the flag propagates through all three. External attach (`initial: false`) still rejects active contracts.
- Any invalid card or phase rolls the **whole create** back (single transaction; `call!` raises `FailedResult`).
- The applied-rate-card param shape is shared via `ContractRateCardsController::APPLIED_RATE_CARD_PARAMS` so the attach and create surfaces can't drift.

## Scope
- **REST only.** GraphQL `createContract` parity is deliberately a **follow-up** (the ticket frames it as "a second step"): it needs a full nested GraphQL input tree — AppliedRateCard → RatePhase → RateOverride input objects — none of which exists yet (there's no GraphQL contract-rate-card attach surface either). Building that is its own chunk of work.

## Testing
- `Contracts::CreateService` — immediate-start plan-less contract created with cards is **active and priced**; invalid card / currency mismatch rolls the create back.
- `ContractRateCards::CreateService` — `initial: true` bypasses the active lock; default `false` still returns `contract_locked`.
- Request spec — `POST` with `applied_rate_cards` prices the active contract, **and** a post-creation attach on that active contract still returns `contract_locked` (the acceptance criterion).
- Regression: 103 plan-side / rate-phase caller examples green (the `initial: false` default preserves all existing callers). Rubocop clean.