### PR TITLE
misc(clickhouse): stop routing to the enriched store

### DIFF
--- a/app/services/events/stores/store_factory.rb
+++ b/app/services/events/stores/store_factory.rb
@@ -33,17 +33,11 @@ module Events
       def self.store_class(organization:)
         return override[:store_class] if override
 
-        event_store = Events::Stores::PostgresStore
-
         if supports_clickhouse? && organization.clickhouse_events_store?
-          event_store = Events::Stores::ClickhouseStore
-
-          if organization.feature_flag_enabled?(:enriched_events_aggregation)
-            event_store = Events::Stores::ClickhouseEnrichedStore
-          end
+          Events::Stores::ClickhouseStore
+        else
+          Events::Stores::PostgresStore
         end
-
-        event_store
       end
 
       def self.new_instance(organization:, billing_context:, **kwargs)

--- a/spec/services/events/stores/store_factory_spec.rb
+++ b/spec/services/events/stores/store_factory_spec.rb
@@ -5,9 +5,8 @@ require "rails_helper"
 RSpec.describe Events::Stores::StoreFactory do
   subject(:store_instance) { described_class.new_instance(organization:, **arguments) }
 
-  let(:organization) { create(:organization, clickhouse_events_store:, feature_flags:) }
+  let(:organization) { create(:organization, clickhouse_events_store:) }
   let(:clickhouse_events_store) { false }
-  let(:feature_flags) { [] }
 
   let(:arguments) do
     time = Time.current
@@ -46,14 +45,6 @@ RSpec.describe Events::Stores::StoreFactory do
 
         it "returns an instance of a Clickhouse store" do
           expect(store_instance).to be_a(Events::Stores::ClickhouseStore)
-        end
-
-        context "when enriched_events_aggregation feature flag is enabled" do
-          let(:feature_flags) { ["enriched_events_aggregation"] }
-
-          it "returns an instance of a ClickhouseEnrichedStore" do
-            expect(store_instance).to be_a(Events::Stores::ClickhouseEnrichedStore)
-          end
         end
       end
     end


### PR DESCRIPTION
## Context

The enriched events store was an alternative aggregation implementation reading from
`events_enriched_expanded`, selected by the store factory when the `enriched_events_aggregation`
feature flag was enabled. The flag was never turned on for any organization, so ClickHouse
organizations have always been served by the regular ClickHouse store.

## Description

- Drop the feature flag lookup from `Events::Stores::StoreFactory`, so the store selection only
  depends on whether the organization uses the ClickHouse event store.

The enriched store itself stays in place for now: the ClickHouse store still delegates its charge
and filter listing to it. This PR only makes the aggregation path unreachable, as a first step
towards removing the flag and then the store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
