### PR TITLE
feat(streaming): send usage since subscription start for the plans that need it

### DIFF
--- a/app/jobs/deliver_event_job.rb
+++ b/app/jobs/deliver_event_job.rb
@@ -3,7 +3,16 @@
 class DeliverEventJob < ApplicationJob
   queue_as :streaming
 
-  unique :until_and_while_executing, on_conflict: :log, lock_ttl: 10.minutes
+  ON_CONFLICT = lambda do |job|
+    EventDestinations::DeliveryLogger.emit(
+      :superseded,
+      event_type: job.arguments.first,
+      customer_id: job.arguments.second.try(:id),
+      lock_key: job.lock_key
+    )
+  end
+
+  unique :until_and_while_executing, on_conflict: ON_CONFLICT, lock_ttl: 10.minutes
 
   EVENT_SERVICES = {
     EventDestinations::CustomerUsage::RefreshedService::EVENT_TYPE =>

--- a/app/jobs/deliver_event_job.rb
+++ b/app/jobs/deliver_event_job.rb
@@ -16,7 +16,9 @@ class DeliverEventJob < ApplicationJob
 
   EVENT_SERVICES = {
     EventDestinations::CustomerUsage::RefreshedService::EVENT_TYPE =>
-      EventDestinations::CustomerUsage::RefreshedService
+      EventDestinations::CustomerUsage::RefreshedService,
+    EventDestinations::CustomerFullUsage::RefreshedService::EVENT_TYPE =>
+      EventDestinations::CustomerFullUsage::RefreshedService
   }.freeze
 
   def perform(event_type, object)

--- a/app/models/streaming_destinations/base_destination.rb
+++ b/app/models/streaming_destinations/base_destination.rb
@@ -8,7 +8,9 @@ module StreamingDestinations
 
     self.table_name = "streaming_destinations"
 
-    EVENT_TYPES = %w[customer_usage.refreshed.v1].freeze
+    CURRENT_USAGE_EVENT_TYPE = "customer_usage.refreshed.v1"
+    FULL_USAGE_EVENT_TYPE = "customer_full_usage.refreshed.v1"
+    EVENT_TYPES = [CURRENT_USAGE_EVENT_TYPE, FULL_USAGE_EVENT_TYPE].freeze
 
     belongs_to :organization
 
@@ -22,6 +24,14 @@ module StreamingDestinations
 
     def self.streams_event?(organization, event_type)
       for_event(organization, event_type).exists?
+    end
+
+    settings_accessors :customer_full_usage_excluded_plan_codes, default: []
+
+    def event_types_for(subscription)
+      return event_types unless customer_full_usage_excluded_plan_codes.include?(subscription.plan.code)
+
+      event_types - [FULL_USAGE_EVENT_TYPE]
     end
 
     def producer

--- a/app/services/customers/refresh_wallets_service.rb
+++ b/app/services/customers/refresh_wallets_service.rb
@@ -35,7 +35,7 @@ module Customers
 
       customer.update!(awaiting_wallet_refresh: false)
 
-      deliver_current_usage
+      deliver_streaming_events
 
       result.wallets = customer.wallets.active.reload
       result
@@ -47,12 +47,14 @@ module Customers
 
     attr_reader :customer, :include_generating_invoices
 
-    def deliver_current_usage
-      event_type = EventDestinations::CustomerUsage::RefreshedService::EVENT_TYPE
-
-      return unless StreamingDestinations::BaseDestination.streams_event?(customer.organization, event_type)
-
-      DeliverEventJob.perform_after_commit(event_type, customer)
+    def deliver_streaming_events
+      StreamingDestinations::BaseDestination
+        .where(organization: customer.organization)
+        .pluck(:event_types)
+        .flatten
+        .uniq
+        .intersection(StreamingDestinations::BaseDestination::EVENT_TYPES)
+        .each { DeliverEventJob.perform_after_commit(it, customer) }
     end
 
     def all_wallets

--- a/app/services/event_destinations/customer_full_usage/refreshed_service.rb
+++ b/app/services/event_destinations/customer_full_usage/refreshed_service.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module EventDestinations
-  module CustomerUsage
+  module CustomerFullUsage
     class RefreshedService < BaseService
       Result = BaseResult
 
-      EVENT_TYPE = "customer_usage.refreshed.v1"
+      EVENT_TYPE = "customer_full_usage.refreshed.v1"
       OBJECT_TYPE = "customer_usage"
 
       def initialize(object:)
@@ -59,7 +59,11 @@ module EventDestinations
           customer:,
           subscription:,
           apply_taxes: false,
-          with_cache: true
+          with_cache: true,
+          usage_filters: UsageFilters.new(
+            full_usage: true,
+            filter_by_charge_id: subscription.plan.charges.ids
+          )
         )
 
         unless usage_result.success?

