### PR TITLE
fix(plans): scope draft invoice refresh

### DIFF
--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -81,7 +81,7 @@ module Plans
 
       cascade_subscription_fee_update(old_amount_cents)
 
-      plan.invoices.draft.update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
+      flag_draft_invoices_for_refresh
 
       SendWebhookJob.perform_after_commit("plan.updated", plan) if send_webhook
       result.plan = plan.reload
@@ -97,6 +97,32 @@ module Plans
     attr_reader :plan, :params, :timestamp, :partial_metadata, :send_webhook
 
     delegate :organization, to: :plan
+
+    def flag_draft_invoices_for_refresh
+      matching_subscription_join = ActiveRecord::Base.sanitize_sql_array([
+        <<~SQL.squish,
+          CROSS JOIN LATERAL (
+            SELECT 1
+            FROM invoice_subscriptions
+            INNER JOIN subscriptions
+              ON subscriptions.id = invoice_subscriptions.subscription_id
+            WHERE invoice_subscriptions.invoice_id = invoices.id
+              AND subscriptions.plan_id = :plan_id
+            LIMIT 1
+          ) matching_subscription
+        SQL
+        {plan_id: plan.id}
+      ])
+
+      # Check subscriptions only for the organization's draft invoices.
+      # LIMIT 1 keeps the lateral lookup dependent on each candidate invoice.
+      invoice_ids = organization.invoices.draft
+        .joins(matching_subscription_join)
+        .select(:id)
+
+      Invoice.where(id: invoice_ids)
+        .update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
+    end
 
     def update_metadata!
       return unless params.key?(:metadata)

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -193,12 +193,65 @@ RSpec.describe Plans::UpdateService do
       end
     end
 
-    it "marks invoices as ready to be refreshed" do
-      subscription = create(:subscription, organization:, plan:)
-      invoice = create(:invoice, :draft)
-      create(:invoice_subscription, invoice:, subscription:)
+    context "when marking draft invoices for refresh" do
+      let(:update_args) { {name: plan_name} }
+      let(:customer) { create(:customer, organization:) }
+      let(:subscription) { create(:subscription, organization:, plan:, customer:) }
+      let(:invoice) { create(:invoice, :draft, customer:) }
 
-      expect { plans_service.call }.to change { invoice.reload.ready_to_be_refreshed }.to(true)
+      before do
+        create(:invoice_subscription, organization:, invoice:, subscription:)
+      end
+
+      it "marks the plan's draft invoices as ready to be refreshed" do
+        expect { plans_service.call }.to change { invoice.reload.ready_to_be_refreshed }.to(true)
+      end
+
+      it "marks consolidated invoices shared with other subscriptions" do
+        other_plan = create(:plan, organization:)
+        other_subscription = create(:subscription, organization:, customer:, plan: other_plan)
+        same_plan_subscription = create(:subscription, organization:, customer:, plan:)
+        create(:invoice_subscription, organization:, invoice:, subscription: other_subscription)
+        create(:invoice_subscription, organization:, invoice:, subscription: same_plan_subscription)
+
+        expect { plans_service.call }.to change { invoice.reload.ready_to_be_refreshed }.to(true)
+      end
+
+      context "when the subscription is terminated" do
+        let(:subscription) { create(:subscription, :terminated, organization:, plan:, customer:) }
+
+        it "still marks its draft invoices as ready to be refreshed" do
+          expect { plans_service.call }.to change { invoice.reload.ready_to_be_refreshed }.to(true)
+        end
+      end
+
+      context "when the invoice is finalized" do
+        let(:invoice) { create(:invoice, customer:, status: :finalized) }
+
+        it "updates the plan without marking the invoice for refresh" do
+          expect(plans_service.call).to be_success
+          expect(invoice.reload.ready_to_be_refreshed).to be(false)
+        end
+      end
+
+      context "when the invoice belongs to another plan" do
+        let(:other_plan) { create(:plan, organization:) }
+        let(:subscription) { create(:subscription, organization:, customer:, plan: other_plan) }
+
+        it "does not mark the invoice for refresh" do
+          expect(plans_service.call).to be_success
+          expect(invoice.reload.ready_to_be_refreshed).to be(false)
+        end
+      end
+
+      context "when an invoice from another organization is linked to the subscription" do
+        let(:invoice) { create(:invoice, :draft) }
+
+        it "does not mark the other organization's invoice for refresh" do
+          expect(plans_service.call).to be_success
+          expect(invoice.reload.ready_to_be_refreshed).to be(false)
+        end
+      end
     end
 
     context "with activity logs" do


### PR DESCRIPTION
## Summary

Plan updates synchronously mark associated draft invoices for refresh. The previous query could scan large amounts of invoice history even when no draft invoices matched.

Start from the organization’s draft invoices and use `CROSS JOIN LATERAL ... LIMIT 1` to check for a subscription on the updated plan. This avoids unnecessary subscription lookups when there are no drafts.

## Benchmark results

Median UPDATE execution time across four runs per version:

| Matching drafts | Drafts on other plans | Previous | Revised | Speedup |
|---:|---:|---:|---:|---:|
| 0 | 0 | 10.90 s | 2.28 ms | ~4,776× |
| 100 | 0 | 10.64 s | 95 ms | ~111× |
| 10,000 | 0 | 14.64 s | 1.43 s | ~10.3× |
| 0 | 400,000 | 10.43 s | 1.17 s | ~8.9× |
| 100 | 400,000 | 11.18 s | 1.27 s | ~8.8× |
| 400,000 | 400,000 | Timeout, 4/4 runs | Timeout, 4/4 runs | Unknown |

## Test protocol

Created an isolated benchmark organization in a local database containing approximately 24 million existing invoices. Seeded 800,000 additional invoices and invoice-subscription links, split between two plans with 40,000 subscriptions each.

For each draft distribution, verified identical target invoice IDs, then measured both actual UPDATE statements using `EXPLAIN (ANALYZE, BUFFERS, WAL, TIMING OFF)`. Ran four rounds with alternating execution order and rolled back to a savepoint between measurements to restore the same starting data. All fixture changes were rolled back afterward.

These are local measurements; cache state and physical effects of previous writes are not reset by rollback. Both versions still exceed the 60-second limit when updating 400,000 invoices.

## Validation

- Six focused specs pass, covering draft refresh, consolidated invoices, terminated subscriptions, finalized invoices, unrelated plans, and organization isolation.
- RuboCop passes.
