### PR TITLE
fix(catalog): forbid hiding fees on a fixed rate card

### DIFF
--- a/app/models/rate_card.rb
+++ b/app/models/rate_card.rb
@@ -8,11 +8,6 @@ class RateCard < ApplicationRecord
 
   self.discard_column = :deleted_at
 
-  # wallet_targetable is being removed from the product catalog; the column is
-  # dropped in a follow-up release. Ignore it until then.
-  # TODO: drop the wallet_targetable column, then remove this ignore.
-  self.ignored_columns += %w[wallet_targetable]
-
   BILLING_TIMINGS = {
     arrears: "arrears",
     advance: "advance"
@@ -63,9 +58,16 @@ class RateCard < ApplicationRecord
   end
 
   def validate_display_on_invoice
-    return if advance? || display_on_invoice?
+    return if display_on_invoice?
 
-    errors.add(:display_on_invoice, :not_allowed_for_billing_timing)
+    # A fixed product bills one fee per period, so its line must always show —
+    # hiding it charges the customer an amount with nothing to reconcile it to.
+    # This holds on both timings; the flag only makes sense for usage on advance.
+    if product&.fixed?
+      errors.add(:display_on_invoice, :not_allowed_for_product_type)
+    elsif !advance?
+      errors.add(:display_on_invoice, :not_allowed_for_billing_timing)
+    end
   end
 
   # Usage proration spreads a recurring quantity across the period, so it

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,6 +59,7 @@ en:
         not_allowed_for_aggregation_type: not_allowed_for_aggregation_type
         not_allowed_for_billing_timing: not_allowed_for_billing_timing
         not_allowed_for_product: not_allowed_for_product
+        not_allowed_for_product_type: not_allowed_for_product_type
         not_allowed_with_display_on_invoice: not_allowed_with_display_on_invoice
         not_allowed_with_proration: not_allowed_with_proration
         not_compatible_with_aggregation_type: not_compatible_with_aggregation_type

--- a/spec/models/rate_card_spec.rb
+++ b/spec/models/rate_card_spec.rb
@@ -72,6 +72,24 @@ RSpec.describe RateCard do
       it "accepts a displayed arrears card" do
         expect(build(:rate_card, billing_timing: "arrears", display_on_invoice: true)).to be_valid
       end
+
+      context "with a fixed product" do
+        let(:product) { build(:product, :fixed) }
+
+        it "rejects hiding fees on both timings, reporting the product type" do
+          %w[advance arrears].each do |timing|
+            card = build(:rate_card, product:, organization: product.organization, billing_timing: timing, display_on_invoice: false)
+            card.valid?
+            expect(card.errors.where(:display_on_invoice).map(&:type)).to eq([:not_allowed_for_product_type])
+          end
+        end
+
+        it "accepts a displayed card on either timing" do
+          %w[advance arrears].each do |timing|
+            expect(build(:rate_card, product:, organization: product.organization, billing_timing: timing, display_on_invoice: true)).to be_valid
+          end
+        end
+      end
     end
 
     describe "proration compatibility" do

--- a/spec/services/rate_cards/create_service_spec.rb
+++ b/spec/services/rate_cards/create_service_spec.rb
@@ -34,6 +34,21 @@ RSpec.describe RateCards::CreateService do
     expect(rate_card.regroup_paid_fees).to eq("none")
   end
 
+  context "when hiding fees on a fixed product" do
+    let(:product) { create(:product, :fixed, organization:) }
+
+    before do
+      params[:billing_timing] = "advance"
+      params[:display_on_invoice] = false
+      params[:proration] = false
+    end
+
+    it "rejects it with a product-type error" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:display_on_invoice]).to eq(["not_allowed_for_product_type"])
+    end
+  end
+
   context "when regroup_paid_fees is explicitly null" do
     before { params[:regroup_paid_fees] = nil }
 


### PR DESCRIPTION
## Description

A fixed product bills exactly one fee per period, so its line must always show on the invoice. The rule was **timing-aware only** — `display_on_invoice: false` was rejected on `arrears` but **accepted on `advance`**, letting a fixed card charge the customer an amount with no line to reconcile it to.

**Fix:** reject `display_on_invoice: false` on any **fixed-product** rate card, on **both** timings, with `not_allowed_for_product_type` (new code, added to `en.yml`; matches the `not_allowed_for_*` validation family). Usage cards are unchanged — allowed on advance, rejected on arrears. Per the ticket, a fixed card on arrears now reports the **product-type** reason rather than the timing one.