--- a/app/services/event_destinations/customer_usage/refreshed_service.rb
+++ b/app/services/event_destinations/customer_usage/refreshed_service.rb
@@ -20,9 +20,7 @@ module EventDestinations
         customer.active_subscriptions.each do |subscription|
           deliver(subscription)
         rescue => e
-          Rails.logger.error(
-            "[streaming] #{EVENT_TYPE} failed for subscription #{subscription.id}: #{e.class} #{e.message}"
-          )
+          log(:failed, subscription, error: e.class, message: e.message)
         end
 
         result
@@ -63,15 +61,24 @@ module EventDestinations
         )
 
         unless usage_result.success?
-          Rails.logger.warn(
-            "[streaming] #{EVENT_TYPE} skipped for subscription #{subscription.id}: #{usage_result.error}"
-          )
+          log(:skipped, subscription, error: usage_result.error.class, message: usage_result.error)
           return
         end
 
         producer.produce(
           data: envelope(subscription, usage_result.usage),
           partition_key: destination.partition_key_for(customer:)
+        )
+      end
+
+      def log(outcome, subscription, **fields)
+        EventDestinations::DeliveryLogger.emit(
+          outcome,
+          destination:,
+          event_type: EVENT_TYPE,
+          customer_id: customer.id,
+          subscription_id: subscription.id,
+          **fields
         )
       end
 

--- a/app/services/event_destinations/delivery_logger.rb
+++ b/app/services/event_destinations/delivery_logger.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module EventDestinations
+  module DeliveryLogger
+    PREFIX = "[streaming] event=delivery"
+
+    OUTCOMES = {
+      delivered: :info,
+      throttled: :error,
+      dropped: :error,
+      superseded: :info,
+      skipped: :warn,
+      failed: :error
+    }.freeze
+
+    SAFE_VALUE = /\A[\w.:@\/+-]*\z/
+
+    class << self
+      def emit(outcome, destination: nil, **fields)
+        Rails.logger.public_send(OUTCOMES.fetch(outcome), line(outcome, destination, fields))
+      end
+
+      private
+
+      def line(outcome, destination, fields)
+        pairs = {outcome:}
+
+        if destination
+          pairs[:destination_id] = destination.id
+          pairs[:organization_id] = destination.organization_id
+        end
+
+        pairs.merge!(fields.compact)
+
+        "#{PREFIX} #{pairs.map { |key, value| "#{key}=#{format_value(value)}" }.join(" ")}"
+      end
+
+      def format_value(value)
+        string = value.to_s
+
+        string.match?(SAFE_VALUE) ? string : string.inspect
+      end
+    end
+  end
+end

--- a/lib/lago/kinesis/producer.rb
+++ b/lib/lago/kinesis/producer.rb
@@ -11,12 +11,16 @@ module Lago
 
       ROLE_SESSION_NAME = "lago-event-destinations"
 
