### PR TITLE
feat(stripe): support Lago-owned SPTs

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -167,6 +167,7 @@ module Api
             :payment_provider,
             :payment_provider_code,
             :provider_customer_id,
+            :default_shared_payment_token,
             :sync,
             :sync_with_provider,
             :document_locale,

--- a/app/models/payment_provider_customers/stripe_customer.rb
+++ b/app/models/payment_provider_customers/stripe_customer.rb
@@ -11,7 +11,15 @@ module PaymentProviderCustomers
     validate :link_payment_method_can_exist_only_with_card
     validate :customer_balance_must_be_exclusive
 
-    settings_accessors :payment_method_id
+    settings_accessors :payment_method_id, :default_shared_payment_token
+
+    validates :default_shared_payment_token,
+      format: {with: /\Aspt_[a-zA-Z0-9]+\z/}, length: {maximum: 255}, allow_nil: true
+    validate :shared_payment_token_requires_card
+
+    def shared_payment_token?
+      default_shared_payment_token.present?
+    end
 
     def provider_payment_methods
       get_from_settings("provider_payment_methods")
@@ -30,6 +38,13 @@ module PaymentProviderCustomers
     end
 
     private
+
+    def shared_payment_token_requires_card
+      return unless shared_payment_token?
+      return if provider_payment_methods&.include?("card")
+
+      errors.add(:default_shared_payment_token, "requires card in provider_payment_methods")
+    end
 
     def allowed_provider_payment_methods
       return if (provider_payment_methods - PAYMENT_METHODS).blank?

--- a/app/serializers/v1/customer_serializer.rb
+++ b/app/serializers/v1/customer_serializer.rb
@@ -74,7 +74,11 @@ module V1
       when :stripe
         configuration[:provider_customer_id] = model.stripe_customer&.provider_customer_id
         configuration[:provider_payment_methods] = model.stripe_customer&.provider_payment_methods
-        configuration.merge!(model.stripe_customer&.settings&.symbolize_keys || {})
+        settings = model.stripe_customer&.settings&.symbolize_keys || {}
+        configuration.merge!(settings.except(:default_shared_payment_token))
+        if settings.key?(:default_shared_payment_token)
+          configuration[:has_shared_payment_token] = model.stripe_customer.shared_payment_token?
+        end
       when :gocardless
         configuration[:provider_customer_id] = model.gocardless_customer&.provider_customer_id
         configuration.merge!(model.gocardless_customer&.settings&.symbolize_keys || {})

--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -49,7 +49,7 @@ module Invoices
           payable_payment_status: "pending"
         )
 
-        payment.payment_method_id = determine_payment_method&.id
+        payment.payment_method_id = stripe_shared_payment_token? ? nil : determine_payment_method&.id
         payment.save!
 
         result.payment = payment
@@ -150,11 +150,22 @@ module Invoices
         return false if invoice.self_billed?
         return false if invoice.payment_succeeded? || invoice.voided? || invoice.closed?
         return false if current_payment_provider.blank?
+        if current_payment_provider_customer.is_a?(PaymentProviderCustomers::StripeCustomer) &&
+            current_payment_provider_customer.shared_payment_token? && determined_payment_method.manual_payment
+          return false
+        end
 
         current_payment_provider_customer&.provider_customer_id &&
           (determine_payment_method.present? ||
             provider_payment_method_pending_backfill? ||
-            stripe_customer_balance_only?)
+            stripe_customer_balance_only? ||
+            stripe_shared_payment_token?)
+      end
+
+      def stripe_shared_payment_token?
+        current_payment_provider_customer.is_a?(PaymentProviderCustomers::StripeCustomer) &&
+          current_payment_provider_customer.shared_payment_token? &&
+          !determined_payment_method.manual_payment
       end
 
       # NOTE: A Stripe customer_balance (V-BAN) customer has no instrument to pull from, so no
@@ -264,9 +275,13 @@ module Invoices
       #       nil means: skip automatic payment (manual type or no payment method configured)
       #       payment_method_params takes precedence (used for retry with override)
       def determine_payment_method
-        @determine_payment_method ||= PaymentMethods::DetermineService.call(
+        determined_payment_method.payment_method
+      end
+
+      def determined_payment_method
+        @determined_payment_method ||= PaymentMethods::DetermineService.call(
           invoice:, customer:, payment_method_params:
-        ).payment_method
+        )
       end
     end
   end

--- a/app/services/payment_methods/determine_service.rb
+++ b/app/services/payment_methods/determine_service.rb
@@ -2,7 +2,7 @@
 
 module PaymentMethods
   class DetermineService < BaseService
-    Result = BaseResult[:payment_method]
+    Result = BaseResult[:payment_method, :manual_payment]
 
     def initialize(invoice:, customer:, payment_method_params:)
       @invoice = invoice
