### PR TITLE
feat(organization): Ignore pre_filter_events column

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -8,7 +8,7 @@ class Organization < ApplicationRecord
   include HasFeatureFlags
   include Organizations::Sluggable
 
-  self.ignored_columns += [:clickhouse_aggregation]
+  self.ignored_columns += [:clickhouse_aggregation, :pre_filter_events]
 
   EMAIL_SETTINGS = [
     "invoice.finalized",


### PR DESCRIPTION
## Context

`pre_filter_events` was added on `organizations` as an exploratory flag and was never enabled. It is going away, and the column can only be dropped once no running instance selects it anymore.

## Description

- Add `pre_filter_events` to `Organization.ignored_columns` so the column is no longer selected before it is removed.

The migration dropping the column comes in a follow-up PR, once this one is deployed everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
