### PR TITLE
chore(db): drop the rate_cards.wallet_targetable column

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,6 +67,7 @@ Lago/NoDropColumnOrTable:
     - "db/migrate/20260409161142_create_enriched_store_subscription_migrations.rb"
     - "db/migrate/20260908211313_drop_retired_pricing_type_and_plan_id.rb"
     - "db/migrate/20260908222044_drop_subscription_rate_cards.rb"
+    - "db/migrate/20260910095513_drop_wallet_targetable_from_rate_cards.rb"
 
 # TODO: Fix these services
 Lago/ServiceCall:

--- a/app/controllers/api/v2/contract_rate_cards/rate_phases_controller.rb
+++ b/app/controllers/api/v2/contract_rate_cards/rate_phases_controller.rb
@@ -85,7 +85,6 @@ module Api
               :proration,
               :display_on_invoice,
               :regroup_paid_fees,
-              :wallet_targetable,
               :applied_pricing_unit_code,
               {rate_properties: {}}
             ]
@@ -124,7 +123,6 @@ module Api
               :proration,
               :display_on_invoice,
               :regroup_paid_fees,
-              :wallet_targetable,
               :applied_pricing_unit_code,
               {rate_properties: {}}
             ]

--- a/app/controllers/api/v2/contract_rate_cards_controller.rb
+++ b/app/controllers/api/v2/contract_rate_cards_controller.rb
@@ -115,7 +115,6 @@ module Api
               :proration,
               :display_on_invoice,
               :regroup_paid_fees,
-              :wallet_targetable,
               :applied_pricing_unit_code,
               {rate_properties: {}}
             ]}

--- a/app/controllers/api/v2/plan_rate_cards/rate_phases_controller.rb
+++ b/app/controllers/api/v2/plan_rate_cards/rate_phases_controller.rb
@@ -85,7 +85,6 @@ module Api
               :proration,
               :display_on_invoice,
               :regroup_paid_fees,
-              :wallet_targetable,
               :applied_pricing_unit_code,
               {rate_properties: {}}
             ]
@@ -124,7 +123,6 @@ module Api
               :proration,
               :display_on_invoice,
               :regroup_paid_fees,
-              :wallet_targetable,
               :applied_pricing_unit_code,
               {rate_properties: {}}
             ]

--- a/app/controllers/api/v2/plan_rate_cards_controller.rb
+++ b/app/controllers/api/v2/plan_rate_cards_controller.rb
@@ -111,7 +111,6 @@ module Api
               :proration,
               :display_on_invoice,
               :regroup_paid_fees,
-              :wallet_targetable,
               :applied_pricing_unit_code,
               {rate_properties: {}}
             ]}

--- a/app/controllers/api/v2/rate_cards_controller.rb
+++ b/app/controllers/api/v2/rate_cards_controller.rb
@@ -114,7 +114,6 @@ module Api
           :display_on_invoice,
           :regroup_paid_fees,
           :applied_pricing_unit_code,
-          :wallet_targetable,
           tax_codes: [],
           rates: [
             :code,
@@ -140,7 +139,6 @@ module Api
           :display_on_invoice,
           :regroup_paid_fees,
           :applied_pricing_unit_code,
-          :wallet_targetable,
           tax_codes: []
         )
       end

--- a/app/graphql/types/rate_cards/create_input.rb
+++ b/app/graphql/types/rate_cards/create_input.rb
@@ -19,7 +19,6 @@ module Types
       argument :rates, [Types::RateCardRates::Input], required: false
       argument :regroup_paid_fees, Types::RateCards::RegroupPaidFeesEnum, required: false
       argument :tax_codes, [String], required: false
-      argument :wallet_targetable, Boolean, required: false
     end
   end
 end

--- a/app/graphql/types/rate_cards/object.rb
+++ b/app/graphql/types/rate_cards/object.rb
@@ -22,7 +22,6 @@ module Types
       field :regroup_paid_fees, Types::RateCards::RegroupPaidFeesEnum, null: false
 
       field :applied_pricing_unit_code, String, null: true
-      field :wallet_targetable, Boolean, null: true
 
       # Lock signals for clients: deletion locks at any plan/subscription
       # attachment, rate edits lock once a subscription bills the card.

