### PR TITLE
fix(usage): minimize ignored charge filters [ING-637]

### DIFF
--- a/app/services/events/billing_period_filters/matching_and_ignored_service.rb
+++ b/app/services/events/billing_period_filters/matching_and_ignored_service.rb
@@ -21,7 +21,7 @@ module Events
           end
         end
 
-        result.ignored_filters = children.map do |child_filter|
+        ignored_filters = children.map do |child_filter|
           child = target_filter.filter_values(child_filter).dup
 
           if child.keys.sort == result.matching_filters.keys.sort
@@ -38,6 +38,8 @@ module Events
 
           child
         end.compact
+
+        result.ignored_filters = MinimizeIgnoredFiltersService.call(ignored_filters:).ignored_filters
 
         result
       end

--- a/app/services/events/billing_period_filters/minimize_ignored_filters_service.rb
+++ b/app/services/events/billing_period_filters/minimize_ignored_filters_service.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+module Events
+  module BillingPeriodFilters
+    # Rewrites the ignored filters into an equivalent, much smaller, list of clauses.
+    #
+    # An ignored filter is a conjunction of `key IN (values)` conditions, and the event stores
+    # render the whole list as `NOT (clause_1 OR clause_2 OR ...)`. On charges holding thousands
+    # of filters, the default filter ignores every sibling and the SQL grows past the ClickHouse
+    # `max_query_size` limit, which makes the aggregation fail.
+    #
+    # Merging can turn two clauses into one covering a third, and dropping a clause can bring the
+    # two remaining ones down to a single key, so the rewrites are applied until the list stops
+    # shrinking. None of them changes the set of matched events.
+    class MinimizeIgnoredFiltersService < BaseService
+      Result = BaseResult[:ignored_filters]
+
+      def initialize(ignored_filters:)
+        @ignored_filters = ignored_filters
+        super
+      end
+
+      def call
+        filters = factorize(normalized_filters)
+
+        loop do
+          reduced = factorize(absorb(filters))
+          break if reduced == filters
+
+          filters = reduced
+        end
+
+        result.ignored_filters = filters
+        result
+      end
+
+      private
+
+      attr_reader :ignored_filters
+
+      # Mirrors what the stores already skip when rendering the SQL: a key without values, and
+      # a clause left without any key. Dropping them here changes the list, not the query.
+      def normalized_filters
+        ignored_filters.filter_map do |filter|
+          filter.filter_map { |key, values| [key, values.uniq] if values.present? }.to_h.presence
+        end
+      end
+
+      # `(a = 1 AND b = 2) OR (a = 1 AND b = 3)` is rewritten as `a = 1 AND b IN (2, 3)`.
+      def factorize(filters)
+        filters.group_by { |filter| filter.keys.sort }.flat_map do |keys, group|
+          keys.reduce(group) { |merged, pivot| merge_on(merged, pivot) }
+        end
+      end
+
+      def merge_on(filters, pivot)
+        return filters if filters.size < 2
+
+        filters.group_by { |filter| comparable(filter.except(pivot)) }.map do |_, group|
+          if group.size == 1
+            group.first
+          else
+            group.first.merge(pivot => group.flat_map { it[pivot] }.uniq)
+          end
+        end
+      end
+
+      # Comparing every pair is quadratic, which does not scale on the charges this service
+      # exists for, so clauses are indexed by the values they allow on a pivot key.
+      def absorb(filters)
+        clauses = filters.each_with_index.to_a
+        index = index_by_pivot_value(clauses)
+
+        clauses.reject do |filter, position|
+          candidates(index, filter).any? do |other, other_position|
+            next false if other_position == position
+            next false unless covers?(other, filter)
+
+            # Equivalent clauses cover each other, only the first occurrence is kept.
+            other_position < position || !covers?(filter, other)
+          end
+        end.map(&:first)
+      end
+
+      def index_by_pivot_value(clauses)
+        clauses.group_by { |filter, _| filter.keys.sort }.to_h do |signature, group|
+          pivot = pivot_key(signature, group)
+          buckets = {}
+
+          group.each do |clause|
+            clause.first[pivot].each { (buckets[it] ||= []) << clause }
+          end
+
+          [signature, [pivot, buckets]]
+        end
+      end
+
+      # The more distinct values a key holds, the smaller the buckets it produces.
+      def pivot_key(signature, group)
+        signature.max_by { |key| group.flat_map { |filter, _| filter[key] }.uniq.size }
+      end
+
+      # A covering clause has to allow every value this one allows, so one of them is enough
+      # to narrow the search.
+      def candidates(index, filter)
+        keys = filter.keys
+
+        index.filter_map do |signature, (pivot, buckets)|
+          buckets[filter[pivot].first] if (signature - keys).empty?
+        end.flatten(1)
+      end
+
+      # `covered` only matches events already matched by `covering` when `covering` constrains a
+      # subset of the keys, and allows every value `covered` allows on those keys.
+      def covers?(covering, covered)
+        covering.all? do |key, values|
+          covered.key?(key) && (covered[key] - values).empty?
+        end
+      end
+
+      def comparable(filter)
+        filter.transform_values(&:sort).sort.to_h
+      end
+    end
+  end
+end

