### PR TITLE
fix: permit payment method in payment request controller

### DIFF
--- a/app/controllers/api/v1/payment_requests_controller.rb
+++ b/app/controllers/api/v1/payment_requests_controller.rb
@@ -43,7 +43,11 @@ module Api
         params.require(:payment_request).permit(
           :email,
           :external_customer_id,
-          lago_invoice_ids: []
+          lago_invoice_ids: [],
+          payment_method: [
+            :payment_method_type,
+            :payment_method_id
+          ]
         )
       end
 

--- a/app/services/payment_requests/create_service.rb
+++ b/app/services/payment_requests/create_service.rb
@@ -2,7 +2,7 @@
 
 module PaymentRequests
   class CreateService < BaseService
-    Result = BaseResult[:payment_request]
+    Result = BaseResult[:payment_request, :payment_method]
 
     def initialize(organization:, params:, dunning_campaign: nil)
       @organization = organization
@@ -40,7 +40,7 @@ module PaymentRequests
         SendWebhookJob.perform_later("payment_request.created", payment_request)
         Utils::ActivityLog.produce(payment_request, "payment_request.created")
 
-        payment_result = PaymentRequests::Payments::CreateService.call_async(payable: payment_request, payment_method_params: payment_method)
+        payment_result = PaymentRequests::Payments::CreateService.call_async(payable: payment_request, payment_method_params:)
         PaymentRequestMailer.with(payment_request:).requested.deliver_later unless payment_result.success?
       end
 
@@ -67,6 +67,7 @@ module PaymentRequests
       # - the invoices have different currencies
       # - the invoices have different billing entities
       # - the invoices are not ready for payment processing
+      # - the requested payment method is invalid
 
       return result.forbidden_failure! unless License.premium?
       return result.not_found_failure!(resource: "customer") unless customer
@@ -85,8 +86,16 @@ module PaymentRequests
       end
 
       if invoices.exists?(ready_for_payment_processing: false)
-        result.not_allowed_failure!(code: "invoices_not_ready_for_payment_processing")
+        return result.not_allowed_failure!(code: "invoices_not_ready_for_payment_processing")
       end
+
+      valid_payment_method?
+    end
+
+    def valid_payment_method?
+      result.payment_method = payment_method
+
+      PaymentMethods::ValidateService.new(result, payment_method: payment_method_params).valid?
     end
 
     def customer
@@ -101,8 +110,15 @@ module PaymentRequests
       @email ||= params[:email] || customer.email
     end
 
+    def payment_method_params
+      @payment_method_params ||= params[:payment_method]&.to_h || {}
+    end
+
     def payment_method
-      @payment_method ||= params[:payment_method]&.to_h || {}
+      return @payment_method if defined?(@payment_method)
+      return @payment_method = nil if payment_method_params[:payment_method_id].blank?
+
+      @payment_method = customer.payment_methods.find_by(id: payment_method_params[:payment_method_id])
     end
 
     def currency

--- a/spec/requests/api/v1/payment_requests_controller_spec.rb
+++ b/spec/requests/api/v1/payment_requests_controller_spec.rb
@@ -51,6 +51,40 @@ RSpec.describe Api::V1::PaymentRequestsController do
       expect(json[:payment_request][:invoices].map { |i| i[:lago_id] }).to contain_exactly(invoice.id)
       expect(json[:payment_request][:customer][:lago_id]).to eq(customer.id)
     end
+
+    context "with payment_method" do
+      let(:payment_method_id) { SecureRandom.uuid }
+      let(:params) do
+        {
+          email: customer.email,
+          external_customer_id: customer.external_id,
+          lago_invoice_ids: [invoice.id],
+          payment_method: {
+            payment_method_type: "provider",
+            payment_method_id:
+          }
+        }
+      end
+
+      it "forwards the payment method to PaymentRequests::CreateService" do
+        subject
+
+        expect(PaymentRequests::CreateService).to have_received(:call).with(
+          organization:,
+          params: {
+            email: customer.email,
+            external_customer_id: customer.external_id,
+            lago_invoice_ids: [invoice.id],
+            payment_method: {
+              payment_method_type: "provider",
+              payment_method_id:
+            }
+          }
+        )
+
+        expect(response).to have_http_status(:success)
+      end
+    end
   end
 
   describe "GET /api/v1/payment_requests" do

--- a/spec/services/payment_requests/create_service_spec.rb
+++ b/spec/services/payment_requests/create_service_spec.rb
@@ -133,6 +133,114 @@ RSpec.describe PaymentRequests::CreateService, :premium do
       end
     end
 
+    context "when a payment method is provided" do
+      let(:payment_method) { create(:payment_method, organization:, customer:) }
+
+      before { params[:payment_method] = payment_method_params }
+
+      context "when the payment method belongs to the customer" do
+        let(:payment_method_params) do
+          {payment_method_type: "provider", payment_method_id: payment_method.id}
+        end
+
+        it "creates the payment request and forwards the payment method" do
+          allow(PaymentRequests::Payments::CreateService).to receive(:call_async).and_call_original
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.payment_method).to eq(payment_method)
+          expect(PaymentRequests::Payments::CreateService).to have_received(:call_async)
+            .with(payable: result.payment_request, payment_method_params:)
+        end
+      end
+
+      context "when the payment method type is manual" do
+        let(:payment_method_params) { {payment_method_type: "manual"} }
+
+        it "creates the payment request" do
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.payment_method).to be_nil
+        end
+      end
+
+      context "when the payment method type is invalid" do
+        let(:payment_method_params) do
+          {payment_method_type: "invalid", payment_method_id: payment_method.id}
+        end
+
+        it "returns a validation failure" do
+          result = create_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:payment_method]).to eq(["invalid_payment_method"])
+        end
+
+        it "does not create a payment request" do
+          expect { create_service.call }.not_to change(PaymentRequest, :count)
+        end
+      end
+
+      context "when the payment method type is manual but an id is provided" do
+        let(:payment_method_params) do
+          {payment_method_type: "manual", payment_method_id: payment_method.id}
+        end
+
+        it "returns a validation failure" do
+          result = create_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:payment_method]).to eq(["invalid_payment_method"])
+        end
+      end
+
+      context "when the payment method does not exist" do
+        let(:payment_method_params) do
+          {payment_method_type: "provider", payment_method_id: SecureRandom.uuid}
+        end
+
+        it "returns a validation failure" do
+          result = create_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:payment_method]).to eq(["invalid_payment_method"])
+        end
+
+        it "does not create a payment request" do
+          expect { create_service.call }.not_to change(PaymentRequest, :count)
+        end
+      end
+
+      context "when the payment method belongs to another customer of the organization" do
+        let(:other_customer) { create(:customer, organization:) }
+        let(:other_payment_method) { create(:payment_method, organization:, customer: other_customer) }
+        let(:payment_method_params) do
+          {payment_method_type: "provider", payment_method_id: other_payment_method.id}
+        end
+
+        it "returns a validation failure" do
+          result = create_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:payment_method]).to eq(["invalid_payment_method"])
+        end
+
+        it "does not enqueue a payment creation" do
+          allow(PaymentRequests::Payments::CreateService).to receive(:call_async).and_call_original
+
+          create_service.call
+
+          expect(PaymentRequests::Payments::CreateService).not_to have_received(:call_async)
+        end
+      end
+    end
+
     it "creates a payment request" do
       expect { create_service.call }.to change { customer.payment_requests.count }.by(1)
     end


### PR DESCRIPTION
## Context

Payment request controller missed permit for payment method and it was not possible to provide custom payment method from the API path.

## Description

This PR fixes the issue from above.
