### PR TITLE
fix(events): replay queries ClickHouse cannot parse [ING-638]

### DIFF
--- a/app/services/events/stores/utils/clickhouse_connection.rb
+++ b/app/services/events/stores/utils/clickhouse_connection.rb
@@ -6,41 +6,67 @@ module Events
       class ClickhouseConnection
         MAX_RETRIES = 3
         MEMORY_ERROR_CODE = "MEMORY_LIMIT_EXCEEDED"
+        PARSER_LIMIT_ERRORS = ["Max query size exceeded", "TOO_BIG_AST"].freeze
 
         RETRYABLE_ERRORS = [Errno::ECONNRESET, ActiveRecord::ActiveRecordError, NoMethodError, Net::ReadTimeout]
 
+        # ClickHouse refuses to parse a statement larger than `max_query_size` or expanding to
+        # more than `max_ast_elements` nodes. A charge carrying thousands of filters serializes
+        # into a predicate past both defaults, so the query that hit one of them is replayed with
+        # the limits raised. They travel as request parameters rather than in a `SETTINGS`
+        # clause, as the parser needs the buffer size before it starts reading the statement.
+        QUERY_SETTINGS = {max_query_size: 4_194_304, max_ast_elements: 500_000}.freeze
+
         def self.with_retry(&)
-          attempts = 0
-
-          begin
-            attempts += 1
-
-            yield
-          rescue *RETRYABLE_ERRORS => e
-            raise Events::Stores::Clickhouse::MemoryLimitError, e.message if memory_limit_error?(e)
-
-            if attempts < MAX_RETRIES
-              sleep(0.05)
-              retry
+          with_parser_limit_retry do |settings|
+            if settings.empty?
+              yield
+            else
+              # Leasing the connection makes the settings apply to the relations built inside
+              # the block, which would otherwise check out a connection of their own.
+              ::Clickhouse::BaseRecord.with_connection do |connection|
+                connection.with_settings(**settings) { yield }
+              end
             end
-
-            raise
           end
         end
 
         def self.connection_with_retry(&)
+          with_parser_limit_retry do |settings|
+            ::Clickhouse::BaseRecord.with_connection do |connection|
+              if settings.empty?
+                yield connection
+              else
+                connection.with_settings(**settings) { yield connection }
+              end
+            end
+          end
+        end
+
+        # Queries run at the ClickHouse defaults. Only the one ClickHouse refused to parse is
+        # replayed with the limits raised, and replaying it is what the retry would have done
+        # anyway, identically and to no effect.
+        def self.with_parser_limit_retry
           attempts = 0
+          settings = {}
 
           begin
             attempts += 1
-            ::Clickhouse::BaseRecord.with_connection(&)
+
+            yield settings
           rescue *RETRYABLE_ERRORS => e
             raise Events::Stores::Clickhouse::MemoryLimitError, e.message if memory_limit_error?(e)
+
+            if settings.empty? && parser_limit_error?(e)
+              settings = QUERY_SETTINGS
+              retry
+            end
 
             if attempts < MAX_RETRIES
               sleep(0.05)
               retry
             end
+
             raise
           end
         end
@@ -49,6 +75,12 @@ module Events
           return false unless error.is_a?(ActiveRecord::ActiveRecordError)
 
           error.message.include?(MEMORY_ERROR_CODE)
+        end
+
+        def self.parser_limit_error?(error)
+          return false unless error.is_a?(ActiveRecord::ActiveRecordError)
+
+          PARSER_LIMIT_ERRORS.any? { error.message.include?(it) }
         end
       end
     end

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -361,4 +361,51 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
       end
     end
   end
