### PR TITLE
perf(plans): Optimize subscription and invoice counts

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -123,9 +123,13 @@ class Plan < ApplicationRecord
 
   def active_subscriptions_count
     count = subscriptions.active.count
-    return count unless children
+    active_count_per_child = Subscription.active
+      .where(Subscription.arel_table[:plan_id].eq(Plan.arel_table[:id]))
+      .select("COUNT(*)")
 
-    count + children.joins(:subscriptions).merge(Subscription.active).select("subscriptions.id").distinct.count
+    # Count through the (plan_id, status) index for each override instead of
+    # joining all active subscriptions before filtering by the parent plan.
+    count + children.sum(Arel::Nodes::Grouping.new(active_count_per_child.arel)).to_i
   end
 
   def customers_count
@@ -136,10 +140,10 @@ class Plan < ApplicationRecord
   end
 
   def draft_invoices_count
-    count = subscriptions.joins(:invoices).merge(Invoice.draft).select(:invoice_id).distinct.count
-    return count unless children
+    draft_invoices = Invoice.draft.where(organization_id:)
+    count = subscriptions.joins(:invoices).merge(draft_invoices).select(:invoice_id).distinct.count
 
-    count + children.joins(:subscriptions).joins(:invoices).merge(Invoice.draft).select(:invoice_id).distinct.count
+    count + children.joins(subscriptions: :invoices).merge(draft_invoices).select(:invoice_id).distinct.count
   end
 
   private

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -470,13 +470,60 @@ RSpec.describe Plan do
 
   describe "#active_subscriptions_count" do
     let(:plan) { create(:plan) }
+    let(:organization) { plan.organization }
+    let(:customer) { create(:customer, organization:) }
+    let(:overridden_plan) { create(:plan, organization:, parent: plan) }
 
-    it "returns the number of active subscriptions" do
-      create(:subscription, plan:)
-      overridden_plan = create(:plan, parent_id: plan.id)
-      create(:subscription, plan: overridden_plan)
+    it "counts active subscriptions on the plan and all its overrides" do
+      create_list(:subscription, 2, plan:, customer:)
+      create_list(:subscription, 3, plan: overridden_plan, customer:)
+      another_override = create(:plan, organization:, parent: plan)
+      create(:subscription, plan: another_override, customer:)
+
+      expect(plan.active_subscriptions_count).to eq(6)
+    end
+
+    it "excludes non-active subscriptions on the plan and its overrides" do
+      [plan, overridden_plan].each do |subscription_plan|
+        create(:subscription, plan: subscription_plan, customer:)
+        %i[pending terminated canceled incomplete].each do |status|
+          create(:subscription, status, plan: subscription_plan, customer:)
+        end
+      end
 
       expect(plan.active_subscriptions_count).to eq(2)
+    end
+
+    it "excludes discarded overrides and subscriptions on unrelated plans" do
+      discarded_override = create(:plan, organization:, parent: plan, deleted_at: Time.current)
+      unrelated_plan = create(:plan, organization:)
+      [discarded_override, unrelated_plan].each do |subscription_plan|
+        create(:subscription, plan: subscription_plan, customer:)
+      end
+      create(:subscription)
+
+      expect(plan.active_subscriptions_count).to eq(0)
+    end
+
+    it "returns the direct count when there are no overrides" do
+      create(:subscription, plan:, customer:)
+
+      expect(plan.active_subscriptions_count).to eq(1)
+    end
+
+    it "returns zero when there are no subscriptions" do
+      overridden_plan
+
+      expect(plan.active_subscriptions_count).to eq(0)
+    end
+
+    it "counts subscriptions on an override without counting its parent or siblings" do
+      create(:subscription, plan:, customer:)
+      create_list(:subscription, 2, plan: overridden_plan, customer:)
+      sibling = create(:plan, organization:, parent: plan)
+      create(:subscription, plan: sibling, customer:)
+
+      expect(overridden_plan.active_subscriptions_count).to eq(2)
     end
   end
 