--- a/spec/services/events/billing_period_filters/matching_and_ignored_service_spec.rb
+++ b/spec/services/events/billing_period_filters/matching_and_ignored_service_spec.rb
@@ -69,12 +69,9 @@ RSpec.describe Events::BillingPeriodFilters::MatchingAndIgnoredService do
       context "when selecting f3" do
         let(:current_filter) { f3 }
 
-        it "expands all configured values on both keys and keeps explicit children" do
+        it "expands all configured values on both keys and keeps the most generic child" do
           expect(service_result.matching_filters).to eq({"size" => %w[512 1024], "steps" => %w[25 50 75 100]})
-          expect(service_result.ignored_filters).to eq([
-            {"model" => ["llama-2"], "size" => ["512"], "steps" => ["25"]},
-            {"size" => ["512"], "steps" => ["25"]}
-          ])
+          expect(service_result.ignored_filters).to eq([{"size" => ["512"], "steps" => ["25"]}])
         end
       end
 
@@ -84,8 +81,6 @@ RSpec.describe Events::BillingPeriodFilters::MatchingAndIgnoredService do
         it "expands all configured values and ignores all more specific filters" do
           expect(service_result.matching_filters).to eq({"size" => %w[512 1024]})
           expect(service_result.ignored_filters).to eq([
-            {"model" => ["llama-2"], "size" => ["512"], "steps" => ["25"]},
-            {"size" => ["512"], "steps" => ["25"]},
             {"size" => %w[512 1024], "steps" => %w[25 50 75 100]},
             {"size" => ["512"]}
           ])
@@ -98,8 +93,6 @@ RSpec.describe Events::BillingPeriodFilters::MatchingAndIgnoredService do
         it "keeps different-key children and subtracts its value from the all-values sibling" do
           expect(service_result.matching_filters).to eq({"size" => ["512"]})
           expect(service_result.ignored_filters).to eq([
-            {"model" => ["llama-2"], "size" => ["512"], "steps" => ["25"]},
-            {"size" => ["512"], "steps" => ["25"]},
             {"size" => %w[512 1024], "steps" => %w[25 50 75 100]},
             {"size" => ["1024"]}
           ])
@@ -156,9 +149,13 @@ RSpec.describe Events::BillingPeriodFilters::MatchingAndIgnoredService do
       context "when selecting the newer empty filter" do
         let(:current_filter) { empty_b }
 
-        it "keeps the older empty duplicate and the explicit-valued child" do
+        it "drops the older empty duplicate, which excludes nothing, and keeps the explicit-valued child" do
+          allow(Events::BillingPeriodFilters::MinimizeIgnoredFiltersService).to receive(:call).and_call_original
+
           expect(service_result.matching_filters).to eq({})
-          expect(service_result.ignored_filters).to eq([{}, {"size" => ["512"]}])
+          expect(service_result.ignored_filters).to eq([{"size" => ["512"]}])
+          expect(Events::BillingPeriodFilters::MinimizeIgnoredFiltersService).to have_received(:call)
+            .with(ignored_filters: [{}, {"size" => ["512"]}])
         end
       end
 
