### PR TITLE
feat(events): accept external_contract_id on ingestion

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -169,6 +169,11 @@ module Api
 
       private
 
+      # external_contract_id is the v2 alias for external_subscription_id, folded
+      # into external_subscription_id when the event is stored (Events::Create*
+      # services). It is permitted here so it reaches those services, but not on
+      # the estimate/index surfaces, which resolve the id against subscriptions
+      # and are not contract-aware yet.
       def create_params
         params
           .require(:event)
@@ -177,6 +182,7 @@ module Api
             :code,
             :timestamp,
             :external_subscription_id,
+            :external_contract_id,
             :precise_total_amount_cents,
             properties: {}
           )
@@ -190,6 +196,7 @@ module Api
               :code,
               :timestamp,
               :external_subscription_id,
+              :external_contract_id,
               :precise_total_amount_cents,
               properties: {} # rubocop:disable Style/HashAsLastArrayItem
             ]

--- a/app/services/events/create_batch_service.rb
+++ b/app/services/events/create_batch_service.rb
@@ -46,7 +46,9 @@ module Events
         event.organization_id = organization.id
         event.code = event_params[:code]
         event.transaction_id = event_params[:transaction_id]
-        event.external_subscription_id = event_params[:external_subscription_id]
+        # external_contract_id is the v2 alias for external_subscription_id; an
+        # explicit external_subscription_id wins. See Events::CreateService.
+        event.external_subscription_id = event_params[:external_subscription_id].presence || event_params[:external_contract_id]
         event.properties = event_params[:properties] || {}
         event.metadata = metadata || {}
         event.timestamp = Time.zone.at(event_params[:timestamp] ? BigDecimal(event_params[:timestamp].to_s) : timestamp)

--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -20,7 +20,11 @@ module Events
       event.organization_id = organization.id
       event.code = params[:code]
       event.transaction_id = params[:transaction_id]
-      event.external_subscription_id = params[:external_subscription_id]
+      # external_contract_id is the v2 alias: a catalog org addresses its
+      # agreement by contract id, a legacy org by subscription id. Single-engine
+      # orgs carry one, and the event always stores it under
+      # external_subscription_id; an explicit external_subscription_id wins.
+      event.external_subscription_id = params[:external_subscription_id].presence || params[:external_contract_id]
       event.properties = params[:properties] || {}
       event.metadata = metadata || {}
       event.timestamp = event_timestamp

--- a/spec/requests/api/v1/events_controller_spec.rb
+++ b/spec/requests/api/v1/events_controller_spec.rb
@@ -40,6 +40,47 @@ RSpec.describe Api::V1::EventsController do
       expect { subject }.not_to change(Clickhouse::ApiLog, :count)
     end
 
+    context "when a product-catalog org sends external_contract_id" do
+      let(:organization) { create(:organization, feature_flags: ["product_catalog"]) }
+      let(:contract) { create(:contract, organization:, customer:) }
+      let(:create_params) do
+        {
+          code: metric.code,
+          transaction_id: SecureRandom.uuid,
+          external_contract_id: contract.external_id,
+          timestamp: Time.current.to_i,
+          properties: {foo: "bar"}
+        }
+      end
+
+      it "stores the contract id under external_subscription_id" do
+        expect { subject }.to change(Event, :count).by(1)
+
+        expect(response).to have_http_status(:success)
+        expect(json[:event][:external_subscription_id]).to eq(contract.external_id)
+        expect(Event.order(:created_at).last.external_subscription_id).to eq(contract.external_id)
+      end
+    end
+
+    context "when both external_subscription_id and external_contract_id are sent" do
+      let(:create_params) do
+        {
+          code: metric.code,
+          transaction_id: SecureRandom.uuid,
+          external_subscription_id: subscription.external_id,
+          external_contract_id: "ignored-contract-id",
+          timestamp: Time.current.to_i,
+          properties: {foo: "bar"}
+        }
+      end
+
+      it "keeps the explicit external_subscription_id" do
+        subject
+
+        expect(json[:event][:external_subscription_id]).to eq(subscription.external_id)
+      end
+    end
+
     context "with duplicated transaction_id" do
       let!(:event) { create(:event, organization:, external_subscription_id: subscription.external_id) }
 
@@ -156,6 +197,29 @@ RSpec.describe Api::V1::EventsController do
 
       expect(response).to have_http_status(:ok)
       expect(json[:events].first[:external_subscription_id]).to eq(subscription.external_id)
+    end
+
+    context "when a product-catalog org sends external_contract_id" do
+      let(:organization) { create(:organization, feature_flags: ["product_catalog"]) }
+      let(:contract) { create(:contract, organization:, customer:) }
+      let(:batch_params) do
+        [
+          {
+            code: metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_contract_id: contract.external_id,
+            timestamp: Time.current.to_i,
+            properties: {foo: "bar"}
+          }
+        ]
+      end
+
+      it "stores the contract id under external_subscription_id" do
+        expect { subject }.to change(Event, :count).by(1)
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:events].first[:external_subscription_id]).to eq(contract.external_id)
+      end
     end
 
     context "with invalid timestamp for one event" do


### PR DESCRIPTION
## What
Events ingestion now accepts **`external_contract_id`** as an alias for `external_subscription_id` on the event **create**, **batch**, and **index-filter** surfaces (and the estimate variants that share those params).

It's a pure alias — the event stores a single external agreement id under `external_subscription_id` (never dropped, never renamed). Single-engine orgs carry exactly one id, so a catalog org sends `external_contract_id` and a legacy org `external_subscription_id`; if both are sent, the explicit `external_subscription_id` wins.

Normalisation happens once at the **controller param layer** (`normalize_agreement_id`), so `Events::CreateService`, `CreateBatchService`, and the estimate services are untouched.