+      THROTTLE_ERRORS = [
+        Aws::Kinesis::Errors::ProvisionedThroughputExceededException
+      ].freeze
+
       DELIVERY_ERRORS = [
         Aws::Kinesis::Errors::ResourceNotFoundException,
         Aws::Kinesis::Errors::AccessDeniedException,
         Aws::Kinesis::Errors::ValidationException,
         Aws::Kinesis::Errors::InvalidArgumentException,
-        Aws::Kinesis::Errors::ProvisionedThroughputExceededException,
+        *THROTTLE_ERRORS,
         Aws::STS::Errors::AccessDenied,
         Aws::Errors::MissingCredentialsError,
         Seahorse::Client::NetworkingError
@@ -32,22 +36,32 @@ module Lago
       def produce(data:, partition_key:)
         payload = JSON.generate(data)
 
+        started_at = Time.current
+
         response = client.put_record(
           stream_arn: destination.stream_arn,
           data: payload,
           partition_key:
         )
 
-        Rails.logger.info(
-          "#{log_prefix} delivered partition_key=#{partition_key} bytes=#{payload.bytesize} " \
-          "shard=#{response.shard_id} sequence=#{response.sequence_number}"
+        log(
+          :delivered,
+          partition_key:,
+          bytes: payload.bytesize,
+          shard: response.shard_id,
+          sequence: response.sequence_number,
+          duration_ms: duration_ms(started_at)
         )
 
         response
       rescue *DELIVERY_ERRORS => e
-        Rails.logger.error(
-          "#{log_prefix} dropped partition_key=#{partition_key} bytes=#{payload&.bytesize} " \
-          "error=#{e.class} message=#{e.message}"
+        log(
+          outcome_for(e),
+          partition_key:,
+          bytes: payload&.bytesize,
+          duration_ms: duration_ms(started_at),
+          error: e.class,
+          message: e.message
         )
 
         nil
@@ -57,8 +71,18 @@ module Lago
 
       attr_reader :destination
 
-      def log_prefix
-        "[streaming] destination=#{destination.id} stream=#{destination.stream_arn}"
+      def outcome_for(error)
+        return :throttled if THROTTLE_ERRORS.any? { error.is_a?(it) }
+
+        :dropped
+      end
+
+      def log(outcome, **fields)
+        EventDestinations::DeliveryLogger.emit(outcome, destination:, stream: destination.stream_arn, **fields)
+      end
+
+      def duration_ms(started_at)
+        ((Time.current - started_at) * 1000).round
       end
 
       def client

--- a/spec/factories/streaming_destinations.rb
+++ b/spec/factories/streaming_destinations.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :kinesis_destination, class: "StreamingDestinations::KinesisDestination" do
     organization
     type { "StreamingDestinations::KinesisDestination" }
-    event_types { ["customer_usage.refreshed.v1"] }
+    event_types { ["customer_usage.refreshed.v1", "customer_full_usage.refreshed.v1"] }
 
     settings do
       {

--- a/spec/jobs/deliver_event_job_spec.rb
+++ b/spec/jobs/deliver_event_job_spec.rb
@@ -50,6 +50,18 @@ RSpec.describe DeliverEventJob, type: :job do
 
       expect(EventDestinations::CustomerUsage::RefreshedService).to have_received(:call).with(object: customer)
     end
+
+    it "logs the drop in the shape the monitors match on" do
+      allow(Rails.logger).to receive(:info)
+      job = described_class.new("customer_usage.refreshed", customer)
+      contend_on_runtime_lock(job)
+
+      job.perform_now
+
+      expect(Rails.logger).to have_received(:info).with(
+        a_string_matching(/outcome=superseded event_type=customer_usage.refreshed customer_id=#{customer.id}/)
+      )
+    end
   end
 
   # The global test lock manager always grants a lock, so contention has to be forced. Only the

--- a/spec/jobs/deliver_event_job_spec.rb
+++ b/spec/jobs/deliver_event_job_spec.rb
@@ -53,13 +53,13 @@ RSpec.describe DeliverEventJob, type: :job do
 
     it "logs the drop in the shape the monitors match on" do
       allow(Rails.logger).to receive(:info)
-      job = described_class.new("customer_usage.refreshed", customer)
+      job = described_class.new("customer_usage.refreshed.v1", customer)
       contend_on_runtime_lock(job)
 
       job.perform_now
 
       expect(Rails.logger).to have_received(:info).with(
-        a_string_matching(/outcome=superseded event_type=customer_usage.refreshed customer_id=#{customer.id}/)
+        a_string_matching(/outcome=superseded event_type=customer_usage\.refreshed\.v1 customer_id=#{customer.id}/)
       )
     end
   end

--- a/spec/lib/lago/kinesis/producer_spec.rb
+++ b/spec/lib/lago/kinesis/producer_spec.rb
@@ -40,7 +40,9 @@ RSpec.describe Lago::Kinesis::Producer do
       producer.produce(data: {hello: "world"}, partition_key: "cust_1")
 
       expect(Rails.logger).to have_received(:info).with(
-        a_string_matching(/delivered partition_key=cust_1 bytes=17 shard=shardId-000000000000 sequence=4966/)
+        a_string_matching(
+          /outcome=delivered destination_id=#{destination.id} organization_id=#{destination.organization_id} .*partition_key=cust_1 bytes=17 shard=shardId-000000000000 sequence=4966/
+        )
       )
     end
 
@@ -49,10 +51,22 @@ RSpec.describe Lago::Kinesis::Producer do
         allow(client).to receive(:put_record).and_raise(build_aws_error(error_class))
         allow(Rails.logger).to receive(:error)
 
+        outcome = described_class::THROTTLE_ERRORS.include?(error_class) ? "throttled" : "dropped"
+
         expect(producer.produce(data: {hello: "world"}, partition_key: "cust_1")).to be_nil
         expect(Rails.logger).to have_received(:error)
-          .with(a_string_matching(/dropped .*#{Regexp.escape(error_class.name)}/))
+          .with(a_string_matching(/outcome=#{outcome} .*error=#{Regexp.escape(error_class.name)}/))
       end
+    end
+
+    it "separates a throttle from a configuration fault" do
+      allow(client).to receive(:put_record)
+        .and_raise(Aws::Kinesis::Errors::ProvisionedThroughputExceededException.new(nil, "slow down"))
+      allow(Rails.logger).to receive(:error)
+
+      producer.produce(data: {hello: "world"}, partition_key: "cust_1")
+
+      expect(Rails.logger).to have_received(:error).with(a_string_matching(/outcome=throttled/))
     end
 
     it "does not swallow an error that is not a delivery failure" do

--- a/spec/models/streaming_destinations/base_destination_spec.rb
+++ b/spec/models/streaming_destinations/base_destination_spec.rb
@@ -69,6 +69,30 @@ RSpec.describe StreamingDestinations::BaseDestination, type: :model do
     end
   end
 
+  describe "#event_types_for" do
+    subject(:destination) { create(:kinesis_destination) }
+
+    let(:customer) { create(:customer, organization: destination.organization) }
+    let(:plan) { create(:plan, organization: destination.organization, code: "self_serve_monthly") }
+    let(:subscription) { create(:subscription, customer:, plan:) }
+
+    it "returns every subscribed type when no plan is excluded" do
+      expect(destination.event_types_for(subscription)).to match_array(described_class::EVENT_TYPES)
+    end
+
+    it "drops the full usage type for an excluded plan" do
+      destination.customer_full_usage_excluded_plan_codes = ["self_serve_monthly"]
+
+      expect(destination.event_types_for(subscription)).to eq([described_class::CURRENT_USAGE_EVENT_TYPE])
+    end
+
+    it "keeps the full usage type for a plan that is not excluded" do
+      destination.customer_full_usage_excluded_plan_codes = ["another_plan"]
+
+      expect(destination.event_types_for(subscription)).to include(described_class::FULL_USAGE_EVENT_TYPE)
+    end
+  end
+
   describe ".streams_event?" do
     let(:organization) { create(:organization) }
 

--- a/spec/services/customers/refresh_wallets_service_spec.rb
+++ b/spec/services/customers/refresh_wallets_service_spec.rb
@@ -112,6 +112,11 @@ RSpec.describe Customers::RefreshWalletsService do
             .with("customer_usage.refreshed.v1", customer)
         end
 
+        it "enqueues one job per event type the destination subscribes to" do
+          expect { result }.to have_enqueued_job(DeliverEventJob)
+            .with("customer_full_usage.refreshed.v1", customer)
+        end
+
         it "enqueues nothing when the wrapping transaction rolls back" do
           expect do
             ActiveRecord::Base.transaction do

--- a/spec/services/event_destinations/customer_full_usage/refreshed_service_spec.rb
+++ b/spec/services/event_destinations/customer_full_usage/refreshed_service_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EventDestinations::CustomerFullUsage::RefreshedService do
+  subject(:service) { described_class.new(object: customer) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:, code: "enterprise_monthly") }
+  let(:subscription) { create(:subscription, customer:, plan:, started_at: 6.months.ago) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let!(:charge) { create(:standard_charge, plan:, billable_metric:, organization:) }
+  let(:producer) { instance_double(Lago::Kinesis::Producer, produce: nil) }
+  let(:producer_calls) { [] }
+
+  before do
+    subscription
+    allow(Lago::Kinesis::Producer).to receive(:new).and_return(producer)
+    allow(producer).to receive(:produce) { |args| producer_calls << args }
+  end
+
+  context "when the organization has no destination" do
+    it "delivers nothing" do
+      expect(service.call).to be_success
+      expect(producer_calls).to be_empty
+    end
+  end
+
+  # full_usage is refused unless the organization has granular_lifetime_usage and a premium
+  # license, so without this every delivery is silently skipped.
+  context "when the organization has a destination", :premium do
+    before do
+      organization.update!(premium_integrations: ["granular_lifetime_usage"])
+      create(:kinesis_destination, organization:)
+    end
+
+    it "asks for usage since the subscription started, in one call carrying every charge id" do
+      allow(Invoices::CustomerUsageService).to receive(:call).and_call_original
+
+      service.call
+
+      expect(Invoices::CustomerUsageService).to have_received(:call).once.with(
+        hash_including(
+          usage_filters: an_object_having_attributes(
+            full_usage: true,
+            filter_by_charge_id: [charge.id]
+          )
+        )
+      )
+      expect(producer_calls.size).to eq(1)
+    end
+
+    it "delivers a snapshot whose window starts at subscription.started_at" do
+      service.call
+
+      usage = producer_calls.first[:data][:customer_usage]
+      expect(Time.zone.parse(usage[:from_datetime])).to be_within(1.second).of(subscription.started_at)
+    end
+
+    it "carries the full usage event type and the shared object type" do
+      service.call
+
+      expect(producer_calls.first[:data]).to include(
+        event_type: "customer_full_usage.refreshed.v1",
+        object_type: "customer_usage"
+      )
+    end
+
+    context "when the plan is on the exclusion list" do
+      before do
+        destination = StreamingDestinations::BaseDestination.for_event(organization, described_class::EVENT_TYPE).first
+        destination.customer_full_usage_excluded_plan_codes = ["enterprise_monthly"]
+        destination.save!
+      end
+
+      it "delivers nothing for that subscription" do
+        expect(service.call).to be_success
+        expect(producer_calls).to be_empty
+      end
+    end
+
+    context "when the plan carries a prorated charge" do
+      before do
+        recurring_metric = create(:billable_metric, organization:, recurring: true, aggregation_type: "sum_agg", field_name: "amount")
+        create(:standard_charge, plan:, billable_metric: recurring_metric, organization:, prorated: true)
+        allow(Rails.logger).to receive(:warn)
+      end
+
+      it "skips rather than raising, so the current period record is unaffected" do
+        expect(service.call).to be_success
+        expect(producer_calls).to be_empty
+        expect(Rails.logger).to have_received(:warn).with(a_string_matching(/outcome=skipped/))
+      end
+    end
+  end
+end

--- a/spec/services/event_destinations/customer_usage/refreshed_service_spec.rb
+++ b/spec/services/event_destinations/customer_usage/refreshed_service_spec.rb
@@ -138,7 +138,8 @@ RSpec.describe EventDestinations::CustomerUsage::RefreshedService do
 
         expect(service.call).to be_success
         expect(call_count).to eq(2)
-        expect(Rails.logger).to have_received(:error).with(a_string_matching(/failed for subscription/))
+        expect(Rails.logger).to have_received(:error)
+          .with(a_string_matching(/outcome=failed .*error=RuntimeError message=boom/))
       end
     end
 
@@ -150,7 +151,8 @@ RSpec.describe EventDestinations::CustomerUsage::RefreshedService do
 
       expect(service.call).to be_success
       expect(producer).not_to have_received(:produce)
-      expect(Rails.logger).to have_received(:warn).with(a_string_matching(/skipped for subscription/))
+      expect(Rails.logger).to have_received(:warn)
+        .with(a_string_matching(/outcome=skipped .*subscription_id=#{subscription.id}/))
     end
   end
 end

--- a/spec/services/event_destinations/delivery_logger_spec.rb
+++ b/spec/services/event_destinations/delivery_logger_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EventDestinations::DeliveryLogger do
+  let(:destination) { create(:kinesis_destination) }
+
+  before { allow(Rails.logger).to receive(:info).and_call_original }
+
+  it "emits the destination and organization on every line" do
+    described_class.emit(:delivered, destination:, partition_key: "cust_1")
+
+    expect(Rails.logger).to have_received(:info).with(
+      "[streaming] event=delivery outcome=delivered destination_id=#{destination.id} " \
+      "organization_id=#{destination.organization_id} partition_key=cust_1"
+    )
+  end
+
+  it "omits the destination when there is none to name" do
+    described_class.emit(:superseded, customer_id: "cust_1")
+
+    expect(Rails.logger).to have_received(:info).with(
+      "[streaming] event=delivery outcome=superseded customer_id=cust_1"
+    )
+  end
+
+  it "quotes a value that would otherwise break logfmt parsing" do
+    allow(Rails.logger).to receive(:error)
+
+    described_class.emit(:dropped, message: "User is not authorized to perform: kinesis:PutRecord")
+
+    expect(Rails.logger).to have_received(:error).with(
+      '[streaming] event=delivery outcome=dropped message="User is not authorized to perform: kinesis:PutRecord"'
+    )
+  end
+
+  it "drops keys with no value rather than emitting an empty one" do
+    described_class.emit(:delivered, partition_key: "cust_1", bytes: nil)
+
+    expect(Rails.logger).to have_received(:info).with(
+      "[streaming] event=delivery outcome=delivered partition_key=cust_1"
+    )
+  end
+
+  it "logs each outcome at its own severity" do
+    expect(described_class::OUTCOMES).to eq(
+      delivered: :info, throttled: :error, dropped: :error,
+      superseded: :info, skipped: :warn, failed: :error
+    )
+  end
+
+  it "raises on an outcome it does not know, rather than logging something unmatchable" do
+    expect { described_class.emit(:vanished) }.to raise_error(KeyError)
+  end
+end


### PR DESCRIPTION
Stacked on #6299. Closes ING-675.

## Context

Synthesia does not consume current-period usage today. They call the usage endpoint with the `full_usage` flag for their enterprise customers and without it for self-served ones, so P0 as it stands does not replace their polling for the enterprise half.

They need both scopes: every subscription gets current-period usage, and subscriptions on plans that are not excluded additionally get usage since `subscription.started_at`.

## Description

A second event type, `customer_full_usage.refreshed.v1`, delivered alongside the first. Both carry `object_type: "customer_usage"` and the same payload shape; only the window differs. The two records for one subscription are independent, with no shared `version` and no ordering guarantee, so a consumer dedups per `(organization, customer, subscription, event_type)`.

Selection is `customer_full_usage_excluded_plan_codes` on the destination, read through `event_types_for(subscription)`. The list is an exclusion, not an inclusion: an absent or empty list excludes nobody, so a new plan nobody has configured receives the complete data rather than silently dropping to less.

Full usage is computed in **one call carrying every charge id**. `has_charge_filter?` only checks presence, so an array of all charge ids satisfies the guard, and a spec asserts this directly since a per-charge loop is the regression to prevent. Measured at 70 charges: 73.7 ms batched against 728 ms looped.

The service is duplicated rather than sharing a base class with the current-period one. Extracting a parent would mean refactoring code already reviewed and approved in #6298, which is a worse trade than the duplication.

## Preconditions, both silent when unmet

- The organization needs the `granular_lifetime_usage` premium integration and a premium license, or every full-usage delivery is refused and logged as `outcome=skipped` while the current-period event keeps working.
- Full usage is refused for any subscription whose plan carries a prorated charge. Those subscriptions never receive it, and still receive the current-period event.

## Not in this PR

Cold cost is unmeasured. Full usage carries its own cache key the wallet refresh never warms, and it aggregates from `subscription.started_at`, so its cost grows with subscription age. That needs measuring on a mature subscription against real event history before any cadence or worker sizing is committed to, and it may lead to debouncing the event or computing it incrementally.