@@ -26,8 +26,13 @@ module PaymentMethods
 
     attr_reader :invoice, :customer, :payment_method_params
 
+    def manual_payment
+      result.manual_payment = true
+      nil
+    end
+
     def determine_override_payment_method
-      return nil if payment_method_params[:payment_method_type] == "manual"
+      return manual_payment if payment_method_params[:payment_method_type] == "manual"
 
       if payment_method_params[:payment_method_id].present?
         customer.payment_methods.find_by(id: payment_method_params[:payment_method_id])
@@ -51,7 +56,7 @@ module PaymentMethods
       subscription = invoice.invoice_subscriptions.first&.subscription
       return nil unless subscription
 
-      return nil if subscription.payment_method_type == "manual"
+      return manual_payment if subscription.payment_method_type == "manual"
 
       if subscription.payment_method_id.present?
         return customer.payment_methods.find_by(id: subscription.payment_method_id)
@@ -64,7 +69,7 @@ module PaymentMethods
       wallet_transaction = invoice.wallet_transactions.first
       return nil unless wallet_transaction
 
-      return nil if wallet_transaction.payment_method_type == "manual"
+      return manual_payment if wallet_transaction.payment_method_type == "manual"
 
       if wallet_transaction.payment_method_id.present?
         return customer.payment_methods.find_by(id: wallet_transaction.payment_method_id)
@@ -72,12 +77,12 @@ module PaymentMethods
 
       if wallet_transaction.source.to_s.in?(%w[interval threshold])
         rule = wallet_transaction.wallet.recurring_transaction_rules.active.first
-        return nil if rule&.payment_method_type == "manual"
+        return manual_payment if rule&.payment_method_type == "manual"
         return customer.payment_methods.find_by(id: rule.payment_method_id) if rule&.payment_method_id.present?
       end
 
       wallet = wallet_transaction.wallet
-      return nil if wallet.payment_method_type == "manual"
+      return manual_payment if wallet.payment_method_type == "manual"
 
       if wallet.payment_method_id.present?
         return customer.payment_methods.find_by(id: wallet.payment_method_id)

--- a/app/services/payment_providers/stripe/customers/create_service.rb
+++ b/app/services/payment_providers/stripe/customers/create_service.rb
@@ -31,6 +31,10 @@ module PaymentProviders
             provider_customer.sync_with_provider = params[:sync_with_provider].presence
           end
 
+          if params.key?(:default_shared_payment_token)
+            provider_customer.default_shared_payment_token = params[:default_shared_payment_token].presence
+          end
+
           provider_customer = handle_provider_payment_methods(provider_customer:, params:)
           provider_customer.save!
 

--- a/app/services/payment_providers/stripe/payments/create_service.rb
+++ b/app/services/payment_providers/stripe/payments/create_service.rb
@@ -122,12 +122,15 @@ module PaymentProviders
           # payable have been settled by another payment path
           raise Invoices::Payments::AlreadyPaidError if invoice.reload.payment_succeeded?
 
+          options = {
+            api_key: payment_provider.secret_key,
+            idempotency_key: "payment-#{payment.id}"
+          }
+          options[:stripe_version] = "2026-04-22.preview" if provider_customer.shared_payment_token?
+
           ::Stripe::PaymentIntent.create(
             payload,
-            {
-              api_key: payment_provider.secret_key,
-              idempotency_key: "payment-#{payment.id}"
-            }
+            options
           )
         end
 
@@ -145,6 +148,9 @@ module PaymentProviders
         end
 
         def shared_payment_token
+          # Locally configured tokens take priority, including when Stripe has a saved card.
+          return provider_customer.default_shared_payment_token if provider_customer.shared_payment_token?
+
           # NOTE: Only use the shared payment token if no other payment method exist (no default, nothing in the list)
           return nil unless invoice.organization.feature_flag_enabled?(:stripe_shared_payment_token)
           return nil if stripe_customer.deleted?
@@ -173,6 +179,7 @@ module PaymentProviders
             payload.merge!(customer_balance_fields)
           elsif shared_payment_token
             payload[:payment_method_data] = {shared_payment_granted_token: shared_payment_token}
+            payload[:payment_method_types] = ["card"] if provider_customer.shared_payment_token?
             payload.delete(:return_url)
             payload.delete(:off_session)
           else

