### PR TITLE
misc(clickhouse): remove enriched aggregation flag

### DIFF
--- a/app/config/feature_flags.yaml
+++ b/app/config/feature_flags.yaml
@@ -2,10 +2,6 @@ postgres_enriched_events:
   description: "Turn on events pre-enrichement for organizations using the PG event store"
   owners: ["@vincent-pochet"]
 
-enriched_events_aggregation:
-  description: "Use the enriched events store for aggregation queries in ClickHouse"
-  owners: ["@vincent-pochet"]
-
 wallet_traceability:
   description: "Enable wallet traceability on newly created wallets"
   owners: ["@groyoh", "@D1353L"]

--- a/app/services/events/stores/store_factory.rb
+++ b/app/services/events/stores/store_factory.rb
@@ -33,17 +33,11 @@ module Events
       def self.store_class(organization:)
         return override[:store_class] if override
 
-        event_store = Events::Stores::PostgresStore
-
         if supports_clickhouse? && organization.clickhouse_events_store?
-          event_store = Events::Stores::ClickhouseStore
-
-          if organization.feature_flag_enabled?(:enriched_events_aggregation)
-            event_store = Events::Stores::ClickhouseEnrichedStore
-          end
+          Events::Stores::ClickhouseStore
+        else
+          Events::Stores::PostgresStore
         end
-
-        event_store
       end
 
       def self.new_instance(organization:, billing_context:, **kwargs)

--- a/schema.graphql
+++ b/schema.graphql
@@ -6632,7 +6632,6 @@ Organization Feature Flag Values
 """
 enum FeatureFlagEnum {
   account_tree
-  enriched_events_aggregation
   fixed_charge_usage_delta_migration
   lazy_charge_usage_cache
   multi_connection

--- a/schema.json
+++ b/schema.json
@@ -32446,12 +32446,6 @@
               "deprecationReason": null
             },
             {
-              "name": "enriched_events_aggregation",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "wallet_traceability",
               "description": null,
               "isDeprecated": false,

--- a/spec/services/events/stores/store_factory_spec.rb
+++ b/spec/services/events/stores/store_factory_spec.rb
@@ -5,9 +5,8 @@ require "rails_helper"
 RSpec.describe Events::Stores::StoreFactory do
   subject(:store_instance) { described_class.new_instance(organization:, **arguments) }
 
-  let(:organization) { create(:organization, clickhouse_events_store:, feature_flags:) }
+  let(:organization) { create(:organization, clickhouse_events_store:) }
   let(:clickhouse_events_store) { false }
-  let(:feature_flags) { [] }
 
   let(:arguments) do
     time = Time.current
@@ -46,14 +45,6 @@ RSpec.describe Events::Stores::StoreFactory do
 
         it "returns an instance of a Clickhouse store" do
           expect(store_instance).to be_a(Events::Stores::ClickhouseStore)
-        end
-
-        context "when enriched_events_aggregation feature flag is enabled" do
-          let(:feature_flags) { ["enriched_events_aggregation"] }
-
-          it "returns an instance of a ClickhouseEnrichedStore" do
-            expect(store_instance).to be_a(Events::Stores::ClickhouseEnrichedStore)
-          end
         end
       end
     end


### PR DESCRIPTION
> Stacked on #6368, which removed the last reader of the flag.

## Context

Nothing reads the `enriched_events_aggregation` feature flag anymore now that the store factory no
longer uses it to pick an aggregation store. The flag was never enabled for any organization, so no
organization carries the value and no cleanup of `organizations.feature_flags` is needed.

## Description

- Remove the `enriched_events_aggregation` flag definition.
- Regenerate the GraphQL schema dumps, since `FeatureFlagEnum` is built from the flag definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