@@ -496,18 +543,59 @@ RSpec.describe Plan do
 
   describe "#draft_invoices_count" do
     let(:plan) { create(:plan) }
+    let(:organization) { plan.organization }
+    let(:customer) { create(:customer, organization:) }
+    let(:overridden_plan) { create(:plan, organization:, parent: plan) }
 
-    it "returns the number draft invoices" do
-      subscription = create(:subscription, plan:)
-      invoice = create(:invoice, :draft)
+    it "returns the number of draft invoices for the plan and its overrides" do
+      subscription = create(:subscription, plan:, customer:)
+      invoice = create(:invoice, :draft, customer:)
       create(:invoice_subscription, invoice:, subscription:)
 
-      overridden_plan = create(:plan, parent_id: plan.id)
-      subscription2 = create(:subscription, plan: overridden_plan)
-      invoice2 = create(:invoice, :draft)
+      subscription2 = create(:subscription, plan: overridden_plan, customer:)
+      invoice2 = create(:invoice, :draft, customer:)
       create(:invoice_subscription, invoice: invoice2, subscription: subscription2)
 
       expect(plan.draft_invoices_count).to eq(2)
+    end
+
+    it "counts an invoice shared by multiple override subscriptions once" do
+      invoice = create(:invoice, :draft, customer:)
+      another_override = create(:plan, organization:, parent: plan)
+      [overridden_plan, overridden_plan, another_override].each do |child|
+        subscription = create(:subscription, plan: child, customer:)
+        create(:invoice_subscription, invoice:, subscription:)
+      end
+
+      expect(plan.draft_invoices_count).to eq(1)
+    end
+
+    it "excludes finalized invoices and discarded overrides" do
+      [plan, overridden_plan].each do |invoice_plan|
+        subscription = create(:subscription, plan: invoice_plan, customer:)
+        invoice = create(:invoice, status: :finalized, customer:)
+        create(:invoice_subscription, invoice:, subscription:)
+      end
+      discarded_plan = create(:plan, organization:, parent: plan, deleted_at: Time.current)
+      subscription = create(:subscription, plan: discarded_plan, customer:)
+      invoice = create(:invoice, :draft, customer:)
+      create(:invoice_subscription, invoice:, subscription:)
+
+      expect(plan.draft_invoices_count).to eq(0)
+    end
+
+    it "excludes invoices belonging to another organization" do
+      invoice = create(:invoice, :draft)
+      [plan, overridden_plan].each do |invoice_plan|
+        subscription = create(:subscription, plan: invoice_plan, customer:)
+        create(:invoice_subscription, invoice:, subscription:)
+      end
+
+      expect(plan.draft_invoices_count).to eq(0)
+    end
+
+    it "returns zero when there are no invoices or overrides" do
+      expect(plan.draft_invoices_count).to eq(0)
     end
   end
 


### PR DESCRIPTION
Plans with many overrides can load slowly because active-subscription and draft-invoice counts scan records beyond the relevant plans.

Sum active-subscription counts per override within SQL, allowing PostgreSQL to use the existing `(plan_id, status)` index. Scope draft-invoice counts to the plan's organization and remove the duplicate subscription join, while retaining distinct invoice counting and excluding discarded overrides.

Validation:
- 11 focused model examples passed for active-subscription and draft-invoice counts, including statuses, empty results, unrelated plans, discarded overrides, and shared invoices.
- RuboCop passed for both changed files.
- `EXPLAIN ANALYZE` on the EU read replica confirmed index-only scans using the existing subscription index. No migration is required.

Commands:
```sh
lago exec api bundle exec rspec spec/models/plan_spec.rb --example '#active_subscriptions_count' --example '#draft_invoices_count'
lago exec api bundle exec rubocop app/models/plan.rb spec/models/plan_spec.rb
```