--- a/docs/lago-owned-shared-payment-tokens.md
+++ b/docs/lago-owned-shared-payment-tokens.md
@@ -1,0 +1,50 @@
+# Lago-owned Stripe Shared Payment Tokens
+
+The customer supplies an SPT to Lago. Lago stores it on its Stripe provider-customer connection and uses it directly in a Stripe PaymentIntent. No Stripe Customer `invoice_settings.default_shared_payment_token` update is required.
+
+## Configure a customer
+
+Send this body to `POST /api/v1/customers`, authenticated with the organization's Lago API key:
+
+```json
+{
+  "customer": {
+    "external_id": "your-agent-id",
+    "currency": "USD",
+    "billing_configuration": {
+      "payment_provider": "stripe",
+      "payment_provider_code": "your-stripe-integration",
+      "sync_with_provider": true,
+      "provider_payment_methods": ["card"],
+      "default_shared_payment_token": "spt_REPLACE"
+    }
+  }
+}
+```
+
+Wait for Lago to create/link the Stripe customer before collection. For an existing customer, submit its external ID and the billing configuration with the token. Omission preserves the token; explicit `null` clears it. Customer responses show `has_shared_payment_token`, not the credential. Storage uses the Stripe provider-customer's existing `settings` JSON; no database migration is required. The token is not separately encrypted by this patch.
+
+Issue invoices normally. Do not use `skip_psp` or manual reconciliation. The collector sets:
+
+```ruby
+payment_method_data: {shared_payment_granted_token: token}
+payment_method_types: ["card"]
+```
+
+It removes `off_session` and `return_url` for SPT payments and sends `Stripe-Version: 2026-04-22.preview`. Normal payment idempotency, Stripe response handling and invoice reconciliation remain in Lago.
+
+## Selection and scope
+
+- An explicitly configured Lago token takes priority over saved cards. A rejected token fails collection; there is no fallback to a card and no automatic token removal.
+- Clearing the token restores normal payment-method selection.
+- Explicit manual-payment choices are preserved. Automatic collection also works for customers whose only payment credential is an SPT.
+- Existing main's feature-flagged Stripe-Customer token lookup remains available when no Lago token is configured. It retains its existing fallback priority.
+- This implements Orb's billing-side customer storage and token-first selection. Per-invoice token overrides and Orb's no-dunning policy are not implemented; Lago's existing retries remain.
+- The verified test-helper token was single-use. Obtain a fresh eligible token before another payment; recurring mandate behavior was not tested.
+- API support only; no token input has been added to Lago's dashboard UI.
+
+## Validation scope
+
+The request spec exercises API storage and redaction, omission and explicit clearing, format/card validation, native invoice collection, token priority over a saved card, and failure without card fallback.
+
+The equivalent local integration has also been exercised with a buyer-issued token, a Lago credit invoice and settled wallet credits. Stripe inbound webhook delivery was not part of that check; invoice reconciliation used the PaymentIntent response.

