### PR TITLE
perf(usage): cut per-fee tax lookups and scope the alert existence check

### DIFF
--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -183,6 +183,15 @@ module Invoices
       invoice.fees_amount_cents = invoice.fees.sum(&:amount_cents)
       plan = subscription.plan
 
+      # NOTE: Fees::ApplyTaxesService falls back to plan.taxes then customer.taxes for
+      #       every fee. `.any?` on an unloaded association issues a fresh EXISTS query
+      #       and never caches, so the loop below cost 2 round-trips per fee. Both
+      #       associations are invoice-level constants here — load them once.
+      #       This path already fans out over charges x charge filters, so the fee count
+      #       is where the round-trips multiply.
+      plan.taxes.load
+      customer.taxes.load
+
       invoice.fees.each do |fee|
         taxes_result = Fees::ApplyTaxesService.call(fee:, customer:, plan:)
         taxes_result.raise_if_error!

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -75,7 +75,12 @@ module Invoices
         .plan
         .charges
         .joins(:billable_metric)
-        .includes(:taxes, :applied_pricing_unit, billable_metric: :organization, filters: {values: :billable_metric_filter})
+        # NOTE: :plan looks redundant next to subscription.plan.charges, but the charges come back
+        #       as fresh records with an unloaded belongs_to. Fees::ChargeService resolves the fee
+        #       currency through charge.plan.amount (Sources::Charge#currency and
+        #       ChargeModels::PricingStructure.from_charge), which fired one SELECT on plans per
+        #       charge — 62 of the 500 queries in a sampled cached current_usage request.
+        .includes(:plan, :taxes, :applied_pricing_unit, billable_metric: :organization, filters: {values: :billable_metric_filter})
       if usage_filters.filter_by_charge_id.present?
         charges = charges.where(id: usage_filters.filter_by_charge_id)
       elsif usage_filters.filter_by_charge_code.present?

--- a/app/services/usage_monitoring/track_subscription_activity_service.rb
+++ b/app/services/usage_monitoring/track_subscription_activity_service.rb
@@ -45,7 +45,11 @@ module UsageMonitoring
     end
 
     def has_alerts?
-      Alert.where(subscription_external_id: subscription.external_id).any?
+      # NOTE: subscription_external_id is only unique within an organization, so an
+      #       unscoped lookup both scans every organization's alerts and can match a
+      #       different tenant's row. ProcessSubscriptionActivityService already scopes
+      #       the equivalent query by organization_id.
+      Alert.where(organization_id: organization.id, subscription_external_id: subscription.external_id).any?
     end
   end
 end

--- a/spec/services/usage_monitoring/track_subscription_activity_service_spec.rb
+++ b/spec/services/usage_monitoring/track_subscription_activity_service_spec.rb
@@ -31,6 +31,32 @@ RSpec.describe UsageMonitoring::TrackSubscriptionActivityService, :premium do
     end
   end
 
+  context "when the subscription has an alert" do
+    let(:organization) { create(:organization, premium_integrations: %w[salesforce]) }
+
+    it "tracks activity" do
+      create(:alert, organization:, subscription_external_id: subscription.external_id)
+      expect { subject.call }.to change { organization.subscription_activities.count }.by(1)
+    end
+  end
+
+  context "when another organization has an alert on the same external id" do
+    let(:organization) { create(:organization, premium_integrations: %w[salesforce]) }
+    let(:other_organization) { create(:organization) }
+
+    it "does not track activity" do
+      create(
+        :alert,
+        organization: other_organization,
+        subscription_external_id: subscription.external_id
+      )
+
+      subject.call
+
+      expect(organization.subscription_activities.count).to eq(0)
+    end
+  end
+
   context "when organization does use any integration with subscription tracking" do
     let(:organization) { create(:organization, premium_integrations: %w[salesforce]) }
 


### PR DESCRIPTION
## Context

Proposed fix coming out of the investigation into the **prod-eu-1 API latency regression** (Sep 2026): `estimate_fees` went from 0.3s to tens of seconds, plan updates started timing out.