+
+  # ClickHouse rejects a query before running it when the statement is larger than
+  # `max_query_size` (256 kB) or expands to more than `max_ast_elements` (50 000) nodes.
+  # A charge carrying thousands of filters serializes into a predicate past both limits,
+  # so the rejected query is replayed with them raised.
+  describe "filters larger than the ClickHouse parser defaults" do
+    subject(:event_store) do
+      described_class.new(
+        code: billable_metric.code,
+        billing_context: Billing::Context.from(subscription:),
+        boundaries:,
+        filters: {ignored_filters:},
+        deduplicate: true
+      )
+    end
+
+    let(:billable_metric) { create(:sum_billable_metric, field_name: "value", code: "bm:code") }
+    let(:organization) { billable_metric.organization }
+    let(:customer) { create(:customer, organization:) }
+    let(:subscription) { create(:subscription, customer:, started_at: DateTime.parse("2023-03-15")) }
+    let(:boundaries) do
+      {
+        from_datetime: subscription.started_at.beginning_of_day,
+        to_datetime: subscription.started_at.end_of_month.end_of_day,
+        charges_duration: 31
+      }
+    end
+    let(:ignored_filters) do
+      Array.new(2_000) do |index|
+        {"model" => ["model-#{index}"], "type" => ["type-#{index}"], "zone" => ["zone-#{index}"]}
+      end
+    end
+
+    before do
+      create_event(timestamp: DateTime.parse("2023-03-16"), value: 10, properties: {"model" => "kept"})
+    end
+
+    it "exceeds both parser defaults" do
+      sql = event_store.count_query
+
+      expect(sql.size).to be > 262_144
+    end
+
+    it "aggregates instead of failing to parse" do
+      expect(event_store.count).to eq(Events::Stores::BaseStore::AggregationResult.new(value: 1, events_count: 1))
+    end
+  end
 end

--- a/spec/services/events/stores/utils/clickhouse_connection_spec.rb
+++ b/spec/services/events/stores/utils/clickhouse_connection_spec.rb
@@ -6,12 +6,59 @@ RSpec.describe Events::Stores::Utils::ClickhouseConnection do
   let(:memory_error_message) do
     "Code: 241. DB::Exception: (total) memory limit exceeded: would use 1.00 GiB (MEMORY_LIMIT_EXCEEDED)"
   end
+  let(:parser_limit_error_message) do
+    "Code: 62. DB::Exception: Max query size exceeded (can be increased with the `max_query_size` setting)"
+  end
+  let(:too_big_ast_error_message) { "Code: 168. DB::Exception: AST is too big. Maximum: 50000. (TOO_BIG_AST)" }
+  let(:connection) do
+    double("connection").tap do |conn| # rubocop:disable RSpec/VerifiedDoubles
+      allow(conn).to receive(:with_settings) { |**, &block| block.call }
+    end
+  end
 
-  before { allow(described_class).to receive(:sleep) }
+  before do
+    allow(described_class).to receive(:sleep)
+    allow(::Clickhouse::BaseRecord).to receive(:with_connection).and_yield(connection)
+  end
 
   describe ".with_retry" do
     it "returns the block result on success" do
       expect(described_class.with_retry { "value" }).to eq("value")
+    end
+
+    it "runs at the ClickHouse defaults" do
+      described_class.with_retry { "value" }
+
+      expect(::Clickhouse::BaseRecord).not_to have_received(:with_connection)
+    end
+
+    it "replays the query with the parser limits raised when ClickHouse refuses to parse it" do
+      attempts = 0
+
+      result = described_class.with_retry do
+        attempts += 1
+        raise ActiveRecord::ActiveRecordError, parser_limit_error_message if attempts == 1
+
+        "value"
+      end
+
+      expect(result).to eq("value")
+      expect(attempts).to eq(2)
+      expect(connection).to have_received(:with_settings).with(**described_class::QUERY_SETTINGS)
+      expect(described_class).not_to have_received(:sleep)
+    end
+
+    it "raises when the query still does not parse with the limits raised" do
+      attempts = 0
+
+      expect do
+        described_class.with_retry do
+          attempts += 1
+          raise ActiveRecord::ActiveRecordError, parser_limit_error_message
+        end
+      end.to raise_error(ActiveRecord::ActiveRecordError)
+
+      expect(attempts).to eq(described_class::MAX_RETRIES)
     end
 
     described_class::RETRYABLE_ERRORS.each do |error_class|
