### PR TITLE
perf(usage): skip last_seen_at without lazy cache

### DIFF
--- a/app/services/events/post_process_service.rb
+++ b/app/services/events/post_process_service.rb
@@ -82,7 +82,7 @@ module Events
     end
 
     def expire_cached_charges
-      return if organization.feature_flag_enabled?(:lazy_charge_usage_cache)
+      return if Subscriptions::ChargeCacheService.lazy_validation_enabled?(organization)
       return if active_subscription.nil?
       return unless billable_metric
 

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -266,8 +266,14 @@ module Invoices
         subscription:,
         boundaries:,
         codes: filtered_metric_codes,
-        with_last_seen_at: charge_cache_enabled?
+        with_last_seen_at: last_seen_at_needed?
       )
+    end
+
+    # MAX(enriched_at) is the widest aggregate of the combinations query, so it is only worth
+    # computing when an entry will be written *and* lazily validated against it.
+    def last_seen_at_needed?
+      charge_cache_enabled? && Subscriptions::ChargeCacheService.lazy_validation_enabled?(organization)
     end
 
     # nil when every charge of the plan is computed, so the whole plan is looked up as before.
@@ -277,9 +283,10 @@ module Invoices
       charges.except(:includes).joins(:billable_metric).distinct.pluck("billable_metrics.code")
     end
 
-    # Single gate for the charge cache: it drives both the middleware passed to Fees::ChargeService
-    # and whether the ingestion timestamps are requested. The two must never diverge, because a nil
-    # timestamp written into a live cache stays valid forever (see Events::BillingPeriodFilterService).
+    # Single gate for the charge cache: it drives the middleware passed to Fees::ChargeService, and
+    # #last_seen_at_needed? narrows it for the ingestion timestamps. Neither may be looser than the
+    # other, because a reader that skips the timestamps accepts any lazily validated entry until it
+    # expires (CacheService#valid_cache?).
     # Usage filtered by group is never cached, as its fees are a subset of the charge fees.
     def charge_cache_enabled?
       with_cache &&
@@ -290,7 +297,7 @@ module Invoices
     # Full usage is cached only with lazy validation, the one invalidation that clears its key.
     def full_usage_cache_enabled?
       organization.granular_lifetime_usage_enabled? &&
-        organization.feature_flag_enabled?(:lazy_charge_usage_cache) &&
+        Subscriptions::ChargeCacheService.lazy_validation_enabled?(organization) &&
         !usage_filters.skip_grouping &&
         usage_filters.filter_by_presentation.nil?
     end

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -200,7 +200,11 @@ module Invoices
       # resolved: without it every configured filter is aggregated and the default bucket excludes
       # all of them inline, making the query grow with the pricing configuration until the store
       # rejects it.
-      charge_filters = Events::BillingPeriodFilterService.for_charges!(subscription:, boundaries:).filter_targets
+      charge_filters = Events::BillingPeriodFilterService.for_charges!(
+        subscription:,
+        boundaries:,
+        with_last_seen_at: Subscriptions::ChargeCacheService.lazy_validation_enabled?(subscription.organization)
+      ).filter_targets
 
       invoice.fees << Parallel.flat_map(charges, in_threads: ENV["LAGO_PARALLEL_THREADS_COUNT"]&.to_i || 0) do |charge|
         OpenTelemetry::Context.with_current(context) do

--- a/app/services/subscriptions/charge_cache_service.rb
+++ b/app/services/subscriptions/charge_cache_service.rb
@@ -12,6 +12,14 @@ module Subscriptions
     # windows can coincide, but started_at is editable, so they never share an entry.
     FULL_USAGE_KEY_SEGMENT = "full-usage"
 
+    # Lazy validation is the only consumer of the ingestion watermark: without it
+    # invalidate_if_older_than is never read, so callers can skip computing the watermark. A caller
+    # that writes to this cache must ask here before skipping it, because CacheService#valid_cache?
+    # accepts any entry when the reader has no watermark to compare against.
+    def self.lazy_validation_enabled?(organization)
+      organization.feature_flag_enabled?(:lazy_charge_usage_cache)
+    end
+
     def self.expire_for_subscriptions(subscription_ids)
       Subscription
         .where(id: subscription_ids)
@@ -82,7 +90,7 @@ module Subscriptions
     def lazy_validation?
       return @lazy_validation if defined?(@lazy_validation)
 
-      @lazy_validation = subscription.organization.feature_flag_enabled?(:lazy_charge_usage_cache)
+      @lazy_validation = self.class.lazy_validation_enabled?(subscription.organization)
     end
   end
 end

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -809,10 +809,12 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
       end
     end
 