--- a/spec/requests/lago_owned_spt_spec.rb
+++ b/spec/requests/lago_owned_spt_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Lago-owned shared payment tokens", type: :request do
+  let(:organization) { create(:organization) }
+  let(:provider) { create(:stripe_provider, organization:, code: "spt_local") }
+  let(:customer) { create(:customer, organization:, payment_provider: "stripe", payment_provider_code: provider.code) }
+  let(:token) { "spt_localtest" }
+  let(:stripe_customer) do
+    create(:stripe_customer, customer:, payment_provider: provider, provider_payment_methods: ["card"],
+      default_shared_payment_token: token)
+  end
+
+  describe "customer configuration" do
+    it "stores the token through the API without exposing it in customer responses" do
+      post_with_token(organization, "/api/v1/customers", customer: {
+        external_id: "spt_api_customer", currency: "USD",
+        billing_configuration: {payment_provider: "stripe", payment_provider_code: provider.code,
+                                provider_customer_id: "cus_api", default_shared_payment_token: token}
+      })
+
+      expect(response).to have_http_status(:ok)
+      stored = organization.customers.find_by!(external_id: "spt_api_customer").stripe_customer
+      expect(stored.default_shared_payment_token).to eq(token)
+      expect(json[:customer][:billing_configuration][:has_shared_payment_token]).to be(true)
+      expect(json[:customer][:billing_configuration]).not_to have_key(:default_shared_payment_token)
+    end
+
+    it "preserves the token when omitted and clears it when explicitly null" do
+      stripe_customer
+      service = PaymentProviders::Stripe::Customers::CreateService
+      result = service.call(customer:, payment_provider_id: provider.id, params: {})
+      expect(result).to be_success
+      expect(stripe_customer.reload.default_shared_payment_token).to eq(token)
+
+      result = service.call(customer:, payment_provider_id: provider.id, params: {default_shared_payment_token: nil})
+      expect(result).to be_success
+      expect(stripe_customer.reload.default_shared_payment_token).to be_nil
+    end
+
+    it "rejects a PaymentMethod ID as an SPT" do
+      stripe_customer.default_shared_payment_token = "pm_not_a_token"
+      expect(stripe_customer).not_to be_valid
+      expect(stripe_customer.errors[:default_shared_payment_token]).to be_present
+    end
+
+    it "rejects a token with a bank-transfer-only connection" do
+      stripe_customer.provider_payment_methods = ["customer_balance"]
+      expect(stripe_customer).not_to be_valid
+      expect(stripe_customer.errors[:default_shared_payment_token]).to be_present
+    end
+  end
+
+  describe "native invoice collection" do
+    let(:invoice) do
+      create(:invoice, organization:, customer:, invoice_type: :one_off,
+        total_amount_cents: 100, currency: "USD", ready_for_payment_processing: true)
+    end
+    let(:stripe_default) { nil }
+    let(:stripe_status) { 200 }
+    let(:stripe_body) { {id: "pi_spt_test", status: "succeeded", amount: 100, currency: "usd"} }
+
+    before do
+      stripe_customer
+      stub_request(:get, "https://api.stripe.com/v1/customers/#{stripe_customer.provider_customer_id}")
+        .to_return(body: {id: stripe_customer.provider_customer_id, object: "customer",
+                          invoice_settings: {default_payment_method: stripe_default}, default_source: nil}.to_json)
+      stub_request(:post, "https://api.stripe.com/v1/payment_intents")
+        .with(body: hash_including("amount" => "100", "currency" => "usd",
+          "payment_method_data" => {"shared_payment_granted_token" => token}))
+        .to_return(status: stripe_status, body: stripe_body.to_json)
+    end
+
+    it "collects an invoice for a token-only customer and reconciles the native payment" do
+      result = Invoices::Payments::CreateService.call(invoice:)
+
+      expect(result).to be_success
+      expect(invoice.reload.payment_status).to eq("succeeded")
+      expect(invoice.total_paid_amount_cents).to eq(100)
+      expect(invoice.payments.sole.provider_payment_id).to eq("pi_spt_test")
+      expect(stripe_customer.reload.default_shared_payment_token).to eq(token)
+    end
+
+    context "with an existing Stripe default card" do
+      let(:stripe_default) { "pm_existing_card" }
+
+      it "still submits only the SPT" do
+        Invoices::Payments::CreateService.call(invoice:)
+
+        expect(invoice.reload.payment_status).to eq("succeeded")
+        expect(WebMock).to have_requested(:post, "https://api.stripe.com/v1/payment_intents")
+          .with { |request| !Rack::Utils.parse_nested_query(request.body).key?("payment_method") }.once
+      end
+    end
+
+    context "when Stripe rejects the token" do
+      let(:stripe_default) { "pm_existing_card" }
+      let(:stripe_status) { 400 }
+      let(:stripe_body) { {error: {type: "invalid_request_error", code: "resource_missing", message: "Token deactivated"}} }
+
+      it "fails the invoice without retrying with the card or clearing the token" do
+        Invoices::Payments::CreateService.call(invoice:)
+
+        expect(invoice.reload.payment_status).to eq("failed")
+        expect(invoice.total_paid_amount_cents).to eq(0)
+        expect(invoice.payments.sole.status).to eq("failed")
+        expect(stripe_customer.reload.default_shared_payment_token).to eq(token)
+        expect(WebMock).to have_requested(:post, "https://api.stripe.com/v1/payment_intents").once
+      end
+    end
+  end
+end


### PR DESCRIPTION
Agents can set `billing_configuration.default_shared_payment_token` through Lago's customer API and have Lago collect invoices using that token, without relying on Stripe's customer-default-token field.

The token is stored on the Stripe provider-customer connection. An explicitly configured Lago token takes priority over saved cards; rejection does not fall back to a card. Omitting the field preserves it, while explicit `null` clears it. Customer responses expose `has_shared_payment_token` instead of the credential. Explicit manual-payment choices remain manual, and token-only customers can be collected automatically.

SPT collection supplies `payment_method_data.shared_payment_granted_token`, restricts the payment method to card and uses Stripe API version `2026-04-22.preview`. The existing feature-flagged Stripe-customer token lookup remains available when no Lago token is configured.

### Validation

- Rebased the existing implementation onto current `main` without conflicts.
- All eight changed Ruby files pass syntax checks in a Ruby 4.0.6 container.
- The seven focused SPT request examples pass in the existing local Lago API container with unrelated ClickHouse migrations disabled. That container runs Ruby 3.4.8 and the equivalent local implementation; this is not an exact-current-main RSpec result.
- The two-container agent/hash integration completed a fresh Stripe test flow: buyer-issued SPT → Lago credit invoice → settled wallet credit → hash usage debit → HTTP 402 at zero balance. Retry and restart checks preserved the same identity and operation results.
- Changed-file secret scan passed; local paths, personal names and sandbox account/invoice identifiers were removed from the documentation.

This is a draft pending current-main CI validation under Ruby 4.0.6. The token uses the existing settings JSON without additional encryption. The patch keeps Lago's existing retry policy and adds no dashboard input, per-invoice token override or automatic token clearing.
