### PR TITLE
fix(catalog): lock code and currency on a contracted plan

### DIFF
--- a/app/services/catalog_plans/update_service.rb
+++ b/app/services/catalog_plans/update_service.rb
@@ -19,12 +19,17 @@ module CatalogPlans
     def call
       return result.not_found_failure!(resource: "plan") unless catalog_plan
 
-      # The currency is fixed once anything prices against the plan — plan-level
-      # rate cards, or a contract (whose fees bill in the card currency and
-      # invoice in the plan currency). Changing it would desync already-attached
-      # cards from the currency they were validated against.
-      currency_change = params.key?(:currency) && params[:currency] != catalog_plan.currency
-      if currency_change && (catalog_plan.applied_rate_cards.exists? || catalog_plan.attached_to_contracts?)
+      # A contract prices against the plan by reference — it serializes the
+      # plan_code through the association (so the code must stay stable) and its
+      # fees invoice in the plan currency. Once a contract is attached both are
+      # frozen; name, description and invoice display name stay editable.
+      if catalog_plan.attached_to_contracts? && (code_change_requested? || currency_change_requested?)
+        return result.single_validation_failure!(field: :plan, error_code: "plan_locked")
+      end
+
+      # Plan-level rate cards freeze the currency too, before any contract: the
+      # cards were validated against it and changing it would desync them.
+      if currency_change_requested? && catalog_plan.applied_rate_cards.exists?
         return result.single_validation_failure!(field: :currency, error_code: "not_editable_with_applied_rate_cards")
       end
 
@@ -45,5 +50,13 @@ module CatalogPlans
     private
 
     attr_reader :catalog_plan, :params, :send_webhook
+
+    def code_change_requested?
+      params.key?(:code) && params[:code] != catalog_plan.code
+    end
+
+    def currency_change_requested?
+      params.key?(:currency) && params[:currency] != catalog_plan.currency
+    end
   end
 end

--- a/spec/services/catalog_plans/update_service_spec.rb
+++ b/spec/services/catalog_plans/update_service_spec.rb
@@ -72,20 +72,50 @@ RSpec.describe CatalogPlans::UpdateService do
     end
   end
 
-  context "when changing the currency of a plan attached to a contract with direct rate cards" do
+  context "when changing the currency of a plan attached to a contract" do
     let(:catalog_plan) { create(:catalog_plan, currency: "EUR") }
     let(:params) { {currency: "USD"} }
 
     before do
       customer = create(:customer, organization: catalog_plan.organization)
-      contract = create(:contract, organization: catalog_plan.organization, customer:, catalog_plan:)
-      create(:contract_rate_card, organization: catalog_plan.organization, contract:)
+      create(:contract, organization: catalog_plan.organization, customer:, catalog_plan:)
     end
 
-    it "rejects the change even without plan-level rate cards" do
+    it "rejects it as plan_locked, even without plan-level rate cards" do
       expect(catalog_plan.applied_rate_cards).to be_empty
       expect(result).not_to be_success
-      expect(result.error.messages[:currency]).to eq(["not_editable_with_applied_rate_cards"])
+      expect(result.error.messages[:plan]).to eq(["plan_locked"])
+    end
+  end
+
+  context "when the plan is attached to a contract" do
+    let(:catalog_plan) { create(:catalog_plan, name: "Growth", code: "growth", description: "Old") }
+
+    before do
+      customer = create(:customer, organization: catalog_plan.organization)
+      create(:contract, organization: catalog_plan.organization, customer:, catalog_plan:)
+    end
+
+    it "rejects a code change" do
+      result = described_class.call(catalog_plan:, params: {code: "growth-v2"})
+
+      expect(result).not_to be_success
+      expect(result.error.messages[:plan]).to eq(["plan_locked"])
+      expect(catalog_plan.reload.code).to eq("growth")
+    end
+
+    it "still allows editing the name, description and invoice display name" do
+      result = described_class.call(catalog_plan:, params: {name: "Renamed", description: "New", invoice_display_name: "On Invoice"})
+
+      expect(result).to be_success
+      expect(catalog_plan.reload).to have_attributes(name: "Renamed", description: "New", invoice_display_name: "On Invoice")
+    end
+
+    it "accepts the unchanged code passed back with an editable field" do
+      result = described_class.call(catalog_plan:, params: {code: "growth", name: "Renamed"})
+
+      expect(result).to be_success
+      expect(catalog_plan.reload.name).to eq("Renamed")
     end
   end
 end


### PR DESCRIPTION
## Problem
`CatalogPlans::UpdateService` let the **code** through when a plan was linked to a contract — a real gap: a contract serializes its `plan_code` **through the plan association**, so editing an attached plan's code silently rewrote the `plan_code` reported by every existing contract. Currency *was* blocked, but with a misleading `not_editable_with_applied_rate_cards` error even when the plan had no rate cards and the lock actually came from the contract.

## Fix
Once a plan is `attached_to_contracts?`, a change to **`code` or `currency`** is rejected with `plan_locked` (the established "attached to contracts" grammar). **`name`, `description`, `invoice_display_name` stay editable.** A plan-level rate card still freezes the currency on its own — before any contract — with the specific `not_editable_with_applied_rate_cards` error. Passing an unchanged value back alongside an editable field is fine; only an actual change is rejected.