--- a/app/graphql/types/rate_cards/update_input.rb
+++ b/app/graphql/types/rate_cards/update_input.rb
@@ -17,7 +17,6 @@ module Types
       argument :proration, Boolean, required: false
       argument :regroup_paid_fees, Types::RateCards::RegroupPaidFeesEnum, required: false
       argument :tax_codes, [String], required: false
-      argument :wallet_targetable, Boolean, required: false
     end
   end
 end

--- a/app/models/rate_card.rb
+++ b/app/models/rate_card.rb
@@ -8,6 +8,11 @@ class RateCard < ApplicationRecord
 
   self.discard_column = :deleted_at
 
+  # wallet_targetable is being removed from the product catalog; the column is
+  # dropped in a follow-up release. Ignore it until then.
+  # TODO: drop the wallet_targetable column, then remove this ignore.
+  self.ignored_columns += %w[wallet_targetable]
+
   BILLING_TIMINGS = {
     arrears: "arrears",
     advance: "advance"
@@ -124,7 +129,6 @@ end
 #  name                      :string           not null
 #  proration                 :boolean          default(FALSE), not null
 #  regroup_paid_fees         :enum             default("none"), not null
-#  wallet_targetable         :boolean
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  organization_id           :uuid             not null

--- a/app/serializers/v2/rate_card_serializer.rb
+++ b/app/serializers/v2/rate_card_serializer.rb
@@ -16,7 +16,6 @@ module V2
         display_on_invoice: model.display_on_invoice,
         regroup_paid_fees: model.regroup_paid_fees,
         applied_pricing_unit_code: model.applied_pricing_unit_code,
-        wallet_targetable: model.wallet_targetable,
         rates_count: model.rates.size,
         created_at: model.created_at.iso8601,
         updated_at: model.updated_at.iso8601

--- a/app/services/charge_models/pricing_structure.rb
+++ b/app/services/charge_models/pricing_structure.rb
@@ -43,7 +43,7 @@ module ChargeModels
         charge_model: billing_segment.rate.rate_model,
         properties: billing_segment.rate_properties,
         prorated: billing_segment.contract_rate_card.rate_card.proration?,
-        accepts_target_wallet: billing_segment.contract_rate_card.rate_card.wallet_targetable?,
+        accepts_target_wallet: false,
         currency: Money::Currency.new(billing_segment.currency)
       )
     end

--- a/app/services/fees/charge_service/sources/billing_segment.rb
+++ b/app/services/fees/charge_service/sources/billing_segment.rb
@@ -65,13 +65,7 @@ module Fees
 
         # NOTE: Product-catalog pricing groups will move to product/plan data once that feature is supported.
         def pricing_group_keys
-          keys = properties["pricing_group_keys"]&.dup || []
-
-          if rate_card.wallet_targetable? && !keys.include?(::Charge::EVENT_TARGET_WALLET_CODE)
-            keys << ::Charge::EVENT_TARGET_WALLET_CODE
-          end
-
-          keys
+          properties["pricing_group_keys"]&.dup || []
         end
 
         # NOTE: Product-catalog presentation groups will move to product/plan data once that feature is supported.

--- a/app/services/rate_cards/create_service.rb
+++ b/app/services/rate_cards/create_service.rb
@@ -29,10 +29,6 @@ module RateCards
         return result.not_found_failure!(resource: "product_filter") unless product_filter
       end
 
-      if params[:wallet_targetable] && !organization.events_targeting_wallets_enabled?
-        return result.single_validation_failure!(field: :wallet_targetable, error_code: "feature_unavailable")
-      end
-
       if params[:applied_pricing_unit_code].present? && !organization.pricing_units.exists?(code: params[:applied_pricing_unit_code])
         return result.single_validation_failure!(field: :applied_pricing_unit_code, error_code: "value_is_invalid")
       end
@@ -45,8 +41,7 @@ module RateCards
         description: params[:description],
         currency: params[:currency],
         billing_timing: params[:billing_timing] || "arrears",
