### PR TITLE
feat(rate-cards): filter by products and product categories

### DIFF
--- a/app/controllers/api/v2/rate_cards_controller.rb
+++ b/app/controllers/api/v2/rate_cards_controller.rb
@@ -63,8 +63,8 @@ module Api
             limit: params[:per_page] || PER_PAGE
           },
           filters: {
-            product_id: params[:product_id],
-            product_filter_id: params[:product_filter_id],
+            product_ids: Array(params[:product_id]).presence,
+            product_filter_ids: Array(params[:product_filter_id]).presence,
             code: params[:code],
             product_code: params[:product_code],
             product_filter_code: params[:product_filter_code]

--- a/app/graphql/resolvers/rate_cards_resolver.rb
+++ b/app/graphql/resolvers/rate_cards_resolver.rb
@@ -13,20 +13,22 @@ module Resolvers
     argument :code, String, required: false
     argument :limit, Integer, required: false
     argument :page, Integer, required: false
+    argument :product_category_ids, [ID], required: false
     argument :product_code, String, required: false
     argument :product_filter_code, String, required: false
-    argument :product_filter_id, ID, required: false
-    argument :product_id, ID, required: false
+    argument :product_filter_ids, [ID], required: false
+    argument :product_ids, [ID], required: false
     argument :search_term, String, required: false
+    argument :without_product_category, Boolean, required: false
 
     type Types::RateCards::Object.collection_type, null: false
 
-    def resolve(page: nil, limit: nil, search_term: nil, product_id: nil, product_filter_id: nil, code: nil, product_code: nil, product_filter_code: nil)
+    def resolve(page: nil, limit: nil, search_term: nil, product_ids: nil, product_filter_ids: nil, product_category_ids: nil, without_product_category: nil, code: nil, product_code: nil, product_filter_code: nil)
       result = ::RateCardsQuery.call(
         organization: current_organization,
         search_term:,
         pagination: {page:, limit:},
-        filters: {product_id:, product_filter_id:, code:, product_code:, product_filter_code:}
+        filters: {product_ids:, product_filter_ids:, product_category_ids:, without_product_category:, code:, product_code:, product_filter_code:}
       )
 
       result.rate_cards

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -35,6 +35,19 @@ class Product < ApplicationRecord
 
   default_scope -> { kept }
 
+  # Filters by product_category, treating "no category" as a selectable value:
+  # with both, the chosen categories OR uncategorized; with only the flag,
+  # uncategorized only; otherwise the chosen categories.
+  scope :in_categories, ->(category_ids, include_uncategorized: false) {
+    if category_ids.present? && include_uncategorized
+      where(product_category_id: category_ids).or(where(product_category_id: nil))
+    elsif include_uncategorized
+      where(product_category_id: nil)
+    else
+      where(product_category_id: category_ids)
+    end
+  }
+
   def self.ransackable_attributes(_auth_object = nil)
     %w[name code]
   end

--- a/app/queries/products_query.rb
+++ b/app/queries/products_query.rb
@@ -36,13 +36,7 @@ class ProductsQuery < BaseQuery
 
   # The product_category dimension is a multi-select: chosen product_categories OR "no product_category".
   def with_product_category(scope)
-    if filters.product_category_ids.present? && filters.without_product_category.present?
-      scope.where(product_category_id: filters.product_category_ids).or(scope.where(product_category_id: nil))
-    elsif filters.without_product_category.present?
-      scope.where(product_category_id: nil)
-    else
-      scope.where(product_category_id: filters.product_category_ids)
-    end
+    scope.in_categories(filters.product_category_ids, include_uncategorized: filters.without_product_category.present?)
   end
 
   def with_product_type(scope)

--- a/app/queries/rate_cards_query.rb
+++ b/app/queries/rate_cards_query.rb
@@ -54,24 +54,14 @@ class RateCardsQuery < BaseQuery
     scope.where(product_filter_id: filters.product_filter_ids)
   end
 
-  # A rate card reaches a product_category through its product. The dimension is
-  # a multi-select: cards on products in the chosen categories OR on products
-  # with no category.
+  # A rate card reaches a product_category through its product, so scope the
+  # cards to the matching products (shared Product.in_categories rule).
   def with_product_category(scope)
-    scope.where(product_id: category_scoped_product_ids)
-  end
-
-  def category_scoped_product_ids
-    products = organization.products
-
-    if filters.product_category_ids.present? && filters.without_product_category.present?
-      products.where(product_category_id: filters.product_category_ids)
-        .or(products.where(product_category_id: nil)).select(:id)
-    elsif filters.without_product_category.present?
-      products.where(product_category_id: nil).select(:id)
-    else
-      products.where(product_category_id: filters.product_category_ids).select(:id)
-    end
+    matching_products = organization.products.in_categories(
+      filters.product_category_ids,
+      include_uncategorized: filters.without_product_category.present?
+    )
+    scope.where(product_id: matching_products.select(:id))
   end
 
   def with_code(scope)

--- a/app/queries/rate_cards_query.rb
+++ b/app/queries/rate_cards_query.rb
@@ -3,8 +3,10 @@
 class RateCardsQuery < BaseQuery
   Result = BaseResult[:rate_cards]
   Filters = BaseFilters[
-    :product_id,
-    :product_filter_id,
+    :product_ids,
+    :product_filter_ids,
+    :product_category_ids,
+    :without_product_category,
     :code,
     :product_code,
     :product_filter_code
@@ -15,8 +17,11 @@ class RateCardsQuery < BaseQuery
     rate_cards = paginate(rate_cards)
     rate_cards = apply_consistent_ordering(rate_cards)
 
-    rate_cards = with_product(rate_cards) if filters.product_id.present?
-    rate_cards = with_product_filter(rate_cards) if filters.product_filter_id.present?
+    rate_cards = with_products(rate_cards) if filters.product_ids.present?
+    rate_cards = with_product_filters(rate_cards) if filters.product_filter_ids.present?
+    if filters.product_category_ids.present? || filters.without_product_category.present?
+      rate_cards = with_product_category(rate_cards)
+    end
     rate_cards = with_code(rate_cards) if filters.code.present?
     rate_cards = with_product_code(rate_cards) if filters.product_code.present?
     rate_cards = with_product_filter_code(rate_cards) if filters.product_filter_code.present?
@@ -41,12 +46,32 @@ class RateCardsQuery < BaseQuery
     }
   end
 
-  def with_product(scope)
-    scope.where(product_id: filters.product_id)
+  def with_products(scope)
+    scope.where(product_id: filters.product_ids)
   end
 
-  def with_product_filter(scope)
-    scope.where(product_filter_id: filters.product_filter_id)
+  def with_product_filters(scope)
+    scope.where(product_filter_id: filters.product_filter_ids)
+  end
+
+  # A rate card reaches a product_category through its product. The dimension is
+  # a multi-select: cards on products in the chosen categories OR on products
+  # with no category.
+  def with_product_category(scope)
+    scope.where(product_id: category_scoped_product_ids)
+  end
+
+  def category_scoped_product_ids
+    products = organization.products
+
+    if filters.product_category_ids.present? && filters.without_product_category.present?
+      products.where(product_category_id: filters.product_category_ids)
+        .or(products.where(product_category_id: nil)).select(:id)
+    elsif filters.without_product_category.present?
+      products.where(product_category_id: nil).select(:id)
+    else
+      products.where(product_category_id: filters.product_category_ids).select(:id)
+    end
   end
 
   def with_code(scope)

--- a/schema.graphql
+++ b/schema.graphql
@@ -12413,7 +12413,7 @@ type Query {
   """
   Query rate cards of an organization
   """
-  rateCards(code: String, limit: Int, page: Int, productCode: String, productFilterCode: String, productFilterId: ID, productId: ID, searchTerm: String): RateCardCollection!
+  rateCards(code: String, limit: Int, page: Int, productCategoryIds: [ID!], productCode: String, productFilterCode: String, productFilterIds: [ID!], productIds: [ID!], searchTerm: String, withoutProductCategory: Boolean): RateCardCollection!
 
   """
   Query a single role

--- a/schema.json
+++ b/schema.json
@@ -67183,6 +67183,26 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "productCategoryIds",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "productCode",
                   "description": null,
                   "type": {
@@ -67207,24 +67227,40 @@
                   "deprecationReason": null
                 },
                 {
-                  "name": "productFilterId",
+                  "name": "productFilterIds",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
                   },
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
                 },
                 {
-                  "name": "productId",
+                  "name": "productIds",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
                   },
                   "defaultValue": null,
                   "isDeprecated": false,
@@ -67236,6 +67272,18 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "withoutProductCategory",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null,

--- a/spec/graphql/resolvers/rate_cards_resolver_spec.rb
+++ b/spec/graphql/resolvers/rate_cards_resolver_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Resolvers::RateCardsResolver do
 
   let(:query) do
     <<~GQL
-      query($searchTerm: String, $productId: ID) {
-        rateCards(limit: 5, searchTerm: $searchTerm, productId: $productId) {
+      query($searchTerm: String, $productIds: [ID!], $productCategoryIds: [ID!], $withoutProductCategory: Boolean) {
+        rateCards(limit: 5, searchTerm: $searchTerm, productIds: $productIds, productCategoryIds: $productCategoryIds, withoutProductCategory: $withoutProductCategory) {
           collection { id name code currency }
           metadata { currentPage totalCount }
         }
@@ -29,7 +29,8 @@ RSpec.describe Resolvers::RateCardsResolver do
     GQL
   end
 
-  let(:product) { create(:product, organization:) }
+  let(:product_category) { create(:product_category, organization:) }
+  let(:product) { create(:product, organization:, product_category:) }
   let!(:card_one) { create(:rate_card, organization:, product:, name: "Growth USD", code: "growth_usd") }
   let!(:card_two) { create(:rate_card, organization:, name: "Standard EUR", code: "standard_eur") }
 
@@ -44,11 +45,29 @@ RSpec.describe Resolvers::RateCardsResolver do
     expect(response["metadata"]["totalCount"]).to eq(2)
   end
 
-  context "with a product filter" do
-    let(:variables) { {productId: product.id} }
+  context "with a productIds filter" do
+    let(:variables) { {productIds: [product.id]} }
 
-    it "returns only the cards of that item" do
+    it "returns only the cards of those items" do
       expect(execution["data"]["rateCards"]["collection"].map { it["id"] }).to eq([card_one.id])
+    end
+  end
+
+  context "with a productCategoryIds filter" do
+    let(:variables) { {productCategoryIds: [product_category.id]} }
+
+    it "returns only the cards of products in that category" do
+      expect(execution["data"]["rateCards"]["collection"].map { it["id"] }).to eq([card_one.id])
+    end
+  end
+
+  context "with a withoutProductCategory filter" do
+    # card_one and card_two are on products that each carry a category.
+    let!(:standalone_card) { create(:rate_card, organization:, product: create(:product, :standalone, organization:), code: "standalone") }
+    let(:variables) { {withoutProductCategory: true} }
+
+    it "returns only the cards of uncategorized products" do
+      expect(execution["data"]["rateCards"]["collection"].map { it["id"] }).to eq([standalone_card.id])
     end
   end
 

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -30,6 +30,31 @@ RSpec.describe Product do
     end
   end
 
+  describe "Scopes" do
+    describe ".in_categories" do
+      let(:organization) { create(:organization) }
+      let(:category) { create(:product_category, organization:) }
+      let!(:categorized) { create(:product, organization:, product_category: category) }
+      let!(:uncategorized) { create(:product, :standalone, organization:) }
+
+      # A product in a different category, to prove the filter excludes it.
+      before { create(:product, organization:) }
+
+      it "returns products in the given categories" do
+        expect(described_class.in_categories([category.id])).to eq([categorized])
+      end
+
+      it "returns uncategorized products when include_uncategorized is set" do
+        expect(described_class.in_categories([], include_uncategorized: true)).to eq([uncategorized])
+      end
+
+      it "returns products in the categories or uncategorized when both are given" do
+        expect(described_class.in_categories([category.id], include_uncategorized: true))
+          .to match_array([categorized, uncategorized])
+      end
+    end
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:code) }

--- a/spec/queries/rate_cards_query_spec.rb
+++ b/spec/queries/rate_cards_query_spec.rb
@@ -49,6 +49,16 @@ RSpec.describe RateCardsQuery do
     it "returns only the cards of that product filter" do
       expect(result.rate_cards).to eq([filtered_card])
     end
+
+    context "with several product filters" do
+      let(:other_filter) { create(:product_filter, organization:, product:, code: "other_filter") }
+      let!(:other_filtered_card) { create(:rate_card, organization:, product:, product_filter: other_filter, code: "other_filtered") }
+      let(:filters) { {product_filter_ids: [item_filter.id, other_filter.id]} }
+
+      it "returns the cards of all requested product filters" do
+        expect(result.rate_cards).to match_array([filtered_card, other_filtered_card])
+      end
+    end
   end
 
   # card_one / card_two default products each carry their own category, so they

--- a/spec/queries/rate_cards_query_spec.rb
+++ b/spec/queries/rate_cards_query_spec.rb
@@ -23,11 +23,64 @@ RSpec.describe RateCardsQuery do
     expect(result.rate_cards).to match_array([card_one, card_two])
   end
 
-  context "with a product filter" do
-    let(:filters) { {product_id: product.id} }
+  context "with a product_ids filter" do
+    let(:filters) { {product_ids: [product.id]} }
 
     it "returns only the cards of that product" do
       expect(result.rate_cards).to eq([card_one])
+    end
+
+    context "with several products" do
+      let(:other_product) { create(:product, organization:) }
+      let!(:card_three) { create(:rate_card, organization:, product: other_product, code: "extra") }
+      let(:filters) { {product_ids: [product.id, other_product.id]} }
+
+      it "returns the cards of all requested products" do
+        expect(result.rate_cards).to match_array([card_one, card_three])
+      end
+    end
+  end
+
+  context "with a product_filter_ids filter" do
+    let(:item_filter) { create(:product_filter, organization:, product:) }
+    let!(:filtered_card) { create(:rate_card, organization:, product:, product_filter: item_filter) }
+    let(:filters) { {product_filter_ids: [item_filter.id]} }
+
+    it "returns only the cards of that product filter" do
+      expect(result.rate_cards).to eq([filtered_card])
+    end
+  end
+
+  # card_one / card_two default products each carry their own category, so they
+  # never match these fixtures unless filtered by their own category.
+  context "with product_category filters" do
+    let(:product_category) { create(:product_category, organization:) }
+    let(:categorized_product) { create(:product, organization:, product_category:) }
+    let!(:categorized_card) { create(:rate_card, organization:, product: categorized_product, code: "categorized") }
+    let!(:standalone_card) { create(:rate_card, organization:, product: create(:product, :standalone, organization:), code: "standalone") }
+
+    context "with product_category_ids" do
+      let(:filters) { {product_category_ids: [product_category.id]} }
+
+      it "returns only the cards of products in that category" do
+        expect(result.rate_cards).to eq([categorized_card])
+      end
+    end
+
+    context "with without_product_category" do
+      let(:filters) { {without_product_category: true} }
+
+      it "returns only the cards of products with no category" do
+        expect(result.rate_cards).to eq([standalone_card])
+      end
+    end
+
+    context "with both combined" do
+      let(:filters) { {product_category_ids: [product_category.id], without_product_category: true} }
+
+      it "returns cards in the category and cards on uncategorized products" do
+        expect(result.rate_cards).to match_array([categorized_card, standalone_card])
+      end
     end
   end
 


### PR DESCRIPTION
## Description

- **Category dimension** on `RateCardsQuery` + `RateCardsResolver`: `productCategoryIds: [ID]` and `withoutProductCategory: Boolean`, reaching the category through the card's product and mirroring the products-query multi-select (chosen categories **OR** no category).
- **Plural selection**: resolver now takes `productIds` / `productFilterIds` (`[ID]`) instead of the singular scalars.
- **V2 REST** keeps its singular `product_id` / `product_filter_id` params (its own public contract) and wraps them into the now-plural query filters — a single value still works, and arrays are accepted transparently.
- Regenerated `schema.graphql` / `schema.json`.

## GraphQL schema change (FE)

```
rateCards(
  ...,
  productIds: [ID!],
  productFilterIds: [ID!],
  productCategoryIds: [ID!],
  withoutProductCategory: Boolean
)
```

`productId` / `productFilterId` (singular) are **removed** from the GraphQL surface — the FE must switch to the plural args.