-    # The charge cache is lazily invalidated with the ingestion timestamps requested by
-    # Events::BillingPeriodFilterService, so a cached charge must always have asked for them:
-    # an entry stored without a timestamp stays valid for the rest of the billing period, for
-    # every later reader. Each example asserts both halves so they cannot drift apart.
+    # A lazily validated charge cache is invalidated with the ingestion timestamps requested by
+    # Events::BillingPeriodFilterService, so such an entry must always have asked for them: one
+    # stored without a timestamp stays valid for the rest of the billing period, for every later
+    # reader. Without the flag the cache is expired eagerly on event reception instead
+    # (Events::PostProcessService) and the timestamps are dead weight, so they are not requested.
+    # Each example asserts both halves so they cannot drift apart.
     describe "charge cache gate" do
       let(:charge_cache_key) do
         [
@@ -831,10 +833,37 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
           described_class.new(customer:, subscription:, apply_taxes: false, with_cache: true)
         end
 
-        it "caches the charge and requests the ingestion timestamps" do
+        it "caches the charge and skips the ingestion timestamps" do
           expect { usage_service.call }.to change { Rails.cache.exist?(charge_cache_key) }.from(false).to(true)
           expect(Events::BillingPeriodFilterService).to have_received(:for_charges!)
-            .with(hash_including(codes: nil, with_last_seen_at: true))
+            .with(hash_including(codes: nil, with_last_seen_at: false))
+        end
+
+        context "when the cache is lazily validated" do
+          # created_at predates the aggregation: CacheService refuses to store a value whose
+          # watermark is younger than SETTLE_WINDOW.
+          let(:events) do
+            create_list(:event, 2, organization:, subscription:, customer:,
+              code: billable_metric.code, timestamp:, created_at: 1.hour.ago)
+          end
+
+          let(:charge_cache_key) do
+            [
+              "charge-usage",
+              Subscriptions::ChargeCacheService::LAZY_CACHE_KEY_VERSION,
+              charge.id,
+              subscription.id,
+              charge.updated_at.iso8601
+            ].join("/")
+          end
+
+          before { organization.enable_feature_flag!(:lazy_charge_usage_cache) }
+
+          it "caches the charge and requests the ingestion timestamps" do
+            expect { usage_service.call }.to change { Rails.cache.exist?(charge_cache_key) }.from(false).to(true)
+            expect(Events::BillingPeriodFilterService).to have_received(:for_charges!)
+              .with(hash_including(codes: nil, with_last_seen_at: true))
+          end
         end
       end
 
@@ -849,10 +878,10 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
           )
         end
 
-        it "restricts the lookup to the filtered codes and keeps the timestamps" do
+        it "restricts the lookup to the filtered codes" do
           expect { usage_service.call }.to change { Rails.cache.exist?(charge_cache_key) }.from(false).to(true)
           expect(Events::BillingPeriodFilterService).to have_received(:for_charges!)
-            .with(hash_including(codes: [billable_metric.code], with_last_seen_at: true))
+            .with(hash_including(codes: [billable_metric.code], with_last_seen_at: false))
         end
       end
 

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -485,6 +485,31 @@ RSpec.describe Invoices::PreviewService, cache: :memory do
               expect(Events::BillingPeriodFilterService).to have_received(:for_charges!)
             end
 
+            # The preview middleware caches by default and shares its keys with CustomerUsageService,
+            # and a reader without a watermark accepts any lazily validated entry, so the timestamps
+            # must be requested whenever the entry it writes will be validated against them.
+            it "skips the ingestion timestamps", transaction: false do
+              allow(Events::BillingPeriodFilterService).to receive(:for_charges!).and_call_original
+
+              travel_to(timestamp) { preview_service.call }
+
+              expect(Events::BillingPeriodFilterService).to have_received(:for_charges!)
+                .with(hash_including(with_last_seen_at: false))
+            end
+
+            context "when the cache is lazily validated" do
+              before { organization.enable_feature_flag!(:lazy_charge_usage_cache) }
+
+              it "requests the ingestion timestamps", transaction: false do
+                allow(Events::BillingPeriodFilterService).to receive(:for_charges!).and_call_original
+
+                travel_to(timestamp) { preview_service.call }
+
+                expect(Events::BillingPeriodFilterService).to have_received(:for_charges!)
+                  .with(hash_including(with_last_seen_at: true))
+              end
+            end
+
             context "with charge filters" do
               let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: "count_agg") }
 


### PR DESCRIPTION
## Context

The charge usage cache is invalidated in one of two ways. With `lazy_charge_usage_cache` enabled, an entry keeps the ingestion watermark it aggregated and is validated at read time against the most recent event. Without the flag, the entry is expired when the event is received and the watermark is never read.

That watermark is the `MAX(enriched_at)` aggregate of the billing period filter query, so requesting it reads the column for every event matching the subscription and the metric.

## Description

- Gate the watermark on lazy validation rather than on the charge cache alone, so organizations relying on eager expiration stop requesting it.
- Add `ChargeCacheService.lazy_validation_enabled?` as the single predicate, shared by the full usage gate and by the eager expiration that is its complement.
- Request the watermark in the invoice preview under that same condition, where it was previously always asked for.
- Cover both gates in the customer usage and preview specs, which previously asserted the watermark was always requested.

Measured against a week of production query logs, `enriched_at` is roughly five percent of what this query reads, so this is cleanup rather than a material reduction in cluster pressure. The bulk is the `properties` map, untouched here.