-        applied_pricing_unit_code: params[:applied_pricing_unit_code],
-        wallet_targetable: params[:wallet_targetable]
+        applied_pricing_unit_code: params[:applied_pricing_unit_code]
       }
       # NOT NULL columns with DB defaults: only set when a value is given.
       attributes[:proration] = params[:proration] unless params[:proration].nil?

--- a/app/services/rate_cards/update_service.rb
+++ b/app/services/rate_cards/update_service.rb
@@ -8,7 +8,7 @@ module RateCards
 
     # Billing-semantic fields freeze once a rate exists — changing them would
     # alter what the existing rates mean; create a new card instead.
-    LOCKED_WITH_RATES = %i[currency applied_pricing_unit_code billing_timing proration regroup_paid_fees display_on_invoice wallet_targetable].freeze
+    LOCKED_WITH_RATES = %i[currency applied_pricing_unit_code billing_timing proration regroup_paid_fees display_on_invoice].freeze
 
     def initialize(rate_card:, params:)
       @rate_card = rate_card
@@ -31,10 +31,6 @@ module RateCards
 
       boolean_failure = boolean_params_failure
       return boolean_failure if boolean_failure
-
-      if params[:wallet_targetable] && !rate_card.organization.events_targeting_wallets_enabled?
-        return result.single_validation_failure!(field: :wallet_targetable, error_code: "feature_unavailable")
-      end
 
       if params[:applied_pricing_unit_code].present? && !rate_card.organization.pricing_units.exists?(code: params[:applied_pricing_unit_code])
         return result.single_validation_failure!(field: :applied_pricing_unit_code, error_code: "value_is_invalid")
@@ -92,7 +88,6 @@ module RateCards
       rate_card.display_on_invoice = params[:display_on_invoice] if params.key?(:display_on_invoice)
       rate_card.regroup_paid_fees = params[:regroup_paid_fees] if params.key?(:regroup_paid_fees)
       rate_card.applied_pricing_unit_code = params[:applied_pricing_unit_code] if params.key?(:applied_pricing_unit_code)
-      rate_card.wallet_targetable = params[:wallet_targetable] if params.key?(:wallet_targetable)
     end
   end
 end

--- a/app/services/rate_cards/validates_boolean_params.rb
+++ b/app/services/rate_cards/validates_boolean_params.rb
@@ -4,7 +4,7 @@ module RateCards
   # Rails casts any non-falsey value to true on boolean columns; reject
   # non-boolean input from the permissive REST layer instead. nil is allowed.
   module ValidatesBooleanParams
-    BOOLEAN_FIELDS = %i[proration display_on_invoice wallet_targetable].freeze
+    BOOLEAN_FIELDS = %i[proration display_on_invoice].freeze
 
     private
 

--- a/app/services/rate_overrides/create_service.rb
+++ b/app/services/rate_overrides/create_service.rb
@@ -8,7 +8,7 @@ module RateOverrides
     # one has misunderstood the contract, not made a typo — reject it.
     NOT_OVERRIDABLE_FIELDS = %i[
       billing_timing currency proration display_on_invoice
-      regroup_paid_fees wallet_targetable applied_pricing_unit_code
+      regroup_paid_fees applied_pricing_unit_code
     ].freeze
 
     def initialize(rate_card:, params:)