@@ -193,12 +190,9 @@ RSpec.describe Events::BillingPeriodFilters::MatchingAndIgnoredService do
           create_filter_values(different_key_child, steps_filter, ["25"])
         end
 
-        it "keeps both the same-key subset and different-key child intact" do
+        it "drops the different-key child already covered by the same-key subset" do
           expect(service_result.matching_filters).to match({"size" => match_array(%w[512 1024])})
-          expect(service_result.ignored_filters).to eq([
-            {"size" => ["512"]},
-            {"size" => ["512"], "steps" => ["25"]}
-          ])
+          expect(service_result.ignored_filters).to eq([{"size" => ["512"]}])
         end
       end
     end
@@ -231,9 +225,9 @@ RSpec.describe Events::BillingPeriodFilters::MatchingAndIgnoredService do
         create_filter_values(mixed_child, steps_filter, %w[25 75])
       end
 
-      it "subtracts matching values from the non-subset child" do
+      it "subtracts matching values from the non-subset child and drops the emptied key" do
         expect(service_result.matching_filters).to match({"size" => match_array(%w[512 1024]), "steps" => match_array(%w[25 50])})
-        expect(service_result.ignored_filters).to eq([{"size" => [], "steps" => ["75"]}])
+        expect(service_result.ignored_filters).to eq([{"steps" => ["75"]}])
       end
     end
 
@@ -270,12 +264,17 @@ RSpec.describe Events::BillingPeriodFilters::MatchingAndIgnoredService do
       context "when selecting the newest duplicate" do
         let(:current_filter) { filter_c }
 
-        it "keeps both older siblings verbatim" do
+        it "keeps a single clause for both identical older siblings" do
+          allow(Events::BillingPeriodFilters::MinimizeIgnoredFiltersService).to receive(:call).and_call_original
+
           expect(service_result.matching_filters).to eq({"size" => ["512"], "steps" => ["25"]})
-          expect(service_result.ignored_filters).to eq([
-            {"size" => ["512"], "steps" => ["25"]},
-            {"size" => ["512"], "steps" => ["25"]}
-          ])
+          expect(service_result.ignored_filters).to eq([{"size" => ["512"], "steps" => ["25"]}])
+          expect(Events::BillingPeriodFilters::MinimizeIgnoredFiltersService).to have_received(:call).with(
+            ignored_filters: [
+              {"size" => ["512"], "steps" => ["25"]},
+              {"size" => ["512"], "steps" => ["25"]}
+            ]
+          )
         end
       end
     end