@@ -60,14 +107,29 @@ RSpec.describe Events::Stores::Utils::ClickhouseConnection do
   end
 
   describe ".connection_with_retry" do
-    let(:connection) { Object.new }
-
-    before do
-      allow(::Clickhouse::BaseRecord).to receive(:with_connection).and_yield(connection)
-    end
-
     it "yields the connection and returns the block result on success" do
       expect(described_class.connection_with_retry { |conn| conn }).to eq(connection)
+    end
+
+    it "runs at the ClickHouse defaults" do
+      described_class.connection_with_retry { |conn| conn }
+
+      expect(connection).not_to have_received(:with_settings)
+    end
+
+    it "replays the query with the parser limits raised when ClickHouse refuses to parse it" do
+      attempts = 0
+
+      result = described_class.connection_with_retry do |_conn|
+        attempts += 1
+        raise ActiveRecord::ActiveRecordError, parser_limit_error_message if attempts == 1
+
+        "value"
+      end
+
+      expect(result).to eq("value")
+      expect(attempts).to eq(2)
+      expect(connection).to have_received(:with_settings).with(**described_class::QUERY_SETTINGS)
     end
 
     described_class::RETRYABLE_ERRORS.each do |error_class|
@@ -132,6 +194,32 @@ RSpec.describe Events::Stores::Utils::ClickhouseConnection do
       error = StandardError.new(memory_error_message)
 
       expect(described_class.memory_limit_error?(error)).to be(false)
+    end
+  end
+
+  describe ".parser_limit_error?" do
+    it "is true for an ActiveRecord error about the query size" do
+      error = ActiveRecord::ActiveRecordError.new(parser_limit_error_message)
+
+      expect(described_class.parser_limit_error?(error)).to be(true)
+    end
+
+    it "is true for an ActiveRecord error about the AST size" do
+      error = ActiveRecord::ActiveRecordError.new(too_big_ast_error_message)
+
+      expect(described_class.parser_limit_error?(error)).to be(true)
+    end
+
+    it "is false for an ActiveRecord error with an unrelated message" do
+      error = ActiveRecord::ActiveRecordError.new("Code: 159. DB::Exception: Timeout exceeded")
+
+      expect(described_class.parser_limit_error?(error)).to be(false)
+    end
+
+    it "is false for a non-ActiveRecord error mentioning a parser limit" do
+      error = StandardError.new(parser_limit_error_message)
+
+      expect(described_class.parser_limit_error?(error)).to be(false)
     end
   end
 end


### PR DESCRIPTION
Part of ING-638

## Context

ClickHouse refuses a query before running it when the statement is larger than `max_query_size` (256 kB) or expands to more than `max_ast_elements` (50 000) nodes. A charge carrying thousands of filters serializes into a predicate past both limits, and every aggregation on the affected subscriptions fails with `Max query size exceeded`.

That error is already retryable, so the events store spends its three attempts re-sending a statement that cannot parse, and fails anyway.

## Description

- Replay a query rejected for one of those two limits once with `max_query_size` at 4 MiB and `max_ast_elements` at 500 000, instead of re-sending it unchanged.
- Leave queries that parse at the ClickHouse defaults, so nothing pays for a larger parser buffer to accommodate the rare oversized predicate.
- Lease the connection on the replay, so relations built inside the block run with the same settings as statements sent to the yielded connection.
- Gate the change with a store spec whose predicate exceeds both defaults.

Raising the first limit alone is not enough: the statement then parses and fails on the second with `AST is too big`. The limits travel as request parameters rather than in a `SETTINGS` clause, because the parser needs the buffer size before it starts reading the statement, so a clause inside the query it sizes cannot be read in time.

This buys headroom rather than removing the cause. Lowering the predicate itself is #6382.