--- a/db/migrate/20260910095513_drop_wallet_targetable_from_rate_cards.rb
+++ b/db/migrate/20260910095513_drop_wallet_targetable_from_rate_cards.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DropWalletTargetableFromRateCards < ActiveRecord::Migration[8.0]
+  def up
+    safety_assured do
+      remove_column :rate_cards, :wallet_targetable
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5671,7 +5671,6 @@ CREATE TABLE public.rate_cards (
     display_on_invoice boolean DEFAULT true NOT NULL,
     regroup_paid_fees public.rate_card_regroup_paid_fees DEFAULT 'none'::public.rate_card_regroup_paid_fees NOT NULL,
     applied_pricing_unit_code character varying,
-    wallet_targetable boolean,
     deleted_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
@@ -14791,6 +14790,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260910095513'),
 ('20260908222044'),
 ('20260908211313'),
 ('20260908180522'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -3729,7 +3729,6 @@ input CreateRateCardInput {
   rates: [RateCardRateInput!]
   regroupPaidFees: RateCardRegroupPaidFeesEnum
   taxCodes: [String!]
-  walletTargetable: Boolean
 }
 
 """
@@ -12741,7 +12740,6 @@ type RateCard {
   regroupPaidFees: RateCardRegroupPaidFeesEnum!
   taxes: [Tax!]!
   updatedAt: ISO8601DateTime!
-  walletTargetable: Boolean
 }
 
 enum RateCardBillingTimingEnum {
@@ -15492,7 +15490,6 @@ input UpdateRateCardInput {
   proration: Boolean
   regroupPaidFees: RateCardRegroupPaidFeesEnum
   taxCodes: [String!]
-  walletTargetable: Boolean
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -17492,18 +17492,6 @@
               "deprecationReason": null
             },
             {
-              "name": "walletTargetable",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "clientMutationId",
               "description": "A unique identifier for the client performing the mutation.",
               "type": {
@@ -69669,18 +69657,6 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
-            },
-            {
-              "name": "walletTargetable",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -83207,18 +83183,6 @@
                     "ofType": null
                   }
                 }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "walletTargetable",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/services/fees/charge_service/sources/billing_segment_spec.rb
+++ b/spec/services/fees/charge_service/sources/billing_segment_spec.rb
@@ -203,13 +203,5 @@ RSpec.describe Fees::ChargeService::Sources::BillingSegment do
     it "returns the pricing group keys from the stored properties" do
       expect(source.pricing_group_keys).to eq(["region"])
     end
-
-    context "when the rate card accepts target wallet grouping" do
-      let(:rate_card) { build(:rate_card, organization:, product:, currency: "USD", wallet_targetable: true) }
-
-      it "adds the target wallet code to the pricing group keys" do
-        expect(source.pricing_group_keys).to eq(["region", ::Charge::EVENT_TARGET_WALLET_CODE])
-      end
-    end
   end
 end

--- a/spec/services/rate_cards/create_service_spec.rb
+++ b/spec/services/rate_cards/create_service_spec.rb
@@ -169,15 +169,6 @@ RSpec.describe RateCards::CreateService do
     end
   end
 
-  context "when wallet_targetable is set without the organization feature" do
-    before { params[:wallet_targetable] = true }
-
-    it "returns a validation failure" do
-      expect(result).not_to be_success
-      expect(result.error.messages[:wallet_targetable]).to eq(["feature_unavailable"])
-    end
-  end
-
   context "when applied_pricing_unit_code is unknown" do
     before { params[:applied_pricing_unit_code] = "unknown" }
 

--- a/spec/services/rate_cards/update_service_spec.rb
+++ b/spec/services/rate_cards/update_service_spec.rb
@@ -97,15 +97,6 @@ RSpec.describe RateCards::UpdateService do
     end
   end
 
-  context "when wallet_targetable is set without the organization feature" do
-    let(:params) { {wallet_targetable: true} }
-
-    it "returns a validation failure" do
-      expect(result).not_to be_success
-      expect(result.error.messages[:wallet_targetable]).to eq(["feature_unavailable"])
-    end
-  end
-
   context "when applied_pricing_unit_code is unknown" do
     let(:params) { {applied_pricing_unit_code: "unknown"} }
 
@@ -196,15 +187,6 @@ RSpec.describe RateCards::UpdateService do
       it "returns a validation failure" do
         expect(result).not_to be_success
         expect(result.error.messages[:display_on_invoice]).to eq(["not_editable_with_rates"])
-      end
-    end
-
-    context "when changing wallet_targetable" do
-      let(:params) { {wallet_targetable: false} }
-
-      it "returns a validation failure" do
-        expect(result).not_to be_success
-        expect(result.error.messages[:wallet_targetable]).to eq(["not_editable_with_rates"])
       end
     end
 


### PR DESCRIPTION
> ⚠️ **DRAFT / HOLD — do not merge until #6353 is merged AND deployed to production.**

## What
`remove_column :rate_cards, :wallet_targetable`, registered in the `Lago/NoDropColumnOrTable` allowlist.