--- a/spec/services/events/billing_period_filters/minimize_ignored_filters_service_spec.rb
+++ b/spec/services/events/billing_period_filters/minimize_ignored_filters_service_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::BillingPeriodFilters::MinimizeIgnoredFiltersService do
+  subject(:service_result) { described_class.call(ignored_filters:) }
+
+  context "when there is no ignored filter" do
+    let(:ignored_filters) { [] }
+
+    it "returns an empty list" do
+      expect(service_result.ignored_filters).to eq([])
+    end
+  end
+
+  context "when clauses cannot be reduced" do
+    let(:ignored_filters) { [{"size" => ["512"]}, {"steps" => ["25"]}] }
+
+    it "keeps them untouched" do
+      expect(service_result.ignored_filters).to eq([{"size" => ["512"]}, {"steps" => ["25"]}])
+    end
+  end
+
+  describe "normalization" do
+    context "when a key has no value" do
+      let(:ignored_filters) { [{"size" => [], "steps" => ["75"]}] }
+
+      it "drops the key, as the event stores skip it when building the SQL" do
+        expect(service_result.ignored_filters).to eq([{"steps" => ["75"]}])
+      end
+    end
+
+    context "when a clause has no key left" do
+      let(:ignored_filters) { [{}, {"size" => []}, {"steps" => ["25"]}] }
+
+      it "drops the clause, as it would exclude every event" do
+        expect(service_result.ignored_filters).to eq([{"steps" => ["25"]}])
+      end
+    end
+
+    context "when a key holds duplicated values" do
+      let(:ignored_filters) { [{"size" => %w[512 512 1024]}] }
+
+      it "deduplicates them" do
+        expect(service_result.ignored_filters).to eq([{"size" => %w[512 1024]}])
+      end
+    end
+  end
+
+  describe "absorption" do
+    context "with duplicated clauses" do
+      let(:ignored_filters) { [{"size" => ["512"]}, {"size" => ["512"]}] }
+
+      it "keeps the first occurrence only" do
+        expect(service_result.ignored_filters).to eq([{"size" => ["512"]}])
+      end
+    end
+
+    context "with a clause constraining more keys than another one" do
+      let(:ignored_filters) { [{"size" => ["512"], "steps" => ["25"]}, {"size" => ["512"]}] }
+
+      it "drops the more specific clause" do
+        expect(service_result.ignored_filters).to eq([{"size" => ["512"]}])
+      end
+    end
+
+    context "with a clause allowing more values than another one" do
+      let(:ignored_filters) { [{"size" => ["512"], "steps" => ["25"]}, {"size" => %w[512 1024], "steps" => %w[25 50]}] }
+
+      it "drops the narrower clause" do
+        expect(service_result.ignored_filters).to eq([{"size" => %w[512 1024], "steps" => %w[25 50]}])
+      end
+    end
+
+    context "when clauses only partially overlap" do
+      let(:ignored_filters) { [{"size" => ["512"], "steps" => ["25"]}, {"size" => ["512"], "steps" => ["50"]}] }
+
+      it "keeps both, merged on the differing key" do
+        expect(service_result.ignored_filters).to eq([{"size" => ["512"], "steps" => %w[25 50]}])
+      end
+    end
+  end
+
+  describe "factorization" do
+    context "when clauses differ on a single key" do
+      let(:ignored_filters) do
+        [
+          {"model" => ["llama-2"], "size" => ["512"]},
+          {"model" => ["llama-3"], "size" => ["512"]},
+          {"model" => ["llama-4"], "size" => ["512"]}
+        ]
+      end
+
+      it "merges them into a single clause" do
+        expect(service_result.ignored_filters).to eq([{"model" => %w[llama-2 llama-3 llama-4], "size" => ["512"]}])
+      end
+    end
+
+    context "when clauses differ on several keys" do
+      let(:ignored_filters) do
+        %w[512 1024].flat_map do |size|
+          %w[25 50].map { |steps| {"size" => [size], "steps" => [steps]} }
+        end
+      end
+
+      it "merges the full grid into a single clause" do
+        expect(service_result.ignored_filters).to eq([{"size" => %w[512 1024], "steps" => %w[25 50]}])
+      end
+    end
+
+    context "when clauses do not cover the full grid" do
+      let(:ignored_filters) do
+        [
+          {"size" => ["512"], "steps" => ["25"]},
+          {"size" => ["512"], "steps" => ["50"]},
+          {"size" => ["1024"], "steps" => ["25"]}
+        ]
+      end
+
+      it "merges what it can and keeps the rest" do
+        expect(service_result.ignored_filters).to eq([
+          {"size" => %w[512 1024], "steps" => ["25"]},
+          {"size" => ["512"], "steps" => ["50"]}
+        ])
+      end
+    end
+
+    context "when clauses do not constrain the same keys" do
+      let(:ignored_filters) { [{"size" => ["512"]}, {"steps" => ["25"]}] }
+
+      it "does not merge them" do
+        expect(service_result.ignored_filters).to eq([{"size" => ["512"]}, {"steps" => ["25"]}])
+      end
+    end
+
+    context "when clauses list the same values in a different order" do
+      let(:ignored_filters) do
+        [
+          {"size" => %w[512 1024], "steps" => ["25"]},
+          {"size" => %w[1024 512], "steps" => ["50"]}
+        ]
+      end
+
+      it "still merges them" do
+        expect(service_result.ignored_filters).to eq([{"size" => %w[512 1024], "steps" => %w[25 50]}])
+      end
+    end
+  end
+
+  describe "with a charge holding thousands of filters" do
+    let(:models) { Array.new(160) { "model-#{it}" } }
+    let(:types) { %w[input output cached] }
+    let(:zones) { %w[eu us] }
+
+    # Reproduces the shape that broke the ClickHouse `max_query_size` limit in production:
+    # a filter per model and type, plus one per model, type and zone.
+    let(:ignored_filters) do
+      models.flat_map do |model|
+        types.flat_map do |type|
+          [{"model" => [model], "type" => [type]}] +
+            zones.map { {"model" => [model], "type" => [type], "zone" => [it]} }
+        end
+      end
+    end
+
+    it "reduces the whole set to a single clause" do
+      expect(ignored_filters.size).to eq(1440)
+      expect(service_result.ignored_filters).to eq([{"model" => models, "type" => types}])
+    end
+  end
+end