The database is **not** the bottleneck. On `lago-production-eu` across the whole regression window: CPU 10-20%, read latency 0.6 ms, connections flat at ~900, no RDS Proxy in the path. Yet ~98% of the wall time of slow (>10s) `lago-api` requests is the Rails `db` field.

It is round-trip **count**, not query cost. From Tempo on prod-eu-1:

| Trace | Wall time | Spans |
|---|---|---|
| `GET /api/v1/fees` | 27.5 s | ~1000 |
| `GET /api/v1/customers/:id/current_usage` | 11.3 s | 515 |
| `dedicated_wallets` job | 10-18 s | 6,000-9,400 |
| `dedicated_alerts` job | 10-12 s | 3,100-3,200 |

Every individual query is sub-millisecond. A thousand of them serially is 27 seconds. What tipped it over was volume: `api/v1/wallets#update` went from 2-12 rps through August to 43-49 rps from Sep 7, and `customers/usage#current` from 7-35 to 52-63 rps. The fan-out is multiplicative, so Rails workers fill with round-trip waiting, Envoy in-flight requests go 10-20 → 55-65, and every tenant queues behind it — including low-volume endpoints like `estimate_fees`, which runs at ~0 rps and is purely a victim.

## What this PR changes

Two contributors, both cheap to remove. Neither is the whole fix.

### 1. Per-fee tax lookups in `Invoices::CustomerUsageService#compute_amounts`

`Fees::ApplyTaxesService` is called once per fee, and `applicable_taxes` falls back to `plan.taxes` then `customer.taxes`. `.any?` on an **unloaded** association issues a fresh `EXISTS` query every call and never caches the result — so the loop cost two round-trips per fee, on a path that has already fanned out over charges × charge filters.

Both are invoice-level constants here, so they are loaded once before the loop.

Measured on prod-eu-1 over 25 minutes: **27,877 queries against `taxes`** for 13,531 `current_usage` requests, plus 9,826 against `charges_taxes`.

### 2. Unscoped alert lookup in `UsageMonitoring::TrackSubscriptionActivityService#has_alerts?`

```ruby
Alert.where(subscription_external_id: subscription.external_id).any?
```

`subscription_external_id` is only unique within an organization. This scanned every tenant's alerts on every event post-process, and could match a **different** organization's row — creating a `SubscriptionActivity` for an organization that has no alerts, which then schedules a full `CustomerUsageService` run.

`ProcessSubscriptionActivityService` already scopes the equivalent query by `organization_id`; this aligns with it. Spec added for the cross-organization case.

## What this PR does *not* fix

The structural part, which needs a design decision rather than a patch:

- **`Customers::RefreshWalletsService#subscription_usages`** recomputes full usage for **every active subscription** on every wallet refresh — and that refresh is triggered by `Wallets::UpdateService` (`needs_refresh?` → `Customers::RefreshWalletJob`) and by every `Wallets::Balance::{Increase,Decrease,UpdateOngoing}Service`. This is the 6,000-9,400-span job. Note this loop predates the July cascade change (#5825); `git show acb56725e^` shows it already there.
- **`Fees::ChargeService#init_metered_items_fees`** creates one fee — and one aggregation — per charge filter, per charge, per subscription.
- **`UsageMonitoring::ProcessSubscriptionActivityService#current_usage`** reaches the same `CustomerUsageService` from the alerts path, which is being fed ~20 alert create/destroy calls per second on this cluster.

## Testing

Ruby syntax checked; **the suite was not run locally** (no Postgres and a Ruby version mismatch on this machine). Relying on CI. The tax change is behaviour-preserving by construction — `.load.any?` and `.any?` return the same thing; only the query count differs. The alert change is an intentional behaviour change, covered by the new spec.

## Tracking

Grafana dashboard for the regression: `eu-api-latency-regression` (Lago folder) — https://getlago.grafana.net/d/eu-api-latency-regression?from=now-30d&to=now
