### PR TITLE
fix: Make contract billing migration retryable

### DIFF
--- a/db/migrate/20260908154307_add_contract_billing_relations.rb
+++ b/db/migrate/20260908154307_add_contract_billing_relations.rb
@@ -6,8 +6,14 @@ class AddContractBillingRelations < ActiveRecord::Migration[8.0]
   def change
     reversible do |direction|
       direction.up do
-        add_reference :contracts, :billing_entity, type: :uuid, index: {algorithm: :concurrently}, foreign_key: {validate: false}
-        add_reference :contracts, :payment_method, type: :uuid, index: {algorithm: :concurrently}, foreign_key: {validate: false}
+        # Non-transactional DDL can leave a reference partially created after a failure.
+        add_column :contracts, :billing_entity_id, :uuid, if_not_exists: true
+        add_index :contracts, :billing_entity_id, algorithm: :concurrently, if_not_exists: true
+        add_foreign_key :contracts, :billing_entities, column: :billing_entity_id, validate: false, if_not_exists: true
+
+        add_column :contracts, :payment_method_id, :uuid, if_not_exists: true
+        add_index :contracts, :payment_method_id, algorithm: :concurrently, if_not_exists: true
+        add_foreign_key :contracts, :payment_methods, column: :payment_method_id, validate: false, if_not_exists: true
       end
 
       direction.down do
@@ -16,7 +22,7 @@ class AddContractBillingRelations < ActiveRecord::Migration[8.0]
       end
     end
 
-    add_column :contracts, :purchase_order_number, :string
-    add_column :contracts, :consolidate_invoice, :boolean, default: true, null: false
+    add_column :contracts, :purchase_order_number, :string, if_not_exists: true
+    add_column :contracts, :consolidate_invoice, :boolean, default: true, null: false, if_not_exists: true
   end
 end


### PR DESCRIPTION
## Context

A failed non-transactional migration can leave billing columns behind and cause duplicate-column errors on retry.

## Description

Make column, index, and foreign-key additions independently retryable so the migration can complete after partial execution.