--- a/spec/services/fees/charge_service/sources/billing_segment_spec.rb
+++ b/spec/services/fees/charge_service/sources/billing_segment_spec.rb
@@ -105,11 +105,7 @@ RSpec.describe Fees::ChargeService::Sources::BillingSegment do
       context "when product_filter is nil" do
         it "excludes all product filters with nil values expanded to configured values" do
           expect(service_result.matching_filters).to eq({})
-          expect(service_result.ignored_filters).to match_array([
-            {"region" => ["us"]},
-            {"region" => ["us"], "size" => ["512"]},
-            {"region" => %w[us eu]}
-          ])
+          expect(service_result.ignored_filters).to eq([{"region" => %w[us eu]}])
         end
 
         it "uses an empty filter only for matching without persisting or selecting it" do
@@ -141,11 +137,7 @@ RSpec.describe Fees::ChargeService::Sources::BillingSegment do
           expect(default_source.properties).to eq(segment_rate_properties)
           expect(default_source).to have_attributes(product_filter: nil, selected_filter: nil)
           expect(result.matching_filters).to eq({})
-          expect(result.ignored_filters).to match_array([
-            {"region" => ["us"]},
-            {"region" => ["us"], "size" => ["512"]},
-            {"region" => %w[us eu]}
-          ])
+          expect(result.ignored_filters).to eq([{"region" => %w[us eu]}])
         end
       end
 
@@ -164,10 +156,7 @@ RSpec.describe Fees::ChargeService::Sources::BillingSegment do
         it "matches all configured values rather than nil or arbitrary values carrying the key" do
           expect(product_filter.to_h).to eq("region" => [nil])
           expect(service_result.matching_filters).to eq("region" => %w[us eu])
-          expect(service_result.ignored_filters).to match_array([
-            {"region" => ["us"]},
-            {"region" => ["us"], "size" => ["512"]}
-          ])
+          expect(service_result.ignored_filters).to eq([{"region" => ["us"]}])
         end
       end
     end


### PR DESCRIPTION
Part of ING-637

## Context

Usage for the default bucket of a charge excludes every event already billed by one of the charge's other filters, one `NOT (... OR ...)` clause per filter with the values inlined as literals. The predicate therefore grows without bound with the number of filters on the charge.

On a charge carrying 2892 filters it reaches ~700 kB, past the 256 kB ClickHouse parses by default, and the aggregation fails with `Max query size exceeded`. Current usage, daily usage and wallet refresh all break for those subscriptions.

## Description

- Rewrite the ignored filters into a smaller list describing the same set of events, in `Events::BillingPeriodFilters::MinimizeIgnoredFiltersService`.
- Drop keys without values, which the event stores already skip when building the SQL.
- Merge clauses differing on a single key by taking the union of that key's values.
- Drop a clause whose events are all matched by another, more generic, one.
- Index clauses by the values they allow on a pivot key, so absorption compares a handful of candidates rather than every pair.

```
charge with 2892 filters, 164 models x 3 types x optional zone and tier

before: 2892 clauses, 698_094 bytes   # over the 262_144 ClickHouse parses
after:      2 clauses,   9_156 bytes
```

Charges whose filters do not overlap are left untouched. This lowers the predicate rather than raising the ClickHouse ceiling, which is worth doing separately.

## Behavior change to be aware of

- Several existing expectations now list fewer ignored filters. Each dropped clause was already covered by another, so the excluded events are unchanged.
